### PR TITLE
Java: prepare gapic-generator for proto/grpc artifact move to gcj

### DIFF
--- a/src/main/java/com/google/api/codegen/config/PackageMetadataConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackageMetadataConfig.java
@@ -307,11 +307,6 @@ public abstract class PackageMetadataConfig {
           createProtoPackageDependencies(configMap, "proto_test_deps"));
     }
 
-    if (configMap.containsKey("generated_ga_package_version")) {
-      builder.generatedGAPackageVersionBound(
-          createVersionMap(
-              (Map<String, Map<String, String>>) configMap.get("generated_ga_package_version")));
-    }
     return builder.build();
   }
 

--- a/src/main/java/com/google/api/codegen/grpcmetadatagen/GrpcMetadataProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/grpcmetadatagen/GrpcMetadataProviderFactory.java
@@ -50,14 +50,16 @@ public class GrpcMetadataProviderFactory {
             new JavaPackageMetadataTransformer(
                 ImmutableMap.of(
                     "LICENSE.snip", "LICENSE",
-                    "metadatagen/java/grpc/build_grpc.gradle.snip", "build.gradle"),
+                    "metadatagen/java/grpc/build_grpc.gradle.snip", "build.gradle",
+                    "metadatagen/java/grpc/pom_grpc.xml.snip", "pom.xml"),
                 artifactType));
       case PROTOBUF:
         return new JavaGrpcMetadataProvider(
             new JavaPackageMetadataTransformer(
                 ImmutableMap.of(
                     "LICENSE.snip", "LICENSE",
-                    "metadatagen/java/grpc/build_protobuf.gradle.snip", "build.gradle"),
+                    "metadatagen/java/grpc/build_protobuf.gradle.snip", "build.gradle",
+                    "metadatagen/java/grpc/pom_protobuf.xml.snip", "pom.xml"),
                 artifactType));
     }
 

--- a/src/main/java/com/google/api/codegen/grpcmetadatagen/java/JavaPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/grpcmetadatagen/java/JavaPackageMetadataTransformer.java
@@ -63,8 +63,8 @@ public class JavaPackageMetadataTransformer {
    */
   protected final List<PackageMetadataView.Builder> generateMetadataViewBuilders(
       ApiModel model, PackageMetadataConfig config, ArtifactType artifactType) {
-    JavaPackageMetadataNamer namer =
-        new JavaPackageMetadataNamer(config.packageName(TargetLanguage.JAVA), artifactType);
+    String packageName = config.packageName(TargetLanguage.JAVA);
+    JavaPackageMetadataNamer namer = new JavaPackageMetadataNamer(packageName, artifactType);
 
     List<PackageDependencyView> additionalDependencies = new ArrayList<>();
 
@@ -85,6 +85,7 @@ public class JavaPackageMetadataTransformer {
               .generateMetadataView(
                   namer, config, model, entry.getKey(), entry.getValue(), TargetLanguage.JAVA)
               .additionalDependencies(additionalDependencies)
+              .packageName(packageName)
               .identifier(namer.getMetadataIdentifier())
               .protoPackageName(namer.getProtoPackageName())
               .grpcPackageName(namer.getGrpcPackageName())

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageMetadataView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageMetadataView.java
@@ -46,6 +46,9 @@ public abstract class PackageMetadataView implements ViewModel {
   public abstract String gapicConfigName();
 
   @Nullable
+  public abstract String packageName();
+
+  @Nullable
   public abstract String identifier();
 
   @Nullable
@@ -196,6 +199,8 @@ public abstract class PackageMetadataView implements ViewModel {
     public abstract Builder outputPath(String val);
 
     public abstract Builder templateFileName(String val);
+
+    public abstract Builder packageName(String packageName);
 
     public abstract Builder identifier(String val);
 

--- a/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
@@ -8,7 +8,8 @@
   apply plugin: 'java'
 
   description = 'GAPIC library for {@metadata.identifier}'
-  group = 'com.google.api'
+  group = 'com.google.cloud'
+  version = '0.0.0-SNAPSHOT'
   sourceCompatibility = 1.7
   targetCompatibility = 1.7
 
@@ -16,6 +17,9 @@
     mavenCentral()
     mavenLocal()
   }
+
+  compileJava.options.encoding = 'UTF-8'
+  javadoc.options.encoding = 'UTF-8'
 
   dependencies {
     compile 'com.google.api:gax:{@metadata.gaxVersionBound.lower}'
@@ -47,7 +51,7 @@
       testCompile project(':{@metadata.grpcPackageName}')
     @end
     @join dependency : metadata.protoPackageTestDependencies
-      testCompile project(':grpc-{@dependency.name}')
+      testCompile '{@dependency.group}:grpc-{@dependency.name}:{@dependency.versionBound.lower}'
     @end
   }
 
@@ -70,6 +74,14 @@
     }
   }
 
-  compileJava.options.encoding = 'UTF-8'
-  javadoc.options.encoding = 'UTF-8'
+  clean {
+    delete 'all-jars'
+  }
+
+  task allJars(type: Copy) {
+    dependsOn test, jar
+    into 'all-jars'
+    // Replace with `from configurations.testRuntime, jar` to include test dependencies
+    from configurations.runtime, jar
+  }
 @end

--- a/src/main/resources/com/google/api/codegen/java/static/gradle/wrapper/gradle-wrapper.properties
+++ b/src/main/resources/com/google/api/codegen/java/static/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip

--- a/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build_base.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build_base.gradle.snip
@@ -9,7 +9,7 @@
 
   description = {@description(metadata)}
   group = 'com.google.api.grpc'
-  version = "{@metadata.packageVersionBound.lower}"
+  version = '0.0.0-SNAPSHOT'
   sourceCompatibility = 1.7
   targetCompatibility = 1.7
 

--- a/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build_protobuf.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build_protobuf.gradle.snip
@@ -10,6 +10,6 @@
     compile '{@dependency.group}:{@dependency.name}:{@dependency.versionBound.lower}'
   @end
   @join dependency : metadata.protoPackageDependencies
-    compile project(':proto-{@dependency.name}')
+    compile '{@dependency.group}:proto-{@dependency.name}:{@dependency.versionBound.lower}'
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/pom_base.xml.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/pom_base.xml.snip
@@ -1,0 +1,23 @@
+@snippet generate(metadata)
+  <project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>{@metadata.identifier}</artifactId>
+    <version>0.0.0-SNAPSHOT</version><!-- {x-version-update:{@metadata.identifier}:current} -->
+    <name>{@metadata.identifier}</name>
+    <description>{@description(metadata)}</description>
+    <parent>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>google-api-pom</artifactId>
+      <version>0.0.0-SNAPSHOT</version><!-- {x-version-update:google-api-pom:current} -->
+    </parent>
+    <dependencies>
+      {@dependencies(metadata)}
+    </dependencies>
+  </project>
+@end
+
+@abstract dependencies(metadata)
+
+@abstract description(metadata)

--- a/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/pom_grpc.xml.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/pom_grpc.xml.snip
@@ -1,0 +1,23 @@
+@extends "metadatagen/java/grpc/pom_base.xml.snip"
+
+@override description(metadata)
+  GRPC library for {@metadata.identifier}
+@end
+
+@override dependencies(metadata)
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-{@metadata.packageName}</artifactId>
+      <scope>compile</scope>
+    </dependency>
+@end

--- a/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/pom_protobuf.xml.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/pom_protobuf.xml.snip
@@ -1,0 +1,27 @@
+@extends "metadatagen/java/grpc/pom_base.xml.snip"
+
+@override description(metadata)
+  PROTO library for {@metadata.identifier}
+@end
+
+@override dependencies(metadata)
+  <dependency>
+    <groupId>com.google.protobuf</groupId>
+    <artifactId>protobuf-java</artifactId>
+    <scope>compile</scope>
+  </dependency>
+  @join dependency : metadata.additionalDependencies
+    <dependency>
+      <groupId>{@dependency.group}</groupId>
+      <artifactId>{@dependency.name}</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  @end
+  @join dependency : metadata.protoPackageDependencies
+    <dependency>
+      <groupId>{@dependency.group}</groupId>
+      <artifactId>proto-{@dependency.name}</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    @end
+@end

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/common_protos_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/common_protos_pkg.yaml
@@ -23,12 +23,6 @@ generated_package_version:
     upper: '0.16dev'
   nodejs:
     lower: '0.7.1'
-  java:
-    lower: '0.1.7'
-
-generated_ga_package_version:
-  java:
-    lower: '1.0.0'
 
 # Dependencies
 gax_version:

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_common_protos.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_common_protos.baseline
@@ -212,7 +212,7 @@ apply plugin: 'java'
 
 description = 'PROTO library for proto-google-common-protos'
 group = 'com.google.api.grpc'
-version = "0.1.7"
+version = '0.0.0-SNAPSHOT'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
@@ -252,3 +252,25 @@ artifacts {
 
 compileJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
+============== file: pom.xml ==============
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>proto-google-common-protos</artifactId>
+  <version>0.0.0-SNAPSHOT</version><!-- {x-version-update:proto-google-common-protos:current} -->
+  <name>proto-google-common-protos</name>
+  <description>PROTO library for proto-google-common-protos</description>
+  <parent>
+    <groupId>com.google.api.grpc</groupId>
+    <artifactId>google-api-pom</artifactId>
+    <version>0.0.0-SNAPSHOT</version><!-- {x-version-update:google-api-pom:current} -->
+  </parent>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_grpc_stubs.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_grpc_stubs.baseline
@@ -212,7 +212,7 @@ apply plugin: 'java'
 
 description = 'GRPC library for grpc-google-cloud-library-v1'
 group = 'com.google.api.grpc'
-version = "0.1.7"
+version = '0.0.0-SNAPSHOT'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
@@ -251,3 +251,35 @@ artifacts {
 
 compileJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
+============== file: pom.xml ==============
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>grpc-google-cloud-library-v1</artifactId>
+  <version>0.0.0-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-library-v1:current} -->
+  <name>grpc-google-cloud-library-v1</name>
+  <description>GRPC library for grpc-google-cloud-library-v1</description>
+  <parent>
+    <groupId>com.google.api.grpc</groupId>
+    <artifactId>google-api-pom</artifactId>
+    <version>0.0.0-SNAPSHOT</version><!-- {x-version-update:google-api-pom:current} -->
+  </parent>
+  <dependencies>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-library-v1</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_library.baseline
@@ -212,7 +212,7 @@ apply plugin: 'java'
 
 description = 'PROTO library for proto-google-cloud-library-v1'
 group = 'com.google.api.grpc'
-version = "0.1.7"
+version = '0.0.0-SNAPSHOT'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
@@ -224,8 +224,8 @@ repositories {
 dependencies {
   compile 'com.google.protobuf:protobuf-java:3.0.0'
   compile 'com.google.api:api-common:0.0.2'
-  compile project(':proto-google-common-protos')
-  compile project(':proto-google-some-other-package-v1')
+  compile 'com.google.api.grpc:proto-google-common-protos:0.1.6'
+  compile 'com.google.api.grpc:proto-google-some-other-package-v1:0.0.0'
 }
 
 sourceSets {
@@ -255,3 +255,40 @@ artifacts {
 
 compileJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
+============== file: pom.xml ==============
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>proto-google-cloud-library-v1</artifactId>
+  <version>0.0.0-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-library-v1:current} -->
+  <name>proto-google-cloud-library-v1</name>
+  <description>PROTO library for proto-google-cloud-library-v1</description>
+  <parent>
+    <groupId>com.google.api.grpc</groupId>
+    <artifactId>google-api-pom</artifactId>
+    <version>0.0.0-SNAPSHOT</version><!-- {x-version-update:google-api-pom:current} -->
+  </parent>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-common-protos</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-some-other-package-v1</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
@@ -25,12 +25,6 @@ generated_package_version:
     upper: '0.16dev'
   nodejs:
     lower: '0.7.1'
-  java:
-    lower: '0.1.7'
-
-generated_ga_package_version:
-  java:
-    lower: '1.0.0'
 
 # Dependencies
 gax_version:

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_stubs_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_stubs_pkg.yaml
@@ -25,12 +25,6 @@ generated_package_version:
     upper: '0.16dev'
   nodejs:
     lower: '0.7.1'
-  java:
-    lower: '0.1.7'
-
-generated_ga_package_version:
-  java:
-    lower: '1.0.0'
 
 # Dependencies
 gax_version:

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -14097,7 +14097,8 @@ buildscript {
 apply plugin: 'java'
 
 description = 'GAPIC library for google-cloud-simplecompute-v1'
-group = 'com.google.api'
+group = 'com.google.cloud'
+version = '0.0.0-SNAPSHOT'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
@@ -14105,6 +14106,9 @@ repositories {
   mavenCentral()
   mavenLocal()
 }
+
+compileJava.options.encoding = 'UTF-8'
+javadoc.options.encoding = 'UTF-8'
 
 dependencies {
   compile 'com.google.api:gax:1.0.0'
@@ -14133,8 +14137,16 @@ sourceSets {
   }
 }
 
-compileJava.options.encoding = 'UTF-8'
-javadoc.options.encoding = 'UTF-8'
+clean {
+  delete 'all-jars'
+}
+
+task allJars(type: Copy) {
+  dependsOn test, jar
+  into 'all-jars'
+  // Replace with `from configurations.testRuntime, jar` to include test dependencies
+  from configurations.runtime, jar
+}
 ============== file: src/test/java/com/google/cloud/simplecompute/v1/AddressClientTest.java ==============
 /*
  * Copyright 2018 Google LLC

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -20,7 +20,8 @@ buildscript {
 apply plugin: 'java'
 
 description = 'GAPIC library for google-cloud-library-v1'
-group = 'com.google.api'
+group = 'com.google.cloud'
+version = '0.0.0-SNAPSHOT'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
@@ -28,6 +29,9 @@ repositories {
   mavenCentral()
   mavenLocal()
 }
+
+compileJava.options.encoding = 'UTF-8'
+javadoc.options.encoding = 'UTF-8'
 
 dependencies {
   compile 'com.google.api:gax:1.0.0'
@@ -40,7 +44,7 @@ dependencies {
   compile project(':proto-google-cloud-library-v1')
   // Remove this line if you are bundling your proto-generated classes together with your client classes
   testCompile project(':grpc-google-cloud-library-v1')
-  testCompile project(':grpc-google-some-test-package-v1')
+  testCompile 'com.google.api.grpc:grpc-google-some-test-package-v1:0.0.0'
 }
 
 task smokeTest(type: Test) {
@@ -62,8 +66,16 @@ sourceSets {
   }
 }
 
-compileJava.options.encoding = 'UTF-8'
-javadoc.options.encoding = 'UTF-8'
+clean {
+  delete 'all-jars'
+}
+
+task allJars(type: Copy) {
+  dependsOn test, jar
+  into 'all-jars'
+  // Replace with `from configurations.testRuntime, jar` to include test dependencies
+  from configurations.runtime, jar
+}
 ============== file: src/main/java/com/google/gcloud/pubsub/v1/LibraryClient.java ==============
 /*
  * Copyright 2018 Google LLC

--- a/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
@@ -20,7 +20,8 @@ buildscript {
 apply plugin: 'java'
 
 description = 'GAPIC library for google-cloud-library-v1'
-group = 'com.google.api'
+group = 'com.google.cloud'
+version = '0.0.0-SNAPSHOT'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
@@ -28,6 +29,9 @@ repositories {
   mavenCentral()
   mavenLocal()
 }
+
+compileJava.options.encoding = 'UTF-8'
+javadoc.options.encoding = 'UTF-8'
 
 dependencies {
   compile 'com.google.api:gax:1.0.0'
@@ -61,8 +65,16 @@ sourceSets {
   }
 }
 
-compileJava.options.encoding = 'UTF-8'
-javadoc.options.encoding = 'UTF-8'
+clean {
+  delete 'all-jars'
+}
+
+task allJars(type: Copy) {
+  dependsOn test, jar
+  into 'all-jars'
+  // Replace with `from configurations.testRuntime, jar` to include test dependencies
+  from configurations.runtime, jar
+}
 ============== file: src/main/java/com/google/gcloud/example/NoTemplatesApiServiceClient.java ==============
 /*
  * Copyright 2018 Google LLC

--- a/src/test/java/com/google/api/codegen/testsrc/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_pkg.yaml
@@ -26,12 +26,6 @@ generated_package_version:
     lower: '0.1.0'
   ruby:
     lower: '0.6.8'
-  java:
-    lower: '0.1.0'
-
-generated_ga_package_version:
-  java:
-    lower: '1.0.0'
 
 release_level:
   python: ALPHA

--- a/src/test/java/com/google/api/codegen/testsrc/longrunning_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/longrunning_pkg.yaml
@@ -23,12 +23,6 @@ generated_package_version:
     lower: '0.1.0'
   ruby:
     lower: '0.6.8'
-  java:
-    lower: '0.1.0'
-
-generated_ga_package_version:
-  java:
-    lower: '1.0.0'
 
 release_level:
   python: ALPHA

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg.yaml
@@ -26,12 +26,6 @@ generated_package_version:
     lower: '0.1.0'
   ruby:
     lower: '0.6.8'
-  java:
-    lower: '0.1.0'
-
-generated_ga_package_version:
-  java:
-    lower: '1.0.0'
 
 release_level:
   python: ALPHA

--- a/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg.yaml
@@ -25,10 +25,6 @@ generated_package_version:
   ruby:
     lower: '0.6.8'
 
-generated_ga_package_version:
-  java:
-    lower: '1.0.0'
-
 release_level:
   python: BETA
   java: BETA


### PR DESCRIPTION
1) Generate non-standalone `pom.xml` for grpc and proto artifacts (assumes presence of a parent pom). The poms expect a parent to be present. This can be temporary (the pom generation can be moved somewhere else in the future). The artifacts are optional and are not required during self-service (oping the pom.xml out of self-service is TBD).
2) Remove `generated_package_version` and `generated_ga_package_version` support from java generation. By default (including self-service) all artifacts (including gapic) are generated with `0.0.0-SNAPSHOT` version.
3) "Resurrect" the usage of `dep-name_version` config properties (for example `google-common-protos_version` and `google-some-other-package-v1_version`). This corresponds to the plan of moving common dependencies to their own repo and releasing new versions of them only when necessary. Also this allows making self-service much more user friendly: now to build a client user needs to run generation only for that client and does not have to generate common dependencies (they will be pulled by gradle during build). Also this makes googleapis `api_defaults.yaml` obsolete for java.
4) Add `allJars` task in generated gapic `build.gradle`. This should simplify self-service, allowing to group all dependencies (and the generated jars themselves) in one folder, after which users of the self-service can choose which to copy to their build (i.e. it is an "exploded" fat jar, since the self-service users were already doing that: manipulating the dependencies content of the fat jar).
5) Upgrade `gradle-wrapper.propeities` used for generated artifacts to version `4.7`.