### PR TITLE
Python interceptor 2

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -4,7 +4,7 @@
 @snippet generate(xapiClass)
     {@licenseSection(xapiClass.fileHeader)}
 
-    {@moduleDocstring(xapiClass)}
+    """Accesses the {@xapiClass.servicePhraseName}."""
     {@renderImportSection(xapiClass.fileHeader.importSection)}
 
 
@@ -13,171 +13,241 @@
     ).version
 
 
-    {@serviceClass(xapiClass)}
-@end
-
-
-@private moduleDocstring(xapiClass)
-    """Accesses the {@xapiClass.servicePhraseName}."""
-@end
-
-
-@private serviceClass(xapiClass)
     class {@xapiClass.name}(object):
         @if xapiClass.doc.lines
-            {@documentation(xapiClass.doc)}
+            @if xapiClass.doc.remainingLines
+                """
+                @join line : xapiClass.doc.lines
+                    {@line}
+                @end
+                """
+            @else
+                """{@xapiClass.doc.firstLine}"""
+            @end
+
 
         @end
-        {@constantSection(xapiClass)}
+        SERVICE_ADDRESS = '{@xapiClass.serviceAddress}:{@xapiClass.servicePort}'
+        """The default address of the service."""
 
-        @if xapiClass.pathTemplates
-            {@pathTemplateSection(xapiClass)}
-
-        @end
-        {@initMethodSection(xapiClass)}
-
-        {@serviceMethodsSection(xapiClass)}
-
-@end
-
-@private documentation(doc)
-    @if doc.remainingLines
-        """
-        @join line : doc.lines
-            {@line}
-        @end
-        """
-    @else
-        """{@doc.firstLine}"""
-    @end
-@end
-
-@private constantSection(xapiClass)
-    SERVICE_ADDRESS = '{@xapiClass.serviceAddress}:{@xapiClass.servicePort}'
-    """The default address of the service."""
-
-    @# The scopes needed to make gRPC calls to all of the methods defined in
-    @# this service
-    _DEFAULT_SCOPES = (
-        @join auth_scope : xapiClass.authScopes on BREAK
-            '{@auth_scope}',
-        @end
-    )
-
-    @# The name of the interface for this client. This is the key used to find
-    @# method configuration in the client_config dictionary.
-    _INTERFACE_NAME = '{@xapiClass.interfaceKey}'
-@end
-
-@private constructDefaults(xapiClass)
-    defaults = api_callable.construct_settings(
-        '{@xapiClass.interfaceKey}',
-        {@xapiClass.clientConfigName}.config,
-        client_config,
-        config.STATUS_CODE_NAMES,
-        metrics_headers=metrics_headers,
-        @if xapiClass.hasPageStreamingMethods
-            page_descriptors=self._PAGE_DESCRIPTORS,
-        @end
-    )
-@end
-
-@private initMethodSection(xapiClass)
-    def __init__(self, channel=None, credentials=None,
-            client_config={@xapiClass.clientConfigName}.config,
-            client_info=None):
-        """Constructor.
-
-        Args:
-            channel (grpc.Channel): A ``Channel`` instance through
-                which to make calls. This argument is mutually exclusive
-                with ``credentials``; providing both will raise an exception.
-            credentials (google.auth.credentials.Credentials): The
-                authorization credentials to attach to requests. These
-                credentials identify this application to the service. If none
-                are specified, the client will attempt to ascertain the
-                credentials from the environment.
-            client_config (dict): A dictionary of call options for each
-                method. If not specified, the default configuration is used.
-            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
-                The client info used to send a user-agent string along with
-                API requests. If ``None``, then default info will be used.
-                Generally, you only need to set this if you're developing
-                your own client library.
-        """
-        # gRPC channel & client stub initialization.
-        @# If both `channel` and `credentials` are specified, raise an
-        @# exception (channels come with credentials baked in already).
-        if channel is not None and credentials is not None:
-            raise ValueError(
-                'The `channel` and `credentials` arguments to {} are mutually '
-                'exclusive.'.format(self.__class__.__name__),
-            )
-
-        @# Create the channel.
-        if channel is None:
-            channel = google.api_core.grpc_helpers.create_channel(
-                self.SERVICE_ADDRESS,
-                credentials=credentials,
-                scopes=self._DEFAULT_SCOPES,
-            )
-
-        @# Create the gRPC stubs.
-        @join stub : xapiClass.stubs
-            self.{@stub.name} = (
-                {@stub.grpcClientTypeName}(channel))
-        @end
-
-        @if xapiClass.hasLongRunningOperations
-            @# Operations client for methods that return long-running operations
-            @# futures.
-            self.operations_client = (
-                google.api_core.operations_v1.OperationsClient(channel))
-        @end
-
-        # Client information initialization.
-        if client_info is None:
-            client_info = (
-                google.api_core.gapic_v1.client_info.DEFAULT_CLIENT_INFO)
-        client_info.gapic_version = _GAPIC_LIBRARY_VERSION
-
-        @# Parse out the default settings for retry and timeout for each RPC
-        @# from the client configuration.
-        @# (Ordinarily, these are the defaults specified in the `*_config.py`
-        @# file next to this one.)
-        method_configs = google.api_core.gapic_v1.config.parse_method_configs(
-            client_config['interfaces'][self._INTERFACE_NAME],
+        @# The scopes needed to make gRPC calls to all of the methods defined in
+        @# this service
+        _DEFAULT_SCOPES = (
+            @join auth_scope : xapiClass.authScopes on BREAK
+                '{@auth_scope}',
+            @end
         )
 
-        @# Write the "inner API call" methods to the class.
-        @# These are wrapped versions of the gRPC stub methods, with retry and
-        @# timeout configuration applied, called by the public methods on
-        @# this class.
-        @join apiMethod : xapiClass.apiMethods
-            self._{@apiMethod.name} = google.api_core.gapic_v1.method.wrap_method(
-                self.{@apiMethod.stubName}.{@apiMethod.grpcMethodName},
-                default_retry=method_configs['{@apiMethod.grpcMethodName}'].retry,
-                default_timeout=method_configs['{@apiMethod.grpcMethodName}'].timeout,
-                client_info=client_info,
-            )
+        @# The name of the interface for this client. This is the key used to find
+        @# method configuration in the client_config dictionary.
+        _INTERFACE_NAME = '{@xapiClass.interfaceKey}'
+
+        @if xapiClass.formatResourceFunctions
+
+            @join function : xapiClass.formatResourceFunctions
+                @@classmethod
+                def {@function.name}(cls, {@createResourceFunctionParams(function.resourceIdParams)}):
+                    """Return a fully-qualified {@function.entityName} string."""
+                    return google.api_core.path_template.expand(
+                        '{@function.pattern}',
+                        {@createRenderParams(function.resourceIdParams)}
+                    )
+
+            @end
         @end
-@end
+        def __init__(self, channel=None, credentials=None,
+                client_config={@xapiClass.clientConfigName}.config,
+                client_info=None):
+            """Constructor.
 
-@private pathTemplateSection(xapiClass)
-    @join function : xapiClass.formatResourceFunctions
+            Args:
+                channel (grpc.Channel): A ``Channel`` instance through
+                    which to make calls. This argument is mutually exclusive
+                    with ``credentials``; providing both will raise an exception.
+                credentials (google.auth.credentials.Credentials): The
+                    authorization credentials to attach to requests. These
+                    credentials identify this application to the service. If none
+                    are specified, the client will attempt to ascertain the
+                    credentials from the environment.
+                client_config (dict): A dictionary of call options for each
+                    method. If not specified, the default configuration is used.
+                client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                    The client info used to send a user-agent string along with
+                    API requests. If ``None``, then default info will be used.
+                    Generally, you only need to set this if you're developing
+                    your own client library.
+            """
+            # gRPC channel & client stub initialization.
+            @# If both `channel` and `credentials` are specified, raise an
+            @# exception (channels come with credentials baked in already).
+            if channel is not None and credentials is not None:
+                raise ValueError(
+                    'The `channel` and `credentials` arguments to {} are mutually '
+                    'exclusive.'.format(self.__class__.__name__),
+                )
 
-        {@createResourceFunction(function)}
-    @end
-@end
+            @# Create the channel.
+            if channel is None:
+                channel = google.api_core.grpc_helpers.create_channel(
+                    self.SERVICE_ADDRESS,
+                    credentials=credentials,
+                    scopes=self._DEFAULT_SCOPES,
+                )
 
-@private createResourceFunction(function)
-    @@classmethod
-    def {@function.name}(cls, {@createResourceFunctionParams(function.resourceIdParams)}):
-        """Return a fully-qualified {@function.entityName} string."""
-        return google.api_core.path_template.expand(
-            '{@function.pattern}',
-            {@createRenderParams(function.resourceIdParams)}
-        )
+            @# Create the gRPC stubs.
+            @join stub : xapiClass.stubs
+                self.{@stub.name} = (
+                    {@stub.grpcClientTypeName}(channel))
+            @end
+
+            @if xapiClass.hasLongRunningOperations
+                @# Operations client for methods that return long-running operations
+                @# futures.
+                self.operations_client = (
+                    google.api_core.operations_v1.OperationsClient(channel))
+            @end
+
+            # Client information initialization.
+            if client_info is None:
+                client_info = (
+                    google.api_core.gapic_v1.client_info.DEFAULT_CLIENT_INFO)
+            client_info.gapic_version = _GAPIC_LIBRARY_VERSION
+
+            @# Parse out the default settings for retry and timeout for each RPC
+            @# from the client configuration.
+            @# (Ordinarily, these are the defaults specified in the `*_config.py`
+            @# file next to this one.)
+            method_configs = google.api_core.gapic_v1.config.parse_method_configs(
+                client_config['interfaces'][self._INTERFACE_NAME],
+            )
+
+            @# Write the "inner API call" methods to the class.
+            @# These are wrapped versions of the gRPC stub methods, with retry and
+            @# timeout configuration applied, called by the public methods on
+            @# this class.
+            @join apiMethod : xapiClass.apiMethods
+                self._{@apiMethod.name} = google.api_core.gapic_v1.method.wrap_method(
+                    self.{@apiMethod.stubName}.{@apiMethod.grpcMethodName},
+                    default_retry=method_configs['{@apiMethod.grpcMethodName}'].retry,
+                    default_timeout=method_configs['{@apiMethod.grpcMethodName}'].timeout,
+                    client_info=client_info,
+                )
+            @end
+
+        @# Service calls
+        @join apiMethod : xapiClass.apiMethods on BREAK.add(BREAK)
+            def {@apiMethod.name}(
+                    {@renderMethodParams(apiMethod.methodParams)}):
+                """
+                @join line : util.trimDocs(apiMethod.doc.mainDocLines)
+                    {@line}
+                @end
+
+                @if apiMethod.hasRequestStreaming
+                    EXPERIMENTAL: This method interface might change in the future.
+
+                @end
+                {@exampleCode(apiMethod, apiMethod.initCode)}
+
+                Args:
+                    @join paramDoc : apiMethod.doc.paramDocs
+                        @if paramDoc.lines
+                            {@paramDoc.paramName} ({@paramDoc.typeName}): {@paramDoc.firstLine}
+                                @join line : paramDoc.remainingLines
+                                    {@line}
+                                @end
+                        @else
+                            {@paramDoc.paramName} ({@paramDoc.typeName})
+                        @end
+                    @end
+                @if apiMethod.doc.returnsDocLines
+
+                    Returns:
+                        @join line : apiMethod.doc.returnsDocLines
+                              {@line}
+                        @end
+                @end
+
+                Raises:
+                    @join line : apiMethod.doc.throwsDocLines
+                        {@line}
+                    @end
+                """
+                @if apiMethod.isSingularRequestMethod
+                    @if apiMethod.oneofParams
+                        @join oneOf : apiMethod.oneofParams on BREAK
+                            @# Sanity check: We have some fields which are mutually exclusive;
+                            @# raise ValueError if more than one is sent.
+                            google.api_core.protobuf_helpers.check_oneof(
+                                @join oneOfField : oneOf on BREAK
+                                    {@oneOfField}={@oneOfField},
+                                @end
+                            )
+
+                        @end
+
+
+                    @end
+                    @if apiMethod.optionalRequestObjectParamsNoPageToken
+                        @if apiMethod.requiredRequestObjectParams
+                            request = {@apiMethod.requestTypeName}(
+                                {@requestObjectParams(apiMethod.requiredRequestObjectParams)},
+                                {@requestObjectParams(apiMethod.optionalRequestObjectParamsNoPageToken)},
+                            )
+                        @else
+                            request = {@apiMethod.requestTypeName}(
+                                {@requestObjectParams(apiMethod.optionalRequestObjectParamsNoPageToken)},
+                            )
+                        @end
+                    @else
+                        @if apiMethod.requiredRequestObjectParams
+                            request = {@apiMethod.requestTypeName}(
+                                {@requestObjectParams(apiMethod.requiredRequestObjectParams)},
+                            )
+                        @else
+                            request = {@apiMethod.requestTypeName}()
+                        @end
+                    @end
+
+                    @if apiMethod.headerRequestParams
+
+                        routing_header = google.api_core.gapic_v1.routing_header(
+                            [{@routingHeader(apiMethod.headerRequestParams)}],
+                        )
+                        metadata.append(routing_header)
+
+                    @end
+                @end
+                @switch apiMethod.type
+                @case "OptionalArrayMethod"
+                    @if apiMethod.hasReturnValue
+                        return self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
+                    @else
+                        self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
+                    @end
+                @case "PagedOptionalArrayMethod"
+                    iterator = google.api_core.page_iterator.GRPCIterator(
+                        client=None,
+                        method=functools.partial(self._{@apiMethod.name}{@optionalParams(apiMethod)}),
+                        request={@apiMethod.requestVariableName},
+                        items_field='{@apiMethod.pageStreamingView.resourcesFieldName}',
+                        request_token_field='{@apiMethod.pageStreamingView.requestTokenFieldName}',
+                        response_token_field='{@apiMethod.pageStreamingView.responseTokenFieldName}',
+                    )
+                    return iterator
+                @case "LongRunningOptionalArrayMethod"
+                    operation = self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
+                    return google.api_core.operation.from_gapic(
+                        operation,
+                        self.operations_client,
+                        {@apiMethod.longRunningView.operationPayloadTypeName},
+                        metadata_type={@apiMethod.longRunningView.metadataTypeName},
+                    )
+                @default
+                    {@unhandledCase()}
+                @end
+        @end
+
 @end
 
 @private createResourceFunctionParams(params)
@@ -192,126 +262,8 @@
     @end
 @end
 
-@private methodComments(apiMethod, apiMethodDoc)
-    """
-    @join line : util.trimDocs(apiMethodDoc.mainDocLines)
-        {@line}
-    @end
-
-    @if apiMethod.hasRequestStreaming
-        EXPERIMENTAL: This method interface might change in the future.
-
-    @end
-    {@exampleCode(apiMethod, apiMethod.initCode)}
-
-    Args:
-        @join paramDoc : apiMethodDoc.paramDocs
-            @if paramDoc.lines
-                {@paramDoc.paramName} ({@paramDoc.typeName}): {@paramDoc.firstLine}
-                    @join line : paramDoc.remainingLines
-                        {@line}
-                    @end
-            @else
-                {@paramDoc.paramName} ({@paramDoc.typeName})
-            @end
-        @end
-    @if apiMethodDoc.returnsDocLines
-
-        Returns:
-            @join line : apiMethodDoc.returnsDocLines
-                  {@line}
-            @end
-    @end
-
-    Raises:
-        @join line : apiMethodDoc.throwsDocLines
-            {@line}
-        @end
-    """
-@end
-
-@private serviceMethodsSection(xapiClass)
-    @# Service calls
-    @join apiMethod : xapiClass.apiMethods on BREAK.add(BREAK)
-        {@flattenedMethod(apiMethod)}
-    @end
-@end
-
-@private callLine(apiMethod)
-    @switch apiMethod.type
-    @case "OptionalArrayMethod"
-        @if apiMethod.hasReturnValue
-            return self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
-        @else
-            self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
-        @end
-    @case "PagedOptionalArrayMethod"
-        iterator = google.api_core.page_iterator.GRPCIterator(
-            client=None,
-            method=functools.partial(self._{@apiMethod.name}{@optionalParams(apiMethod)}),
-            request={@apiMethod.requestVariableName},
-            items_field='{@apiMethod.pageStreamingView.resourcesFieldName}',
-            request_token_field='{@apiMethod.pageStreamingView.requestTokenFieldName}',
-            response_token_field='{@apiMethod.pageStreamingView.responseTokenFieldName}',
-        )
-        return iterator
-    @case "LongRunningOptionalArrayMethod"
-        operation = self._{@apiMethod.name}({@apiMethod.requestVariableName}{@optionalParams(apiMethod)})
-        return google.api_core.operation.from_gapic(
-            operation,
-            self.operations_client,
-            {@apiMethod.longRunningView.operationPayloadTypeName},
-            metadata_type={@apiMethod.longRunningView.metadataTypeName},
-        )
-    @default
-        {@unhandledCase()}
-    @end
-@end
-
 @private optionalParams(apiMethod)
     , retry=retry, timeout=timeout, metadata=metadata
-@end
-
-@private flattenedMethod(apiMethod)
-    def {@apiMethod.name}(
-            {@renderMethodParams(apiMethod.methodParams)}):
-        {@methodComments(apiMethod, apiMethod.doc)}
-        @if apiMethod.isSingularRequestMethod
-            @if apiMethod.oneofParams
-                {@checkOneOfParams(apiMethod.oneofParams)}
-
-            @end
-            @if apiMethod.optionalRequestObjectParamsNoPageToken
-                @if apiMethod.requiredRequestObjectParams
-                    request = {@apiMethod.requestTypeName}(
-                        {@requestObjectParams(apiMethod.requiredRequestObjectParams)},
-                        {@requestObjectParams(apiMethod.optionalRequestObjectParamsNoPageToken)},
-                    )
-                @else
-                    request = {@apiMethod.requestTypeName}(
-                        {@requestObjectParams(apiMethod.optionalRequestObjectParamsNoPageToken)},
-                    )
-                @end
-            @else
-                @if apiMethod.requiredRequestObjectParams
-                    request = {@apiMethod.requestTypeName}(
-                        {@requestObjectParams(apiMethod.requiredRequestObjectParams)},
-                    )
-                @else
-                    request = {@apiMethod.requestTypeName}()
-                @end
-            @end
-
-            @if apiMethod.headerRequestParams
-
-                routing_header = google.api_core.gapic_v1.routing_header(
-                    [{@routingHeader(apiMethod.headerRequestParams)}],
-                )
-                metadata.append(routing_header)
-
-            @end
-        @end
-        {@callLine(apiMethod)}
 @end
 
 @private renderMethodParams(params)
@@ -321,19 +273,6 @@
         @else
             {@param.name}
         @end
-    @end
-@end
-
-@private checkOneOfParams(oneOfs)
-    @join oneOf : oneOfs on BREAK
-        @# Sanity check: We have some fields which are mutually exclusive;
-        @# raise ValueError if more than one is sent.
-        google.api_core.protobuf_helpers.check_oneof(
-            @join oneOfField : oneOf on BREAK
-                {@oneOfField}={@oneOfField},
-            @end
-        )
-
     @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -42,8 +42,26 @@
         @# method configuration in the client_config dictionary.
         _INTERFACE_NAME = '{@xapiClass.interfaceKey}'
 
-        @if xapiClass.formatResourceFunctions
 
+        @@classmethod
+        def create_channel(cls, credentials=none, **kwargs):
+            """Create a secure channel with credentials scoped to this API.
+            Args:
+                credentials (google.auth.credentials.Credentials): The credentials. If
+                    not specified, then this function will attempt to ascertain the
+                    credentials from the environment using :func:`google.auth.default`..
+                kwargs: Additional key-word args passed to
+                    :func:`google.auth.transport.grpc.secure_authorized_channel`.
+            Returns:
+                grpc.Channel: The created channel.
+            """
+            return google.api_core.grpc_helpers.create_channel(
+                cls.SERVICE_ADDRESS,
+                credentials=credentials,
+                scopes=cls._DEFAULT_SCOPES,
+            )
+
+        @if xapiClass.formatResourceFunctions
             @join function : xapiClass.formatResourceFunctions
                 @@classmethod
                 def {@function.name}(cls, {@createResourceFunctionParams(function.resourceIdParams)}):

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -1063,6 +1063,24 @@ class LibraryServiceClient(object):
 
 
     @classmethod
+    def create_channel(cls, credentials=none, **kwargs):
+        """Create a secure channel with credentials scoped to this API.
+        Args:
+            credentials (google.auth.credentials.Credentials): The credentials. If
+                not specified, then this function will attempt to ascertain the
+                credentials from the environment using :func:`google.auth.default`..
+            kwargs: Additional key-word args passed to
+                :func:`google.auth.transport.grpc.secure_authorized_channel`.
+        Returns:
+            grpc.Channel: The created channel.
+        """
+        return google.api_core.grpc_helpers.create_channel(
+            cls.SERVICE_ADDRESS,
+            credentials=credentials,
+            scopes=cls._DEFAULT_SCOPES,
+        )
+
+    @classmethod
     def shelf_path(cls, shelf_id):
         """Return a fully-qualified shelf string."""
         return google.api_core.path_template.expand(

--- a/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
@@ -808,6 +808,25 @@ class NoTemplatesAPIServiceClient(object):
     # method configuration in the client_config dictionary.
     _INTERFACE_NAME = 'google.cloud.example.v1.NoTemplatesAPIService'
 
+
+    @classmethod
+    def create_channel(cls, credentials=none, **kwargs):
+        """Create a secure channel with credentials scoped to this API.
+        Args:
+            credentials (google.auth.credentials.Credentials): The credentials. If
+                not specified, then this function will attempt to ascertain the
+                credentials from the environment using :func:`google.auth.default`..
+            kwargs: Additional key-word args passed to
+                :func:`google.auth.transport.grpc.secure_authorized_channel`.
+        Returns:
+            grpc.Channel: The created channel.
+        """
+        return google.api_core.grpc_helpers.create_channel(
+            cls.SERVICE_ADDRESS,
+            credentials=credentials,
+            scopes=cls._DEFAULT_SCOPES,
+        )
+
     def __init__(self, channel=None, credentials=None,
             client_config=no_templates_api_service_client_config.config,
             client_info=None):


### PR DESCRIPTION
Depends on #1968. 

# What
This PR adds a class method to the generated clients which is used to create a gRPC channel that is scoped to the API. Currently, the way to use interceptors is a clunky flow since wrapped methods are generated at initialization making it such that all interceptors must be bound to the channel prior to initialization. This, in turn, makes it such that the user must know both the gRPC target and the auth scopes. This added method takes away the need for the user to know the target and scopes.

# Usage
## Simple Usage
```py
import grpc

from google.cloud.example import library_v1

channel = library_v1.LibraryServiceClient.create_channel()
channel = grpc.intercept_channel(channel, ExampleInterceptor())

client = library_v1.LibraryServiceClient(channel=channel)
```

## Wrapping with custom exceptions
```py 
import grpc

from google.cloud.example import library_v1

class CustomExceptionInterceptor(grpc.UnaryUnaryClientInterceptor):
    def intercept_unary_unary(self, continuation, client_call_details, request):
        response = continuation(client_call_details, request_or_iterator)
        if response.exception():
            raise CustomException(response.exception())
        return response


channel = library_v1.LibraryServiceClient.create_channel()
channel = grpc.intercept_channel(channel, CustomExceptionInterceptor())

client = library_v1.LibraryServiceClient(channel=channel)
```

## Adding custom metadata
```py
import grpc

from google.cloud.example import library_v1

class CustomExceptionInterceptor(grpc.UnaryUnaryClientInterceptor):
    def intercept_unary_unary(self, continuation, client_call_details, request):
        metadata = []
        if client_call_details.metadata is not None:
            metadata = list(client_call_details.metadata)
        metadata.append((
            '<HEADER>',
            '<VALUE'>,
        ))
        client_call_details = _ClientCallDetails(
            client_call_details.method, client_call_details.timeout, metadata,
            client_call_details.credentials)
        return continuation(client_call_details, request_or_iterator)


channel = library_v1.LibraryServiceClient.create_channel()
channel = grpc.intercept_channel(channel, CustomExceptionInterceptor())

client = library_v1.LibraryServiceClient(channel=channel)
```