### PR TITLE
Configure library_gapic.yaml to cover all Java calling forms

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -88,7 +88,7 @@ public class StaticLangApiMethodTransformer {
         additionalParams,
         Synchronicity.Sync,
         methodViewBuilder,
-        Arrays.asList(CallingForm.FlattenedPaging));
+        Arrays.asList(CallingForm.FlattenedPaged));
 
     return methodViewBuilder.type(ClientMethodType.PagedFlattenedMethod).build();
   }
@@ -109,7 +109,7 @@ public class StaticLangApiMethodTransformer {
         additionalParams,
         Synchronicity.Async,
         methodViewBuilder,
-        Arrays.asList(CallingForm.FlattenedAsyncPaging));
+        Arrays.asList(CallingForm.FlattenedAsyncPaged));
 
     return methodViewBuilder.type(ClientMethodType.PagedFlattenedAsyncMethod).build();
   }
@@ -159,7 +159,7 @@ public class StaticLangApiMethodTransformer {
         Synchronicity.Async,
         additionalParams,
         methodViewBuilder,
-        Arrays.asList(CallingForm.RequestAsyncPaging));
+        Arrays.asList(CallingForm.RequestAsyncPaged));
 
     return methodViewBuilder.type(ClientMethodType.AsyncPagedRequestObjectMethod).build();
   }
@@ -177,7 +177,7 @@ public class StaticLangApiMethodTransformer {
         context,
         namer.getPagedCallableName(method),
         methodViewBuilder,
-        Arrays.asList(CallingForm.CallablePaging));
+        Arrays.asList(CallingForm.CallablePaged));
 
     return methodViewBuilder.type(ClientMethodType.PagedCallableMethod).build();
   }
@@ -341,6 +341,11 @@ public class StaticLangApiMethodTransformer {
   }
 
   public StaticLangApiMethodView generateCallableMethod(MethodContext context) {
+    return generateCallableMethod(context, Arrays.asList(CallingForm.Callable));
+  }
+
+  public StaticLangApiMethodView generateCallableMethod(
+      MethodContext context, List<CallingForm> callingForms) {
     MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
@@ -349,10 +354,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(namer.getCallableMethodName(method));
     methodViewBuilder.exampleName(context.getNamer().getCallableMethodExampleName(method));
     setCallableMethodFields(
-        context,
-        namer.getCallableName(method),
-        methodViewBuilder,
-        Arrays.asList(CallingForm.Callable));
+        context, namer.getCallableName(method), methodViewBuilder, callingForms);
     methodViewBuilder.responseTypeName(
         context
             .getMethodModel()
@@ -380,7 +382,7 @@ public class StaticLangApiMethodTransformer {
         namer.getCallableMethodName(method),
         Synchronicity.Sync,
         methodViewBuilder,
-        Arrays.asList(CallingForm.RequestStreaming));
+        Arrays.asList(CallingForm.RequestServerStreaming));
     setStaticLangGrpcStreamingReturnTypeName(context, methodViewBuilder);
 
     return methodViewBuilder.type(ClientMethodType.RequestObjectMethod).build();

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
@@ -24,8 +24,10 @@ import com.google.api.codegen.transformer.ImportTypeTable;
 import com.google.api.codegen.transformer.InterfaceContext;
 import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.StaticLangApiMethodTransformer;
+import com.google.api.codegen.viewmodel.CallingForm;
 import com.google.api.codegen.viewmodel.StaticLangApiMethodView;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -76,22 +78,27 @@ public class JavaMethodViewGenerator {
         apiMethods.add(
             clientMethodTransformer.generateUnpagedListCallableMethod(requestMethodContext));
       } else if (methodConfig.isGrpcStreaming()) {
+        List<CallingForm> callingForms;
         ImportTypeTable typeTable = context.getImportTypeTable();
         switch (methodConfig.getGrpcStreamingType()) {
           case BidiStreaming:
             typeTable.saveNicknameFor("com.google.api.gax.rpc.BidiStreamingCallable");
+            callingForms = Collections.singletonList(CallingForm.CallableBidiStreaming);
             break;
           case ClientStreaming:
             typeTable.saveNicknameFor("com.google.api.gax.rpc.ClientStreamingCallable");
+            callingForms = Collections.singletonList(CallingForm.CallableClientStreaming);
             break;
           case ServerStreaming:
             typeTable.saveNicknameFor("com.google.api.gax.rpc.ServerStreamingCallable");
+            callingForms = Collections.singletonList(CallingForm.CallableServerStreaming);
             break;
           default:
             throw new IllegalArgumentException(
                 "Invalid streaming type: " + methodConfig.getGrpcStreamingType());
         }
-        apiMethods.add(clientMethodTransformer.generateCallableMethod(requestMethodContext));
+        apiMethods.add(
+            clientMethodTransformer.generateCallableMethod(requestMethodContext, callingForms));
       } else if (methodConfig.isLongRunningOperation()) {
         context.getImportTypeTable().saveNicknameFor("com.google.api.gax.rpc.OperationCallable");
         if (methodConfig.isFlattening()) {

--- a/src/main/java/com/google/api/codegen/viewmodel/CallingForm.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/CallingForm.java
@@ -20,24 +20,29 @@ package com.google.api.codegen.viewmodel;
  * language.
  */
 public enum CallingForm {
-  Request,
+  Request, // Java
   RequestAsync,
-  RequestStreaming,
-  RequestPaged,
-  RequestAsyncPaging,
-  Flattened,
-  FlattenedPaging,
+  RequestAsyncPaged,
+  RequestServerStreaming,
+  RequestPaged, // Java
+
+  Flattened, // Java
+  FlattenedPaged, // Java
   FlattenedAsync,
-  FlattenedAsyncPaging,
-  Callable,
-  CallableList,
-  CallablePaging,
+  FlattenedAsyncPaged,
+
+  Callable, // Java
+  CallableList, // Java
+  CallablePaged, // Java
+  CallableClientStreaming, // Java
+  CallableServerStreaming, // Java
+  CallableBidiStreaming, // Java
 
   LongRunningRequest,
-  LongRunningRequestAsync,
+  LongRunningRequestAsync, // Java
   LongRunningFlattened,
-  LongRunningFlattenedAsync,
-  LongRunningCallable,
+  LongRunningFlattenedAsync, // Java
+  LongRunningCallable, // Java
 
   // Used only if code does not yet support deciding on one of the other ones. The goal is to have
   // this value never set.

--- a/src/main/resources/com/google/api/codegen/java/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/method_sample.snip
@@ -98,7 +98,7 @@
   @end
 @end
 
-@private bidiStreamingCallableSampleCode(apiMethod, initCode)
+@snippet bidiStreamingCallableSampleCode(apiMethod, initCode)
   {@responseObserver(apiMethod)}
   ApiStreamObserver<StreamingRecognizeRequest> requestObserver =
       {@apiMethod.apiVariableName}.{@apiMethod.name}().bidiStreamingCall(responseObserver));
@@ -107,7 +107,7 @@
   requestObserver.onNext(request);
 @end
 
-@private serverStreamingCallableSampleCode(apiMethod, initCode)
+@snippet serverStreamingCallableSampleCode(apiMethod, initCode)
   {@responseObserver(apiMethod)}
 
   {@initCode(initCode)}
@@ -116,7 +116,7 @@
       {@sampleMethodCallArgList(initCode.fieldSettings)}, responseObserver));
 @end
 
-@private clientStreamingCallableSampleCode(apiMethod, initCode)
+@snippet clientStreamingCallableSampleCode(apiMethod, initCode)
   {@responseObserver(apiMethod)}
   ApiStreamObserver<StreamingRecognizeRequest> requestObserver =
       {@apiMethod.apiVariableName}.{@apiMethod.name}().clientStreamingCall(responseObserver));

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -13,8 +13,9 @@
        
    @let apiMethod = sampleFile.classView.libraryMethod
      @let sample = apiMethod.samples.get(0)
-       //     calling form "{@sample.callingForm.toString}"
+       //     calling form: "{@sample.callingForm.toString}"
        //     valueSet "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
+       //       description: "{@sample.valueSet.description}"
        //       {@sample.valueSet.parameters}
        //     apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
 
@@ -40,32 +41,34 @@
 # For real use, we'll want to switch on the calling form id.
 @private generateSample(apiMethod, callingForm, initCode)
     @switch callingForm
-    @case "FlattenedPaging"
-      {@pagedCallableMethodSampleCode(apiMethod, initCode)}
-    @case "RequestPaged"
-      {@pagedRequestObjectMethod(apiMethod, initCode)}
-    @case "CallablePaging"
-      {@pagedCallableMethodSampleCode(apiMethod, initCode)}
-    @case "CallableList"
-      {@unpagedListCallableMethodSampleCode(apiMethod, initCode)}
-    @case "Flattened"
-      {@syncMethodSampleCode(apiMethod, initCode)}
     @case "Request"
       {@syncMethodSampleCode(apiMethod, initCode)}
+    @case "RequestPaged"
+      {@pagedIterableMethodSampleCode(apiMethod, initCode)}
+    @case "Flattened"
+      {@syncMethodSampleCode(apiMethod, initCode)}
+    @case "FlattenedPaged"
+      {@pagedCallableMethodSampleCode(apiMethod, initCode)}      
     @case "Callable"
-      @if apiMethod.isStreaming
-        {@streamingCallableMethodSampleCode(apiMethod, initCode)}
-      @else
-        {@callableMethodSampleCode(apiMethod, initCode)}
-      @end
-    @case "LongRunningFlattenedAsync"
-      {@asyncOperationMethodSampleCode(apiMethod, initCode)}
+      {@callableMethodSampleCode(apiMethod, initCode)}
+    @case "CallableList"
+      {@unpagedListCallableMethodSampleCode(apiMethod, initCode)}
+    @case "CallablePaged"
+      {@pagedCallableMethodSampleCode(apiMethod, initCode)}
+    @case "CallableClientStreaming"
+      {@clientStreamingCallableSampleCode(apiMethod, initCode)}
+    @case "CallableServerStreaming"
+      {@serverStreamingCallableSampleCode(apiMethod, initCode)}
+    @case "CallableBidiStreaming"
+      {@bidiStreamingCallableSampleCode(apiMethod, initCode)}      
     @case "LongRunningRequestAsync"
       {@asyncOperationMethodSampleCode(apiMethod, initCode)}
+    @case "LongRunningFlattenedAsync"
+      {@asyncOperationMethodSampleCode(apiMethod, initCode)}
     @case "LongRunningCallable"
-      {@asyncOperationCallableMethodSampleCall(apiMethod, initCode)}
+      {@asyncOperationCallableMethodSampleCode(apiMethod, initCode)}
     @default
-      $unhandledCase: {@apiMethod.getClass.getSimpleName}$
+      $unhandledCallingForm: {@callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
     @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -16,6 +16,7 @@
      @let sample = apiMethod.samples.get(0)
        //     calling form "{@sample.callingForm.toString}"
        //     valueSet "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
+       //       description: "{@sample.valueSet.description}"
        //       {@sample.valueSet.parameters}
        //     apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
 

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -18,6 +18,7 @@
     @let sample = apiMethod.samples.get(0)
       @##     calling form "{@sample.callingForm.toString}"
       @##     valueSet "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
+      @##       description: "{@sample.valueSet.description}"
       @##       {@sample.valueSet.parameters}
       @##     apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
       

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -7285,6 +7285,400 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     }
   }
 }
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/discussbookcallable/DiscussBookCallableSampleCallableBidiStreamingProg.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookCallableSampleCallableBidiStreamingProg" ]
+//// STUB standalone sample "DiscussBookCallableSampleCallableBidiStreamingProg" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "CallableBidiStreaming"
+//     valueSet "prog" ("Programming Books")
+//       description: "Testing calling forms: {Java:[CallableBidiStreaming]}"
+//       [name=BASIC]
+//     apiMethod "discussBookCallable" of type "CallableMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ApiStreamObserver&lt;Comment&gt; responseObserver =
+    new ApiStreamObserver&lt;Comment&gt;() {
+      {@literal @}Override
+      public void onNext(Comment response) {
+        // Do something when receive a response
+      }
+
+      {@literal @}Override
+      public void onError(Throwable t) {
+        // Add error-handling
+      }
+
+      {@literal @}Override
+      public void onCompleted() {
+        // Do something when complete.
+      }
+    };
+ApiStreamObserver&lt;StreamingRecognizeRequest&gt; requestObserver =
+    libraryClient.discussBookCallable().bidiStreamingCall(responseObserver));
+
+String name = "BASIC";
+DiscussBookRequest request = DiscussBookRequest.newBuilder()
+  .setName(name)
+  .build();
+requestObserver.onNext(request);
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbooks/FindRelatedBooksSampleFlattenedPagedOdyssey.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleFlattenedPagedOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksSampleFlattenedPagedOdyssey" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "FlattenedPaged"
+//     valueSet "odyssey" ("The Odyssey")
+//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged]}"
+//       [names[0]=Odyssey, shelves[0]=Classics]
+//     apiMethod "findRelatedBooks" of type "PagedFlattenedMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
+ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+List&lt;ShelfName&gt; shelves = Arrays.asList(shelvesElement);
+ApiFuture&lt;FindRelatedBooksPagedResponse&gt; future = libraryClient.findRelatedBooks().futureCall(ShelfBookName.toStringList(names), ShelfName.toStringList(shelves));
+// Do something
+for (ShelfBookName element : future.get().iterateAllAsShelfBookName()) {
+  // doThingsWith(element);
+}
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbooks/FindRelatedBooksSampleRequestPagedOdyssey.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestPagedOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksSampleRequestPagedOdyssey" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "RequestPaged"
+//     valueSet "odyssey" ("The Odyssey")
+//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged]}"
+//       [names[0]=Odyssey, shelves[0]=Classics]
+//     apiMethod "findRelatedBooks" of type "PagedRequestObjectMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
+ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+List&lt;ShelfName&gt; shelves = Arrays.asList(shelvesElement);
+FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+  .addAllNames(ShelfBookName.toStringList(names))
+  .addAllShelves(ShelfName.toStringList(shelves))
+  .build();
+for (ShelfBookName element : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
+  // doThingsWith(element);
+}
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbookscallable/FindRelatedBooksCallableSampleCallableListOdyssey.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksCallableSampleCallableListOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksCallableSampleCallableListOdyssey" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "CallableList"
+//     valueSet "odyssey" ("The Odyssey")
+//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged]}"
+//       [names[0]=Odyssey, shelves[0]=Classics]
+//     apiMethod "findRelatedBooksCallable" of type "UnpagedListCallableMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
+ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+List&lt;ShelfName&gt; shelves = Arrays.asList(shelvesElement);
+FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+  .addAllNames(ShelfBookName.toStringList(names))
+  .addAllShelves(ShelfName.toStringList(shelves))
+  .build();
+while (true) {
+  FindRelatedBooksResponse response = libraryClient.findRelatedBooksCallable().call(request);
+  for (ShelfBookName element : ShelfBookName.parseList(response.getNamesList())) {
+    // doThingsWith(element);
+  }
+  String nextPageToken = response.getNextPageToken();
+  if (!Strings.isNullOrEmpty(nextPageToken)) {
+    request = request.toBuilder().setPageToken(nextPageToken).build();
+  } else {
+    break;
+  }
+}
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbookspagedcallable/FindRelatedBooksPagedCallableSampleCallablePagedOdyssey.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksPagedCallableSampleCallablePagedOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksPagedCallableSampleCallablePagedOdyssey" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "CallablePaged"
+//     valueSet "odyssey" ("The Odyssey")
+//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged]}"
+//       [names[0]=Odyssey, shelves[0]=Classics]
+//     apiMethod "findRelatedBooksPagedCallable" of type "PagedCallableMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
+ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+List&lt;ShelfName&gt; shelves = Arrays.asList(shelvesElement);
+FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+  .addAllNames(ShelfBookName.toStringList(names))
+  .addAllShelves(ShelfName.toStringList(shelves))
+  .build();
+ApiFuture&lt;FindRelatedBooksPagedResponse&gt; future = libraryClient.findRelatedBooksPagedCallable().futureCall(request);
+// Do something
+for (ShelfBookName element : future.get().iterateAllAsShelfBookName()) {
+  // doThingsWith(element);
+}
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookasync/GetBigBookAsyncSampleLongRunningFlattenedAsyncWap.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookAsyncSampleLongRunningFlattenedAsyncWap" ]
+//// STUB standalone sample "GetBigBookAsyncSampleLongRunningFlattenedAsyncWap" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "LongRunningFlattenedAsync"
+//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable]}"
+//       [name="War and Peace"]
+//     apiMethod "getBigBookAsync" of type "AsyncOperationFlattenedMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+Book response = libraryClient.getBigBookAsync(name.toString()).get();
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookasync/GetBigBookAsyncSampleLongRunningRequestAsyncWap.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookAsyncSampleLongRunningRequestAsyncWap" ]
+//// STUB standalone sample "GetBigBookAsyncSampleLongRunningRequestAsyncWap" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "LongRunningRequestAsync"
+//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable]}"
+//       [name="War and Peace"]
+//     apiMethod "getBigBookAsync" of type "AsyncOperationRequestObjectMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+GetBookRequest request = GetBookRequest.newBuilder()
+  .setName(name.toString())
+  .build();
+Book response = libraryClient.getBigBookAsync(request).get();
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookcallable/GetBigBookCallableSampleCallableWap.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookCallableSampleCallableWap" ]
+//// STUB standalone sample "GetBigBookCallableSampleCallableWap" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "Callable"
+//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable]}"
+//       [name="War and Peace"]
+//     apiMethod "getBigBookCallable" of type "CallableMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+GetBookRequest request = GetBookRequest.newBuilder()
+  .setName(name.toString())
+  .build();
+ApiFuture&lt;Operation&gt; future = libraryClient.getBigBookCallable().futureCall(request);
+// Do something
+Operation response = future.get();
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookoperationcallable/GetBigBookOperationCallableSampleLongRunningCallableWap.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookOperationCallableSampleLongRunningCallableWap" ]
+//// STUB standalone sample "GetBigBookOperationCallableSampleLongRunningCallableWap" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "LongRunningCallable"
+//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable]}"
+//       [name="War and Peace"]
+//     apiMethod "getBigBookOperationCallable" of type "OperationCallableMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+GetBookRequest request = GetBookRequest.newBuilder()
+  .setName(name.toString())
+  .build();
+OperationFuture&lt;Operation&gt; future = libraryClient.getBigBookOperationCallable().futureCall(request);
+// Do something
+Book response = future.get();
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/monologaboutbookcallable/MonologAboutBookCallableSampleCallableClientStreamingProg.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookCallableSampleCallableClientStreamingProg" ]
+//// STUB standalone sample "MonologAboutBookCallableSampleCallableClientStreamingProg" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "CallableClientStreaming"
+//     valueSet "prog" ("Programming Books")
+//       description: "Testing calling forms: {Java:[CallableClientStreaming]}"
+//       [name=BASIC]
+//     apiMethod "monologAboutBookCallable" of type "CallableMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ApiStreamObserver&lt;Comment&gt; responseObserver =
+    new ApiStreamObserver&lt;Comment&gt;() {
+      {@literal @}Override
+      public void onNext(Comment response) {
+        // Do something when receive a response
+      }
+
+      {@literal @}Override
+      public void onError(Throwable t) {
+        // Add error-handling
+      }
+
+      {@literal @}Override
+      public void onCompleted() {
+        // Do something when complete.
+      }
+    };
+ApiStreamObserver&lt;StreamingRecognizeRequest&gt; requestObserver =
+    libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver));
+
+String name = "BASIC";
+DiscussBookRequest request = DiscussBookRequest.newBuilder()
+  .setName(name)
+  .build();
+requestObserver.onNext(request);
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
 ============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesSampleFlattenedPiVersion.java ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleFlattenedPiVersion" ]
 //// STUB standalone sample "PublishSeriesSampleFlattenedPiVersion" /////
@@ -7295,8 +7689,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Flattened"
+//     calling form: "Flattened"
 //     valueSet "pi_version" ("Pi version")
+//       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeries" of type "FlattenedMethod"
 
@@ -7332,8 +7727,9 @@ PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, editi
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Flattened"
+//     calling form: "Flattened"
 //     valueSet "second_edition" ("Second edition")
+//       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 //       [edition=2]
 //     apiMethod "publishSeries" of type "FlattenedMethod"
 
@@ -7363,8 +7759,9 @@ PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, editi
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Request"
+//     calling form: "Request"
 //     valueSet "pi_version" ("Pi version")
+//       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeries" of type "RequestObjectMethod"
 
@@ -7404,8 +7801,9 @@ PublishSeriesResponse response = libraryClient.publishSeries(request);
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Request"
+//     calling form: "Request"
 //     valueSet "second_edition" ("Second edition")
+//       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 //       [edition=2]
 //     apiMethod "publishSeries" of type "RequestObjectMethod"
 
@@ -7441,8 +7839,9 @@ PublishSeriesResponse response = libraryClient.publishSeries(request);
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Callable"
+//     calling form: "Callable"
 //     valueSet "pi_version" ("Pi version")
+//       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeriesCallable" of type "CallableMethod"
 
@@ -7484,8 +7883,9 @@ PublishSeriesResponse response = future.get();
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Callable"
+//     calling form: "Callable"
 //     valueSet "second_edition" ("Second edition")
+//       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 //       [edition=2]
 //     apiMethod "publishSeriesCallable" of type "CallableMethod"
 
@@ -7507,6 +7907,105 @@ PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
 ApiFuture&lt;PublishSeriesResponse&gt; future = libraryClient.publishSeriesCallable().futureCall(request);
 // Do something
 PublishSeriesResponse response = future.get();
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/streambookscallable/StreamBooksCallableSampleCallableServerStreamingProg.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksCallableSampleCallableServerStreamingProg" ]
+//// STUB standalone sample "StreamBooksCallableSampleCallableServerStreamingProg" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "CallableServerStreaming"
+//     valueSet "prog" ("Programming Books")
+//       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
+//       [name=BASIC]
+//     apiMethod "streamBooksCallable" of type "CallableMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ApiStreamObserver&lt;Book&gt; responseObserver =
+    new ApiStreamObserver&lt;Book&gt;() {
+      {@literal @}Override
+      public void onNext(Book response) {
+        // Do something when receive a response
+      }
+
+      {@literal @}Override
+      public void onError(Throwable t) {
+        // Add error-handling
+      }
+
+      {@literal @}Override
+      public void onCompleted() {
+        // Do something when complete.
+      }
+    };
+
+String name = "BASIC";
+StreamBooksRequest request = StreamBooksRequest.newBuilder()
+  .setName(name)
+  .build();
+
+libraryClient.streamBooksCallable().serverStreamingCall(request, responseObserver));
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/streamshelvescallable/StreamShelvesCallableSampleCallableServerStreamingEmpty.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesCallableSampleCallableServerStreamingEmpty" ]
+//// STUB standalone sample "StreamShelvesCallableSampleCallableServerStreamingEmpty" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form: "CallableServerStreaming"
+//     valueSet "empty" ("Server streaming")
+//       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
+//       []
+//     apiMethod "streamShelvesCallable" of type "CallableMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+ApiStreamObserver&lt;StreamShelvesResponse&gt; responseObserver =
+    new ApiStreamObserver&lt;StreamShelvesResponse&gt;() {
+      {@literal @}Override
+      public void onNext(StreamShelvesResponse response) {
+        // Do something when receive a response
+      }
+
+      {@literal @}Override
+      public void onError(Throwable t) {
+        // Add error-handling
+      }
+
+      {@literal @}Override
+      public void onCompleted() {
+        // Do something when complete.
+      }
+    };
+
+StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+
+libraryClient.streamShelvesCallable().serverStreamingCall(request, responseObserver));
 */
 // [END core_sample]
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -248,6 +248,242 @@ module.exports.v1 = gapic.v1;
 // Alias `module.exports` as `module.exports.default`, for future-proofing.
 module.exports.default = Object.assign({}, module.exports);
 
+============== file: src/samples/v1/discuss_book_sample_generic_prog.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookSampleGenericProg" ]
+//// STUB standalone sample "DiscussBookSampleGenericProg" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form "Generic"
+//     valueSet "prog" ("Programming Books")
+//       description: "Testing calling forms: {Java:[CallableBidiStreaming]}"
+//       [name=BASIC]
+//     apiMethod "discussBook" of type "OptionalArrayMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+var stream = client.discussBook().on('data', response => {
+  // doThingsWith(response)
+});
+var name = 'BASIC';
+var request = {
+  name: name,
+};
+// Write request objects.
+stream.write(request);
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/samples/v1/find_related_books_sample_generic_odyssey.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleGenericOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksSampleGenericOdyssey" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form "Generic"
+//     valueSet "odyssey" ("The Odyssey")
+//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged]}"
+//       [names[0]=Odyssey, shelves[0]=Classics]
+//     apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+// Iterate over all elements.
+var namesElement = 'Odyssey';
+var names = [namesElement];
+var shelvesElement = 'Classics';
+var shelves = [shelvesElement];
+var request = {
+  names: names,
+  shelves: shelves,
+};
+
+client.findRelatedBooks(request)
+  .then(responses => {
+    var resources = responses[0];
+    for (let i = 0; i < resources.length; i += 1) {
+      // doThingsWith(resources[i])
+    }
+  })
+  .catch(err => {
+    console.error(err);
+  });
+
+// Or obtain the paged response.
+var namesElement = 'Odyssey';
+var names = [namesElement];
+var shelvesElement = 'Classics';
+var shelves = [shelvesElement];
+var request = {
+  names: names,
+  shelves: shelves,
+};
+
+
+var options = {autoPaginate: false};
+var callback = responses => {
+  // The actual resources in a response.
+  var resources = responses[0];
+  // The next request if the response shows that there are more responses.
+  var nextRequest = responses[1];
+  // The actual response object, if necessary.
+  // var rawResponse = responses[2];
+  for (let i = 0; i < resources.length; i += 1) {
+    // doThingsWith(resources[i]);
+  }
+  if (nextRequest) {
+    // Fetch the next page.
+    return client.findRelatedBooks(nextRequest, options).then(callback);
+  }
+}
+client.findRelatedBooks(request, options)
+  .then(callback)
+  .catch(err => {
+    console.error(err);
+  });
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/samples/v1/get_big_book_sample_generic_wap.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleGenericWap" ]
+//// STUB standalone sample "GetBigBookSampleGenericWap" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form "Generic"
+//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable]}"
+//       [name="War and Peace"]
+//     apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+
+// Handle the operation using the promise pattern.
+client.getBigBook({name: formattedName})
+  .then(responses => {
+    var operation = responses[0];
+    var initialApiResponse = responses[1];
+
+    // Operation#promise starts polling for the completion of the LRO.
+    return operation.promise();
+  })
+  .then(responses => {
+    // The final result of the operation.
+    var result = responses[0];
+
+    // The metadata value of the completed operation.
+    var metadata = responses[1];
+
+    // The response of the api call returning the complete operation.
+    var finalApiResponse = responses[2];
+  })
+  .catch(err => {
+    console.error(err);
+  });
+
+var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+
+// Handle the operation using the event emitter pattern.
+client.getBigBook({name: formattedName})
+  .then(responses => {
+    var operation = responses[0];
+    var initialApiResponse = responses[1];
+
+    // Adding a listener for the "complete" event starts polling for the
+    // completion of the operation.
+    operation.on('complete', (result, metadata, finalApiResponse) => {
+      // doSomethingWith(result);
+    });
+
+    // Adding a listener for the "progress" event causes the callback to be
+    // called on any change in metadata when the operation is polled.
+    operation.on('progress', (metadata, apiResponse) => {
+      // doSomethingWith(metadata)
+    });
+
+    // Adding a listener for the "error" event handles any errors found during polling.
+    operation.on('error', err => {
+      // throw(err);
+    });
+  })
+  .catch(err => {
+    console.error(err);
+  });
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/samples/v1/monolog_about_book_sample_generic_prog.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookSampleGenericProg" ]
+//// STUB standalone sample "MonologAboutBookSampleGenericProg" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form "Generic"
+//     valueSet "prog" ("Programming Books")
+//       description: "Testing calling forms: {Java:[CallableClientStreaming]}"
+//       [name=BASIC]
+//     apiMethod "monologAboutBook" of type "OptionalArrayMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+var stream = client.monologAboutBook((err, response) => {
+  if (err) {
+    console.error(err);
+    return;
+  }
+  // doThingsWith(response)
+});
+var name = 'BASIC';
+var request = {
+  name: name,
+};
+// Write request objects.
+stream.write(request);
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
 ============== file: src/samples/v1/publish_series_sample_generic_pi_version.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleGenericPiVersion" ]
 //// STUB standalone sample "PublishSeriesSampleGenericPiVersion" /////
@@ -260,6 +496,7 @@ module.exports.default = Object.assign({}, module.exports);
 
 //     calling form "Generic"
 //     valueSet "pi_version" ("Pi version")
+//       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeries" of type "OptionalArrayMethod"
 
@@ -308,6 +545,7 @@ client.publishSeries(request)
 
 //     calling form "Generic"
 //     valueSet "second_edition" ("Second edition")
+//       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 //       [edition=2]
 //     apiMethod "publishSeries" of type "OptionalArrayMethod"
 
@@ -334,6 +572,68 @@ client.publishSeries(request)
   .catch(err => {
     console.error(err);
   });
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/samples/v1/stream_books_sample_generic_prog.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksSampleGenericProg" ]
+//// STUB standalone sample "StreamBooksSampleGenericProg" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form "Generic"
+//     valueSet "prog" ("Programming Books")
+//       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
+//       [name=BASIC]
+//     apiMethod "streamBooks" of type "OptionalArrayMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+var name = 'BASIC';
+client.streamBooks({name: name}).on('data', response => {
+  // doThingsWith(response)
+});
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/samples/v1/stream_shelves_sample_generic_empty.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesSampleGenericEmpty" ]
+//// STUB standalone sample "StreamShelvesSampleGenericEmpty" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form "Generic"
+//     valueSet "empty" ("Server streaming")
+//       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
+//       []
+//     apiMethod "streamShelves" of type "OptionalArrayMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+
+client.streamShelves({}).on('data', response => {
+  // doThingsWith(response)
+});
 */
 // [END core_sample]
 

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -3436,6 +3436,182 @@ def lint_setup_py(session):
     session.install('docutils', 'pygments')
     session.run(
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')
+============== file: samples/google/cloud/example/library_v1/gapic/discuss_book/discuss_book_sample_generic_prog.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookSampleGenericProg" ]
+#### STUB standalone sample "DiscussBookSampleGenericProg" #####
+
+# FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+# To run with the published packaged, execute the following before running this code:
+#   pip install google-cloud-library
+
+# [START full_sample]
+
+# FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+##     calling form "Generic"
+##     valueSet "prog" ("Programming Books")
+##       description: "Testing calling forms: {Java:[CallableBidiStreaming]}"
+##       [name=BASIC]
+##     apiMethod "discuss_book" of type "OptionalArrayMethod"
+
+# [START core_sample]
+
+# FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+from google.cloud.example import library_v1
+
+client = library_v1.LibraryServiceClient()
+
+name = 'BASIC'
+request = {'name': name}
+
+requests = [request]
+for element in client.discuss_book(requests):
+    # process element
+    pass
+print(response)
+
+# [END core_sample]
+
+# FIXME: Insert here clean-up code.
+
+# [END full_sample]
+============== file: samples/google/cloud/example/library_v1/gapic/find_related_books/find_related_books_sample_generic_odyssey.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleGenericOdyssey" ]
+#### STUB standalone sample "FindRelatedBooksSampleGenericOdyssey" #####
+
+# FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+# To run with the published packaged, execute the following before running this code:
+#   pip install google-cloud-library
+
+# [START full_sample]
+
+# FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+##     calling form "Generic"
+##     valueSet "odyssey" ("The Odyssey")
+##       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged]}"
+##       [names[0]=Odyssey, shelves[0]=Classics]
+##     apiMethod "find_related_books" of type "PagedOptionalArrayMethod"
+
+# [START core_sample]
+
+# FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+from google.cloud.example import library_v1
+
+client = library_v1.LibraryServiceClient()
+
+names_element = 'Odyssey'
+names = [names_element]
+shelves_element = 'Classics'
+shelves = [shelves_element]
+
+
+# Iterate over all results
+for element in client.find_related_books(names, shelves):
+    # process element
+    pass
+
+# Or iterate over results one page at a time
+for page in client.find_related_books(names, shelves, options=CallOptions(page_token=INITIAL_PAGE)):
+    for element in page:
+        # process element
+        pass
+print(response)
+
+# [END core_sample]
+
+# FIXME: Insert here clean-up code.
+
+# [END full_sample]
+============== file: samples/google/cloud/example/library_v1/gapic/get_big_book/get_big_book_sample_generic_wap.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleGenericWap" ]
+#### STUB standalone sample "GetBigBookSampleGenericWap" #####
+
+# FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+# To run with the published packaged, execute the following before running this code:
+#   pip install google-cloud-library
+
+# [START full_sample]
+
+# FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+##     calling form "Generic"
+##     valueSet "wap" ("GetBigBook: 'War and Peace'")
+##       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable]}"
+##       [name="War and Peace"]
+##     apiMethod "get_big_book" of type "LongRunningOptionalArrayMethod"
+
+# [START core_sample]
+
+# FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+from google.cloud.example import library_v1
+
+client = library_v1.LibraryServiceClient()
+
+name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+
+response = client.get_big_book(name)
+
+def callback(operation_future):
+    # Handle result.
+    result = operation_future.result()
+
+response.add_done_callback(callback)
+
+# Handle metadata.
+metadata = response.metadata()
+print(response)
+
+# [END core_sample]
+
+# FIXME: Insert here clean-up code.
+
+# [END full_sample]
+============== file: samples/google/cloud/example/library_v1/gapic/monolog_about_book/monolog_about_book_sample_generic_prog.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookSampleGenericProg" ]
+#### STUB standalone sample "MonologAboutBookSampleGenericProg" #####
+
+# FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+# To run with the published packaged, execute the following before running this code:
+#   pip install google-cloud-library
+
+# [START full_sample]
+
+# FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+##     calling form "Generic"
+##     valueSet "prog" ("Programming Books")
+##       description: "Testing calling forms: {Java:[CallableClientStreaming]}"
+##       [name=BASIC]
+##     apiMethod "monolog_about_book" of type "OptionalArrayMethod"
+
+# [START core_sample]
+
+# FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+from google.cloud.example import library_v1
+
+client = library_v1.LibraryServiceClient()
+
+name = 'BASIC'
+request = {'name': name}
+
+requests = [request]
+response = client.monolog_about_book(requests)
+print(response)
+
+# [END core_sample]
+
+# FIXME: Insert here clean-up code.
+
+# [END full_sample]
 ============== file: samples/google/cloud/example/library_v1/gapic/publish_series/publish_series_sample_generic_pi_version.py ==============
 #### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleGenericPiVersion" ]
 #### STUB standalone sample "PublishSeriesSampleGenericPiVersion" #####
@@ -3451,6 +3627,7 @@ def lint_setup_py(session):
 
 ##     calling form "Generic"
 ##     valueSet "pi_version" ("Pi version")
+##       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 ##       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 ##     apiMethod "publish_series" of type "OptionalArrayMethod"
 
@@ -3493,6 +3670,7 @@ print(response)
 
 ##     calling form "Generic"
 ##     valueSet "second_edition" ("Second edition")
+##       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 ##       [edition=2]
 ##     apiMethod "publish_series" of type "OptionalArrayMethod"
 
@@ -3515,6 +3693,82 @@ series_uuid = {}
 edition = 2
 
 response = client.publish_series(shelf, books, series_uuid, edition=edition)
+print(response)
+
+# [END core_sample]
+
+# FIXME: Insert here clean-up code.
+
+# [END full_sample]
+============== file: samples/google/cloud/example/library_v1/gapic/stream_books/stream_books_sample_generic_prog.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksSampleGenericProg" ]
+#### STUB standalone sample "StreamBooksSampleGenericProg" #####
+
+# FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+# To run with the published packaged, execute the following before running this code:
+#   pip install google-cloud-library
+
+# [START full_sample]
+
+# FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+##     calling form "Generic"
+##     valueSet "prog" ("Programming Books")
+##       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
+##       [name=BASIC]
+##     apiMethod "stream_books" of type "OptionalArrayMethod"
+
+# [START core_sample]
+
+# FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+from google.cloud.example import library_v1
+
+client = library_v1.LibraryServiceClient()
+
+name = 'BASIC'
+
+for element in client.stream_books(name):
+    # process element
+    pass
+print(response)
+
+# [END core_sample]
+
+# FIXME: Insert here clean-up code.
+
+# [END full_sample]
+============== file: samples/google/cloud/example/library_v1/gapic/stream_shelves/stream_shelves_sample_generic_empty.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesSampleGenericEmpty" ]
+#### STUB standalone sample "StreamShelvesSampleGenericEmpty" #####
+
+# FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+# To run with the published packaged, execute the following before running this code:
+#   pip install google-cloud-library
+
+# [START full_sample]
+
+# FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+##     calling form "Generic"
+##     valueSet "empty" ("Server streaming")
+##       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
+##       []
+##     apiMethod "stream_shelves" of type "OptionalArrayMethod"
+
+# [START core_sample]
+
+# FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+from google.cloud.example import library_v1
+
+client = library_v1.LibraryServiceClient()
+
+for element in client.stream_shelves():
+    # process element
+    pass
 print(response)
 
 # [END core_sample]

--- a/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
@@ -240,13 +240,13 @@ interfaces:
     sample_value_sets:
     - id: pi_version
       title: "Pi version"
-      description: "Calling PublishSeries for the Pi series on the Math shelf"
+      description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
       parameters:
       - shelf.name=Math
       - series_uuid.series_string=xyz3141592654
     - id: second_edition
       title: "Second edition"
-      description: "Calling PublishSeries for a specified edition"
+      description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
       parameters:
       - edition=2
     samples:
@@ -494,6 +494,20 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 30000
+    sample_value_sets:
+    - id: empty
+      title: "Server streaming"
+      description: "Testing calling forms: {Java:[CallableServerStreaming]}"
+    samples:
+      in_code:
+      - calling_forms: ".*"
+        value_sets: ".*"
+      standalone:
+      - calling_forms: ".*"
+        value_sets: ".*"
+      api_explorer:
+      - calling_forms: ".*"
+        value_sets: ".*"    
   - name: StreamBooks
     request_object_method: false
     resource_name_treatment: STATIC_TYPES
@@ -506,6 +520,22 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 30000
+    sample_value_sets:
+    - id: prog
+      title: "Programming Books"
+      description: "Testing calling forms: {Java:[CallableServerStreaming]}"
+      parameters:
+        - name=BASIC
+    samples:
+      in_code:
+      - calling_forms: ".*"
+        value_sets: ".*"
+      standalone:
+      - calling_forms: ".*"
+        value_sets: ".*"
+      api_explorer:
+      - calling_forms: ".*"
+        value_sets: ".*"    
   - name: DiscussBook
     # required_fields makes a difference on sample code.
     required_fields:
@@ -514,6 +544,22 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 30000
+    sample_value_sets:
+    - id: prog
+      title: "Programming Books"
+      description: "Testing calling forms: {Java:[CallableBidiStreaming]}"
+      parameters:
+        - name=BASIC
+    samples:
+      in_code:
+      - calling_forms: ".*"
+        value_sets: ".*"
+      standalone:
+      - calling_forms: ".*"
+        value_sets: ".*"
+      api_explorer:
+      - calling_forms: ".*"
+        value_sets: ".*"
   - name: MonologAboutBook
     # required_fields makes a difference on sample code.
     required_fields:
@@ -522,6 +568,22 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 30000
+    sample_value_sets:
+    - id: prog
+      title: "Programming Books"
+      description: "Testing calling forms: {Java:[CallableClientStreaming]}"
+      parameters:
+        - name=BASIC
+    samples:
+      in_code:
+      - calling_forms: ".*"
+        value_sets: ".*"
+      standalone:
+      - calling_forms: ".*"
+        value_sets: ".*"
+      api_explorer:
+      - calling_forms: ".*"
+        value_sets: ".*"
   - name: FindRelatedBooks
     flattening:
       groups:
@@ -548,6 +610,23 @@ interfaces:
     # TODO(michaelbausor): support %-entity notation for list elements
     #- names[1]%shelf_id=my_shelf
     #- names[1]%book_id=my_first_book
+    sample_value_sets:
+    - id: odyssey
+      title: "The Odyssey"
+      description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged]}"
+      parameters:
+      - names[0]=Odyssey
+      - shelves[0]=Classics
+    samples:
+      in_code:
+      - calling_forms: ".*"
+        value_sets: odyssey
+      standalone:
+      - calling_forms: ".*"
+        value_sets: odyssey
+      api_explorer:
+      - calling_forms: ".*"
+        value_sets: odyssey    
   - name: AddTag
     flattening:
       groups:
@@ -613,6 +692,16 @@ interfaces:
       poll_delay_multiplier: 1.3
       max_poll_delay_millis: 30000
       total_poll_timeout_millis: 86400000
+    sample_value_sets:
+    - id: wap
+      title: "GetBigBook: 'War and Peace'"
+      description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable]}"
+      parameters:
+      - name="War and Peace"
+    samples:
+      standalone:
+      - calling_forms: ".*"
+        value_sets: ".*"
   - name: GetBigNothing
     flattening:
       groups:


### PR DESCRIPTION
This is one part of ensuring that each CallingForm that appears in
the generator code is actually reflected in a generated sample
baseline four the library service we use for testing.

- Each value set configuration in the library service will now say in its
  description which calling forms in which languages should be using
  that value set
- The CallingForm "Generic" is excluded from this, since it is just a
  transition placeholder until all languages employ CallingForm