### PR TITLE
go: import "time" for LRO

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -403,6 +403,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
                   ImportContext.CLIENT,
                   ImportKind.LRO,
                   ImmutableList.<String>of(
+                      "time;;;",
                       "cloud.google.com/go/longrunning;;;",
                       "cloud.google.com/go/longrunning/autogen;lroauto;;"))
               .put(


### PR DESCRIPTION
Package time is used by LRO methods.

Package time is usually already imported for retries,
so the fact that LRO didn't properly import time didn't cause us to
fail.

@jadekler