### PR TITLE
Python: Submodule fix.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** The SurfaceNamer for Python. */
 public class PythonSurfaceNamer extends SurfaceNamer {
@@ -101,7 +102,20 @@ public class PythonSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getVersionedDirectoryNamespace() {
+    Pattern versionNamespacePattern =
+        Pattern.compile(
+            "(.+?)_"
+                + "([vV]\\d+)" // Major version eg: v1
+                + "([pP_]\\d+)?" // Point release eg: p2
+                + "(([aA]lpha|[bB]eta)\\d*)?"); //  Release level eg: alpha3
+    List<String> names = new ArrayList<>();
     String namespace = getPackageName();
+    for (String n : namespace.split("\\.")) {
+      names.add(n);
+      if (versionNamespacePattern.matcher(n).matches()) {
+        return Joiner.on(".").join(names);
+      }
+    }
     return namespace.substring(0, namespace.lastIndexOf('.'));
   }
 

--- a/src/test/java/com/google/api/codegen/GapicCodeGeneratorTest.java
+++ b/src/test/java/com/google/api/codegen/GapicCodeGeneratorTest.java
@@ -122,6 +122,11 @@ public class GapicCodeGeneratorTest extends GapicTestBase2 {
             "no_path_templates_pkg.yaml",
             "no_path_templates"),
         GapicTestBase2.createTestConfig(
+            MainGapicProviderFactory.PYTHON,
+            new String[] {"python_gapic.yaml", "multiple_services_gapic.yaml"},
+            "multiple_services_pkg.yaml",
+            "multiple_services"),
+        GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.NODEJS,
             new String[] {"nodejs_gapic.yaml", "library_gapic.yaml"},
             "library_pkg.yaml",

--- a/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
@@ -608,14 +608,14 @@ napoleon_use_rtype = True
 Client for Google Example API
 =============================
 
-.. automodule:: google.cloud.example_v1.foo
+.. automodule:: google.cloud.example_v1
     :members:
     :inherited-members:
 ============== file: docs/gapic/v1/types.rst ==============
 Types for Google Example API Client
 ===================================
 
-.. automodule:: google.cloud.example_v1.foo.types
+.. automodule:: google.cloud.example_v1.types
     :members:
 ============== file: docs/index.rst ==============
 Python Client for Google Example API (`Alpha`_)
@@ -743,9 +743,7 @@ try:
 except ImportError:
     import pkgutil
     __path__ = pkgutil.extend_path(__path__, __name__)
-============== file: google/cloud/example_v1/__init__.py ==============
-
-============== file: google/cloud/example_v1/foo.py ==============
+============== file: google/cloud/example.py ==============
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -763,9 +761,9 @@ except ImportError:
 
 from __future__ import absolute_import
 
-from google.cloud.example_v1.foo import DecrementerServiceClient
-from google.cloud.example_v1.foo import IncrementerServiceClient
-from google.cloud.example_v1.foo import types
+from google.cloud.example_v1 import DecrementerServiceClient
+from google.cloud.example_v1 import IncrementerServiceClient
+from google.cloud.example_v1 import types
 
 
 __all__ = (
@@ -773,7 +771,7 @@ __all__ = (
     'IncrementerServiceClient',
     'DecrementerServiceClient',
 )
-============== file: google/cloud/example_v1/foo/__init__.py ==============
+============== file: google/cloud/example_v1/__init__.py ==============
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -791,7 +789,7 @@ __all__ = (
 
 from __future__ import absolute_import
 
-from google.cloud.example_v1.foo import types
+from google.cloud.example_v1 import types
 from google.cloud.example_v1.foo.gapic import decrementer_service_client
 from google.cloud.example_v1.foo.gapic import incrementer_service_client
 
@@ -808,6 +806,8 @@ __all__ = (
     'IncrementerServiceClient',
     'DecrementerServiceClient',
 )
+============== file: google/cloud/example_v1/foo/__init__.py ==============
+
 ============== file: google/cloud/example_v1/foo/gapic/__init__.py ==============
 
 ============== file: google/cloud/example_v1/foo/gapic/decrementer_service_client.py ==============
@@ -936,9 +936,9 @@ class DecrementerServiceClient(object):
         Decrement.
 
         Example:
-            >>> from google.cloud.example_v1 import foo
+            >>> from google.cloud import example_v1
             >>>
-            >>> client = foo.DecrementerServiceClient()
+            >>> client = example_v1.DecrementerServiceClient()
             >>>
             >>> client.decrement()
 
@@ -1102,9 +1102,9 @@ class IncrementerServiceClient(object):
         Increment.
 
         Example:
-            >>> from google.cloud.example_v1 import foo
+            >>> from google.cloud import example_v1
             >>>
-            >>> client = foo.IncrementerServiceClient()
+            >>> client = example_v1.IncrementerServiceClient()
             >>>
             >>> client.increment()
 
@@ -1142,7 +1142,7 @@ config = {
   }
 }
 
-============== file: google/cloud/example_v1/foo/types.py ==============
+============== file: google/cloud/example_v1/types.py ==============
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1175,7 +1175,7 @@ for module in (http_pb2,
                descriptor_pb2,
                empty_pb2,):
     for name, message in get_messages(module).items():
-        message.__module__ = 'google.cloud.example_v1.foo.types'
+        message.__module__ = 'google.cloud.example_v1.types'
         setattr(sys.modules[__name__], name, message)
         names.append(name)
 
@@ -1338,7 +1338,7 @@ setuptools.setup(
 
 import pytest
 
-from google.cloud.example_v1 import foo
+from google.cloud import example_v1
 from google.cloud.example_v1.foo.proto import multiple_services_pb2
 from google.protobuf import empty_pb2
 
@@ -1383,7 +1383,7 @@ class TestDecrementerServiceClient(object):
 
     def test_decrement(self):
         channel = ChannelStub()
-        client = foo.DecrementerServiceClient(
+        client = example_v1.DecrementerServiceClient(
             channel=channel)
 
         client.decrement()
@@ -1396,7 +1396,7 @@ class TestDecrementerServiceClient(object):
     def test_decrement_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = foo.DecrementerServiceClient(
+        client = example_v1.DecrementerServiceClient(
              channel=channel)
 
         with pytest.raises(CustomException):
@@ -1421,7 +1421,7 @@ class TestDecrementerServiceClient(object):
 
 import pytest
 
-from google.cloud.example_v1 import foo
+from google.cloud import example_v1
 from google.cloud.example_v1.foo.proto import multiple_services_pb2
 from google.protobuf import empty_pb2
 
@@ -1466,7 +1466,7 @@ class TestIncrementerServiceClient(object):
 
     def test_increment(self):
         channel = ChannelStub()
-        client = foo.IncrementerServiceClient(
+        client = example_v1.IncrementerServiceClient(
             channel=channel)
 
         client.increment()
@@ -1479,7 +1479,7 @@ class TestIncrementerServiceClient(object):
     def test_increment_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = foo.IncrementerServiceClient(
+        client = example_v1.IncrementerServiceClient(
              channel=channel)
 
         with pytest.raises(CustomException):

--- a/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
@@ -1,0 +1,1487 @@
+============== file: LICENSE ==============
+                            Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+============== file: MANIFEST.in ==============
+include README.rst LICENSE
+recursive-include google *.json *.proto
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__
+
+============== file: README.rst ==============
+Python Client for Google Example API (`Alpha`_)
+===============================================
+
+`Google Example API`_: This description tests descriptions that span multiple lines. This is a service that increments and decrements a counter.
+
+- `Client Library Documentation`_
+- `Product Documentation`_
+
+.. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. _Google Example API: https://cloud.google.com/multiple_services
+.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/multiple_services/usage.html
+.. _Product Documentation:  https://cloud.google.com/multiple_services
+
+Quick Start
+-----------
+
+In order to use this library, you first need to go through the following steps:
+
+1. `Select or create a Cloud Platform project.`_
+2. `Enable billing for your project.`_
+3. `Enable the Google Example API.`_
+4. `Setup Authentication.`_
+
+.. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
+.. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
+.. _Enable the Google Example API.:  https://cloud.google.com/multiple_services
+.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/stable/core/auth.html
+
+Installation
+~~~~~~~~~~~~
+
+Install this library in a `virtualenv`_ using pip. `virtualenv`_ is a tool to
+create isolated Python environments. The basic problem it addresses is one of
+dependencies and versions, and indirectly permissions.
+
+With `virtualenv`_, it's possible to install this library without needing system
+install permissions, and without clashing with the installed system
+dependencies.
+
+.. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
+
+
+Mac/Linux
+^^^^^^^^^
+
+.. code-block:: console
+
+    pip install virtualenv
+    virtualenv <your-env>
+    source <your-env>/bin/activate
+    <your-env>/bin/pip install google-cloud-multiple_services
+
+
+Windows
+^^^^^^^
+
+.. code-block:: console
+
+    pip install virtualenv
+    virtualenv <your-env>
+    <your-env>\Scripts\activate
+    <your-env>\Scripts\pip.exe install google-cloud-multiple_services
+
+Next Steps
+~~~~~~~~~~
+
+-  Read the `Client Library Documentation`_ for Google Example API
+   API to see other available methods on the client.
+-  Read the `Google Example API Product documentation`_ to learn
+   more about the product and see How-to Guides.
+-  View this `repository’s main README`_ to see the full list of Cloud
+   APIs that we cover.
+
+.. _Google Example API Product documentation:  https://cloud.google.com/multiple_services
+.. _repository’s main README: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+============== file: docs/conf.py ==============
+# -*- coding: utf-8 -*-
+#
+# google-cloud-multiple_services documentation build configuration file
+#
+# This file is execfile()d with the current directory set to its
+# containing dir.
+#
+# Note that not all possible configuration values are present in this
+# autogenerated file.
+#
+# All configuration values have a default; values that are commented out
+# serve to show the default.
+
+import sys
+import os
+import shlex
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+sys.path.insert(0, os.path.abspath('..'))
+
+__version__ = '0.15.0'
+
+# -- General configuration ------------------------------------------------
+
+# If your documentation needs a minimal Sphinx version, state it here.
+#needs_sphinx = '1.0'
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.coverage',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+]
+
+# autodoc/autosummary flags
+autoclass_content = 'both'
+autodoc_default_flags = ['members']
+autosummary_generate = True
+
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# The suffix(es) of source filenames.
+# You can specify multiple suffix as a list of string:
+# source_suffix = ['.rst', '.md']
+source_suffix = '.rst'
+
+# The encoding of source files.
+#source_encoding = 'utf-8-sig'
+
+# The master toctree document.
+master_doc = 'index'
+
+# General information about the project.
+project = u'google-cloud-multiple_services'
+copyright = u'2017, Google'
+author = u'Google APIs'
+
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The full version, including alpha/beta/rc tags.
+release = __version__
+# The short X.Y version.
+version = '.'.join(release.split('.')[0:2])
+
+# The language for content autogenerated by Sphinx. Refer to documentation
+# for a list of supported languages.
+#
+# This is also used if you do content translation via gettext catalogs.
+# Usually you set "language" from the command line for these cases.
+language = None
+
+# There are two options for replacing |today|: either, you set today to some
+# non-false value, then it is used:
+#today = ''
+# Else, today_fmt is used as the format for a strftime call.
+#today_fmt = '%B %d, %Y'
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+exclude_patterns = ['_build']
+
+# The reST default role (used for this markup: `text`) to use for all
+# documents.
+#default_role = None
+
+# If true, '()' will be appended to :func: etc. cross-reference text.
+#add_function_parentheses = True
+
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+#add_module_names = True
+
+# If true, sectionauthor and moduleauthor directives will be shown in the
+# output. They are ignored by default.
+#show_authors = False
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'sphinx'
+
+# A list of ignored prefixes for module index sorting.
+#modindex_common_prefix = []
+
+# If true, keep warnings as "system message" paragraphs in the built documents.
+#keep_warnings = False
+
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = True
+
+
+# -- Options for HTML output ----------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+html_theme = 'sphinx_rtd_theme'
+
+# Theme options are theme-specific and customize the look and feel of a theme
+# further.  For a list of options available for each theme, see the
+# documentation.
+#html_theme_options = {}
+
+# Add any paths that contain custom themes here, relative to this directory.
+#html_theme_path = []
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+#html_title = None
+
+# A shorter title for the navigation bar.  Default is the same as html_title.
+#html_short_title = None
+
+# The name of an image file (relative to this directory) to place at the top
+# of the sidebar.
+#html_logo = None
+
+# The name of an image file (within the static path) to use as favicon of the
+# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
+# pixels large.
+#html_favicon = None
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+# html_static_path = []
+
+# Add any extra paths that contain custom files (such as robots.txt or
+# .htaccess) here, relative to this directory. These files are copied
+# directly to the root of the documentation.
+#html_extra_path = []
+
+# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
+# using the given strftime format.
+#html_last_updated_fmt = '%b %d, %Y'
+
+# If true, SmartyPants will be used to convert quotes and dashes to
+# typographically correct entities.
+#html_use_smartypants = True
+
+# Custom sidebar templates, maps document names to template names.
+#html_sidebars = {}
+
+# Additional templates that should be rendered to pages, maps page names to
+# template names.
+#html_additional_pages = {}
+
+# If false, no module index is generated.
+#html_domain_indices = True
+
+# If false, no index is generated.
+#html_use_index = True
+
+# If true, the index is split into individual pages for each letter.
+#html_split_index = False
+
+# If true, links to the reST sources are added to the pages.
+#html_show_sourcelink = True
+
+# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
+#html_show_sphinx = True
+
+# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
+#html_show_copyright = True
+
+# If true, an OpenSearch description file will be output, and all pages will
+# contain a <link> tag referring to it.  The value of this option must be the
+# base URL from which the finished HTML is served.
+#html_use_opensearch = ''
+
+# This is the file name suffix for HTML files (e.g. ".xhtml").
+#html_file_suffix = None
+
+# Language to be used for generating the HTML full-text search index.
+# Sphinx supports the following languages:
+#   'da', 'de', 'en', 'es', 'fi', 'fr', 'hu', 'it', 'ja'
+#   'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr'
+#html_search_language = 'en'
+
+# A dictionary with options for the search language support, empty by default.
+# Now only 'ja' uses this config value
+#html_search_options = {'type': 'default'}
+
+# The name of a javascript file (relative to the configuration directory) that
+# implements a search results scorer. If empty, the default will be used.
+#html_search_scorer = 'scorer.js'
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = 'google-cloud-multiple_services-doc'
+
+# -- Options for LaTeX output ---------------------------------------------
+
+latex_elements = {
+# The paper size ('letterpaper' or 'a4paper').
+#'papersize': 'letterpaper',
+
+# The font size ('10pt', '11pt' or '12pt').
+#'pointsize': '10pt',
+
+# Additional stuff for the LaTeX preamble.
+#'preamble': '',
+
+# Latex figure (float) alignment
+#'figure_align': 'htbp',
+}
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title,
+#  author, documentclass [howto, manual, or own class]).
+latex_documents = [
+  (master_doc, 'google-cloud-multiple_services.tex', u'google-cloud-multiple_services Documentation',
+   author, 'manual'),
+]
+
+# The name of an image file (relative to this directory) to place at the top of
+# the title page.
+#latex_logo = None
+
+# For "manual" documents, if this is true, then toplevel headings are parts,
+# not chapters.
+#latex_use_parts = False
+
+# If true, show page references after internal links.
+#latex_show_pagerefs = False
+
+# If true, show URL addresses after external links.
+#latex_show_urls = False
+
+# Documents to append as an appendix to all manuals.
+#latex_appendices = []
+
+# If false, no module index is generated.
+#latex_domain_indices = True
+
+
+# -- Options for manual page output ---------------------------------------
+
+# One entry per manual page. List of tuples
+# (source start file, name, description, authors, manual section).
+man_pages = [
+    (master_doc, 'google-cloud-multiple_services', u'google-cloud-multiple_services Documentation',
+     [author], 1)
+]
+
+# If true, show URL addresses after external links.
+#man_show_urls = False
+
+
+# -- Options for Texinfo output -------------------------------------------
+
+# Grouping the document tree into Texinfo files. List of tuples
+# (source start file, target name, title, author,
+#  dir menu entry, description, category)
+texinfo_documents = [
+  (master_doc, 'google-cloud-multiple_services', u'google-cloud-multiple_services Documentation',
+   author, 'google-cloud-multiple_services', 'GAPIC library for the {metadata.shortName} v1 service',
+   'APIs'),
+]
+
+# Documents to append as an appendix to all manuals.
+#texinfo_appendices = []
+
+# If false, no module index is generated.
+#texinfo_domain_indices = True
+
+# How to display URL addresses: 'footnote', 'no', or 'inline'.
+#texinfo_show_urls = 'footnote'
+
+# If true, do not generate a @detailmenu in the "Top" node's menu.
+#texinfo_no_detailmenu = False
+
+
+# Example configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {
+    'python': ('http://python.readthedocs.org/en/latest/', None),
+    'gax': ('https://gax-python.readthedocs.org/en/latest/', None),
+}
+
+
+# Napoleon settings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+
+============== file: docs/gapic/v1/api.rst ==============
+Client for Google Example API
+=============================
+
+.. automodule:: google.cloud.example_v1.foo
+    :members:
+    :inherited-members:
+============== file: docs/gapic/v1/types.rst ==============
+Types for Google Example API Client
+===================================
+
+.. automodule:: google.cloud.example_v1.foo.types
+    :members:
+============== file: docs/index.rst ==============
+Python Client for Google Example API (`Alpha`_)
+===============================================
+
+`Google Example API`_: This description tests descriptions that span multiple lines. This is a service that increments and decrements a counter.
+
+- `Client Library Documentation`_
+- `Product Documentation`_
+
+.. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. _Google Example API: https://cloud.google.com/multiple_services
+.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/multiple_services/usage.html
+.. _Product Documentation:  https://cloud.google.com/multiple_services
+
+Quick Start
+-----------
+
+In order to use this library, you first need to go through the following steps:
+
+1. `Select or create a Cloud Platform project.`_
+2. `Enable billing for your project.`_
+3. `Enable the Google Example API.`_
+4. `Setup Authentication.`_
+
+.. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
+.. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
+.. _Enable the Google Example API.:  https://cloud.google.com/multiple_services
+.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/stable/core/auth.html
+
+Installation
+~~~~~~~~~~~~
+
+Install this library in a `virtualenv`_ using pip. `virtualenv`_ is a tool to
+create isolated Python environments. The basic problem it addresses is one of
+dependencies and versions, and indirectly permissions.
+
+With `virtualenv`_, it's possible to install this library without needing system
+install permissions, and without clashing with the installed system
+dependencies.
+
+.. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
+
+
+Mac/Linux
+^^^^^^^^^
+
+.. code-block:: console
+
+    pip install virtualenv
+    virtualenv <your-env>
+    source <your-env>/bin/activate
+    <your-env>/bin/pip install google-cloud-multiple_services
+
+
+Windows
+^^^^^^^
+
+.. code-block:: console
+
+    pip install virtualenv
+    virtualenv <your-env>
+    <your-env>\Scripts\activate
+    <your-env>\Scripts\pip.exe install google-cloud-multiple_services
+
+Next Steps
+~~~~~~~~~~
+
+-  Read the `Client Library Documentation`_ for Google Example API
+   API to see other available methods on the client.
+-  Read the `Google Example API Product documentation`_ to learn
+   more about the product and see How-to Guides.
+-  View this `repository’s main README`_ to see the full list of Cloud
+   APIs that we cover.
+
+.. _Google Example API Product documentation:  https://cloud.google.com/multiple_services
+.. _repository’s main README: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+
+Api Reference
+-------------
+.. toctree::
+    :maxdepth: 2
+
+    gapic/v1/api
+    gapic/v1/types
+============== file: google/__init__.py ==============
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)
+============== file: google/cloud/__init__.py ==============
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)
+============== file: google/cloud/example_v1/__init__.py ==============
+
+============== file: google/cloud/example_v1/foo.py ==============
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import absolute_import
+
+from google.cloud.example_v1.foo import DecrementerServiceClient
+from google.cloud.example_v1.foo import IncrementerServiceClient
+from google.cloud.example_v1.foo import types
+
+
+__all__ = (
+    'types',
+    'IncrementerServiceClient',
+    'DecrementerServiceClient',
+)
+============== file: google/cloud/example_v1/foo/__init__.py ==============
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import absolute_import
+
+from google.cloud.example_v1.foo import types
+from google.cloud.example_v1.foo.gapic import decrementer_service_client
+from google.cloud.example_v1.foo.gapic import incrementer_service_client
+
+
+class IncrementerServiceClient(incrementer_service_client.IncrementerServiceClient):
+    __doc__ = incrementer_service_client.IncrementerServiceClient.__doc__
+
+class DecrementerServiceClient(decrementer_service_client.DecrementerServiceClient):
+    __doc__ = decrementer_service_client.DecrementerServiceClient.__doc__
+
+
+__all__ = (
+    'types',
+    'IncrementerServiceClient',
+    'DecrementerServiceClient',
+)
+============== file: google/cloud/example_v1/foo/gapic/__init__.py ==============
+
+============== file: google/cloud/example_v1/foo/gapic/decrementer_service_client.py ==============
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Accesses the google.cloud.example.v1.foo DecrementerService API."""
+
+import pkg_resources
+
+import google.api_core.gapic_v1.client_info
+import google.api_core.gapic_v1.config
+import google.api_core.gapic_v1.method
+import google.api_core.grpc_helpers
+
+from google.cloud.example_v1.foo.gapic import decrementer_service_client_config
+from google.cloud.example_v1.foo.proto import multiple_services_pb2
+from google.cloud.example_v1.foo.proto import multiple_services_pb2_grpc
+from google.protobuf import empty_pb2
+
+
+
+_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
+    'google-cloud-multiple_services',
+).version
+
+
+class DecrementerServiceClient(object):
+    SERVICE_ADDRESS = 'no-path-templates.googleapis.com:443'
+    """The default address of the service."""
+
+    # The scopes needed to make gRPC calls to all of the methods defined in
+    # this service
+    _DEFAULT_SCOPES = (
+    )
+
+    # The name of the interface for this client. This is the key used to find
+    # method configuration in the client_config dictionary.
+    _INTERFACE_NAME = 'google.cloud.example.v1.foo.DecrementerService'
+
+    def __init__(self, channel=None, credentials=None,
+            client_config=decrementer_service_client_config.config,
+            client_info=None):
+        """Constructor.
+
+        Args:
+            channel (grpc.Channel): A ``Channel`` instance through
+                which to make calls. This argument is mutually exclusive
+                with ``credentials``; providing both will raise an exception.
+            credentials (google.auth.credentials.Credentials): The
+                authorization credentials to attach to requests. These
+                credentials identify this application to the service. If none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
+            client_config (dict): A dictionary of call options for each
+                method. If not specified, the default configuration is used.
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
+                your own client library.
+        """
+        # If both `channel` and `credentials` are specified, raise an
+        # exception (channels come with credentials baked in already).
+        if channel is not None and credentials is not None:
+            raise ValueError(
+                'The `channel` and `credentials` arguments to {} are mutually '
+                'exclusive.'.format(self.__class__.__name__),
+            )
+
+        # Create the channel.
+        if channel is None:
+            channel = google.api_core.grpc_helpers.create_channel(
+                self.SERVICE_ADDRESS,
+                credentials=credentials,
+                scopes=self._DEFAULT_SCOPES,
+            )
+
+        # Create the gRPC stubs.
+        self.decrementer_service_stub = (
+            multiple_services_pb2_grpc.DecrementerServiceStub(channel))
+
+
+        if client_info is None:
+            client_info = (
+                google.api_core.gapic_v1.client_info.DEFAULT_CLIENT_INFO)
+        client_info.gapic_version = _GAPIC_LIBRARY_VERSION
+
+        # Parse out the default settings for retry and timeout for each RPC
+        # from the client configuration.
+        # (Ordinarily, these are the defaults specified in the `*_config.py`
+        # file next to this one.)
+        method_configs = google.api_core.gapic_v1.config.parse_method_configs(
+            client_config['interfaces'][self._INTERFACE_NAME],
+        )
+
+        # Write the "inner API call" methods to the class.
+        # These are wrapped versions of the gRPC stub methods, with retry and
+        # timeout configuration applied, called by the public methods on
+        # this class.
+        self._decrement = google.api_core.gapic_v1.method.wrap_method(
+            self.decrementer_service_stub.Decrement,
+            default_retry=method_configs['Decrement'].retry,
+            default_timeout=method_configs['Decrement'].timeout,
+            client_info=client_info,
+        )
+
+    # Service calls
+    def decrement(
+            self,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+        Decrement.
+
+        Example:
+            >>> from google.cloud.example_v1 import foo
+            >>>
+            >>> client = foo.DecrementerServiceClient()
+            >>>
+            >>> client.decrement()
+
+        Args:
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will not
+                be retried.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+        """
+        request = multiple_services_pb2.DecrementRequest()
+        self._decrement(request, retry=retry, timeout=timeout, metadata=metadata)
+
+============== file: google/cloud/example_v1/foo/gapic/decrementer_service_client_config.py ==============
+config = {
+  "interfaces": {
+    "google.cloud.example.v1.foo.DecrementerService": {
+      "retry_codes": {},
+      "retry_params": {},
+      "methods": {
+        "Decrement": {
+          "timeout_millis": 10000
+        }
+      }
+    }
+  }
+}
+
+============== file: google/cloud/example_v1/foo/gapic/incrementer_service_client.py ==============
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Accesses the google.cloud.example.v1.foo IncrementerService API."""
+
+import pkg_resources
+
+import google.api_core.gapic_v1.client_info
+import google.api_core.gapic_v1.config
+import google.api_core.gapic_v1.method
+import google.api_core.grpc_helpers
+
+from google.cloud.example_v1.foo.gapic import incrementer_service_client_config
+from google.cloud.example_v1.foo.proto import multiple_services_pb2
+from google.cloud.example_v1.foo.proto import multiple_services_pb2_grpc
+from google.protobuf import empty_pb2
+
+
+
+_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
+    'google-cloud-multiple_services',
+).version
+
+
+class IncrementerServiceClient(object):
+    SERVICE_ADDRESS = 'no-path-templates.googleapis.com:443'
+    """The default address of the service."""
+
+    # The scopes needed to make gRPC calls to all of the methods defined in
+    # this service
+    _DEFAULT_SCOPES = (
+    )
+
+    # The name of the interface for this client. This is the key used to find
+    # method configuration in the client_config dictionary.
+    _INTERFACE_NAME = 'google.cloud.example.v1.foo.IncrementerService'
+
+    def __init__(self, channel=None, credentials=None,
+            client_config=incrementer_service_client_config.config,
+            client_info=None):
+        """Constructor.
+
+        Args:
+            channel (grpc.Channel): A ``Channel`` instance through
+                which to make calls. This argument is mutually exclusive
+                with ``credentials``; providing both will raise an exception.
+            credentials (google.auth.credentials.Credentials): The
+                authorization credentials to attach to requests. These
+                credentials identify this application to the service. If none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
+            client_config (dict): A dictionary of call options for each
+                method. If not specified, the default configuration is used.
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
+                your own client library.
+        """
+        # If both `channel` and `credentials` are specified, raise an
+        # exception (channels come with credentials baked in already).
+        if channel is not None and credentials is not None:
+            raise ValueError(
+                'The `channel` and `credentials` arguments to {} are mutually '
+                'exclusive.'.format(self.__class__.__name__),
+            )
+
+        # Create the channel.
+        if channel is None:
+            channel = google.api_core.grpc_helpers.create_channel(
+                self.SERVICE_ADDRESS,
+                credentials=credentials,
+                scopes=self._DEFAULT_SCOPES,
+            )
+
+        # Create the gRPC stubs.
+        self.incrementer_service_stub = (
+            multiple_services_pb2_grpc.IncrementerServiceStub(channel))
+
+
+        if client_info is None:
+            client_info = (
+                google.api_core.gapic_v1.client_info.DEFAULT_CLIENT_INFO)
+        client_info.gapic_version = _GAPIC_LIBRARY_VERSION
+
+        # Parse out the default settings for retry and timeout for each RPC
+        # from the client configuration.
+        # (Ordinarily, these are the defaults specified in the `*_config.py`
+        # file next to this one.)
+        method_configs = google.api_core.gapic_v1.config.parse_method_configs(
+            client_config['interfaces'][self._INTERFACE_NAME],
+        )
+
+        # Write the "inner API call" methods to the class.
+        # These are wrapped versions of the gRPC stub methods, with retry and
+        # timeout configuration applied, called by the public methods on
+        # this class.
+        self._increment = google.api_core.gapic_v1.method.wrap_method(
+            self.incrementer_service_stub.Increment,
+            default_retry=method_configs['Increment'].retry,
+            default_timeout=method_configs['Increment'].timeout,
+            client_info=client_info,
+        )
+
+    # Service calls
+    def increment(
+            self,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+        Increment.
+
+        Example:
+            >>> from google.cloud.example_v1 import foo
+            >>>
+            >>> client = foo.IncrementerServiceClient()
+            >>>
+            >>> client.increment()
+
+        Args:
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will not
+                be retried.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+        """
+        request = multiple_services_pb2.IncrementRequest()
+        self._increment(request, retry=retry, timeout=timeout, metadata=metadata)
+
+============== file: google/cloud/example_v1/foo/gapic/incrementer_service_client_config.py ==============
+config = {
+  "interfaces": {
+    "google.cloud.example.v1.foo.IncrementerService": {
+      "retry_codes": {},
+      "retry_params": {},
+      "methods": {
+        "Increment": {
+          "timeout_millis": 10000
+        }
+      }
+    }
+  }
+}
+
+============== file: google/cloud/example_v1/foo/types.py ==============
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import absolute_import
+import sys
+
+from google.api_core.protobuf_helpers import get_messages
+
+from google.api import http_pb2
+from google.cloud.example_v1.foo.proto import multiple_services_pb2
+from google.protobuf import descriptor_pb2
+from google.protobuf import empty_pb2
+
+
+names = []
+for module in (http_pb2,
+               multiple_services_pb2,
+               descriptor_pb2,
+               empty_pb2,):
+    for name, message in get_messages(module).items():
+        message.__module__ = 'google.cloud.example_v1.foo.types'
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+
+__all__ = tuple(sorted(names))
+============== file: nox.py ==============
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import absolute_import
+import os
+
+import nox
+
+
+@nox.session
+def default(session):
+    return unit(session, 'default')
+
+
+@nox.session
+@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+def unit(session, py):
+    """Run the unit test suite."""
+
+    # Run unit tests against all supported versions of Python.
+    if py != 'default':
+        session.interpreter = 'python{}'.format(py)
+
+    # Set the virtualenv directory name.
+    session.virtualenv_dirname = 'unit-' + py
+
+    # Install all test dependencies, then install this package in-place.
+    session.install('pytest')
+    session.install('-e', '.')
+
+    # Run py.test against the unit tests.
+    session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
+
+
+@nox.session
+def lint_setup_py(session):
+    """Verify that setup.py is valid (including RST check)."""
+    session.interpreter = 'python3.6'
+    session.install('docutils', 'pygments')
+    session.run(
+        'python', 'setup.py', 'check', '--restructuredtext', '--strict')
+============== file: setup.cfg ==============
+[bdist_wheel]
+universal = 1
+
+============== file: setup.py ==============
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import os
+
+import setuptools
+
+
+
+name = 'google-cloud-multiple_services'
+description = 'Google Example API API client library'
+version = '0.15.0'
+release_status = '3 - Alpha'
+dependencies = [
+  'google-api-core[grpc] >= 1.1.0, < 2.0.0dev',
+
+  'python-other-package >= 12.1.0, < 13.5.1',
+]
+
+
+
+package_root = os.path.abspath(os.path.dirname(__file__))
+
+readme_filename = os.path.join(package_root, 'README.rst')
+with io.open(readme_filename, encoding='utf-8') as readme_file:
+    readme = readme_file.read()
+
+packages = [
+    package for package in setuptools.find_packages()
+    if package.startswith('google')]
+
+namespaces = ['google']
+if 'google.cloud' in packages:
+    namespaces.append('google.cloud')
+
+
+setuptools.setup(
+    name=name,
+    version=version,
+    description=description,
+    long_description=readme,
+    author='Google LLC',
+    author_email='googleapis-packages@oogle.com',
+    license='Apache 2.0',
+    url='https://github.com/GoogleCloudPlatform/google-cloud-python',
+    classifiers=[
+        release_status,
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Operating System :: OS Independent',
+        'Topic :: Internet',
+    ],
+    platforms='Posix; MacOS X; Windows',
+    packages=packages,
+    namespace_packages=namespaces,
+    install_requires=dependencies,
+    extras_require=extras,
+    include_package_data=True,
+    zip_safe=False,
+)
+============== file: tests/unit/gapic/v1/test_decrementer_service_client_v1.py ==============
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests."""
+
+import pytest
+
+from google.cloud.example_v1 import foo
+from google.cloud.example_v1.foo.proto import multiple_services_pb2
+from google.protobuf import empty_pb2
+
+
+
+class MultiCallableStub(object):
+    """Stub for the grpc.UnaryUnaryMultiCallable interface."""
+    def __init__(self, method, channel_stub):
+        self.method = method
+        self.channel_stub = channel_stub
+
+    def __call__(self, request, timeout=None, metadata=None, credentials=None):
+        self.channel_stub.requests.append((self.method, request))
+
+        response = None
+        if self.channel_stub.responses:
+            response = self.channel_stub.responses.pop()
+
+        if isinstance(response, Exception):
+            raise response
+
+        if response:
+            return response
+
+
+class ChannelStub(object):
+    """Stub for the grpc.Channel interface."""
+    def __init__(self, responses = []):
+        self.responses = responses
+        self.requests = []
+
+    def unary_unary(
+            self, method, request_serializer=None, response_deserializer=None):
+        return MultiCallableStub(method, self)
+
+
+class CustomException(Exception):
+    pass
+
+
+class TestDecrementerServiceClient(object):
+
+    def test_decrement(self):
+        channel = ChannelStub()
+        client = foo.DecrementerServiceClient(
+            channel=channel)
+
+        client.decrement()
+
+        assert len(channel.requests) == 1
+        expected_request = multiple_services_pb2.DecrementRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_decrement_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        client = foo.DecrementerServiceClient(
+             channel=channel)
+
+        with pytest.raises(CustomException):
+            client.decrement()
+
+============== file: tests/unit/gapic/v1/test_incrementer_service_client_v1.py ==============
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests."""
+
+import pytest
+
+from google.cloud.example_v1 import foo
+from google.cloud.example_v1.foo.proto import multiple_services_pb2
+from google.protobuf import empty_pb2
+
+
+
+class MultiCallableStub(object):
+    """Stub for the grpc.UnaryUnaryMultiCallable interface."""
+    def __init__(self, method, channel_stub):
+        self.method = method
+        self.channel_stub = channel_stub
+
+    def __call__(self, request, timeout=None, metadata=None, credentials=None):
+        self.channel_stub.requests.append((self.method, request))
+
+        response = None
+        if self.channel_stub.responses:
+            response = self.channel_stub.responses.pop()
+
+        if isinstance(response, Exception):
+            raise response
+
+        if response:
+            return response
+
+
+class ChannelStub(object):
+    """Stub for the grpc.Channel interface."""
+    def __init__(self, responses = []):
+        self.responses = responses
+        self.requests = []
+
+    def unary_unary(
+            self, method, request_serializer=None, response_deserializer=None):
+        return MultiCallableStub(method, self)
+
+
+class CustomException(Exception):
+    pass
+
+
+class TestIncrementerServiceClient(object):
+
+    def test_increment(self):
+        channel = ChannelStub()
+        client = foo.IncrementerServiceClient(
+            channel=channel)
+
+        client.increment()
+
+        assert len(channel.requests) == 1
+        expected_request = multiple_services_pb2.IncrementRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_increment_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        client = foo.IncrementerServiceClient(
+             channel=channel)
+
+        with pytest.raises(CustomException):
+            client.increment()
+

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services_gapic.yaml
@@ -4,7 +4,7 @@ language_settings:
   java:
     package_name: com.google.gcloud.example
   python:
-    package_name: example
+    package_name: google.cloud.example_v1.foo.gapic
   ruby:
     package_name: Google::Example::V1::Foo
     release_level: GA


### PR DESCRIPTION
# What 
This PR fixes an issue where generated python clients would not work if there were names declared after the version namespace in the package name.

For example if there was a namespace:

`foo.bar.baz_v1.qux.gapic`

The generator would think top level surface file would be `foo/bar/baz_v1/qux.py` and try and import the generated clients from `foo/bar/baz_v1/qux/__init__.py`.

This fix makes it such that the generator will correctly generate the top level surface file at `foo/bar/baz.py` and try and import the generated clients from `foo/bar/baz_v1/__init__.py`.