### PR TITLE
dynamic: move LRO decision into generator code

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -71,6 +71,9 @@ public class DynamicLangApiMethodTransformer {
       apiMethod.pageStreamingView(
           pageStreamingTransformer.generateDescriptor(
               context.getSurfaceInterfaceContext(), method));
+    } else if (context.getMethodConfig().isLongRunningOperation()) {
+      apiMethod.longRunningView(lroTransformer.generateDetailView(context));
+      apiMethod.type(ClientMethodType.OperationOptionalArrayMethod);
     } else {
       apiMethod.type(ClientMethodType.OptionalArrayMethod);
     }
@@ -138,10 +141,6 @@ public class DynamicLangApiMethodTransformer {
     apiMethod.packageHasMultipleServices(packageHasMultipleServices);
     apiMethod.packageServiceName(namer.getPackageServiceName(context.getInterfaceConfig()));
     apiMethod.apiVersion(namer.getApiWrapperModuleVersion());
-    apiMethod.longRunningView(
-        context.getMethodConfig().isLongRunningOperation()
-            ? lroTransformer.generateDetailView(context)
-            : null);
 
     apiMethod.oneofParams(context.getMethodConfig().getOneofNames(namer));
     apiMethod.headerRequestParams(

--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -73,7 +73,7 @@ public class DynamicLangApiMethodTransformer {
               context.getSurfaceInterfaceContext(), method));
     } else if (context.getMethodConfig().isLongRunningOperation()) {
       apiMethod.longRunningView(lroTransformer.generateDetailView(context));
-      apiMethod.type(ClientMethodType.OperationOptionalArrayMethod);
+      apiMethod.type(ClientMethodType.LongRunningOptionalArrayMethod);
     } else {
       apiMethod.type(ClientMethodType.OptionalArrayMethod);
     }

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTestTransformer.java
@@ -181,7 +181,7 @@ public class PhpGapicSurfaceTestTransformer implements ModelToViewTransformer {
 
       ClientMethodType clientMethodType = ClientMethodType.OptionalArrayMethod;
       if (methodContext.getMethodConfig().isLongRunningOperation()) {
-        clientMethodType = ClientMethodType.OperationOptionalArrayMethod;
+        clientMethodType = ClientMethodType.LongRunningOptionalArrayMethod;
       } else if (methodContext.getMethodConfig().isPageStreaming()) {
         clientMethodType = ClientMethodType.PagedOptionalArrayMethod;
       }

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTestTransformer.java
@@ -209,7 +209,7 @@ public class PythonGapicSurfaceTestTransformer implements ModelToViewTransformer
         GapicMethodContext methodContext = context.asRequestMethodContext(method);
         ClientMethodType clientMethodType = ClientMethodType.OptionalArrayMethod;
         if (methodContext.getMethodConfig().isLongRunningOperation()) {
-          clientMethodType = ClientMethodType.OperationOptionalArrayMethod;
+          clientMethodType = ClientMethodType.LongRunningOptionalArrayMethod;
         } else if (methodContext.getMethodConfig().isPageStreaming()) {
           clientMethodType = ClientMethodType.PagedOptionalArrayMethod;
         }

--- a/src/main/java/com/google/api/codegen/viewmodel/ClientMethodType.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ClientMethodType.java
@@ -32,7 +32,7 @@ public enum ClientMethodType {
   // PHP
   OptionalArrayMethod,
   PagedOptionalArrayMethod,
-  OperationOptionalArrayMethod,
+  LongRunningOptionalArrayMethod,
   // C#
   FlattenedAsyncCallSettingsMethod,
   FlattenedAsyncCancellationTokenMethod,

--- a/src/main/java/com/google/api/codegen/viewmodel/ClientMethodType.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ClientMethodType.java
@@ -29,7 +29,7 @@ public enum ClientMethodType {
   AsyncOperationFlattenedMethod,
   AsyncOperationRequestObjectMethod,
   OperationCallableMethod,
-  // PHP
+  // Dynamic langs
   OptionalArrayMethod,
   PagedOptionalArrayMethod,
   LongRunningOptionalArrayMethod,

--- a/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
@@ -36,7 +36,7 @@
     @case "OptionalArrayMethod"
         {@optionalArrayMethodSampleCode(apiMethod, additionalCallback)}
     @case "LongRunningOptionalArrayMethod"
-        {@operationSampleCode(apiMethod, additionalCallback)}
+        {@lroSampleCode(apiMethod, additionalCallback)}
     @case "PagedOptionalArrayMethod"
         {@pagedOptionalArrayMethodSampleCode(apiMethod, additionalCallback)}
     @default
@@ -224,7 +224,7 @@
     {@promiseCallbacks(additionalCallback)}
 @end
 
-@private operationSampleCode(apiMethod, additionalCallback)
+@private lroSampleCode(apiMethod, additionalCallback)
   # TODO(landrito) figure out how to remove initcode repetition for method samples.
   {@methodCallSampleCodeLongrunningPromise(apiMethod, additionalCallback)}
 

--- a/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
@@ -35,7 +35,7 @@
     @switch apiMethod.type.toString
     @case "OptionalArrayMethod"
         {@optionalArrayMethodSampleCode(apiMethod, additionalCallback)}
-    @case "OperationOptionalArrayMethod"
+    @case "LongRunningOptionalArrayMethod"
         {@operationSampleCode(apiMethod, additionalCallback)}
     @case "PagedOptionalArrayMethod"
         {@pagedOptionalArrayMethodSampleCode(apiMethod, additionalCallback)}

--- a/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
@@ -25,14 +25,7 @@
 @end
 
 @snippet sampleCode(apiMethod)
-    @switch apiMethod.type.toString
-    @case "OptionalArrayMethod"
-        {@optionalArrayMethodSampleCode(apiMethod, empty())}
-    @case "PagedOptionalArrayMethod"
-        {@pagedOptionalArrayMethodSampleCode(apiMethod, empty())}
-    @default
-        $unhandledCase: {@apiMethod.type.toString}$
-    @end
+    {@sampleCode(apiMethod, empty())}
 @end
 
 @private empty()
@@ -42,6 +35,8 @@
     @switch apiMethod.type.toString
     @case "OptionalArrayMethod"
         {@optionalArrayMethodSampleCode(apiMethod, additionalCallback)}
+    @case "OperationOptionalArrayMethod"
+        {@operationSampleCode(apiMethod, additionalCallback)}
     @case "PagedOptionalArrayMethod"
         {@pagedOptionalArrayMethodSampleCode(apiMethod, additionalCallback)}
     @default
@@ -216,24 +211,24 @@
 @end
 
 @private methodCallSampleCodeWithReturnValue(apiMethod, additionalCallback)
-  @if apiMethod.isLongRunningOperation
-    # TODO(landrito) figure out how to remove initcode repetition for method samples.
-    {@methodCallSampleCodeLongrunningPromise(apiMethod, additionalCallback)}
+  {@initCode(apiMethod)}
+  {@methodCallSampleCodePrefix(apiMethod)}
+    .then(responses => {
+      var response = responses[0];
+      @if additionalCallback
+        console.log(response);
+      @else
+        // doThingsWith(response)
+      @end
+    })
+    {@promiseCallbacks(additionalCallback)}
+@end
 
-    {@methodCallSampleCodeLongrunningEventEmitter(apiMethod, additionalCallback)}
-  @else
-    {@initCode(apiMethod)}
-    {@methodCallSampleCodePrefix(apiMethod)}
-      .then(responses => {
-        var response = responses[0];
-        @if additionalCallback
-          console.log(response);
-        @else
-          // doThingsWith(response)
-        @end
-      })
-      {@promiseCallbacks(additionalCallback)}
-  @end
+@private operationSampleCode(apiMethod, additionalCallback)
+  # TODO(landrito) figure out how to remove initcode repetition for method samples.
+  {@methodCallSampleCodeLongrunningPromise(apiMethod, additionalCallback)}
+
+  {@methodCallSampleCodeLongrunningEventEmitter(apiMethod, additionalCallback)}
 @end
 
 @snippet methodCallSampleCodeLongrunningPromise(apiMethod, additionalCallback)

--- a/src/main/resources/com/google/api/codegen/php/client_impl.snip
+++ b/src/main/resources/com/google/api/codegen/php/client_impl.snip
@@ -439,52 +439,50 @@
                 $request
             @end
         );
+    @case "OperationOptionalArrayMethod"
+        return $this->startOperationsCall(
+            '{@apiMethod.grpcMethodName}',
+            $optionalArgs,
+            $request,
+            @if apiMethod.hasRerouteToGrpcInterface
+                $this->getOperationsClient(),
+                '{@apiMethod.rerouteToGrpcInterface}'
+            @else
+                $this->getOperationsClient()
+            @end
+        )->wait();
     @case "OptionalArrayMethod"
-        @if apiMethod.isLongRunningOperation
-            return $this->startOperationsCall(
-                '{@apiMethod.grpcMethodName}',
-                $optionalArgs,
-                $request,
+        return $this->startCall(
+            '{@apiMethod.grpcMethodName}',
+            {@apiMethod.responseTypeName}::class,
+            $optionalArgs,
+            @if apiMethod.isGrpcStreamingMethod
+                @if apiMethod.isSingularRequestMethod
+                    $request,
+
+                @else
+                    null,
+
+                @end
                 @if apiMethod.hasRerouteToGrpcInterface
-                    $this->getOperationsClient(),
+                    {@streamingCallType(apiMethod)},
                     '{@apiMethod.rerouteToGrpcInterface}'
                 @else
-                    $this->getOperationsClient()
+                    {@streamingCallType(apiMethod)}
+
+                @end
+            );
+            @else
+                @if apiMethod.hasRerouteToGrpcInterface
+                    $request,
+                    Call::UNARY_CALL,
+                    '{@apiMethod.rerouteToGrpcInterface}'
+
+                @else
+                    $request
+
                 @end
             )->wait();
-        @else
-            return $this->startCall(
-                '{@apiMethod.grpcMethodName}',
-                {@apiMethod.responseTypeName}::class,
-                $optionalArgs,
-                @if apiMethod.isGrpcStreamingMethod
-                    @if apiMethod.isSingularRequestMethod
-                        $request,
-
-                    @else
-                        null,
-
-                    @end
-                    @if apiMethod.hasRerouteToGrpcInterface
-                        {@streamingCallType(apiMethod)},
-                        '{@apiMethod.rerouteToGrpcInterface}'
-                    @else
-                        {@streamingCallType(apiMethod)}
-
-                    @end
-                );
-                @else
-                    @if apiMethod.hasRerouteToGrpcInterface
-                        $request,
-                        Call::UNARY_CALL,
-                        '{@apiMethod.rerouteToGrpcInterface}'
-
-                    @else
-                        $request
-
-                    @end
-                )->wait();
-                @end
         @end
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/php/client_impl.snip
+++ b/src/main/resources/com/google/api/codegen/php/client_impl.snip
@@ -439,7 +439,7 @@
                 $request
             @end
         );
-    @case "OperationOptionalArrayMethod"
+    @case "LongRunningOptionalArrayMethod"
         return $this->startOperationsCall(
             '{@apiMethod.grpcMethodName}',
             $optionalArgs,

--- a/src/main/resources/com/google/api/codegen/php/test.snip
+++ b/src/main/resources/com/google/api/codegen/php/test.snip
@@ -238,7 +238,7 @@
     @case "PagedOptionalArrayMethod"
         {@pageStreamingTestCase(test)}
         {@simpleExceptionTestCase(test)}
-    @case "OperationOptionalArrayMethod"
+    @case "LongRunningOptionalArrayMethod"
         {@lroTestCase(test)}
         {@lroExceptionTestCase(test)}
     @default

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -255,7 +255,7 @@
             response_token_field='{@apiMethod.pageStreamingView.responseTokenFieldName}',
         )
         return iterator
-    @case "OperationOptionalArrayMethod"
+    @case "LongRunningOptionalArrayMethod"
         operation = self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
         return google.api_core.operation.from_gapic(
             operation,

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -238,7 +238,24 @@
 @end
 
 @private callLine(apiMethod)
-    @if apiMethod.isLongRunningOperation
+    @switch apiMethod.type
+    @case "OptionalArrayMethod"
+        @if apiMethod.hasReturnValue
+            return self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
+        @else
+            self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
+        @end
+    @case "PagedOptionalArrayMethod"
+        iterator = google.api_core.page_iterator.GRPCIterator(
+            client=None,
+            method=functools.partial(self._{@apiMethod.name}{@optionalParams(apiMethod)}),
+            request={@apiMethod.requestVariableName},
+            items_field='{@apiMethod.pageStreamingView.resourcesFieldName}',
+            request_token_field='{@apiMethod.pageStreamingView.requestTokenFieldName}',
+            response_token_field='{@apiMethod.pageStreamingView.responseTokenFieldName}',
+        )
+        return iterator
+    @case "OperationOptionalArrayMethod"
         operation = self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
         return google.api_core.operation.from_gapic(
             operation,
@@ -246,27 +263,8 @@
             {@apiMethod.longRunningView.operationPayloadTypeName},
             metadata_type={@apiMethod.longRunningView.metadataTypeName},
         )
-    @else
-        @switch apiMethod.type
-        @case "OptionalArrayMethod"
-            @if apiMethod.hasReturnValue
-                return self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
-            @else
-                self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
-            @end
-        @case "PagedOptionalArrayMethod"
-            iterator = google.api_core.page_iterator.GRPCIterator(
-                client=None,
-                method=functools.partial(self._{@apiMethod.name}{@optionalParams(apiMethod)}),
-                request={@apiMethod.requestVariableName},
-                items_field='{@apiMethod.pageStreamingView.resourcesFieldName}',
-                request_token_field='{@apiMethod.pageStreamingView.requestTokenFieldName}',
-                response_token_field='{@apiMethod.pageStreamingView.responseTokenFieldName}',
-            )
-            return iterator
-        @default
-            {@unhandledCase()}
-        @end
+    @default
+        {@unhandledCase()}
     @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -32,7 +32,7 @@
   @case "OptionalArrayMethod"
     {@optionalArrayMethodSampleCode(apiMethod, initCode)}
   @case "LongRunningOptionalArrayMethod"
-    {@operationSampleCode(apiMethod, initCode)}
+    {@lroSampleCode(apiMethod, initCode)}
   @case "PagedOptionalArrayMethod"
     {@pagedOptionalArrayMethodSampleCode(apiMethod, initCode)}
   @default
@@ -172,7 +172,7 @@
   @end
 @end
 
-@private operationSampleCode(apiMethod, initCode)
+@private lroSampleCode(apiMethod, initCode)
   response = {@methodCallSampleCode(apiMethod, initCode)}
 
   def callback(operation_future):

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -20,6 +20,8 @@
   @switch apiMethod.type.toString
   @case "OptionalArrayMethod"
     {@optionalArrayMethodSampleCode(apiMethod)}
+  @case "OperationOptionalArrayMethod"
+    {@operationSampleCode(apiMethod)}
   @case "PagedOptionalArrayMethod"
     {@pagedOptionalArrayMethodSampleCode(apiMethod)}
   @default
@@ -154,20 +156,22 @@
 @private singularResponseSampleCode(apiMethod)
   @if apiMethod.hasReturnValue
     response = {@methodCallSampleCode(apiMethod)}
-    @if apiMethod.isLongRunningOperation
-
-      def callback(operation_future):
-          @# Handle result.
-          result = operation_future.result()
-
-      response.add_done_callback(callback)
-
-      @# Handle metadata.
-      metadata = response.metadata()
-    @end
   @else
     {@methodCallSampleCode(apiMethod)}
   @end
+@end
+
+@private operationSampleCode(apiMethod)
+  response = {@methodCallSampleCode(apiMethod)}
+
+  def callback(operation_future):
+      @# Handle result.
+      result = operation_future.result()
+
+  response.add_done_callback(callback)
+
+  @# Handle metadata.
+  metadata = response.metadata()
 @end
 
 # Render the API method call itself

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -20,7 +20,7 @@
   @switch apiMethod.type.toString
   @case "OptionalArrayMethod"
     {@optionalArrayMethodSampleCode(apiMethod)}
-  @case "OperationOptionalArrayMethod"
+  @case "LongRunningOptionalArrayMethod"
     {@operationSampleCode(apiMethod)}
   @case "PagedOptionalArrayMethod"
     {@pagedOptionalArrayMethodSampleCode(apiMethod)}

--- a/src/main/resources/com/google/api/codegen/py/test.snip
+++ b/src/main/resources/com/google/api/codegen/py/test.snip
@@ -104,7 +104,7 @@ class CustomException(Exception):
         {@simpleTestCase(test, moduleName)}
     @case "PagedOptionalArrayMethod"
         {@pagedStreamingTestCase(test, moduleName)}
-    @case "OperationOptionalArrayMethod"
+    @case "LongRunningOptionalArrayMethod"
         {@operationTestCase(test, moduleName)}
     @default
         {@unhandledCase()}


### PR DESCRIPTION
This commit moves the decision of whether to generate LRO code
into the generator and out of the snippet.
This makes the dynamic langs more similar to static langs,
and helps with sample code generation.