### PR TITLE
Add devsite tags to Java and Python standalone samples

### DIFF
--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -4,21 +4,36 @@
 @snippet generate(sampleFile)
    //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "{@sampleFile.classView.name}" ]
    //// STUB standalone sample "{@sampleFile.classView.name}" /////
+
+   // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+   
+   // [START full_sample]
+
+   // FIXME: Insert here boilerplate code not directly related to the method call itself.
+       
    @let apiMethod = sampleFile.classView.libraryMethod
      @let sample = apiMethod.samples.get(0)
        //     calling form "{@sample.callingForm.toString}"
        //     valueSet "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
        //       {@sample.valueSet.parameters}
        //     apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
-       // TODO: Replace with a full sample
+
+       // [START core_sample]
+
+       // FIXME: Insert here code to prepare the request fields, make the call, process the response.
        
        /*
        @let coreSampleCode = generateSample(apiMethod, sample.initCode)
          {@methodDoc(coreSampleCode)}
        @end
        */
+       // [END core_sample]
+
+       // FIXME: Insert here clean-up code.
+       
      @end
    @end
+   // [END full_sample]
 @end
 
 # adapted from main.snip:apiMethods(xapiClass) and its dependencies

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -4,18 +4,36 @@
 @snippet generate(sampleFile)
   @#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "{@sampleFile.className}" ]
   @#### STUB standalone sample "{@sampleFile.className}" #####
+
+  @# FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+  @# To run with the published packaged, execute the following before running this code:
+  @#   pip install {@sampleFile.gapicPackageName}
+   
+  @# [START full_sample]
+
+  @# FIXME: Insert here boilerplate code not directly related to the method call itself.
+   
   @let apiMethod = sampleFile.libraryMethod
     @let sample = apiMethod.samples.get(0)
       @##     calling form "{@sample.callingForm.toString}"
       @##     valueSet "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
       @##       {@sample.valueSet.parameters}
       @##     apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
-      @## TODO: Replace with a full sample
+      
+      @# [START core_sample]
 
-      @# pip install {@sampleFile.gapicPackageName}
+      @# FIXME: Insert here code to prepare the request fields, make the call, process the response.
+       
       {@sampleCode(apiMethod, sample.initCode)}
       # TODO(pongad): Make this work on non-unary too.
       print(response)
-     @end
+      
+      @# [END core_sample]
+
+      @# FIXME: Insert here clean-up code.
+      
+    @end
   @end
+  @# [END full_sample]
 @end

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -7288,11 +7288,21 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 ============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesSampleFlattenedPiVersion.java ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleFlattenedPiVersion" ]
 //// STUB standalone sample "PublishSeriesSampleFlattenedPiVersion" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
 //     calling form "Flattened"
 //     valueSet "pi_version" ("Pi version")
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeries" of type "FlattenedMethod"
-// TODO: Replace with a full sample
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 /*
 String name = "Math";
@@ -7307,14 +7317,29 @@ SeriesUuid seriesUuid = SeriesUuid.newBuilder()
   .build();
 PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
 */
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
 ============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesSampleFlattenedSecondEdition.java ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleFlattenedSecondEdition" ]
 //// STUB standalone sample "PublishSeriesSampleFlattenedSecondEdition" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
 //     calling form "Flattened"
 //     valueSet "second_edition" ("Second edition")
 //       [edition=2]
 //     apiMethod "publishSeries" of type "FlattenedMethod"
-// TODO: Replace with a full sample
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 /*
 Shelf shelf = Shelf.newBuilder().build();
@@ -7323,14 +7348,29 @@ int edition = 2;
 SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
 PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
 */
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
 ============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesSampleRequestPiVersion.java ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestPiVersion" ]
 //// STUB standalone sample "PublishSeriesSampleRequestPiVersion" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
 //     calling form "Request"
 //     valueSet "pi_version" ("Pi version")
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeries" of type "RequestObjectMethod"
-// TODO: Replace with a full sample
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 /*
 String name = "Math";
@@ -7349,14 +7389,29 @@ PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
   .build();
 PublishSeriesResponse response = libraryClient.publishSeries(request);
 */
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
 ============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesSampleRequestSecondEdition.java ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestSecondEdition" ]
 //// STUB standalone sample "PublishSeriesSampleRequestSecondEdition" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
 //     calling form "Request"
 //     valueSet "second_edition" ("Second edition")
 //       [edition=2]
 //     apiMethod "publishSeries" of type "RequestObjectMethod"
-// TODO: Replace with a full sample
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 /*
 Shelf shelf = Shelf.newBuilder().build();
@@ -7371,14 +7426,29 @@ PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
   .build();
 PublishSeriesResponse response = libraryClient.publishSeries(request);
 */
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
 ============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseriescallable/PublishSeriesCallableSampleCallablePiVersion.java ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesCallableSampleCallablePiVersion" ]
 //// STUB standalone sample "PublishSeriesCallableSampleCallablePiVersion" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
 //     calling form "Callable"
 //     valueSet "pi_version" ("Pi version")
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeriesCallable" of type "CallableMethod"
-// TODO: Replace with a full sample
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 /*
 String name = "Math";
@@ -7399,14 +7469,29 @@ ApiFuture&lt;PublishSeriesResponse&gt; future = libraryClient.publishSeriesCalla
 // Do something
 PublishSeriesResponse response = future.get();
 */
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
 ============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseriescallable/PublishSeriesCallableSampleCallableSecondEdition.java ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesCallableSampleCallableSecondEdition" ]
 //// STUB standalone sample "PublishSeriesCallableSampleCallableSecondEdition" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
 //     calling form "Callable"
 //     valueSet "second_edition" ("Second edition")
 //       [edition=2]
 //     apiMethod "publishSeriesCallable" of type "CallableMethod"
-// TODO: Replace with a full sample
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 /*
 Shelf shelf = Shelf.newBuilder().build();
@@ -7423,6 +7508,11 @@ ApiFuture&lt;PublishSeriesResponse&gt; future = libraryClient.publishSeriesCalla
 // Do something
 PublishSeriesResponse response = future.get();
 */
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
 ============== file: src/test/java/com/google/gcloud/pubsub/v1/LibraryClientTest.java ==============
 /*
  * Copyright 2018 Google LLC

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -3523,13 +3523,25 @@ def lint_setup_py(session):
 ============== file: samples/google/cloud/example/library_v1/gapic/publish_series/publish_series_sample_generic_pi_version.py ==============
 #### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleGenericPiVersion" ]
 #### STUB standalone sample "PublishSeriesSampleGenericPiVersion" #####
+
+# FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+# To run with the published packaged, execute the following before running this code:
+#   pip install google-cloud-library
+
+# [START full_sample]
+
+# FIXME: Insert here boilerplate code not directly related to the method call itself.
+
 ##     calling form "Generic"
 ##     valueSet "pi_version" ("Pi version")
 ##       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 ##     apiMethod "publish_series" of type "OptionalArrayMethod"
-## TODO: Replace with a full sample
 
-# pip install google-cloud-library
+# [START core_sample]
+
+# FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
 from google.cloud.example import library_v1
 
 client = library_v1.LibraryServiceClient()
@@ -3544,16 +3556,34 @@ series_uuid = {'series_string': series_string}
 
 response = client.publish_series(shelf, books, series_uuid)
 print(response)
+
+# [END core_sample]
+
+# FIXME: Insert here clean-up code.
+
+# [END full_sample]
 ============== file: samples/google/cloud/example/library_v1/gapic/publish_series/publish_series_sample_generic_second_edition.py ==============
 #### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleGenericSecondEdition" ]
 #### STUB standalone sample "PublishSeriesSampleGenericSecondEdition" #####
+
+# FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+# To run with the published packaged, execute the following before running this code:
+#   pip install google-cloud-library
+
+# [START full_sample]
+
+# FIXME: Insert here boilerplate code not directly related to the method call itself.
+
 ##     calling form "Generic"
 ##     valueSet "second_edition" ("Second edition")
 ##       [edition=2]
 ##     apiMethod "publish_series" of type "OptionalArrayMethod"
-## TODO: Replace with a full sample
 
-# pip install google-cloud-library
+# [START core_sample]
+
+# FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
 from google.cloud.example import library_v1
 
 client = library_v1.LibraryServiceClient()
@@ -3570,6 +3600,12 @@ edition = 2
 
 response = client.publish_series(shelf, books, series_uuid, edition=edition)
 print(response)
+
+# [END core_sample]
+
+# FIXME: Insert here clean-up code.
+
+# [END full_sample]
 ============== file: setup.cfg ==============
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
- Also, use FIXME instead of TODO to differentiate tasks that we need
  to do in the generator from tasks that our developer customer has to
  do when trying to run the code