### PR TITLE
Make the generation instructions runnable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ More platforms are likely supported when building protoc from C++ source.
 
 There are two main ways to generate clients:
 
-1. Build from source and run directly. This is detailed below.
+1. Build from source and run directly. See below.
 2. Invoke a code generation pipeline through
    [artman]( https://github.com/googleapis/artman/#usage). This takes care of several of the steps
    below and is not documented here.
@@ -55,12 +55,15 @@ There are two main ways to generate clients:
 
 ### Process overview for generating a client library
 
+0. Set up prerequisites for building from source and running directly.
 1. Generate a descriptor file from the proto (once per API)
 2. Run client config generation (once per API)
 3. Manually tweak the generated client config
 4. Run code generation (once per API x language combination of interest)
 
-Each of these steps are described in more detail below. Note: the instructions assume you are running on a
+Step 0 is described below. Subsequent steps are described in the `./generate` script. Run `./generate` to see a description of the commands and manual steps in sequence. Run `./generate usage` to see how to use the same script, after setting the appropriate environment variables, to actually execute the steps.
+
+Note: the instructions assume you are running on a
 Unix-y system; if you are using Windows, you will need to tweak the steps for yourself.
 
 ### Set up prerequisites for building from source and running directly
@@ -94,186 +97,4 @@ Clone the googleapis/googleapis repository (it has some config that is needed):
 git clone https://github.com/googleapis/googleapis
 ```
 
-The `googleapis/googleapis` directory will hereafter be referenced as `${GOOGLEAPIS_DIR}`.
-
-### Generate a descriptor file from the proto
-
-You need to locate/decide on the following before you can generate the descriptor file:
-
-1. The include directory with the proto files bundled with `protoc` (from the `protoc` setup step).
-   Hereafter, this will be referenced as `${PROTOC_INCLUDE_DIR}`.
-2. Any directories containing protos that your API depends on. For Google APIs defined in
-   [googleapis](https://github.com/googleapis/googleapis), this will be `${GOOGLEAPIS_DIR}`.
-3. The directory containing your proto. Hereafter, this will be referenced as `${YOUR_PROTO_DIR}`.
-4. Your proto file (or files). Hereafter, this will be referenced as `${YOUR_PROTO_FILE}`.
-4. The output file name to contain the descriptor file. Hereafter, this will be referenced as
-   `${YOUR_DESCRIPTOR_FILE}`.
-
-Run the following command to generate the proto descriptor file:
-
-```
-protoc -I=${PROTOC_INCLUDE_DIR} -I=${GOOGLEAPIS_DIR} -I=${YOUR_PROTO_DIR} \
-  --include_imports --include_source_info -o ${YOUR_DESCRIPTOR_FILE} ${YOUR_PROTO_FILE}
-```
-
-### Generate proto message classes
-
-*(Skip this section for Node.js — it loads proto files into memory at runtime.)*
-
-You need to locate/decide on the following before you can generate the proto message classes:
-
-1. The output directory to contain the proto files. Hereafter, this will be referenced as `${GENERATED_PROTO_DIR}`.
-2. The language you are generating for. The possible values for `protoc` are
-`java`, `go`, `php`, `ruby`, `python`, and `csharp`. Note: Node.js is not present for the reason listed above.
-Hereafter, this will be referenced as `${PROTO_OUTPUT_LANG}`.
-
-Run the following command to generate the proto message classes:
-
-```
-mkdir -p ${GENERATED_PROTO_DIR}
-protoc -I=${PROTOC_INCLUDE_DIR} -I=${GOOGLEAPIS_DIR} -I=${YOUR_PROTO_DIR} \
-  --${PROTO_OUTPUT_LANG}_out=${GENERATED_PROTO_DIR} ${YOUR_PROTO_FILE}
-```
-
-### Generate grpc stubs
-
-Generating grpc stubs is language-specific.
-
-#### Java
-
-Find the path to the grpc plugin (gradle will pull in the dependency if you don't have it already):
-
-```
-./gradlew showGrpcJavaPluginPath
-```
-
-The command will print out the path to the executable. Hereafter, this will be referenced as `${GRPC_JAVA_PLUGIN}`.
-
-```
-protoc -I=${PROTOC_INCLUDE_DIR} -I=${GOOGLEAPIS_DIR} -I=${YOUR_PROTO_DIR} \
-  --plugin=protoc-gen-grpc=${GRPC_JAVA_PLUGIN} \
-  --grpc_out=${GENERATED_PROTO_DIR} ${YOUR_PROTO_FILE}
-```
-
-#### Other languages
-
-TODO
-
-### Generate initial client config
-
-You need to locate/decide on the following before you call config generation:
-
-1. The service yaml file, hereafter referenced as `${YOUR_SERVICE_YAML}`.
-2. The file name of your output client config file. Hereafter, this will be referenced as
-   `${YOUR_CLIENT_CONFIG}`
-
-Run the following command to generate the client config:
-
-```
-cd ${TOOLKIT_DIR}
-java -cp build/libs/gapic-generator-*-fatjar.jar com.google.api.codegen.configgen.ConfigGeneratorTool \
-  --descriptor_set=${YOUR_DESCRIPTOR_FILE} --service_yaml=${YOUR_SERVICE_YAML} \
-  -o=${YOUR_CLIENT_CONFIG}
-```
-
-You can safely ignore the warning about control-presence.
-
-### Manually tweak the generated client config
-
-The generated client config contains `FIXME` comments with instructions on how to choose values
-in the client config. The client config should work as is, though; tweaks are only necessary to improve
-the quality of the generated output.
-
-### Create a package metadata config file
-
-You need to locate/decide on the following before you create the package metadata config file:
-
-1. The output file to contain the package metadata for your client generation. Hereafter, this will be
-   referenced as `${PKG_META_CONFIG}`.
-2. A short name, which typically does not include the major version. For example, Cloud Language v1's short name
-   is `language`. Hereafter, this will be referenced as `${SHORT_NAME}`.
-3. The major version. The first major version will typically be `v1`. Hereafter, this will be referenced as
-   `${MAJOR_VERSION}`.
-4. The package name, which typically includes the fully-qualified product name and major version.
-   For example, Cloud Language v1's package name is `google-cloud-language-v1`. Hereafter, this will be
-   referenced as `${PACKAGE_NAME}`.
-5. The proto path, which is the proto's package with dots converted to slashes. For example, Cloud Language v1's
-   proto path is `google/cloud/language/v1`. Hereafter, this will be referenced as `${PROTO_PATH}`.
-
-First, copy the contents of api_defaults.yaml and dependencies.yaml into a single file, hereafter
-referenced as `${PKG_META_CONFIG}`.
-
-```
-cp ${GOOGLEAPIS_DIR}/gapic/packaging/api_defaults.yaml ${PKG_META_CONFIG}
-cat < ${GOOGLEAPIS_DIR}/gapic/packaging/dependencies.yaml >> ${PKG_META_CONFIG}
-```
-
-Add the following lines to the end:
-
-```
-artifact_type: GAPIC
-proto_deps:
-- google-common-protos
-short_name: ${SHORT_NAME}
-major_version: ${MAJOR_VERSION}
-package_name:
-  default: ${PACKAGE_NAME}
-proto_path: ${PROTO_PATH}
-```
-
-### Run code generation
-
-You need to locate/decide on the following before you call code generation:
-
-1. The language-specific generator config for your desired output language. Given a language where
-   `${language}` is one of `java`, `go`, `php`, `ruby`, `nodejs`, `py`, or `csharp`, the file is located at
-   `src/main/resources/com/google/api/codegen/${language}/${language}_gapic.yaml` (exception: the Python file is named
-   `python_gapic.yaml`). Hereafter, this will be referenced as `${LANGUAGE_CONFIG}`.
-2. The output directory for your generated client classes. Hereafter, this will be
-   referenced as `${GENERATED_CLIENT_DIR}`.
-
-```
-java -cp build/libs/gapic-generator-*-fatjar.jar com.google.api.codegen.CodeGeneratorTool \
-  --descriptor_set=${YOUR_DESCRIPTOR_FILE} --service_yaml=${YOUR_SERVICE_YAML} \
-  --gapic_yaml=${YOUR_CLIENT_CONFIG} --gapic_yaml=${LANGUAGE_CONFIG} \
-  --package_yaml=${PKG_META_CONFIG} --o=${GENERATED_CLIENT_DIR}
-```
-
-The generated client library code will appear in `${GENERATED_CLIENT_DIR}`.
-
-You can safely ignore the warning about control-presence.
-
-Special note for java: several files will be dumped into the parent directory of `${GENERATED_CLIENT_DIR}`:
-
-- gradle/
-- gradlew
-- gradlew.bat
-
-(There is an open issue to fix this: https://github.com/googleapis/toolkit/issues/1918 )
-
-### Perform fixes to get a working library
-
-The fixes here are language-specific.
-
-#### Java
-
-Copy the proto-generated classes into the client directory tree:
-
-```
-cp -r ${GENERATED_PROTO_DIR}/* ${GENERATED_CLIENT_DIR}/src/main/java
-```
-
-In `${GENERATED_CLIENT_DIR}/build.gradle`, there are a couple dependencies that need to be removed if you
-are bundling your proto-generated classes and grpc stubs in the same package as the client. They have a
-comment starting with "`// Remove this line if you are bundling`". Warning: If you regenerate again, you will
-need to remove the lines from the build.gradle file again. (There is an open issue to fix this:
-https://github.com/googleapis/toolkit/issues/1917 ).
-
-#### Node
-
-Copy the proto files into the correct subdirectory of `${GENERATED_CLIENT_DIR}`.
-(Exact instructions to be added later.)
-
-#### Other languages
-
-TODO
+The `googleapis/googleapis` directory will hereafter be referenced as `${GOOGLEAPIS_DIR}` in the `generate` script that documents subsequent steps.

--- a/generate
+++ b/generate
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Runnable script to document the usage of gapic-generator.
+# - Run it with no arguments to see the list of steps.
+# - Run it with the argument "usage" to learn how to use it to invoke the generator
+#
+# The idea is that by making this documentation runnable, we can easily make sure it stays up to date.
+
+SCRIPT="${BASH_SOURCE[@]}"
+function usage() {
+  cat << eof
+Usage: $SCRIPT [MODE] [PART]
+
+This script can be run in several MODEs: "doc" (the default), "dryrun" (showing the commands with the actual substituted parameters), and "run" (actually running the commands). A value of "usage" prints this message.
+
+This script has two PARTs, labeled "one" and "two", with manual steps after each. You can also use "all" as a value of PART, though this is only recommended (and the default) when running in "doc" MODE.
+eof
+}
+
+MODE="${1:-doc}"
+PART="$2"
+
+[[ "$MODE" == "usage" ]] && { usage ; return 0 ; }
+[[ "$MODE" == "dryrun" ]] && { RUN="eval echo" ; echo "# Dry-run mode" ; }
+[[ "$MODE" == "run" ]] && { RUN= ; echo "# Real-run mode" ; }
+[[ "$MODE" == "doc" ]] && { RUN="echo" ; PART=${PART:-all} ; echo "# Documentation mode" ; }
+[[ -z "$PART" ]] && { usage ; return 2 ; }
+
+MISSINGVARS=
+function checkvar() {
+  local NAME="$1"
+  local DESCRIPTION="$2"
+  local VALUE="${!NAME}"
+  [[ -z "${VALUE}" ]] && { MISSINGVARS="${MISSINGVARS}${NAME} " ; }
+  printf "# %s: %s (you have \"%s\")\n" "${NAME}" "${DESCRIPTION}" "${VALUE}"
+}
+
+
+echo "### Relevant environment variables you need to set:"
+
+# For part one
+checkvar PROTOC_INCLUDE_DIR "The include directory with the proto files bundled with protoc (from the protoc setup step)"
+checkvar GOOGLEAPIS_DIR "Any directories containing protos that your API depends on"
+checkvar YOUR_PROTO_DIR "The directory containing your proto"
+checkvar YOUR_PROTO_FILE "Your proto file (or files)"
+checkvar YOUR_DESCRIPTOR_FILE "The output file name to contain the descriptor file"
+checkvar OUTPUT_LANGUAGE "The language you are generating for. The possible values for protoc are java, go, php, ruby, python, csharp, and nodejs. Note that for nodejs, the proto message class generation step is a no-op."
+checkvar GRPC_JAVA_PLUGIN "The path to the grpc plugin. You can generally obtain this by running './gradlew showGrpcJavaPluginPath'"
+checkvar YOUR_SERVICE_YAML "The service yaml file"
+checkvar YOUR_CLIENT_CONFIG "The file name of your output client config file"
+
+
+# For part two
+checkvar PKG_META_CONFIG "The output file to contain the package metadata for your client generation"
+checkvar SHORT_NAME "A short name, which typically does not include the major version. For example, Cloud Language v1's short name is 'language'"
+checkvar MAJOR_VERSION "The major version. The first major version will typically be 'v1'"
+checkvar PACKAGE_NAME "The package name, which typically includes the fully-qualified product name and major version. For example, Cloud Language v1's package name is 'google-cloud-language-v1'"
+checkvar PROTO_PATH "The proto path, which is the proto's package with dots converted to slashes. For example, Cloud Language v1's proto path is 'google/cloud/language/v1'"
+checkvar PKG_META_CONFIG "Name of single config file that will contain both 'api_defaults.yaml' and 'dependencies.yaml'"
+checkvar GENERATED_CLIENT_DIR "The output directory for your generated client classes"
+
+[[ "$MODE" != "doc" && -n "${MISSINGVARS}" ]] && {  echo -e "\nThe following environment variables are missing. Set them before using this script to run the generator:\n${MISSINGVARS}" ; return 1 ; }
+
+
+if [[ "$PART" == "one" || "$PART" == "all" ]] ;then
+
+echo
+echo '### Generate the proto descriptor file:  ###'
+$RUN 'protoc -I=${PROTOC_INCLUDE_DIR} -I=${GOOGLEAPIS_DIR} -I=${YOUR_PROTO_DIR} \
+  --include_imports --include_source_info -o ${YOUR_DESCRIPTOR_FILE} ${YOUR_PROTO_FILE}'
+
+echo
+echo '### Generate the proto message classes:  ###'
+$RUN '[[ $OUTPUT_LANGUAGE != "nodejs" ]] && \
+{ mkdir -p ${GENERATED_PROTO_DIR} && \
+  protoc -I=${PROTOC_INCLUDE_DIR} -I=${GOOGLEAPIS_DIR} -I=${YOUR_PROTO_DIR} \
+  --${OUTPUT_LANGUAGE}_out=${GENERATED_PROTO_DIR} ${YOUR_PROTO_FILE} ; }'
+
+echo
+echo '### Generate the gRPC stubs (language specific):  ###'
+$RUN '[[ $OUTPUT_LANGUAGE == "java" ]] && \
+{ protoc -I=${PROTOC_INCLUDE_DIR} -I=${GOOGLEAPIS_DIR} -I=${YOUR_PROTO_DIR} \
+    --plugin=protoc-gen-grpc=${GRPC_JAVA_PLUGIN} \
+    --grpc_out=${GENERATED_PROTO_DIR} ${YOUR_PROTO_FILE} ; } '
+$RUN '[[ $OUTPUT_LANGUAGE != "java" ]] && echo "TODO: Fill in" '
+
+echo
+echo '### Generate initial client config:  ###'
+$RUN 'pushd ${TOOLKIT_DIR}
+java -cp build/libs/gapic-generator-*-fatjar.jar com.google.api.codegen.configgen.ConfigGeneratorTool \
+  --descriptor_set=${YOUR_DESCRIPTOR_FILE} --service_yaml=${YOUR_SERVICE_YAML} \
+  -o=${YOUR_CLIENT_CONFIG}
+popd'
+
+echo
+cat << EOF
+# MANUALLY tweak the generated client config
+# The generated client config contains FIXME comments with instructions on how to choose values in the client config. The client config should work as is, though; tweaks are only necessary to improve the quality of the generated output.
+
+# After you have done this, run "${SCRIPT} two"
+EOF
+
+fi # part one
+
+
+if [[ "$PART" == "two" || "$PART" == "all" ]] ;then
+
+echo
+echo '### Create a package metadata config file:  ###'
+$RUN 'cp ${GOOGLEAPIS_DIR}/gapic/packaging/api_defaults.yaml ${PKG_META_CONFIG}
+cat < ${GOOGLEAPIS_DIR}/gapic/packaging/dependencies.yaml >> ${PKG_META_CONFIG}'
+$RUN 'cat >> ${PKG_META_CONFIG} <<EOF
+artifact_type: GAPIC
+proto_deps:
+- google-common-protos
+short_name: ${SHORT_NAME}
+major_version: ${MAJOR_VERSION}
+package_name:
+  default: ${PACKAGE_NAME}
+proto_path: ${PROTO_PATH}
+EOF'
+
+echo
+echo '### Run code generation  ###'
+$RUN  '[[ "$OUTPUT_LANGUAGE" != "python" ]] && { LANGUAGE_CONFIG=src/main/resources/com/google/api/codegen/${OUTPUT_LANGUAGE}/${OUTPUT_LANGUAGE}_gapic.yaml ; }'
+$RUN '[[ "$OUTPUT_LANGUAGE" == "python" ]] && { LANGUAGE_CONFIG=src/main/resources/com/google/api/codegen/py/python_gapic.yaml ; }'
+$RUN 'java -cp build/libs/gapic-generator-*-fatjar.jar com.google.api.codegen.CodeGeneratorTool \
+  --descriptor_set=${YOUR_DESCRIPTOR_FILE} --service_yaml=${YOUR_SERVICE_YAML} \
+  --gapic_yaml=${YOUR_CLIENT_CONFIG} --gapic_yaml=${LANGUAGE_CONFIG} \
+  --package_yaml=${PKG_META_CONFIG} --o=${GENERATED_CLIENT_DIR}'
+
+cat << EOF
+
+# The generated client library code will appear in \${GENERATED_CLIENT_DIR}.
+#
+# You can safely ignore the warning about control-presence.
+#
+# Special note for java: several files will be dumped into the parent directory of \${GENERATED_CLIENT_DIR}:
+#
+# gradle/
+# gradlew
+# gradlew.bat
+# (There is an open issue to fix this: https://github.com/googleapis/toolkit/issues/1918 
+
+EOF
+
+
+echo
+echo '### Perform fixes to get a working library  ###'
+$RUN  'if [[ "$OUTPUT_LANGUAGE" == "java" ]] ;then 
+ cp -r ${GENERATED_PROTO_DIR}/* ${GENERATED_CLIENT_DIR}/src/main/java 
+
+# In ${GENERATED_CLIENT_DIR}/build.gradle, there are a couple dependencies that need to be removed if you are bundling your proto-generated classes and grpc stubs in the same package as the client. They have a comment starting with "// Remove this line if you are bundling". Warning: If you regenerate again, you will need to remove the lines from the build.gradle file again. (There is an open issue to fix this: https://github.com/googleapis/toolkit/issues/1917 ).
+
+fi'
+
+echo
+
+$RUN  'if [[ "$OUTPUT_LANGUAGE" == "nodejs" ]] ;then 
+
+# Copy the proto files into the correct subdirectory of ${GENERATED_CLIENT_DIR}. (Exact instructions to be added later.)
+
+fi'
+
+echo
+echo "TODO: Add instructions for other languages"
+                                                                                                   
+
+fi # part two


### PR DESCRIPTION
This allows us to easily run the documentation we are presenting to
users, thus verifying that it is still accurate.