### PR TITLE
Switching tests to use package_yaml2

### DIFF
--- a/src/main/java/com/google/api/codegen/DiscoGapicGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/DiscoGapicGeneratorApi.java
@@ -114,6 +114,7 @@ public class DiscoGapicGeneratorApi {
       List<String> configFileNames,
       String packageConfigFile,
       String packageConfig2File,
+      String dependencyConfigFile,
       List<String> enabledArtifacts)
       throws IOException {
     if (!new File(discoveryDocPath).exists()) {
@@ -150,7 +151,13 @@ public class DiscoGapicGeneratorApi {
                 + " were set, but only can be provided at once.");
       }
       ApiDefaultsConfig apiDefaultsConfig = ApiDefaultsConfig.load();
-      DependenciesConfig dependenciesConfig = DependenciesConfig.load();
+      DependenciesConfig dependenciesConfig;
+      if (dependencyConfigFile != null) {
+        dependenciesConfig =
+            DependenciesConfig.loadFromURL(new File(dependencyConfigFile).toURI().toURL());
+      } else {
+        dependenciesConfig = DependenciesConfig.load();
+      }
       PackagingConfig packagingConfig = PackagingConfig.load(packageConfig2File);
       packageConfig =
           PackageMetadataConfig.createFromPackaging(
@@ -199,6 +206,7 @@ public class DiscoGapicGeneratorApi {
             configFileNames,
             packageConfigFile,
             packageConfig2File,
+            null,
             enabledArtifacts);
 
     Map<String, Object> outputFiles = Maps.newHashMap();

--- a/src/main/java/com/google/api/codegen/config/DependenciesConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DependenciesConfig.java
@@ -145,9 +145,13 @@ public abstract class DependenciesConfig {
   }
 
   public static DependenciesConfig load() throws IOException {
-    URL apiDefaultsUrl =
+    URL dependenciesUrl =
         DependenciesConfig.class.getResource("/com/google/api/codegen/packaging/dependencies.yaml");
-    String contents = Resources.toString(apiDefaultsUrl, StandardCharsets.UTF_8);
+    return loadFromURL(dependenciesUrl);
+  }
+
+  public static DependenciesConfig loadFromURL(URL url) throws IOException {
+    String contents = Resources.toString(url, StandardCharsets.UTF_8);
     return createFromString(contents);
   }
 }

--- a/src/main/java/com/google/api/codegen/config/PackagingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackagingConfig.java
@@ -19,10 +19,13 @@ import com.google.api.codegen.grpcmetadatagen.ArtifactType;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
+import com.google.common.io.Resources;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -104,7 +107,7 @@ public abstract class PackagingConfig {
             .apiName((String) configMap.get("api_name"))
             .apiVersion((String) configMap.get("api_version"))
             .organizationName((String) configMap.get("organization_name"))
-            .protoPackageDependencies((List<String>) configMap.get("proto_deps"))
+            .protoPackageDependencies(nullToEmpty((List<String>) configMap.get("proto_deps")))
             .releaseLevel(Configs.parseReleaseLevel((String) configMap.get("release_level")))
             .artifactType(ArtifactType.of((String) configMap.get("artifact_type")))
             .protoPath((String) configMap.get("proto_path"));
@@ -115,8 +118,21 @@ public abstract class PackagingConfig {
     return builder.build();
   }
 
+  public static List<String> nullToEmpty(List<String> list) {
+    if (list == null) {
+      return new ArrayList<>();
+    } else {
+      return list;
+    }
+  }
+
   public static PackagingConfig load(String path) throws IOException {
     String contents = new String(Files.readAllBytes(Paths.get(path)), StandardCharsets.UTF_8);
+    return createFromString(contents);
+  }
+
+  public static PackagingConfig loadFromURL(URL url) throws IOException {
+    String contents = Resources.toString(url, StandardCharsets.UTF_8);
     return createFromString(contents);
   }
 }

--- a/src/main/java/com/google/api/codegen/config/PackagingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackagingConfig.java
@@ -18,14 +18,15 @@ import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.grpcmetadatagen.ArtifactType;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -107,7 +108,9 @@ public abstract class PackagingConfig {
             .apiName((String) configMap.get("api_name"))
             .apiVersion((String) configMap.get("api_version"))
             .organizationName((String) configMap.get("organization_name"))
-            .protoPackageDependencies(nullToEmpty((List<String>) configMap.get("proto_deps")))
+            .protoPackageDependencies(
+                MoreObjects.firstNonNull(
+                    (List<String>) configMap.get("proto_deps"), ImmutableList.of()))
             .releaseLevel(Configs.parseReleaseLevel((String) configMap.get("release_level")))
             .artifactType(ArtifactType.of((String) configMap.get("artifact_type")))
             .protoPath((String) configMap.get("proto_path"));
@@ -116,14 +119,6 @@ public abstract class PackagingConfig {
     }
 
     return builder.build();
-  }
-
-  public static List<String> nullToEmpty(List<String> list) {
-    if (list == null) {
-      return new ArrayList<>();
-    } else {
-      return list;
-    }
   }
 
   public static PackagingConfig load(String path) throws IOException {

--- a/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
@@ -24,18 +24,17 @@
   dependencies {
     compile 'com.google.api:gax:{@metadata.gaxVersionBound.lower}'
     testCompile 'com.google.api:gax:{@metadata.gaxVersionBound.lower}:testlib'
-    @if metadata.hasGaxGrpcVersionBound
-      compile 'com.google.api:gax-grpc:{@metadata.gaxGrpcVersionBound.lower}'
-      testCompile 'com.google.api:gax-grpc:{@metadata.gaxGrpcVersionBound.lower}:testlib'
-    @end
-    @if metadata.hasGaxHttpVersionBound
+    @switch metadata.artifactType.toString
+    @case "DISCOGAPIC"
       compile 'com.google.api:gax-httpjson:{@metadata.gaxHttpVersionBound.lower}'
       testCompile 'com.google.api:gax-httpjson:{@metadata.gaxHttpVersionBound.lower}:testlib'
+    @case "GAPIC"
+      compile 'com.google.api:gax-grpc:{@metadata.gaxGrpcVersionBound.lower}'
+      testCompile 'com.google.api:gax-grpc:{@metadata.gaxGrpcVersionBound.lower}:testlib'
+      testCompile 'io.grpc:grpc-netty-shaded:{@metadata.grpcVersionBound.lower}'
+    @default
     @end
     testCompile 'junit:junit:4.12'
-    @if metadata.hasGrpcVersionBound
-      testCompile 'io.grpc:grpc-netty-shaded:{@metadata.grpcVersionBound.lower}'
-    @end
     @switch metadata.artifactType.toString
     @case "DISCOGAPIC"
     @case "DISCOGAPIC_CONFIG"

--- a/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
+++ b/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
@@ -57,6 +57,10 @@ gax_grpc_version:
   java:
     lower: '1.23.0'
 
+gax_http_version:
+  java:
+    lower: '0.40.0'
+
 proto_version:
   python:
     lower: '3.0.0'

--- a/src/test/java/com/google/api/codegen/DiscoGapicTestBase.java
+++ b/src/test/java/com/google/api/codegen/DiscoGapicTestBase.java
@@ -71,11 +71,14 @@ public abstract class DiscoGapicTestBase extends ConfigBaselineTestCase {
           DiscoGapicGeneratorApi.getProviders(
               getTestDataLocator().findTestData(discoveryDocFileName).getPath(),
               gapicConfigFilePaths,
-              getTestDataLocator().findTestData(packageConfigFileName).getPath(),
               null,
+              getTestDataLocator().findTestData(packageConfigFileName).getPath(),
+              getTestDataLocator()
+                  .findTestData("com/google/api/codegen/testsrc/frozen_dependencies.yaml")
+                  .getPath(),
               Collections.emptyList());
     } catch (IOException e) {
-      throw new IllegalArgumentException("Problem creating DiscoGapic generator.");
+      throw new IllegalArgumentException("Problem creating DiscoGapic generator.", e);
     }
 
     config =

--- a/src/test/java/com/google/api/codegen/GapicCodeGeneratorTest.java
+++ b/src/test/java/com/google/api/codegen/GapicCodeGeneratorTest.java
@@ -69,92 +69,92 @@ public class GapicCodeGeneratorTest extends GapicTestBase2 {
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.PHP,
             new String[] {"php_gapic.yaml", "library_gapic.yaml"},
-            "library_pkg.yaml",
+            "library_pkg2.yaml",
             "library"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.PHP,
             new String[] {"php_gapic.yaml", "longrunning_gapic.yaml"},
-            "longrunning_pkg.yaml",
+            "longrunning_pkg2.yaml",
             "longrunning"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.PHP,
             new String[] {"php_gapic.yaml", "no_path_templates_gapic.yaml"},
-            "no_path_templates_pkg.yaml",
+            "no_path_templates_pkg2.yaml",
             "no_path_templates"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.JAVA,
             new String[] {"java_gapic.yaml", "library_gapic.yaml"},
-            "library_pkg.yaml",
+            "library_pkg2.yaml",
             "library"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.JAVA,
             new String[] {"java_gapic.yaml", "no_path_templates_gapic.yaml"},
-            "no_path_templates_pkg.yaml",
+            "no_path_templates_pkg2.yaml",
             "no_path_templates"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.RUBY,
             new String[] {"ruby_gapic.yaml", "library_gapic.yaml"},
-            "library_pkg.yaml",
+            "library_pkg2.yaml",
             "library"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.RUBY_DOC,
             new String[] {"ruby_gapic.yaml", "library_gapic.yaml"},
-            "library_pkg.yaml",
+            "library_pkg2.yaml",
             "library"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.RUBY,
             new String[] {"ruby_gapic.yaml", "multiple_services_gapic.yaml"},
-            "multiple_services_pkg.yaml",
+            "multiple_services_pkg2.yaml",
             "multiple_services"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.RUBY,
             new String[] {"ruby_gapic.yaml", "longrunning_gapic.yaml"},
-            "longrunning_pkg.yaml",
+            "longrunning_pkg2.yaml",
             "longrunning"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.PYTHON,
             new String[] {"python_gapic.yaml", "library_gapic.yaml"},
-            "library_pkg.yaml",
+            "library_pkg2.yaml",
             "library"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.PYTHON,
             new String[] {"python_gapic.yaml", "no_path_templates_gapic.yaml"},
-            "no_path_templates_pkg.yaml",
+            "no_path_templates_pkg2.yaml",
             "no_path_templates"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.PYTHON,
             new String[] {"python_gapic.yaml", "multiple_services_gapic.yaml"},
-            "multiple_services_pkg.yaml",
+            "multiple_services_pkg2.yaml",
             "multiple_services"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.NODEJS,
             new String[] {"nodejs_gapic.yaml", "library_gapic.yaml"},
-            "library_pkg.yaml",
+            "library_pkg2.yaml",
             "library"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.NODEJS_DOC,
             new String[] {"nodejs_gapic.yaml", "library_gapic.yaml"},
-            "library_pkg.yaml",
+            "library_pkg2.yaml",
             "library"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.NODEJS,
             new String[] {"nodejs_gapic.yaml", "no_path_templates_gapic.yaml"},
-            "library_pkg.yaml",
+            "library_pkg2.yaml",
             "no_path_templates"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.NODEJS,
             new String[] {"nodejs_gapic.yaml", "multiple_services_gapic.yaml"},
-            "multiple_services_pkg.yaml",
+            "multiple_services_pkg2.yaml",
             "multiple_services"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.CSHARP,
             new String[] {"csharp_gapic.yaml", "library_gapic.yaml"},
-            "library_pkg.yaml",
+            "library_pkg2.yaml",
             "library"),
         GapicTestBase2.createTestConfig(
             MainGapicProviderFactory.CLIENT_CONFIG,
             new String[] {"client_gapic.yaml", "library_gapic.yaml"},
-            "library_pkg.yaml",
+            "library_pkg2.yaml",
             "library"));
   }
 

--- a/src/test/java/com/google/api/codegen/GapicTestBase2.java
+++ b/src/test/java/com/google/api/codegen/GapicTestBase2.java
@@ -15,8 +15,11 @@
 package com.google.api.codegen;
 
 import com.google.api.Service;
+import com.google.api.codegen.config.ApiDefaultsConfig;
+import com.google.api.codegen.config.DependenciesConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.PackageMetadataConfig;
+import com.google.api.codegen.config.PackagingConfig;
 import com.google.api.codegen.gapic.GapicGeneratorConfig;
 import com.google.api.codegen.gapic.GapicProvider;
 import com.google.api.codegen.gapic.MainGapicProviderFactory;
@@ -27,11 +30,6 @@ import com.google.api.tools.framework.model.testing.ConfigBaselineTestCase;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -81,11 +79,16 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
             model.getDiagCollector(), getTestDataLocator(), gapicConfigFileNames);
     if (!Strings.isNullOrEmpty(packageConfigFileName)) {
       try {
-        URI packageConfigUrl = getTestDataLocator().findTestData(packageConfigFileName).toURI();
-        String contents =
-            new String(Files.readAllBytes(Paths.get(packageConfigUrl)), StandardCharsets.UTF_8);
-        packageConfig = PackageMetadataConfig.createFromString(contents);
-      } catch (IOException | URISyntaxException e) {
+        ApiDefaultsConfig apiDefaultsConfig = ApiDefaultsConfig.load();
+        DependenciesConfig dependenciesConfig =
+            DependenciesConfig.loadFromURL(
+                getTestDataLocator().findTestData("frozen_dependencies.yaml"));
+        PackagingConfig packagingConfig =
+            PackagingConfig.loadFromURL(getTestDataLocator().findTestData(packageConfigFileName));
+        packageConfig =
+            PackageMetadataConfig.createFromPackaging(
+                apiDefaultsConfig, dependenciesConfig, packagingConfig);
+      } catch (IOException e) {
         throw new IllegalArgumentException("Problem creating packageConfig");
       }
     }

--- a/src/test/java/com/google/api/codegen/JavaDiscoGapicGeneratorTest.java
+++ b/src/test/java/com/google/api/codegen/JavaDiscoGapicGeneratorTest.java
@@ -56,7 +56,7 @@ public class JavaDiscoGapicGeneratorTest extends DiscoGapicTestBase {
               "com/google/api/codegen/java/java_discogapic.yaml",
               "com/google/api/codegen/testdata/simplecompute_gapic.yaml",
             },
-            "com/google/api/codegen/testdata/simplecompute_pkg.yaml"
+            "com/google/api/codegen/testdata/simplecompute_pkg2.yaml"
           });
     }
     return builder.build();

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -38,8 +38,8 @@ dependencies {
   testCompile 'com.google.api:gax:1.0.0:testlib'
   compile 'com.google.api:gax-grpc:0.18.0'
   testCompile 'com.google.api:gax-grpc:0.18.0:testlib'
-  testCompile 'junit:junit:4.12'
   testCompile 'io.grpc:grpc-netty-shaded:1.9.0'
+  testCompile 'junit:junit:4.12'
   // Remove this line if you are bundling your proto-generated classes together with your client classes
   compile project(':proto-google-cloud-library-v1')
   // Remove this line if you are bundling your proto-generated classes together with your client classes

--- a/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
@@ -38,8 +38,8 @@ dependencies {
   testCompile 'com.google.api:gax:1.0.0:testlib'
   compile 'com.google.api:gax-grpc:0.18.0'
   testCompile 'com.google.api:gax-grpc:0.18.0:testlib'
-  testCompile 'junit:junit:4.12'
   testCompile 'io.grpc:grpc-netty-shaded:1.9.0'
+  testCompile 'junit:junit:4.12'
   // Remove this line if you are bundling your proto-generated classes together with your client classes
   compile project(':proto-google-cloud-library-v1')
   // Remove this line if you are bundling your proto-generated classes together with your client classes

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -1,5 +1,5 @@
 ============== file: README.md ==============
-# Node.js Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-node#versioning))
+# Node.js Client for Google Example Library API ([Production/Stable](https://github.com/GoogleCloudPlatform/google-cloud-node#versioning))
 
 [Google Example Library API][Product Documentation]:
 A simple Google Example Library API.
@@ -68,7 +68,7 @@ $ npm install --save @google-cloud/library
 {
   "repository": "GoogleCloudPlatform/google-cloud-node",
   "name": "@google-cloud/library",
-  "version": "0.7.1",
+  "version": "0.1.0",
   "author": "Google LLC",
   "description": "Google Example Library API client for Node.js",
   "main": "src/index.js",

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -1,5 +1,5 @@
 ============== file: README.md ==============
-# Node.js Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-node#versioning))
+# Node.js Client for Google Example Library API ([Production/Stable](https://github.com/GoogleCloudPlatform/google-cloud-node#versioning))
 
 [Google Example Library API][Product Documentation]:
 A simple Google Example Library API.
@@ -68,7 +68,7 @@ $ npm install --save @google-cloud/library
 {
   "repository": "GoogleCloudPlatform/google-cloud-node",
   "name": "@google-cloud/library",
-  "version": "0.7.1",
+  "version": "0.1.0",
   "author": "Google LLC",
   "description": "Google Example Library API client for Node.js",
   "main": "src/index.js",

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -1,5 +1,5 @@
 ============== file: README.md ==============
-# Node.js Clients for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-node#versioning))
+# Node.js Clients for Google Example API ([Production/Stable](https://github.com/GoogleCloudPlatform/google-cloud-node#versioning))
 
 [Google Example API][Product Documentation]:
 This description tests descriptions that span multiple lines. This is a service
@@ -35,7 +35,7 @@ $ npm install --save @google-cloud/multiple-services
 {
   "repository": "GoogleCloudPlatform/google-cloud-node",
   "name": "@google-cloud/multiple-services",
-  "version": "0.7.1",
+  "version": "0.1.0",
   "author": "Google LLC",
   "description": "Google Example API client for Node.js",
   "main": "src/index.js",

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -1,5 +1,5 @@
 ============== file: README.md ==============
-# Node.js Client for Google Fake API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-node#versioning))
+# Node.js Client for Google Fake API ([Production/Stable](https://github.com/GoogleCloudPlatform/google-cloud-node#versioning))
 
 [Google Fake API][Product Documentation]:
 Tests no path templates
@@ -34,7 +34,7 @@ $ npm install --save example
 {
   "repository": "GoogleCloudPlatform/google-cloud-node",
   "name": "example",
-  "version": "0.7.1",
+  "version": "0.1.0",
   "author": "Google LLC",
   "description": "Google Fake API client for Node.js",
   "main": "src/index.js",

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -209,15 +209,15 @@ global-exclude *.py[co]
 global-exclude __pycache__
 
 ============== file: README.rst ==============
-Python Client for Google Example Library API (`Alpha`_)
-=======================================================
+Python Client for Google Example Library API (`Production/Stable`_)
+===================================================================
 
 `Google Example Library API`_: A simple Google Example Library API.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. _Production/Stable: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Google Example Library API: https://cloud.google.com/library
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/library/usage.html
 .. _Product Documentation:  https://cloud.google.com/library
@@ -326,7 +326,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '0.15.0'
+__version__ = '0.1.0'
 
 # -- General configuration ------------------------------------------------
 
@@ -637,15 +637,15 @@ Types for Google Example Library API Client
 .. automodule:: google.cloud.example.library_v1.types
     :members:
 ============== file: docs/index.rst ==============
-Python Client for Google Example Library API (`Alpha`_)
-=======================================================
+Python Client for Google Example Library API (`Production/Stable`_)
+===================================================================
 
 `Google Example Library API`_: A simple Google Example Library API.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. _Production/Stable: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Google Example Library API: https://cloud.google.com/library
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/library/usage.html
 .. _Product Documentation:  https://cloud.google.com/library
@@ -3804,8 +3804,8 @@ import setuptools
 
 name = 'google-cloud-library'
 description = 'Google Example Library API API client library'
-version = '0.15.0'
-release_status = '3 - Alpha'
+version = '0.1.0'
+release_status = '5 - Production/Stable'
 dependencies = [
   'google-api-core[grpc] >= 1.1.0, < 2.0.0dev',
 

--- a/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
@@ -209,15 +209,15 @@ global-exclude *.py[co]
 global-exclude __pycache__
 
 ============== file: README.rst ==============
-Python Client for Google Example API (`Alpha`_)
-===============================================
+Python Client for Google Example API (`Production/Stable`_)
+===========================================================
 
 `Google Example API`_: This description tests descriptions that span multiple lines. This is a service that increments and decrements a counter.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. _Production/Stable: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Google Example API: https://cloud.google.com/multiple_services
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/multiple_services/usage.html
 .. _Product Documentation:  https://cloud.google.com/multiple_services
@@ -307,7 +307,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '0.15.0'
+__version__ = '0.1.0'
 
 # -- General configuration ------------------------------------------------
 
@@ -618,15 +618,15 @@ Types for Google Example API Client
 .. automodule:: google.cloud.example_v1.types
     :members:
 ============== file: docs/index.rst ==============
-Python Client for Google Example API (`Alpha`_)
-===============================================
+Python Client for Google Example API (`Production/Stable`_)
+===========================================================
 
 `Google Example API`_: This description tests descriptions that span multiple lines. This is a service that increments and decrements a counter.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. _Production/Stable: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Google Example API: https://cloud.google.com/multiple_services
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/multiple_services/usage.html
 .. _Product Documentation:  https://cloud.google.com/multiple_services
@@ -1263,8 +1263,8 @@ import setuptools
 
 name = 'google-cloud-multiple_services'
 description = 'Google Example API API client library'
-version = '0.15.0'
-release_status = '3 - Alpha'
+version = '0.1.0'
+release_status = '5 - Production/Stable'
 dependencies = [
   'google-api-core[grpc] >= 1.1.0, < 2.0.0dev',
 

--- a/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
@@ -307,7 +307,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '0.15.0'
+__version__ = '0.1.0'
 
 # -- General configuration ------------------------------------------------
 
@@ -1051,7 +1051,7 @@ import setuptools
 
 name = 'google-cloud-library'
 description = 'Google Fake API API client library'
-version = '0.15.0'
+version = '0.1.0'
 release_status = '4 - Beta'
 dependencies = [
   'google-api-core[grpc] >= 1.1.0, < 2.0.0dev',

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -258,7 +258,7 @@ gem "rake", "~> 11.0"
    limitations under the License.
 
 ============== file: README.md ==============
-# Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+# Ruby Client for Google Example Library API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 
 [Google Example Library API][Product Documentation]:
 A simple Google Example Library API.
@@ -560,7 +560,7 @@ require "pathname"
 # rubocop:disable LineLength
 
 ##
-# # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+# # Ruby Client for Google Example Library API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
 # [Google Example Library API][Product Documentation]:
 # A simple Google Example Library API.
@@ -724,7 +724,7 @@ require "library/v1/errors_pb"
 # rubocop:disable LineLength
 
 ##
-# # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+# # Ruby Client for Google Example Library API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
 # [Google Example Library API][Product Documentation]:
 # A simple Google Example Library API.
@@ -2470,7 +2470,7 @@ end
 # rubocop:disable LineLength
 
 ##
-# # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+# # Ruby Client for Google Example Library API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
 # [Google Example Library API][Product Documentation]:
 # A simple Google Example Library API.
@@ -4662,7 +4662,7 @@ end
 
 Gem::Specification.new do |gem|
   gem.name          = "library"
-  gem.version       = "0.6.8"
+  gem.version       = "0.1.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -258,7 +258,7 @@ gem "rake", "~> 11.0"
    limitations under the License.
 
 ============== file: README.md ==============
-# Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+# Ruby Client for Google Example Library API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 
 [Google Example Library API][Product Documentation]:
 A simple Google Example Library API.
@@ -560,7 +560,7 @@ require "pathname"
 # rubocop:disable LineLength
 
 ##
-# # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+# # Ruby Client for Google Example Library API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
 # [Google Example Library API][Product Documentation]:
 # A simple Google Example Library API.
@@ -724,7 +724,7 @@ require "library/v1/errors_pb"
 # rubocop:disable LineLength
 
 ##
-# # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+# # Ruby Client for Google Example Library API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
 # [Google Example Library API][Product Documentation]:
 # A simple Google Example Library API.
@@ -2898,7 +2898,7 @@ end
 
 Gem::Specification.new do |gem|
   gem.name          = "library"
-  gem.version       = "0.6.8"
+  gem.version       = "0.1.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -258,7 +258,7 @@ gem "rake", "~> 11.0"
    limitations under the License.
 
 ============== file: README.md ==============
-# Ruby Client for Google Long Running Operations API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+# Ruby Client for Google Long Running Operations API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 
 [Google Long Running Operations API][Product Documentation]:
 
@@ -589,7 +589,7 @@ end
 
 Gem::Specification.new do |gem|
   gem.name          = "google"
-  gem.version       = "0.6.8"
+  gem.version       = "0.1.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
@@ -648,7 +648,7 @@ module Google
   # rubocop:disable LineLength
 
   ##
-  # # Ruby Client for Google Long Running Operations API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+  # # Ruby Client for Google Long Running Operations API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
   #
   # [Google Long Running Operations API][Product Documentation]:
   #

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -444,7 +444,7 @@ end
 
 Gem::Specification.new do |gem|
   gem.name          = "google-example"
-  gem.version       = "0.6.8"
+  gem.version       = "0.1.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/src/test/java/com/google/api/codegen/testdata/simplecompute_pkg2.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/simplecompute_pkg2.yaml
@@ -1,0 +1,6 @@
+api_name: simplecompute
+api_version: v1
+artifact_type: DISCOGAPIC
+organization_name: google-cloud
+proto_path: google/simplecompute
+release_level: BETA

--- a/src/test/java/com/google/api/codegen/testsrc/frozen_dependencies.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/frozen_dependencies.yaml
@@ -1,0 +1,86 @@
+
+# Dependencies
+auth_version:
+  python:
+    lower: '1.0.2'
+    upper: '2.0dev'
+  nodejs:
+    lower: '0.9.8'
+  ruby:
+    lower: '0.5.1'
+
+gax_version:
+  python:
+    lower: '0.15.0'
+    upper: '0.16.0'
+  nodejs:
+    lower: '0.14.0'
+  php:
+    lower: '0.6.*'
+  ruby:
+    lower: '0.8.0'
+  java:
+    lower: '1.0.0'
+
+gax_grpc_version:
+  csharp:
+    lower: '2.1.0'
+  java:
+    lower: '0.18.0'
+
+gax_http_version:
+  java:
+    lower: '0.18.0'
+
+grpc_version:
+  csharp:
+    lower: '1.6.1'
+  python:
+    lower: '1.0.2'
+    upper: '2.0dev'
+  nodejs:
+    lower: '0.15.0'
+  php:
+    lower: '0.14.1'
+  ruby:
+    lower: '1.0'
+  java:
+    lower: '1.9.0'
+
+proto_version:
+  python:
+    lower: '3.0.0'
+    upper: '4.0dev'
+  nodejs:
+    lower: '^0.8.3'
+  php:
+    lower: '0.7.*'
+  ruby:
+    lower: '3.0'
+
+api_common_version:
+  java:
+    lower: '0.0.2'
+
+google-common-protos_version:
+  python:
+    name_override: googleapis-common-protos
+    lower: '1.5.0'
+    upper: '2.0dev'
+  ruby:
+    name_override: googleapis-common-protos
+    lower: '1.3.1'
+
+google-some-other-package-v1_version:
+  python:
+    name_override: python-other-package
+    lower: '12.1.0'
+    upper: '13.5.1'
+  nodejs:
+    lower: '0.2.1'
+  ruby:
+    lower: '0.2.1'
+
+google-some-test-package-v1_version:
+  java:
+    lower: '0.0.0'

--- a/src/test/java/com/google/api/codegen/testsrc/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_pkg.yaml
@@ -1,4 +1,5 @@
 # Common configuration
+artifact_type: GAPIC
 short_name: library
 major_version: v1
 proto_path: google/library
@@ -18,18 +19,20 @@ package_name:
 
 generated_package_version:
   python:
-    lower: '0.15.0'
-    upper: '0.16dev'
+    lower: '0.1.0'
+    upper: '0.2.0dev'
   nodejs:
-    lower: '0.7.1'
+    lower: '0.1.0'
   php:
     lower: '0.1.0'
   ruby:
-    lower: '0.6.8'
+    lower: '0.1.0'
 
 release_level:
-  python: ALPHA
   java: GA
+  nodejs: GA
+  python: GA
+  ruby: GA
 
 # Dependencies
 auth_version:

--- a/src/test/java/com/google/api/codegen/testsrc/library_pkg2.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_pkg2.yaml
@@ -1,0 +1,11 @@
+api_name: library
+api_version: v1
+artifact_type: GAPIC
+organization_name: google-cloud
+proto_path: google/library
+proto_deps:
+- google-common-protos
+- google-some-other-package-v1
+proto_test_deps:
+- google-some-test-package-v1
+release_level: GA

--- a/src/test/java/com/google/api/codegen/testsrc/longrunning_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/longrunning_pkg.yaml
@@ -15,18 +15,20 @@ package_name:
 
 generated_package_version:
   python:
-    lower: '0.15.0'
-    upper: '0.16dev'
+    lower: '0.1.0'
+    upper: '0.2.0dev'
   nodejs:
-    lower: '0.7.1'
+    lower: '0.1.0'
   php:
     lower: '0.1.0'
   ruby:
-    lower: '0.6.8'
+    lower: '0.1.0'
 
 release_level:
-  python: ALPHA
   java: GA
+  nodejs: GA
+  python: GA
+  ruby: GA
 
 # Dependencies
 auth_version:

--- a/src/test/java/com/google/api/codegen/testsrc/longrunning_pkg2.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/longrunning_pkg2.yaml
@@ -1,0 +1,8 @@
+api_name: longrunning
+api_version: v1
+artifact_type: GAPIC
+organization_name: google-cloud
+proto_path: google/longrunning
+proto_deps:
+- google-common-protos
+release_level: GA

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg.yaml
@@ -1,4 +1,5 @@
 # Common configuration
+artifact_type: GAPIC
 short_name: multiple_services
 major_version: v1
 proto_path: google/multiple_services
@@ -18,19 +19,20 @@ package_name:
 
 generated_package_version:
   python:
-    lower: '0.15.0'
-    upper: '0.16dev'
+    lower: '0.1.0'
+    upper: '0.2.0dev'
   nodejs:
-    lower: '0.7.1'
+    lower: '0.1.0'
   php:
     lower: '0.1.0'
   ruby:
-    lower: '0.6.8'
+    lower: '0.1.0'
 
 release_level:
-  python: ALPHA
   java: GA
-  ruby: BETA
+  nodejs: GA
+  python: GA
+  ruby: GA
 
 # Dependencies
 auth_version:

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg2.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg2.yaml
@@ -1,0 +1,11 @@
+api_name: multiple_services
+api_version: v1
+artifact_type: GAPIC
+organization_name: google-cloud
+proto_path: google/multiple_services
+proto_deps:
+- google-common-protos
+- google-some-other-package-v1
+proto_test_deps:
+- google-some-test-package-v1
+release_level: GA

--- a/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg.yaml
@@ -1,4 +1,5 @@
 # Common configuration
+artifact_type: GAPIC
 short_name: library
 major_version: v1
 proto_path: google/library
@@ -16,18 +17,20 @@ package_name:
 
 generated_package_version:
   python:
-    lower: '0.15.0'
-    upper: '0.16dev'
+    lower: '0.1.0'
+    upper: '0.1.0dev'
   nodejs:
-    lower: '0.7.1'
+    lower: '0.1.0'
   php:
     lower: '0.1.0'
   ruby:
-    lower: '0.6.8'
+    lower: '0.1.0'
 
 release_level:
-  python: BETA
   java: BETA
+  nodejs: BETA
+  python: BETA
+  ruby: BETA
 
 # Dependencies
 auth_version:

--- a/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg2.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg2.yaml
@@ -1,0 +1,9 @@
+api_name: library
+api_version: v1
+artifact_type: GAPIC
+organization_name: google-cloud
+proto_path: google/library
+proto_deps:
+- google-common-protos
+- google-some-other-package-v1
+release_level: BETA


### PR DESCRIPTION
Switching tests to use package_yaml2.

Also:
- Adding a `frozen_dependencies.yaml` file so that tests don't have to be updated when the main `dependencies.yaml` is updated
- Fixing grpc vs httpjson dependencies for Java - instead of triggering based on version presence in DependencyConfig (since all versions will be present), instead triggering based on artifact type
- Creating new files (_pkg2.yaml) instead of updating existing ones, in order to create less noise; I'll delete the old ones in a cleanup phase.
- Some Python/Node/Ruby baselines have diffs due to original dependencies on a multitude of versions in _pkg.yaml files, whereas now everything comes from a single source
- Note: I discovered as part of this update that I completely overlooked grpc metadata generation; I'll to a full testing pass between artman & gapic-generator as a later work item.
