### PR TITLE
Adding Bazel support; dep cleanup; other cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bin
 build
 .gradle
 src-gen
+bazel-*
 
 # Eclipse
 .apt_generated

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,57 @@
+java_plugin(
+    name = "auto_value_plugin",
+    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
+    deps = ["@com_google_auto_value_auto_value//jar"],
+)
+
+java_library(
+    name = "auto_value",
+    exported_plugins = [":auto_value_plugin"],
+    exports = ["@com_google_auto_value_auto_value//jar"],
+)
+
+proto_library(
+    name = "config_proto",
+    srcs = ["src/main/proto/com/google/api/codegen/config.proto"],
+)
+
+java_proto_library(
+    name = "config_java_proto",
+    deps = [":config_proto"],
+)
+
+java_binary(
+    name = "gapic_generator",
+    srcs = glob(["src/main/java/**/*.java"]),
+    resources = glob(["src/main/resources/**/*"]),
+    main_class = "com.google.api.codegen.CodeGeneratorTool",
+    create_executable = True,
+    deps = [
+        ":config_java_proto",
+        ":auto_value",
+        "@cglib_cglib//jar",
+        "@com_atlassian_commonmark_commonmark//jar",
+        "@com_fasterxml_jackson_core_jackson_annotations//jar",
+        "@com_fasterxml_jackson_core_jackson_core//jar",
+        "@com_fasterxml_jackson_core_jackson_databind//jar",
+        "@com_google_api_api_common//jar",
+        "@com_google_api_api_compiler//jar",
+        "@com_google_api_gax//jar",
+        "@com_google_api_grpc_proto_google_common_protos//jar",
+        "@com_google_auto_value_auto_value//jar",
+        "@com_google_auto_value_auto_value_annotations//jar",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_code_gson_gson//jar",
+        "@com_google_guava_guava//jar",
+        "@com_google_inject_guice//jar",
+        "@com_google_protobuf//:protobuf_java",
+        "@commons_cli_commons_cli//jar",
+        "@io_grpc_grpc_core//jar",
+        "@javax_inject_javax_inject//jar",
+        "@org_apache_commons_commons_lang3//jar",
+        "@org_ow2_asm_asm//jar",
+        "@org_threeten_threetenbp//jar",
+        "@org_yaml_snakeyaml//jar",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,142 @@
+workspace(name = "com_google_api_gapic_generator")
+
+maven_jar(
+    name = "com_atlassian_commonmark_commonmark",
+    artifact = "com.atlassian.commonmark:commonmark:0.9.0",
+    sha1 = "4eb11e3f9aaecafc6073b84c15f66376ef8dc5d3",
+)
+
+maven_jar(
+    name = "com_fasterxml_jackson_core_jackson_annotations",
+    artifact = "com.fasterxml.jackson.core:jackson-annotations:2.9.0",
+    sha1 = "07c10d545325e3a6e72e06381afe469fd40eb701",
+)
+
+maven_jar(
+    name = "com_fasterxml_jackson_core_jackson_core",
+    artifact = "com.fasterxml.jackson.core:jackson-core:2.9.0",
+    sha1 = "88e7c6220be3b3497b3074d3fc7754213289b987",
+)
+
+maven_jar(
+    name = "com_fasterxml_jackson_core_jackson_databind",
+    artifact = "com.fasterxml.jackson.core:jackson-databind:2.9.0",
+    sha1 = "14fb5f088cc0b0dc90a73ba745bcade4961a3ee3",
+)
+
+maven_jar(
+    name = "com_google_api_api_common",
+    artifact = "com.google.api:api-common:1.1.0",
+    sha1 = "14733901500ad0744cebf7adf73045a466ce1a11",
+)
+
+maven_jar(
+    name = "com_google_api_api_compiler",
+    artifact = "com.google.api:api-compiler:0.0.7",
+    sha1 = "974c9d5b7d9b6902202f2280839939eb468207fa",
+)
+
+maven_jar(
+    name = "com_google_api_gax",
+    artifact = "com.google.api:gax:1.5.1",
+    sha1 = "3bc202725a07394fa13e83c131ca84eb5b212e77",
+)
+
+maven_jar(
+    name = "com_google_api_grpc_proto_google_common_protos",
+    artifact = "com.google.api.grpc:proto-google-common-protos:1.0.5",
+    sha1 = "3a5e2e2849a918acbba69154c957c36679441fcf",
+)
+
+maven_jar(
+    name = "com_google_auto_value_auto_value",
+    artifact = "com.google.auto.value:auto-value:1.6",
+    sha1 = "a3b1b1404f8acaa88594a017185e013cd342c9a8",
+)
+
+maven_jar(
+    name = "com_google_auto_value_auto_value_annotations",
+    artifact = "com.google.auto.value:auto-value-annotations:1.6",
+    sha1 = "da725083ee79fdcd86d9f3d8a76e38174a01892a",
+)
+
+maven_jar(
+    name = "com_google_code_findbugs_jsr305",
+    artifact = "com.google.code.findbugs:jsr305:3.0.0",
+    sha1 = "5871fb60dc68d67da54a663c3fd636a10a532948",
+)
+
+maven_jar(
+    name = "com_google_code_gson_gson",
+    artifact = "com.google.code.gson:gson:2.3",
+    sha1 = "5fc52c41ef0239d1093a1eb7c3697036183677ce",
+)
+
+maven_jar(
+    name = "com_google_guava_guava",
+    artifact = "com.google.guava:guava:23.0",
+    sha1 = "c947004bb13d18182be60077ade044099e4f26f1",
+)
+
+maven_jar(
+    name = "com_google_inject_guice",
+    artifact = "com.google.inject:guice:4.0",
+    sha1 = "0f990a43d3725781b6db7cd0acf0a8b62dfd1649",
+)
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "1f8b9b202e9a4e467ff0b0f25facb1642727cdf5e69092038f15b37c75b99e45",
+    strip_prefix = "protobuf-3.5.1",
+    urls = ["https://github.com/google/protobuf/archive/v3.5.1.zip"],
+)
+
+maven_jar(
+    name = "commons_cli_commons_cli",
+    artifact = "commons-cli:commons-cli:1.4",
+    sha1 = "c51c00206bb913cd8612b24abd9fa98ae89719b1",
+)
+
+maven_jar(
+    name = "io_grpc_grpc_core",
+    artifact = "io.grpc:grpc-core:1.0.1",
+    sha1 = "dce1c939c2c6110ac571d99f8d2a29b19bdad4db",
+)
+
+maven_jar(
+    name = "org_apache_commons_commons_lang3",
+    artifact = "org.apache.commons:commons-lang3:3.6",
+    sha1 = "9d28a6b23650e8a7e9063c04588ace6cf7012c17",
+)
+
+maven_jar(
+    name = "org_threeten_threetenbp",
+    artifact = "org.threeten:threetenbp:1.3.3",
+    sha1 = "3ea31c96676ff12ab56be0b1af6fff61d1a4f1f2",
+)
+
+maven_jar(
+    name = "org_yaml_snakeyaml",
+    artifact = "org.yaml:snakeyaml:1.18",
+    sha1 = "e4a441249ade301985cb8d009d4e4a72b85bf68e",
+)
+
+# ----- Runtime transitive dependencies
+
+maven_jar(
+    name = "cglib_cglib",
+    artifact = "cglib:cglib:3.1",
+    sha1 = "1f1cb6c7a7479e0c7fd7987109e503914bebe84a",
+)
+
+maven_jar(
+    name = "javax_inject_javax_inject",
+    artifact = "javax.inject:javax.inject:1",
+    sha1 = "6975da39a7040257bd51d21a231b76c915872d38",
+)
+
+maven_jar(
+    name = "org_ow2_asm_asm",
+    artifact = "org.ow2.asm:asm:4.2",
+    sha1 = "4b2c12b92dd045aeabf5b2aeeb3220bf010da9d4",
+)

--- a/build.gradle
+++ b/build.gradle
@@ -59,33 +59,36 @@ ext {
   libraries = [
     // General
 
-    guava: 'com.google.guava:guava:23.0',
-    jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
+    apiCommon: 'com.google.api:api-common:1.1.0',
+    apiCompiler: 'com.google.api:api-compiler:0.0.7',
     autovalue: 'com.google.auto.value:auto-value:1.6',
     autovalueAnnotation: 'com.google.auto.value:auto-value-annotations:1.6',
+    commonmark: 'com.atlassian.commonmark:commonmark:0.9.0',
+    commonProtos: 'com.google.api.grpc:grpc-google-common-protos:1.0.5',
     commonsLang: 'org.apache.commons:commons-lang3:3.6',
     commonsCli: 'commons-cli:commons-cli:1.4',
-    snakeyaml: 'org.yaml:snakeyaml:1.18',
-    commonmark: 'com.atlassian.commonmark:commonmark:0.9.0',
     gax: 'com.google.api:gax:1.5.1',
-
-    // Gapi
-    toolsFx: 'com.google.api:api-compiler:0.0.7',
+    grpcCore: 'io.grpc:grpc-core:1.0.1',
+    gson: 'com.google.code.gson:gson:2.3',
+    guava: 'com.google.guava:guava:23.0',
+    guice: 'com.google.inject:guice:4.0',
+    jacksonAnnotations: 'com.fasterxml.jackson.core:jackson-annotations:2.9.0',
+    jacksonCore: 'com.fasterxml.jackson.core:jackson-core:2.9.0',
+    jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.9.0',
+    jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
+    snakeyaml: 'org.yaml:snakeyaml:1.18',
+    threetenbp: 'org.threeten:threetenbp:1.3.3',
 
     // Testing
     junit: 'junit:junit:4.12',
     mockito: 'org.mockito:mockito-core:2.+',
     truth: 'com.google.truth:truth:0.34',
     toolsFxTesting: 'com.google.api:api-compiler:0.0.6:testing',
-    commonProtos: 'com.google.api.grpc:grpc-google-common-protos:1.0.5',
     junitParams: 'pl.pragmatists:JUnitParams:1.1.1',
 
     // Protobuf
     protobuf: 'com.google.protobuf:protobuf-java:' + protoVersion,
     protoc:  'com.google.protobuf:protoc:' + protoVersion,
-
-    // JSON
-    jackson: 'com.fasterxml.jackson.core:jackson-databind:2.9.0',
 
     // Formatter
     javaFomatter: 'com.google.googlejavaformat:google-java-format:1.1'
@@ -98,19 +101,25 @@ repositories {
 }
 
 dependencies {
-  compile libraries.guava,
+  compile libraries.apiCommon,
+    libraries.apiCompiler,
     libraries.autovalueAnnotation,
+    libraries.commonmark,
     libraries.commonsCli,
     libraries.commonsLang,
     libraries.gax,
-    libraries.jackson,
+    libraries.grpcCore,
+    libraries.gson,
+    libraries.guava,
+    libraries.jacksonAnnotations,
+    libraries.jacksonCore,
+    libraries.jacksonDatabind,
     libraries.javaFomatter,
     libraries.jsr305,
     libraries.protobuf,
     libraries.snakeyaml,
-    libraries.toolsFx,
-    libraries.toolsFxTesting,
-    libraries.commonmark
+    libraries.threetenbp,
+    libraries.toolsFxTesting
 
   testCompile libraries.junit,
     libraries.truth,
@@ -512,6 +521,7 @@ tasks.googleJavaFormat {
   exclude 'build/**'
   exclude 'benchmark/**'
   exclude 'modules/googleapis/third_party'
+  exclude 'bazel-*'
 }
 tasks.verifyGoogleJavaFormat {
   exclude '.apt_generated/**'
@@ -519,5 +529,6 @@ tasks.verifyGoogleJavaFormat {
   exclude 'build/**'
   exclude 'benchmark/**'
   exclude 'modules/googleapis/third_party'
+  exclude 'bazel-*'
 }
 test.dependsOn verifyGoogleJavaFormat

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,6 @@ ext {
   // Shortcuts for libraries we are using
   libraries = [
     // General
-
     apiCommon: 'com.google.api:api-common:1.1.0',
     apiCompiler: 'com.google.api:api-compiler:0.0.7',
     autovalue: 'com.google.auto.value:auto-value:1.6',

--- a/src/main/java/com/google/api/codegen/CodeGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/CodeGeneratorApi.java
@@ -179,7 +179,7 @@ public class CodeGeneratorApi extends ToolDriverBase {
   @VisibleForTesting
   void writeCodeGenOutput(Map<String, ?> outputFiles, String outputPath) throws IOException {
     // TODO: Support zip output.
-    if (outputPath.endsWith(".jar")) {
+    if (outputPath.endsWith(".jar") || outputPath.endsWith(".srcjar")) {
       ToolUtil.writeJar(outputFiles, outputPath);
     } else {
       ToolUtil.writeFiles(outputFiles, outputPath);

--- a/src/main/java/com/google/api/codegen/CodeGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/CodeGeneratorTool.java
@@ -22,6 +22,8 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
+import java.io.File;
+
 // Example usage: (assuming environment variable BASE is the base directory of the project
 // containing the YAMLs, descriptor set, and output)
 //
@@ -106,6 +108,11 @@ public class CodeGeneratorTool {
       String packageConfig,
       String outputDirectory,
       String[] enabledArtifacts) {
+    checkFile(descriptorSet);
+    checkFiles(configs);
+    checkFiles(generatorConfigs);
+    checkFile(packageConfig);
+
     ToolOptions options = ToolOptions.create();
     options.set(ToolOptions.DESCRIPTOR_SET, descriptorSet);
     options.set(ToolOptions.CONFIG_FILES, Lists.newArrayList(configs));
@@ -117,6 +124,19 @@ public class CodeGeneratorTool {
       options.set(CodeGeneratorApi.ENABLED_ARTIFACTS, Lists.newArrayList(enabledArtifacts));
     }
     CodeGeneratorApi codeGen = new CodeGeneratorApi(options);
+
     return codeGen.run();
+  }
+
+  private static void checkFiles(String[] files) {
+    for (String filePath : files) {
+      checkFile(filePath);
+    }
+  }
+
+  private static void checkFile(String filePath) {
+    if (!new File(filePath).exists()) {
+      throw new IllegalArgumentException("File not found: " + filePath);
+    }
   }
 }

--- a/src/main/java/com/google/api/codegen/CodeGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/CodeGeneratorTool.java
@@ -16,13 +16,12 @@ package com.google.api.codegen;
 
 import com.google.api.tools.framework.tools.ToolOptions;
 import com.google.common.collect.Lists;
+import java.io.File;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-
-import java.io.File;
 
 // Example usage: (assuming environment variable BASE is the base directory of the project
 // containing the YAMLs, descriptor set, and output)

--- a/src/main/java/com/google/api/codegen/util/py/PythonRenderingUtil.java
+++ b/src/main/java/com/google/api/codegen/util/py/PythonRenderingUtil.java
@@ -51,6 +51,7 @@ public class PythonRenderingUtil {
     return headerLine(title, '^');
   }
 
+  @SuppressWarnings("InvalidPatternSyntax")
   private String headerLine(String title, char c) {
     return title.replaceAll(".", String.valueOf(c));
   }


### PR DESCRIPTION
For those not familiar with Bazel:

- BUILD.bazel declares the targets that can be built
- WORKSPACE declares the external "projects" (basically where to find dependencies)

Bazel made me add all directly referenced dependencies, which made it clear we were implicitly using code from several libraries but not declaring them in the build.gradle, so I added them there too. 

I had to do a couple other random things to get gapic-generator to build & run through Bazel.

