### PR TITLE
Ruby: only add google-cloud credentials environment variables for gcloud apis

### DIFF
--- a/src/main/java/com/google/api/codegen/ruby/RubyUtil.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyUtil.java
@@ -18,10 +18,15 @@ import com.google.api.codegen.util.NamePath;
 import com.google.api.codegen.util.VersionMatcher;
 
 public class RubyUtil {
+  private static final String GOOGLE_CLOUD_PACKAGE_NAME = "Google::Cloud";
   private static final String LONGRUNNING_PACKAGE_NAME = "Google::Longrunning";
 
   public static boolean isLongrunning(String packageName) {
     return packageName.equals(LONGRUNNING_PACKAGE_NAME);
+  }
+
+  public static boolean isGoogleCloudPackage(String packageName) {
+    return packageName.startsWith(GOOGLE_CLOUD_PACKAGE_NAME);
   }
 
   public static boolean hasMajorVersion(String packageName) {

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -717,9 +717,9 @@ module Library
       "https://www.googleapis.com/auth/cloud-platform",
       "https://www.googleapis.com/auth/library"
     ].freeze
-    PATH_ENV_VARS = %w(LIBRARY_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
-    JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
-    DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+    PATH_ENV_VARS = %w(LIBRARY_KEYFILE)
+    JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON)
+    DEFAULT_PATHS = []
   end
 end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -717,9 +717,9 @@ module Library
       "https://www.googleapis.com/auth/cloud-platform",
       "https://www.googleapis.com/auth/library"
     ].freeze
-    PATH_ENV_VARS = %w(LIBRARY_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
-    JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
-    DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+    PATH_ENV_VARS = %w(LIBRARY_KEYFILE)
+    JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON)
+    DEFAULT_PATHS = []
   end
 end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -16,7 +16,7 @@ jsondoc/*
 ============== file: .rubocop.yml ==============
 AllCops:
   Exclude:
-    - "google-example.gemspec"
+    - "google-cloud-example.gemspec"
     - "lib/google/**/*"
     - "Rakefile"
     - "test/**/*"
@@ -40,10 +40,10 @@ Style/EmptyElse:
   Enabled: false
 Style/HashSyntax:
   Exclude:
-    - "lib/google/example/v1/**/*"
+    - "lib/google/cloud/example/v1/**/*"
 Metrics/LineLength:
   Exclude:
-    - "lib/google/example/v1/**/*"
+    - "lib/google/cloud/example/v1/**/*"
 Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/PerceivedComplexity:
@@ -51,11 +51,11 @@ Metrics/PerceivedComplexity:
 Metrics/AbcSize:
   Max: 25
   Exclude:
-    - "lib/google/example/v1/**/*"
+    - "lib/google/cloud/example/v1/**/*"
 Metrics/MethodLength:
   Max: 20
   Exclude:
-    - "lib/google/example/v1/**/*"
+    - "lib/google/cloud/example/v1/**/*"
 Metrics/ParameterLists:
   Enabled: false
 Style/RescueModifier:
@@ -317,7 +317,7 @@ steps:
 
 ### Installation
 ```
-$ gem install google-example
+$ gem install google-cloud-example
 ```
 
 ### Next Steps
@@ -328,7 +328,7 @@ $ gem install google-example
 - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
-[Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-example/latest/google/multiple_services
+[Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-example/latest/google/multiple_services
 [Product Documentation]: https://cloud.google.com/multiple_services
 
 ============== file: Rakefile ==============
@@ -364,7 +364,7 @@ namespace :test do
   task :coverage do
     require "simplecov"
     SimpleCov.start do
-      command_name "google-example"
+      command_name "google-cloud-example"
       track_files "lib/**/*.rb"
       add_filter "test/"
     end
@@ -374,14 +374,14 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Run the google-example acceptance tests."
+desc "Run the google-cloud-example acceptance tests."
 task :acceptance do
   Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
   task :run do
-    puts "The google-example gem does not have acceptance tests."
+    puts "The google-cloud-example gem does not have acceptance tests."
   end
 
   desc "Run acceptance tests with coverage."
@@ -397,7 +397,7 @@ require "yard"
 require "yard/rake/yardoc_task"
 YARD::Rake::YardocTask.new
 
-desc "Generates JSON output from google-example .yardoc"
+desc "Generates JSON output from google-cloud-example .yardoc"
 task :jsondoc => :yard do
   require "rubygems"
   require "gcloud/jsondoc"
@@ -412,7 +412,7 @@ task :jsondoc => :yard do
         modules: [
           {
             title: "Google::Cloud::Example::V1",
-            include: ["google/example/v1"]
+            include: ["google/cloud/example/v1"]
           },
           {
             title: "Google::Protobuf",
@@ -428,7 +428,7 @@ task :jsondoc => :yard do
   }
 
   generator = Gcloud::Jsondoc::Generator.new registry,
-                                             "google-example",
+                                             "google-cloud-example",
                                              generate: toc_config
   rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
@@ -437,19 +437,19 @@ end
 
 desc "Run yard-doctest example tests."
 task :doctest do
-  puts "The google-example gem does not have doctest tests."
+  puts "The google-cloud-example gem does not have doctest tests."
 end
 
 desc "Run the CI build"
 task :ci do
-  header "BUILDING google-example"
-  header "google-example rubocop", "*"
+  header "BUILDING google-cloud-example"
+  header "google-cloud-example rubocop", "*"
   sh "bundle exec rake rubocop"
-  header "google-example jsondoc", "*"
+  header "google-cloud-example jsondoc", "*"
   sh "bundle exec rake jsondoc"
-  header "google-example doctest", "*"
+  header "google-cloud-example doctest", "*"
   sh "bundle exec rake doctest"
-  header "google-example test", "*"
+  header "google-cloud-example test", "*"
   sh "bundle exec rake test"
 end
 
@@ -458,7 +458,7 @@ namespace :ci do
   desc "Run the CI build, with acceptance tests."
   task :acceptance do
     Rake::Task["ci"].invoke
-    header "google-example acceptance", "*"
+    header "google-cloud-example acceptance", "*"
     sh "bundle exec rake acceptance -v"
   end
   task :a do
@@ -478,17 +478,17 @@ def header str, token = "#"
   puts ""
 end
 
-============== file: google-example.gemspec ==============
+============== file: google-cloud-example.gemspec ==============
 # -*- ruby -*-
 # encoding: utf-8
 
 Gem::Specification.new do |gem|
-  gem.name          = "google-example"
+  gem.name          = "google-cloud-example"
   gem.version       = "0.6.8"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
-  gem.description   = "google-example is the official library for Google Example API."
+  gem.description   = "google-cloud-example is the official library for Google Example API."
   gem.summary       = "API Client library for Google Example API"
   gem.homepage      = "https://github.com/googleapis/googleapis"
   gem.license       = "Apache-2.0"
@@ -511,7 +511,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "simplecov", "~> 0.9"
 end
 
-============== file: lib/google/example.rb ==============
+============== file: lib/google/cloud/example.rb ==============
 # Copyright 2017, Google LLC All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -530,137 +530,139 @@ require "google/gax"
 require "pathname"
 
 module Google
-  # rubocop:disable LineLength
+  module Cloud
+    # rubocop:disable LineLength
 
-  ##
-  # # Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
-  #
-  # [Google Example API][Product Documentation]:
-  # This description tests descriptions that span multiple lines. This is a service
-  # that increments and decrements a counter.
-  # - [Product Documentation][]
-  #
-  # ## Quick Start
-  # In order to use this library, you first need to go through the following
-  # steps:
-  #
-  # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
-  # 2. [Enable the Google Example API.](https://console.cloud.google.com/apis/api/multiple_services)
-  # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
-  #
-  # ### Next Steps
-  # - Read the [Google Example API Product documentation][Product Documentation]
-  #   to learn more about the product and see How-to Guides.
-  # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md)
-  #   to see the full list of Cloud APIs that we cover.
-  #
-  # [Product Documentation]: https://cloud.google.com/multiple_services
-  #
-  #
-  module Example
-    # rubocop:enable LineLength
+    ##
+    # # Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    #
+    # [Google Example API][Product Documentation]:
+    # This description tests descriptions that span multiple lines. This is a service
+    # that increments and decrements a counter.
+    # - [Product Documentation][]
+    #
+    # ## Quick Start
+    # In order to use this library, you first need to go through the following
+    # steps:
+    #
+    # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
+    # 2. [Enable the Google Example API.](https://console.cloud.google.com/apis/api/multiple_services)
+    # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    #
+    # ### Next Steps
+    # - Read the [Google Example API Product documentation][Product Documentation]
+    #   to learn more about the product and see How-to Guides.
+    # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md)
+    #   to see the full list of Cloud APIs that we cover.
+    #
+    # [Product Documentation]: https://cloud.google.com/multiple_services
+    #
+    #
+    module Example
+      # rubocop:enable LineLength
 
-    FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("example"))
+      FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("example"))
 
-    AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
-      .select { |file| File.directory?(file) }
-      .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
-      .select { |dir| File.exist?(dir + ".rb") }
-      .map { |dir| File.basename(dir) }
+      AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
+        .select { |file| File.directory?(file) }
+        .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
+        .select { |dir| File.exist?(dir + ".rb") }
+        .map { |dir| File.basename(dir) }
 
-    module Incrementer
-      ##
-      # @param version [Symbol, String]
-      #   The major version of the service to be used. By default :v1
-      #   is used.
-      # @overload new(version:, credentials:, scopes:, client_config:, timeout:)
-      #   @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-      #     Provides the means for authenticating requests made by the client. This parameter can
-      #     be many types.
-      #     A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
-      #     authenticating requests made by this client.
-      #     A `String` will be treated as the path to the keyfile to be used for the construction of
-      #     credentials for this client.
-      #     A `Hash` will be treated as the contents of a keyfile to be used for the construction of
-      #     credentials for this client.
-      #     A `GRPC::Core::Channel` will be used to make calls through.
-      #     A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
-      #     should already be composed with a `GRPC::Core::CallCredentials` object.
-      #     A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
-      #     metadata for requests, generally, to give OAuth credentials.
-      #   @param scopes [Array<String>]
-      #     The OAuth scopes for this service. This parameter is ignored if
-      #     an updater_proc is supplied.
-      #   @param client_config [Hash]
-      #     A Hash for call options for each method. See
-      #     Google::Gax#construct_settings for the structure of
-      #     this data. Falls back to the default config if not specified
-      #     or the specified config is missing data points.
-      #   @param timeout [Numeric]
-      #     The default timeout, in seconds, for calls made through this client.
-      def self.new(*args, version: :v1, **kwargs)
-        unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
-          raise "The version: #{version} is not available. The available versions " \
-            "are: [#{AVAILABLE_VERSIONS.join(", ")}]"
+      module Incrementer
+        ##
+        # @param version [Symbol, String]
+        #   The major version of the service to be used. By default :v1
+        #   is used.
+        # @overload new(version:, credentials:, scopes:, client_config:, timeout:)
+        #   @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+        #     Provides the means for authenticating requests made by the client. This parameter can
+        #     be many types.
+        #     A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
+        #     authenticating requests made by this client.
+        #     A `String` will be treated as the path to the keyfile to be used for the construction of
+        #     credentials for this client.
+        #     A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+        #     credentials for this client.
+        #     A `GRPC::Core::Channel` will be used to make calls through.
+        #     A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+        #     should already be composed with a `GRPC::Core::CallCredentials` object.
+        #     A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+        #     metadata for requests, generally, to give OAuth credentials.
+        #   @param scopes [Array<String>]
+        #     The OAuth scopes for this service. This parameter is ignored if
+        #     an updater_proc is supplied.
+        #   @param client_config [Hash]
+        #     A Hash for call options for each method. See
+        #     Google::Gax#construct_settings for the structure of
+        #     this data. Falls back to the default config if not specified
+        #     or the specified config is missing data points.
+        #   @param timeout [Numeric]
+        #     The default timeout, in seconds, for calls made through this client.
+        def self.new(*args, version: :v1, **kwargs)
+          unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
+            raise "The version: #{version} is not available. The available versions " \
+              "are: [#{AVAILABLE_VERSIONS.join(", ")}]"
+          end
+
+          require "#{FILE_DIR}/#{version.to_s.downcase}"
+          version_module = Google::Cloud::Example
+            .constants
+            .select {|sym| sym.to_s.downcase == version.to_s.downcase}
+            .first
+          Google::Cloud::Example.const_get(version_module)::Incrementer.new(*args, **kwargs)
         end
-
-        require "#{FILE_DIR}/#{version.to_s.downcase}"
-        version_module = Google::Example
-          .constants
-          .select {|sym| sym.to_s.downcase == version.to_s.downcase}
-          .first
-        Google::Example.const_get(version_module)::Incrementer.new(*args, **kwargs)
       end
-    end
 
-    module Decrementer
-      ##
-      # @param version [Symbol, String]
-      #   The major version of the service to be used. By default :v1
-      #   is used.
-      # @overload new(version:, credentials:, scopes:, client_config:, timeout:)
-      #   @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-      #     Provides the means for authenticating requests made by the client. This parameter can
-      #     be many types.
-      #     A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
-      #     authenticating requests made by this client.
-      #     A `String` will be treated as the path to the keyfile to be used for the construction of
-      #     credentials for this client.
-      #     A `Hash` will be treated as the contents of a keyfile to be used for the construction of
-      #     credentials for this client.
-      #     A `GRPC::Core::Channel` will be used to make calls through.
-      #     A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
-      #     should already be composed with a `GRPC::Core::CallCredentials` object.
-      #     A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
-      #     metadata for requests, generally, to give OAuth credentials.
-      #   @param scopes [Array<String>]
-      #     The OAuth scopes for this service. This parameter is ignored if
-      #     an updater_proc is supplied.
-      #   @param client_config [Hash]
-      #     A Hash for call options for each method. See
-      #     Google::Gax#construct_settings for the structure of
-      #     this data. Falls back to the default config if not specified
-      #     or the specified config is missing data points.
-      #   @param timeout [Numeric]
-      #     The default timeout, in seconds, for calls made through this client.
-      def self.new(*args, version: :v1, **kwargs)
-        unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
-          raise "The version: #{version} is not available. The available versions " \
-            "are: [#{AVAILABLE_VERSIONS.join(", ")}]"
+      module Decrementer
+        ##
+        # @param version [Symbol, String]
+        #   The major version of the service to be used. By default :v1
+        #   is used.
+        # @overload new(version:, credentials:, scopes:, client_config:, timeout:)
+        #   @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+        #     Provides the means for authenticating requests made by the client. This parameter can
+        #     be many types.
+        #     A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
+        #     authenticating requests made by this client.
+        #     A `String` will be treated as the path to the keyfile to be used for the construction of
+        #     credentials for this client.
+        #     A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+        #     credentials for this client.
+        #     A `GRPC::Core::Channel` will be used to make calls through.
+        #     A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+        #     should already be composed with a `GRPC::Core::CallCredentials` object.
+        #     A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+        #     metadata for requests, generally, to give OAuth credentials.
+        #   @param scopes [Array<String>]
+        #     The OAuth scopes for this service. This parameter is ignored if
+        #     an updater_proc is supplied.
+        #   @param client_config [Hash]
+        #     A Hash for call options for each method. See
+        #     Google::Gax#construct_settings for the structure of
+        #     this data. Falls back to the default config if not specified
+        #     or the specified config is missing data points.
+        #   @param timeout [Numeric]
+        #     The default timeout, in seconds, for calls made through this client.
+        def self.new(*args, version: :v1, **kwargs)
+          unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
+            raise "The version: #{version} is not available. The available versions " \
+              "are: [#{AVAILABLE_VERSIONS.join(", ")}]"
+          end
+
+          require "#{FILE_DIR}/#{version.to_s.downcase}"
+          version_module = Google::Cloud::Example
+            .constants
+            .select {|sym| sym.to_s.downcase == version.to_s.downcase}
+            .first
+          Google::Cloud::Example.const_get(version_module)::Decrementer.new(*args, **kwargs)
         end
-
-        require "#{FILE_DIR}/#{version.to_s.downcase}"
-        version_module = Google::Example
-          .constants
-          .select {|sym| sym.to_s.downcase == version.to_s.downcase}
-          .first
-        Google::Example.const_get(version_module)::Decrementer.new(*args, **kwargs)
       end
     end
   end
 end
 
-============== file: lib/google/example/credentials.rb ==============
+============== file: lib/google/cloud/example/credentials.rb ==============
 # Copyright 2017, Google LLC All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -678,18 +680,20 @@ end
 require "googleauth"
 
 module Google
-  module Example
-    class Credentials < Google::Auth::Credentials
-      SCOPE = [
-      ].freeze
-      PATH_ENV_VARS = %w(MULTIPLE_SERVICES_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
-      JSON_ENV_VARS = %w(MULTIPLE_SERVICES_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
-      DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+  module Cloud
+    module Example
+      class Credentials < Google::Auth::Credentials
+        SCOPE = [
+        ].freeze
+        PATH_ENV_VARS = %w(MULTIPLE_SERVICES_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
+        JSON_ENV_VARS = %w(MULTIPLE_SERVICES_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
+        DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+      end
     end
   end
 end
 
-============== file: lib/google/example/v1.rb ==============
+============== file: lib/google/cloud/example/v1.rb ==============
 # Copyright 2017, Google LLC All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -704,155 +708,157 @@ end
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "google/example/v1/incrementer_service_client"
-require "google/example/v1/decrementer_service_client"
+require "google/cloud/example/v1/incrementer_service_client"
+require "google/cloud/example/v1/decrementer_service_client"
 
 module Google
-  # rubocop:disable LineLength
+  module Cloud
+    # rubocop:disable LineLength
 
-  ##
-  # # Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
-  #
-  # [Google Example API][Product Documentation]:
-  # This description tests descriptions that span multiple lines. This is a service
-  # that increments and decrements a counter.
-  # - [Product Documentation][]
-  #
-  # ## Quick Start
-  # In order to use this library, you first need to go through the following
-  # steps:
-  #
-  # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
-  # 2. [Enable the Google Example API.](https://console.cloud.google.com/apis/api/multiple_services)
-  # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
-  #
-  # ### Next Steps
-  # - Read the [Google Example API Product documentation][Product Documentation]
-  #   to learn more about the product and see How-to Guides.
-  # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md)
-  #   to see the full list of Cloud APIs that we cover.
-  #
-  # [Product Documentation]: https://cloud.google.com/multiple_services
-  #
-  #
-  module Example
-    module V1
-      # rubocop:enable LineLength
+    ##
+    # # Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    #
+    # [Google Example API][Product Documentation]:
+    # This description tests descriptions that span multiple lines. This is a service
+    # that increments and decrements a counter.
+    # - [Product Documentation][]
+    #
+    # ## Quick Start
+    # In order to use this library, you first need to go through the following
+    # steps:
+    #
+    # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
+    # 2. [Enable the Google Example API.](https://console.cloud.google.com/apis/api/multiple_services)
+    # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    #
+    # ### Next Steps
+    # - Read the [Google Example API Product documentation][Product Documentation]
+    #   to learn more about the product and see How-to Guides.
+    # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md)
+    #   to see the full list of Cloud APIs that we cover.
+    #
+    # [Product Documentation]: https://cloud.google.com/multiple_services
+    #
+    #
+    module Example
+      module V1
+        # rubocop:enable LineLength
 
-      module Incrementer
-        ##
-        # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-        #   Provides the means for authenticating requests made by the client. This parameter can
-        #   be many types.
-        #   A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
-        #   authenticating requests made by this client.
-        #   A `String` will be treated as the path to the keyfile to be used for the construction of
-        #   credentials for this client.
-        #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
-        #   credentials for this client.
-        #   A `GRPC::Core::Channel` will be used to make calls through.
-        #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
-        #   should already be composed with a `GRPC::Core::CallCredentials` object.
-        #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
-        #   metadata for requests, generally, to give OAuth credentials.
-        # @param scopes [Array<String>]
-        #   The OAuth scopes for this service. This parameter is ignored if
-        #   an updater_proc is supplied.
-        # @param client_config [Hash]
-        #   A Hash for call options for each method. See
-        #   Google::Gax#construct_settings for the structure of
-        #   this data. Falls back to the default config if not specified
-        #   or the specified config is missing data points.
-        # @param timeout [Numeric]
-        #   The default timeout, in seconds, for calls made through this client.
-        def self.new \
-            service_path: nil,
-            port: nil,
-            channel: nil,
-            chan_creds: nil,
-            updater_proc: nil,
-            credentials: nil,
-            scopes: nil,
-            client_config: nil,
-            timeout: nil,
-            lib_name: nil,
-            lib_version: nil
-          kwargs = {
-            service_path: service_path,
-            port: port,
-            channel: channel,
-            chan_creds: chan_creds,
-            updater_proc: updater_proc,
-            credentials: credentials,
-            scopes: scopes,
-            client_config: client_config,
-            timeout: timeout,
-            lib_name: lib_name,
-            lib_version: lib_version
-          }.select { |_, v| v != nil }
-          Google::Example::V1::IncrementerServiceClient.new(**kwargs)
+        module Incrementer
+          ##
+          # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+          #   Provides the means for authenticating requests made by the client. This parameter can
+          #   be many types.
+          #   A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
+          #   authenticating requests made by this client.
+          #   A `String` will be treated as the path to the keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `GRPC::Core::Channel` will be used to make calls through.
+          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+          #   should already be composed with a `GRPC::Core::CallCredentials` object.
+          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+          #   metadata for requests, generally, to give OAuth credentials.
+          # @param scopes [Array<String>]
+          #   The OAuth scopes for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
+          # @param client_config [Hash]
+          #   A Hash for call options for each method. See
+          #   Google::Gax#construct_settings for the structure of
+          #   this data. Falls back to the default config if not specified
+          #   or the specified config is missing data points.
+          # @param timeout [Numeric]
+          #   The default timeout, in seconds, for calls made through this client.
+          def self.new \
+              service_path: nil,
+              port: nil,
+              channel: nil,
+              chan_creds: nil,
+              updater_proc: nil,
+              credentials: nil,
+              scopes: nil,
+              client_config: nil,
+              timeout: nil,
+              lib_name: nil,
+              lib_version: nil
+            kwargs = {
+              service_path: service_path,
+              port: port,
+              channel: channel,
+              chan_creds: chan_creds,
+              updater_proc: updater_proc,
+              credentials: credentials,
+              scopes: scopes,
+              client_config: client_config,
+              timeout: timeout,
+              lib_name: lib_name,
+              lib_version: lib_version
+            }.select { |_, v| v != nil }
+            Google::Cloud::Example::V1::IncrementerServiceClient.new(**kwargs)
+          end
         end
-      end
 
-      module Decrementer
-        ##
-        # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-        #   Provides the means for authenticating requests made by the client. This parameter can
-        #   be many types.
-        #   A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
-        #   authenticating requests made by this client.
-        #   A `String` will be treated as the path to the keyfile to be used for the construction of
-        #   credentials for this client.
-        #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
-        #   credentials for this client.
-        #   A `GRPC::Core::Channel` will be used to make calls through.
-        #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
-        #   should already be composed with a `GRPC::Core::CallCredentials` object.
-        #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
-        #   metadata for requests, generally, to give OAuth credentials.
-        # @param scopes [Array<String>]
-        #   The OAuth scopes for this service. This parameter is ignored if
-        #   an updater_proc is supplied.
-        # @param client_config [Hash]
-        #   A Hash for call options for each method. See
-        #   Google::Gax#construct_settings for the structure of
-        #   this data. Falls back to the default config if not specified
-        #   or the specified config is missing data points.
-        # @param timeout [Numeric]
-        #   The default timeout, in seconds, for calls made through this client.
-        def self.new \
-            service_path: nil,
-            port: nil,
-            channel: nil,
-            chan_creds: nil,
-            updater_proc: nil,
-            credentials: nil,
-            scopes: nil,
-            client_config: nil,
-            timeout: nil,
-            lib_name: nil,
-            lib_version: nil
-          kwargs = {
-            service_path: service_path,
-            port: port,
-            channel: channel,
-            chan_creds: chan_creds,
-            updater_proc: updater_proc,
-            credentials: credentials,
-            scopes: scopes,
-            client_config: client_config,
-            timeout: timeout,
-            lib_name: lib_name,
-            lib_version: lib_version
-          }.select { |_, v| v != nil }
-          Google::Example::V1::DecrementerServiceClient.new(**kwargs)
+        module Decrementer
+          ##
+          # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+          #   Provides the means for authenticating requests made by the client. This parameter can
+          #   be many types.
+          #   A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
+          #   authenticating requests made by this client.
+          #   A `String` will be treated as the path to the keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `GRPC::Core::Channel` will be used to make calls through.
+          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+          #   should already be composed with a `GRPC::Core::CallCredentials` object.
+          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+          #   metadata for requests, generally, to give OAuth credentials.
+          # @param scopes [Array<String>]
+          #   The OAuth scopes for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
+          # @param client_config [Hash]
+          #   A Hash for call options for each method. See
+          #   Google::Gax#construct_settings for the structure of
+          #   this data. Falls back to the default config if not specified
+          #   or the specified config is missing data points.
+          # @param timeout [Numeric]
+          #   The default timeout, in seconds, for calls made through this client.
+          def self.new \
+              service_path: nil,
+              port: nil,
+              channel: nil,
+              chan_creds: nil,
+              updater_proc: nil,
+              credentials: nil,
+              scopes: nil,
+              client_config: nil,
+              timeout: nil,
+              lib_name: nil,
+              lib_version: nil
+            kwargs = {
+              service_path: service_path,
+              port: port,
+              channel: channel,
+              chan_creds: chan_creds,
+              updater_proc: updater_proc,
+              credentials: credentials,
+              scopes: scopes,
+              client_config: client_config,
+              timeout: timeout,
+              lib_name: lib_name,
+              lib_version: lib_version
+            }.select { |_, v| v != nil }
+            Google::Cloud::Example::V1::DecrementerServiceClient.new(**kwargs)
+          end
         end
       end
     end
   end
 end
 
-============== file: lib/google/example/v1/decrementer_service_client.rb ==============
+============== file: lib/google/cloud/example/v1/decrementer_service_client.rb ==============
 # Copyright 2017, Google LLC All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -883,162 +889,164 @@ require "pathname"
 require "google/gax"
 
 require "multiple_services_pb"
-require "google/example/credentials"
+require "google/cloud/example/credentials"
 
 module Google
-  module Example
-    module V1
-      # @!attribute [r] decrementer_service_stub
-      #   @return [Google::Cloud::Example::V1::DecrementerService::Stub]
-      class DecrementerServiceClient
-        attr_reader :decrementer_service_stub
+  module Cloud
+    module Example
+      module V1
+        # @!attribute [r] decrementer_service_stub
+        #   @return [Google::Cloud::Example::V1::DecrementerService::Stub]
+        class DecrementerServiceClient
+          attr_reader :decrementer_service_stub
 
-        # The default address of the service.
-        SERVICE_ADDRESS = "no-path-templates.googleapis.com".freeze
+          # The default address of the service.
+          SERVICE_ADDRESS = "no-path-templates.googleapis.com".freeze
 
-        # The default port of the service.
-        DEFAULT_SERVICE_PORT = 443
+          # The default port of the service.
+          DEFAULT_SERVICE_PORT = 443
 
-        DEFAULT_TIMEOUT = 30
+          DEFAULT_TIMEOUT = 30
 
-        # The scopes needed to make gRPC calls to all of the methods defined in
-        # this service.
-        ALL_SCOPES = [
-        ].freeze
+          # The scopes needed to make gRPC calls to all of the methods defined in
+          # this service.
+          ALL_SCOPES = [
+          ].freeze
 
-        # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-        #   Provides the means for authenticating requests made by the client. This parameter can
-        #   be many types.
-        #   A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
-        #   authenticating requests made by this client.
-        #   A `String` will be treated as the path to the keyfile to be used for the construction of
-        #   credentials for this client.
-        #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
-        #   credentials for this client.
-        #   A `GRPC::Core::Channel` will be used to make calls through.
-        #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
-        #   should already be composed with a `GRPC::Core::CallCredentials` object.
-        #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
-        #   metadata for requests, generally, to give OAuth credentials.
-        # @param scopes [Array<String>]
-        #   The OAuth scopes for this service. This parameter is ignored if
-        #   an updater_proc is supplied.
-        # @param client_config [Hash]
-        #   A Hash for call options for each method. See
-        #   Google::Gax#construct_settings for the structure of
-        #   this data. Falls back to the default config if not specified
-        #   or the specified config is missing data points.
-        # @param timeout [Numeric]
-        #   The default timeout, in seconds, for calls made through this client.
-        def initialize \
-            service_path: SERVICE_ADDRESS,
-            port: DEFAULT_SERVICE_PORT,
-            channel: nil,
-            chan_creds: nil,
-            updater_proc: nil,
-            credentials: nil,
-            scopes: ALL_SCOPES,
-            client_config: {},
-            timeout: DEFAULT_TIMEOUT,
-            lib_name: nil,
-            lib_version: ""
-          # These require statements are intentionally placed here to initialize
-          # the gRPC module only when it's required.
-          # See https://github.com/googleapis/toolkit/issues/446
-          require "google/gax/grpc"
-          require "multiple_services_services_pb"
+          # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+          #   Provides the means for authenticating requests made by the client. This parameter can
+          #   be many types.
+          #   A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
+          #   authenticating requests made by this client.
+          #   A `String` will be treated as the path to the keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `GRPC::Core::Channel` will be used to make calls through.
+          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+          #   should already be composed with a `GRPC::Core::CallCredentials` object.
+          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+          #   metadata for requests, generally, to give OAuth credentials.
+          # @param scopes [Array<String>]
+          #   The OAuth scopes for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
+          # @param client_config [Hash]
+          #   A Hash for call options for each method. See
+          #   Google::Gax#construct_settings for the structure of
+          #   this data. Falls back to the default config if not specified
+          #   or the specified config is missing data points.
+          # @param timeout [Numeric]
+          #   The default timeout, in seconds, for calls made through this client.
+          def initialize \
+              service_path: SERVICE_ADDRESS,
+              port: DEFAULT_SERVICE_PORT,
+              channel: nil,
+              chan_creds: nil,
+              updater_proc: nil,
+              credentials: nil,
+              scopes: ALL_SCOPES,
+              client_config: {},
+              timeout: DEFAULT_TIMEOUT,
+              lib_name: nil,
+              lib_version: ""
+            # These require statements are intentionally placed here to initialize
+            # the gRPC module only when it's required.
+            # See https://github.com/googleapis/toolkit/issues/446
+            require "google/gax/grpc"
+            require "multiple_services_services_pb"
 
-          if channel || chan_creds || updater_proc
-            warn "The `channel`, `chan_creds`, and `updater_proc` parameters will be removed " \
-              "on 2017/09/08"
-            credentials ||= channel
-            credentials ||= chan_creds
-            credentials ||= updater_proc
-          end
-          if service_path != SERVICE_ADDRESS || port != DEFAULT_SERVICE_PORT
-            warn "`service_path` and `port` parameters are deprecated and will be removed"
-          end
+            if channel || chan_creds || updater_proc
+              warn "The `channel`, `chan_creds`, and `updater_proc` parameters will be removed " \
+                "on 2017/09/08"
+              credentials ||= channel
+              credentials ||= chan_creds
+              credentials ||= updater_proc
+            end
+            if service_path != SERVICE_ADDRESS || port != DEFAULT_SERVICE_PORT
+              warn "`service_path` and `port` parameters are deprecated and will be removed"
+            end
 
-          credentials ||= Google::Example::Credentials.default
+            credentials ||= Google::Cloud::Example::Credentials.default
 
-          if credentials.is_a?(String) || credentials.is_a?(Hash)
-            updater_proc = Google::Example::Credentials.new(credentials).updater_proc
-          end
-          if credentials.is_a?(GRPC::Core::Channel)
-            channel = credentials
-          end
-          if credentials.is_a?(GRPC::Core::ChannelCredentials)
-            chan_creds = credentials
-          end
-          if credentials.is_a?(Proc)
-            updater_proc = credentials
-          end
-          if credentials.is_a?(Google::Auth::Credentials)
-            updater_proc = credentials.updater_proc
-          end
+            if credentials.is_a?(String) || credentials.is_a?(Hash)
+              updater_proc = Google::Cloud::Example::Credentials.new(credentials).updater_proc
+            end
+            if credentials.is_a?(GRPC::Core::Channel)
+              channel = credentials
+            end
+            if credentials.is_a?(GRPC::Core::ChannelCredentials)
+              chan_creds = credentials
+            end
+            if credentials.is_a?(Proc)
+              updater_proc = credentials
+            end
+            if credentials.is_a?(Google::Auth::Credentials)
+              updater_proc = credentials.updater_proc
+            end
 
-          google_api_client = "gl-ruby/#{RUBY_VERSION}"
-          google_api_client << " #{lib_name}/#{lib_version}" if lib_name
-          google_api_client << " gapic/0.6.8 gax/#{Google::Gax::VERSION}"
-          google_api_client << " grpc/#{GRPC::VERSION}"
-          google_api_client.freeze
+            google_api_client = "gl-ruby/#{RUBY_VERSION}"
+            google_api_client << " #{lib_name}/#{lib_version}" if lib_name
+            google_api_client << " gapic/0.6.8 gax/#{Google::Gax::VERSION}"
+            google_api_client << " grpc/#{GRPC::VERSION}"
+            google_api_client.freeze
 
-          headers = { :"x-goog-api-client" => google_api_client }
-          client_config_file = Pathname.new(__dir__).join(
-            "decrementer_service_client_config.json"
-          )
-          defaults = client_config_file.open do |f|
-            Google::Gax.construct_settings(
-              "google.cloud.example.v1.DecrementerService",
-              JSON.parse(f.read),
-              client_config,
-              Google::Gax::Grpc::STATUS_CODE_NAMES,
-              timeout,
-              errors: Google::Gax::Grpc::API_ERRORS,
-              kwargs: headers
+            headers = { :"x-goog-api-client" => google_api_client }
+            client_config_file = Pathname.new(__dir__).join(
+              "decrementer_service_client_config.json"
+            )
+            defaults = client_config_file.open do |f|
+              Google::Gax.construct_settings(
+                "google.cloud.example.v1.DecrementerService",
+                JSON.parse(f.read),
+                client_config,
+                Google::Gax::Grpc::STATUS_CODE_NAMES,
+                timeout,
+                errors: Google::Gax::Grpc::API_ERRORS,
+                kwargs: headers
+              )
+            end
+            @decrementer_service_stub = Google::Gax::Grpc.create_stub(
+              service_path,
+              port,
+              chan_creds: chan_creds,
+              channel: channel,
+              updater_proc: updater_proc,
+              scopes: scopes,
+              &Google::Cloud::Example::V1::DecrementerService::Stub.method(:new)
+            )
+
+            @decrement = Google::Gax.create_api_call(
+              @decrementer_service_stub.method(:decrement),
+              defaults["decrement"]
             )
           end
-          @decrementer_service_stub = Google::Gax::Grpc.create_stub(
-            service_path,
-            port,
-            chan_creds: chan_creds,
-            channel: channel,
-            updater_proc: updater_proc,
-            scopes: scopes,
-            &Google::Cloud::Example::V1::DecrementerService::Stub.method(:new)
-          )
 
-          @decrement = Google::Gax.create_api_call(
-            @decrementer_service_stub.method(:decrement),
-            defaults["decrement"]
-          )
-        end
+          # Service calls
 
-        # Service calls
+          # Decrement.
+          #
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/example/v1"
+          #
+          #   decrementer_service_client = Google::Cloud::Example::V1::Decrementer.new
+          #   decrementer_service_client.decrement
 
-        # Decrement.
-        #
-        # @param options [Google::Gax::CallOptions]
-        #   Overrides the default settings for this call, e.g, timeout,
-        #   retries, etc.
-        # @raise [Google::Gax::GaxError] if the RPC is aborted.
-        # @example
-        #   require "google/example/v1"
-        #
-        #   decrementer_service_client = Google::Example::V1::Decrementer.new
-        #   decrementer_service_client.decrement
-
-        def decrement options: nil
-          req = Google::Cloud::Example::V1::DecrementRequest.new
-          @decrement.call(req, options)
-          nil
+          def decrement options: nil
+            req = Google::Cloud::Example::V1::DecrementRequest.new
+            @decrement.call(req, options)
+            nil
+          end
         end
       end
     end
   end
 end
 
-============== file: lib/google/example/v1/decrementer_service_client_config.json ==============
+============== file: lib/google/cloud/example/v1/decrementer_service_client_config.json ==============
 {
   "interfaces": {
     "google.cloud.example.v1.DecrementerService": {
@@ -1053,7 +1061,7 @@ end
   }
 }
 
-============== file: lib/google/example/v1/incrementer_service_client.rb ==============
+============== file: lib/google/cloud/example/v1/incrementer_service_client.rb ==============
 # Copyright 2017, Google LLC All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1084,162 +1092,164 @@ require "pathname"
 require "google/gax"
 
 require "multiple_services_pb"
-require "google/example/credentials"
+require "google/cloud/example/credentials"
 
 module Google
-  module Example
-    module V1
-      # @!attribute [r] incrementer_service_stub
-      #   @return [Google::Cloud::Example::V1::IncrementerService::Stub]
-      class IncrementerServiceClient
-        attr_reader :incrementer_service_stub
+  module Cloud
+    module Example
+      module V1
+        # @!attribute [r] incrementer_service_stub
+        #   @return [Google::Cloud::Example::V1::IncrementerService::Stub]
+        class IncrementerServiceClient
+          attr_reader :incrementer_service_stub
 
-        # The default address of the service.
-        SERVICE_ADDRESS = "no-path-templates.googleapis.com".freeze
+          # The default address of the service.
+          SERVICE_ADDRESS = "no-path-templates.googleapis.com".freeze
 
-        # The default port of the service.
-        DEFAULT_SERVICE_PORT = 443
+          # The default port of the service.
+          DEFAULT_SERVICE_PORT = 443
 
-        DEFAULT_TIMEOUT = 30
+          DEFAULT_TIMEOUT = 30
 
-        # The scopes needed to make gRPC calls to all of the methods defined in
-        # this service.
-        ALL_SCOPES = [
-        ].freeze
+          # The scopes needed to make gRPC calls to all of the methods defined in
+          # this service.
+          ALL_SCOPES = [
+          ].freeze
 
-        # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-        #   Provides the means for authenticating requests made by the client. This parameter can
-        #   be many types.
-        #   A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
-        #   authenticating requests made by this client.
-        #   A `String` will be treated as the path to the keyfile to be used for the construction of
-        #   credentials for this client.
-        #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
-        #   credentials for this client.
-        #   A `GRPC::Core::Channel` will be used to make calls through.
-        #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
-        #   should already be composed with a `GRPC::Core::CallCredentials` object.
-        #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
-        #   metadata for requests, generally, to give OAuth credentials.
-        # @param scopes [Array<String>]
-        #   The OAuth scopes for this service. This parameter is ignored if
-        #   an updater_proc is supplied.
-        # @param client_config [Hash]
-        #   A Hash for call options for each method. See
-        #   Google::Gax#construct_settings for the structure of
-        #   this data. Falls back to the default config if not specified
-        #   or the specified config is missing data points.
-        # @param timeout [Numeric]
-        #   The default timeout, in seconds, for calls made through this client.
-        def initialize \
-            service_path: SERVICE_ADDRESS,
-            port: DEFAULT_SERVICE_PORT,
-            channel: nil,
-            chan_creds: nil,
-            updater_proc: nil,
-            credentials: nil,
-            scopes: ALL_SCOPES,
-            client_config: {},
-            timeout: DEFAULT_TIMEOUT,
-            lib_name: nil,
-            lib_version: ""
-          # These require statements are intentionally placed here to initialize
-          # the gRPC module only when it's required.
-          # See https://github.com/googleapis/toolkit/issues/446
-          require "google/gax/grpc"
-          require "multiple_services_services_pb"
+          # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+          #   Provides the means for authenticating requests made by the client. This parameter can
+          #   be many types.
+          #   A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
+          #   authenticating requests made by this client.
+          #   A `String` will be treated as the path to the keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+          #   credentials for this client.
+          #   A `GRPC::Core::Channel` will be used to make calls through.
+          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+          #   should already be composed with a `GRPC::Core::CallCredentials` object.
+          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+          #   metadata for requests, generally, to give OAuth credentials.
+          # @param scopes [Array<String>]
+          #   The OAuth scopes for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
+          # @param client_config [Hash]
+          #   A Hash for call options for each method. See
+          #   Google::Gax#construct_settings for the structure of
+          #   this data. Falls back to the default config if not specified
+          #   or the specified config is missing data points.
+          # @param timeout [Numeric]
+          #   The default timeout, in seconds, for calls made through this client.
+          def initialize \
+              service_path: SERVICE_ADDRESS,
+              port: DEFAULT_SERVICE_PORT,
+              channel: nil,
+              chan_creds: nil,
+              updater_proc: nil,
+              credentials: nil,
+              scopes: ALL_SCOPES,
+              client_config: {},
+              timeout: DEFAULT_TIMEOUT,
+              lib_name: nil,
+              lib_version: ""
+            # These require statements are intentionally placed here to initialize
+            # the gRPC module only when it's required.
+            # See https://github.com/googleapis/toolkit/issues/446
+            require "google/gax/grpc"
+            require "multiple_services_services_pb"
 
-          if channel || chan_creds || updater_proc
-            warn "The `channel`, `chan_creds`, and `updater_proc` parameters will be removed " \
-              "on 2017/09/08"
-            credentials ||= channel
-            credentials ||= chan_creds
-            credentials ||= updater_proc
-          end
-          if service_path != SERVICE_ADDRESS || port != DEFAULT_SERVICE_PORT
-            warn "`service_path` and `port` parameters are deprecated and will be removed"
-          end
+            if channel || chan_creds || updater_proc
+              warn "The `channel`, `chan_creds`, and `updater_proc` parameters will be removed " \
+                "on 2017/09/08"
+              credentials ||= channel
+              credentials ||= chan_creds
+              credentials ||= updater_proc
+            end
+            if service_path != SERVICE_ADDRESS || port != DEFAULT_SERVICE_PORT
+              warn "`service_path` and `port` parameters are deprecated and will be removed"
+            end
 
-          credentials ||= Google::Example::Credentials.default
+            credentials ||= Google::Cloud::Example::Credentials.default
 
-          if credentials.is_a?(String) || credentials.is_a?(Hash)
-            updater_proc = Google::Example::Credentials.new(credentials).updater_proc
-          end
-          if credentials.is_a?(GRPC::Core::Channel)
-            channel = credentials
-          end
-          if credentials.is_a?(GRPC::Core::ChannelCredentials)
-            chan_creds = credentials
-          end
-          if credentials.is_a?(Proc)
-            updater_proc = credentials
-          end
-          if credentials.is_a?(Google::Auth::Credentials)
-            updater_proc = credentials.updater_proc
-          end
+            if credentials.is_a?(String) || credentials.is_a?(Hash)
+              updater_proc = Google::Cloud::Example::Credentials.new(credentials).updater_proc
+            end
+            if credentials.is_a?(GRPC::Core::Channel)
+              channel = credentials
+            end
+            if credentials.is_a?(GRPC::Core::ChannelCredentials)
+              chan_creds = credentials
+            end
+            if credentials.is_a?(Proc)
+              updater_proc = credentials
+            end
+            if credentials.is_a?(Google::Auth::Credentials)
+              updater_proc = credentials.updater_proc
+            end
 
-          google_api_client = "gl-ruby/#{RUBY_VERSION}"
-          google_api_client << " #{lib_name}/#{lib_version}" if lib_name
-          google_api_client << " gapic/0.6.8 gax/#{Google::Gax::VERSION}"
-          google_api_client << " grpc/#{GRPC::VERSION}"
-          google_api_client.freeze
+            google_api_client = "gl-ruby/#{RUBY_VERSION}"
+            google_api_client << " #{lib_name}/#{lib_version}" if lib_name
+            google_api_client << " gapic/0.6.8 gax/#{Google::Gax::VERSION}"
+            google_api_client << " grpc/#{GRPC::VERSION}"
+            google_api_client.freeze
 
-          headers = { :"x-goog-api-client" => google_api_client }
-          client_config_file = Pathname.new(__dir__).join(
-            "incrementer_service_client_config.json"
-          )
-          defaults = client_config_file.open do |f|
-            Google::Gax.construct_settings(
-              "google.cloud.example.v1.IncrementerService",
-              JSON.parse(f.read),
-              client_config,
-              Google::Gax::Grpc::STATUS_CODE_NAMES,
-              timeout,
-              errors: Google::Gax::Grpc::API_ERRORS,
-              kwargs: headers
+            headers = { :"x-goog-api-client" => google_api_client }
+            client_config_file = Pathname.new(__dir__).join(
+              "incrementer_service_client_config.json"
+            )
+            defaults = client_config_file.open do |f|
+              Google::Gax.construct_settings(
+                "google.cloud.example.v1.IncrementerService",
+                JSON.parse(f.read),
+                client_config,
+                Google::Gax::Grpc::STATUS_CODE_NAMES,
+                timeout,
+                errors: Google::Gax::Grpc::API_ERRORS,
+                kwargs: headers
+              )
+            end
+            @incrementer_service_stub = Google::Gax::Grpc.create_stub(
+              service_path,
+              port,
+              chan_creds: chan_creds,
+              channel: channel,
+              updater_proc: updater_proc,
+              scopes: scopes,
+              &Google::Cloud::Example::V1::IncrementerService::Stub.method(:new)
+            )
+
+            @increment = Google::Gax.create_api_call(
+              @incrementer_service_stub.method(:increment),
+              defaults["increment"]
             )
           end
-          @incrementer_service_stub = Google::Gax::Grpc.create_stub(
-            service_path,
-            port,
-            chan_creds: chan_creds,
-            channel: channel,
-            updater_proc: updater_proc,
-            scopes: scopes,
-            &Google::Cloud::Example::V1::IncrementerService::Stub.method(:new)
-          )
 
-          @increment = Google::Gax.create_api_call(
-            @incrementer_service_stub.method(:increment),
-            defaults["increment"]
-          )
-        end
+          # Service calls
 
-        # Service calls
+          # Increment.
+          #
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/example/v1"
+          #
+          #   incrementer_service_client = Google::Cloud::Example::V1::Incrementer.new
+          #   incrementer_service_client.increment
 
-        # Increment.
-        #
-        # @param options [Google::Gax::CallOptions]
-        #   Overrides the default settings for this call, e.g, timeout,
-        #   retries, etc.
-        # @raise [Google::Gax::GaxError] if the RPC is aborted.
-        # @example
-        #   require "google/example/v1"
-        #
-        #   incrementer_service_client = Google::Example::V1::Incrementer.new
-        #   incrementer_service_client.increment
-
-        def increment options: nil
-          req = Google::Cloud::Example::V1::IncrementRequest.new
-          @increment.call(req, options)
-          nil
+          def increment options: nil
+            req = Google::Cloud::Example::V1::IncrementRequest.new
+            @increment.call(req, options)
+            nil
+          end
         end
       end
     end
   end
 end
 
-============== file: lib/google/example/v1/incrementer_service_client_config.json ==============
+============== file: lib/google/cloud/example/v1/incrementer_service_client_config.json ==============
 {
   "interfaces": {
     "google.cloud.example.v1.IncrementerService": {
@@ -1254,7 +1264,7 @@ end
   }
 }
 
-============== file: test/google/example/v1/decrementer_service_client_test.rb ==============
+============== file: test/google/cloud/example/v1/decrementer_service_client_test.rb ==============
 # Copyright 2017, Google LLC All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1274,8 +1284,8 @@ require "minitest/spec"
 
 require "google/gax"
 
-require "google/example"
-require "google/example/v1/decrementer_service_client"
+require "google/cloud/example"
+require "google/cloud/example/v1/decrementer_service_client"
 require "multiple_services_services_pb"
 
 class CustomTestError < StandardError; end
@@ -1309,7 +1319,7 @@ class MockGrpcClientStub
   end
 end
 
-class MockDecrementerServiceCredentials < Google::Example::Credentials
+class MockDecrementerServiceCredentials < Google::Cloud::Example::Credentials
   def initialize(method_name)
     @method_name = method_name
   end
@@ -1322,10 +1332,10 @@ class MockDecrementerServiceCredentials < Google::Example::Credentials
   end
 end
 
-describe Google::Example::V1::DecrementerServiceClient do
+describe Google::Cloud::Example::V1::DecrementerServiceClient do
 
   describe 'decrement' do
-    custom_error = CustomTestError.new "Custom test error for Google::Example::V1::DecrementerServiceClient#decrement."
+    custom_error = CustomTestError.new "Custom test error for Google::Cloud::Example::V1::DecrementerServiceClient#decrement."
 
     it 'invokes decrement without error' do
 
@@ -1339,8 +1349,8 @@ describe Google::Example::V1::DecrementerServiceClient do
       mock_credentials = MockDecrementerServiceCredentials.new("decrement")
 
       Google::Cloud::Example::V1::DecrementerService::Stub.stub(:new, mock_stub) do
-        Google::Example::Credentials.stub(:default, mock_credentials) do
-          client = Google::Example::Decrementer.new(version: :v1)
+        Google::Cloud::Example::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Example::Decrementer.new(version: :v1)
 
           # Call method
           response = client.decrement
@@ -1362,8 +1372,8 @@ describe Google::Example::V1::DecrementerServiceClient do
       mock_credentials = MockDecrementerServiceCredentials.new("decrement")
 
       Google::Cloud::Example::V1::DecrementerService::Stub.stub(:new, mock_stub) do
-        Google::Example::Credentials.stub(:default, mock_credentials) do
-          client = Google::Example::Decrementer.new(version: :v1)
+        Google::Cloud::Example::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Example::Decrementer.new(version: :v1)
 
           # Call method
           err = assert_raises Google::Gax::GaxError do
@@ -1377,7 +1387,7 @@ describe Google::Example::V1::DecrementerServiceClient do
     end
   end
 end
-============== file: test/google/example/v1/incrementer_service_client_test.rb ==============
+============== file: test/google/cloud/example/v1/incrementer_service_client_test.rb ==============
 # Copyright 2017, Google LLC All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1397,8 +1407,8 @@ require "minitest/spec"
 
 require "google/gax"
 
-require "google/example"
-require "google/example/v1/incrementer_service_client"
+require "google/cloud/example"
+require "google/cloud/example/v1/incrementer_service_client"
 require "multiple_services_services_pb"
 
 class CustomTestError < StandardError; end
@@ -1432,7 +1442,7 @@ class MockGrpcClientStub
   end
 end
 
-class MockIncrementerServiceCredentials < Google::Example::Credentials
+class MockIncrementerServiceCredentials < Google::Cloud::Example::Credentials
   def initialize(method_name)
     @method_name = method_name
   end
@@ -1445,10 +1455,10 @@ class MockIncrementerServiceCredentials < Google::Example::Credentials
   end
 end
 
-describe Google::Example::V1::IncrementerServiceClient do
+describe Google::Cloud::Example::V1::IncrementerServiceClient do
 
   describe 'increment' do
-    custom_error = CustomTestError.new "Custom test error for Google::Example::V1::IncrementerServiceClient#increment."
+    custom_error = CustomTestError.new "Custom test error for Google::Cloud::Example::V1::IncrementerServiceClient#increment."
 
     it 'invokes increment without error' do
 
@@ -1462,8 +1472,8 @@ describe Google::Example::V1::IncrementerServiceClient do
       mock_credentials = MockIncrementerServiceCredentials.new("increment")
 
       Google::Cloud::Example::V1::IncrementerService::Stub.stub(:new, mock_stub) do
-        Google::Example::Credentials.stub(:default, mock_credentials) do
-          client = Google::Example::Incrementer.new(version: :v1)
+        Google::Cloud::Example::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Example::Incrementer.new(version: :v1)
 
           # Call method
           response = client.increment
@@ -1485,8 +1495,8 @@ describe Google::Example::V1::IncrementerServiceClient do
       mock_credentials = MockIncrementerServiceCredentials.new("increment")
 
       Google::Cloud::Example::V1::IncrementerService::Stub.stub(:new, mock_stub) do
-        Google::Example::Credentials.stub(:default, mock_credentials) do
-          client = Google::Example::Incrementer.new(version: :v1)
+        Google::Cloud::Example::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Example::Incrementer.new(version: :v1)
 
           # Call method
           err = assert_raises Google::Gax::GaxError do

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services_gapic.yaml
@@ -6,7 +6,7 @@ language_settings:
   python:
     package_name: example
   ruby:
-    package_name: Google::Example::V1
+    package_name: Google::Cloud::Example::V1
   php:
     package_name: Google\Example\V1
   nodejs:


### PR DESCRIPTION
Fixes: #1403 

* The multiple services baseline changes are due to changing the package name to be `Google::Cloud` to show that the google cloud env variables are preserved in that case.