### PR TITLE
use the latest google-gax version for Node.js

### DIFF
--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -92,7 +92,7 @@ $ npm install --save @google-cloud/library
     "Google Example Library API"
   ],
   "dependencies": {
-    "google-gax": "^0.14.0",
+    "google-gax": "^0.16.1",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0",
     "protobufjs": "^6.8.0"

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -92,7 +92,7 @@ $ npm install --save @google-cloud/library
     "Google Example Library API"
   ],
   "dependencies": {
-    "google-gax": "^0.14.0",
+    "google-gax": "^0.16.1",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0",
     "protobufjs": "^6.8.0"

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -59,7 +59,7 @@ $ npm install --save @google-cloud/multiple-services
     "Google Example API"
   ],
   "dependencies": {
-    "google-gax": "^0.14.0",
+    "google-gax": "^0.16.1",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0",
     "lodash.union": "^4.6.0"

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -58,7 +58,7 @@ $ npm install --save example
     "Google Fake API"
   ],
   "dependencies": {
-    "google-gax": "^0.14.0",
+    "google-gax": "^0.16.1",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0"
   },

--- a/src/test/java/com/google/api/codegen/testsrc/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_pkg.yaml
@@ -46,7 +46,7 @@ gax_version:
     lower: '0.15.0'
     upper: '0.16.0'
   nodejs:
-    lower: '0.14.0'
+    lower: '0.16.1'
   php:
     lower: '0.6.*'
   ruby:

--- a/src/test/java/com/google/api/codegen/testsrc/longrunning_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/longrunning_pkg.yaml
@@ -43,7 +43,7 @@ gax_version:
     lower: '0.15.0'
     upper: '0.16.0'
   nodejs:
-    lower: '0.14.0'
+    lower: '0.16.1'
   php:
     lower: '0.6.*'
   ruby:

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg.yaml
@@ -47,7 +47,7 @@ gax_version:
     lower: '0.15.0'
     upper: '0.16.0'
   nodejs:
-    lower: '0.14.0'
+    lower: '0.16.1'
   php:
     lower: '0.6.*'
   ruby:

--- a/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg.yaml
@@ -44,7 +44,7 @@ gax_version:
     lower: '0.15.0'
     upper: '0.16.0'
   nodejs:
-    lower: '0.14.0'
+    lower: '0.16.1'
   php:
     lower: '0.6.*'
   ruby:


### PR DESCRIPTION
The latest version of `google-gax` brings in new gRPC dependency that we want to use. 0.14.0 is way too old, and minor versions in the 0.x range are pinned (unfortunately). Let's use 0.16.1 explicitly.