### PR TITLE
Assign and use the correct calling forms for NodeJS samples

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -382,7 +382,7 @@ public class StaticLangApiMethodTransformer {
         namer.getCallableMethodName(method),
         Synchronicity.Sync,
         methodViewBuilder,
-        Arrays.asList(CallingForm.RequestServerStreaming));
+        Arrays.asList(CallingForm.RequestStreamingServer));
     setStaticLangGrpcStreamingReturnTypeName(context, methodViewBuilder);
 
     return methodViewBuilder.type(ClientMethodType.RequestObjectMethod).build();

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
@@ -83,15 +83,15 @@ public class JavaMethodViewGenerator {
         switch (methodConfig.getGrpcStreamingType()) {
           case BidiStreaming:
             typeTable.saveNicknameFor("com.google.api.gax.rpc.BidiStreamingCallable");
-            callingForms = Collections.singletonList(CallingForm.CallableBidiStreaming);
+            callingForms = Collections.singletonList(CallingForm.CallableStreamingBidi);
             break;
           case ClientStreaming:
             typeTable.saveNicknameFor("com.google.api.gax.rpc.ClientStreamingCallable");
-            callingForms = Collections.singletonList(CallingForm.CallableClientStreaming);
+            callingForms = Collections.singletonList(CallingForm.CallableStreamingClient);
             break;
           case ServerStreaming:
             typeTable.saveNicknameFor("com.google.api.gax.rpc.ServerStreamingCallable");
-            callingForms = Collections.singletonList(CallingForm.CallableServerStreaming);
+            callingForms = Collections.singletonList(CallingForm.CallableStreamingServer);
             break;
           default:
             throw new IllegalArgumentException(

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSamplesTransformer.java
@@ -28,7 +28,6 @@ import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
-import com.google.api.codegen.transformer.py.NodeJSMethodViewGenerator;
 import com.google.api.codegen.util.js.JSTypeTable;
 import com.google.api.codegen.viewmodel.DynamicLangSampleView;
 import com.google.api.codegen.viewmodel.MethodSampleView;

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -38,7 +38,6 @@ import com.google.api.codegen.transformer.PageStreamingTransformer;
 import com.google.api.codegen.transformer.PathTemplateTransformer;
 import com.google.api.codegen.transformer.ServiceTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
-import com.google.api.codegen.transformer.py.NodeJSMethodViewGenerator;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.js.JSTypeTable;
 import com.google.api.codegen.viewmodel.ApiMethodView;

--- a/src/main/java/com/google/api/codegen/viewmodel/CallingForm.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/CallingForm.java
@@ -20,11 +20,21 @@ package com.google.api.codegen.viewmodel;
  * language.
  */
 public enum CallingForm {
-  Request, // Java
+
+  // By convention, the names of these enum values should be
+  // concatenations of the following descriptive parts (some of which may
+  // be empty), in order:
+  //
+  // [Method signature type][Request pattern][Response pattern][Idiomatic pattern]
+
+  Request, // Java, NodeJS
   RequestAsync,
-  RequestAsyncPaged,
-  RequestServerStreaming,
+  RequestAsyncPaged, // NodeJS
+  RequestAsyncPagedAll, // NodeJS
   RequestPaged, // Java
+  RequestStreamingBidi, // NodeJS
+  RequestStreamingClient, // NodeJS
+  RequestStreamingServer, // NodeJS
 
   Flattened, // Java
   FlattenedPaged, // Java
@@ -34,15 +44,17 @@ public enum CallingForm {
   Callable, // Java
   CallableList, // Java
   CallablePaged, // Java
-  CallableClientStreaming, // Java
-  CallableServerStreaming, // Java
-  CallableBidiStreaming, // Java
+  CallableStreamingBidi, // Java
+  CallableStreamingClient, // Java
+  CallableStreamingServer, // Java
 
-  LongRunningRequest,
-  LongRunningRequestAsync, // Java
+  LongRunningCallable, // Java
+  LongRunningEventEmitter, // NodeJS
   LongRunningFlattened,
   LongRunningFlattenedAsync, // Java
-  LongRunningCallable, // Java
+  LongRunningPromise, // NodeJS
+  LongRunningRequest,
+  LongRunningRequestAsync, // Java
 
   // Used only if code does not yet support deciding on one of the other ones. The goal is to have
   // this value never set.

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -55,18 +55,18 @@
       {@unpagedListCallableMethodSampleCode(apiMethod, initCode)}
     @case "CallablePaged"
       {@pagedCallableMethodSampleCode(apiMethod, initCode)}
-    @case "CallableClientStreaming"
-      {@clientStreamingCallableSampleCode(apiMethod, initCode)}
-    @case "CallableServerStreaming"
-      {@serverStreamingCallableSampleCode(apiMethod, initCode)}
-    @case "CallableBidiStreaming"
+    @case "CallableStreamingBidi"
       {@bidiStreamingCallableSampleCode(apiMethod, initCode)}      
-    @case "LongRunningRequestAsync"
-      {@asyncOperationMethodSampleCode(apiMethod, initCode)}
-    @case "LongRunningFlattenedAsync"
-      {@asyncOperationMethodSampleCode(apiMethod, initCode)}
+    @case "CallableStreamingClient"
+      {@clientStreamingCallableSampleCode(apiMethod, initCode)}
+    @case "CallableStreamingServer"
+      {@serverStreamingCallableSampleCode(apiMethod, initCode)}
     @case "LongRunningCallable"
       {@asyncOperationCallableMethodSampleCode(apiMethod, initCode)}
+    @case "LongRunningFlattenedAsync"
+      {@asyncOperationMethodSampleCode(apiMethod, initCode)}
+    @case "LongRunningRequestAsync"
+      {@asyncOperationMethodSampleCode(apiMethod, initCode)}
     @default
       $unhandledCallingForm: {@callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
     @end

--- a/src/main/resources/com/google/api/codegen/nodejs/README.md.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/README.md.snip
@@ -13,7 +13,7 @@
   @join method : methods on BREAK
     @#### {@method.apiClassName}
     ```js
-     {@decorateSampleCodeUnversioned(method, sampleCode(method))}
+     {@decorateSampleCodeUnversioned(method, sampleCode(method, method.initCode))}
     ```
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
@@ -24,17 +24,16 @@
     {@coreSampleCode}
 @end
 
-@snippet sampleCode(apiMethod)
-    {@sampleCode(apiMethod, apiMethod.initCode)}
-@end
-
 @snippet sampleCode(apiMethod, init)
     {@sampleCode(apiMethod, init, empty())}
 @end
 
-@private empty()
+@snippet empty()
 @end
 
+# TODO(vchudnov-g): When we implement in-code samples, the switch
+# statement below will switch on the callingfrom selected for the
+# sample (as happens now in standalone_sample.snip).
 @snippet sampleCode(apiMethod, init, additionalCallback)
     @switch apiMethod.type.toString
     @case "OptionalArrayMethod"
@@ -70,7 +69,7 @@
       @end
 @end
 
-@private clientStreamingSampleCode(apiMethod, init, additionalCallback)
+@snippet clientStreamingSampleCode(apiMethod, init, additionalCallback)
     var stream = client.{@apiMethod.name}((err, response) => {
       @if additionalCallback
         if (err) {
@@ -91,7 +90,7 @@
     {@sampleWriteStreamingRequest(apiMethod)}
 @end
 
-@private bidiStreamingSampleCode(apiMethod, init, additionalCallback)
+@snippet bidiStreamingSampleCode(apiMethod, init, additionalCallback)
     var stream = client.{@apiMethod.name}().on('data', response => {
       @if additionalCallback
         console.log(response);
@@ -140,7 +139,7 @@
     {@methodCallSampleCodeForPagedResponse(apiMethod, init, additionalCallback)}
 @end
 
-@private methodCallSampleCode(apiMethod, init)
+@snippet methodCallSampleCode(apiMethod, init)
     client.{@apiMethod.name}(\
         {@sampleMethodCallArgList(apiMethod, init)})
 @end
@@ -214,7 +213,7 @@
   @end
 @end
 
-@private methodCallSampleCodeWithReturnValue(apiMethod, init, additionalCallback)
+@snippet methodCallSampleCodeWithReturnValue(apiMethod, init, additionalCallback)
   {@initCode(apiMethod, init)}
   {@methodCallSampleCodePrefix(apiMethod, init)}
     .then(responses => {
@@ -307,7 +306,7 @@
     {@promiseCallbacks(additionalCallback)}
 @end
 
-@private methodCallSampleCodeWithoutReturnValue(apiMethod, init, additionalCallback)
+@snippet methodCallSampleCodeWithoutReturnValue(apiMethod, init, additionalCallback)
     {@initCode(apiMethod, init)}
     @if additionalCallback
       {@methodCallSampleCodePrefix(apiMethod, init)}
@@ -321,7 +320,7 @@
     @end
 @end
 
-@private initCode(apiMethod, init)
+@snippet initCode(apiMethod, init)
   {@initCodeLines(init)}
   @if initializeRequestObject(apiMethod, init)
     {@initializeRequestObject(apiMethod, init)}

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -63,6 +63,6 @@
   @case "LongRunningPromise"
     {@methodCallSampleCodeLongrunningPromise(apiMethod, sample.initCode, empty())}
   @default
-      $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$    
+    $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$    
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -25,7 +25,7 @@
        // FIXME: Insert here code to prepare the request fields, make the call, process the response.
        
        /*
-       {@sampleCode(apiMethod, sample.initCode)}
+       {@standaloneSample(apiMethod, sample)}
        */
        // [END core_sample]
 
@@ -34,4 +34,35 @@
      @end
    @end
    // [END full_sample]
+@end
+
+# FIXME: Replace the following function calls with calls to functions that emit full standalone samples. These stubs have been adapted from method_sample.snip
+@snippet standaloneSample(apiMethod, sample)
+  @switch sample.callingForm
+  @case "Request"
+    @if apiMethod.hasReturnValue
+      {@methodCallSampleCodeWithReturnValue(apiMethod, sample.initCode, empty())}
+    @else
+      {@methodCallSampleCodeWithoutReturnValue(apiMethod, sample.initCode, empty())}
+    @end
+  @case "RequestAsyncPaged"
+    {@methodCallSampleCodeForPagedResponse(apiMethod, sample.initCode, empty())}
+  @case "RequestAsyncPagedAll"
+    {@methodCallSampleCodeForPagedResponseIterative(apiMethod, sample.initCode, empty())}
+  @case "RequestStreamingBidi"
+    {@bidiStreamingSampleCode(apiMethod, sample.initCode, empty())}
+  @case "RequestStreamingClient"
+    {@clientStreamingSampleCode(apiMethod, sample.initCode, empty())}
+  @case "RequestStreamingServer"
+    {@initCode(apiMethod, sample.initCode)}
+      {@methodCallSampleCode(apiMethod, sample.initCode)}.on('data', response => {
+          // doThingsWith(response)
+      });
+  @case "LongRunningEventEmitter"
+    {@methodCallSampleCodeLongrunningEventEmitter(apiMethod, sample.initCode, empty())}
+  @case "LongRunningPromise"
+    {@methodCallSampleCodeLongrunningPromise(apiMethod, sample.initCode, empty())}
+  @default
+      $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$    
+  @end
 @end

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -7285,9 +7285,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     }
   }
 }
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/discussbookcallable/DiscussBookCallableSampleCallableBidiStreamingProg.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookCallableSampleCallableBidiStreamingProg" ]
-//// STUB standalone sample "DiscussBookCallableSampleCallableBidiStreamingProg" /////
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/discussbookcallable/DiscussBookCallableSampleCallableStreamingBidiProg.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookCallableSampleCallableStreamingBidiProg" ]
+//// STUB standalone sample "DiscussBookCallableSampleCallableStreamingBidiProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -7295,7 +7295,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "CallableBidiStreaming"
+//     calling form: "CallableStreamingBidi"
 //     valueSet "prog" ("Programming Books")
 //       description: "Testing calling forms: {Java:[CallableBidiStreaming]}"
 //       [name=BASIC]
@@ -7627,9 +7627,9 @@ Book response = future.get();
 // FIXME: Insert here clean-up code.
 
 // [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/monologaboutbookcallable/MonologAboutBookCallableSampleCallableClientStreamingProg.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookCallableSampleCallableClientStreamingProg" ]
-//// STUB standalone sample "MonologAboutBookCallableSampleCallableClientStreamingProg" /////
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/monologaboutbookcallable/MonologAboutBookCallableSampleCallableStreamingClientProg.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookCallableSampleCallableStreamingClientProg" ]
+//// STUB standalone sample "MonologAboutBookCallableSampleCallableStreamingClientProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -7637,7 +7637,7 @@ Book response = future.get();
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "CallableClientStreaming"
+//     calling form: "CallableStreamingClient"
 //     valueSet "prog" ("Programming Books")
 //       description: "Testing calling forms: {Java:[CallableClientStreaming]}"
 //       [name=BASIC]
@@ -7913,9 +7913,9 @@ PublishSeriesResponse response = future.get();
 // FIXME: Insert here clean-up code.
 
 // [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/streambookscallable/StreamBooksCallableSampleCallableServerStreamingProg.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksCallableSampleCallableServerStreamingProg" ]
-//// STUB standalone sample "StreamBooksCallableSampleCallableServerStreamingProg" /////
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/streambookscallable/StreamBooksCallableSampleCallableStreamingServerProg.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksCallableSampleCallableStreamingServerProg" ]
+//// STUB standalone sample "StreamBooksCallableSampleCallableStreamingServerProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -7923,7 +7923,7 @@ PublishSeriesResponse response = future.get();
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "CallableServerStreaming"
+//     calling form: "CallableStreamingServer"
 //     valueSet "prog" ("Programming Books")
 //       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
 //       [name=BASIC]
@@ -7964,9 +7964,9 @@ libraryClient.streamBooksCallable().serverStreamingCall(request, responseObserve
 // FIXME: Insert here clean-up code.
 
 // [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/streamshelvescallable/StreamShelvesCallableSampleCallableServerStreamingEmpty.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesCallableSampleCallableServerStreamingEmpty" ]
-//// STUB standalone sample "StreamShelvesCallableSampleCallableServerStreamingEmpty" /////
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/streamshelvescallable/StreamShelvesCallableSampleCallableStreamingServerEmpty.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesCallableSampleCallableStreamingServerEmpty" ]
+//// STUB standalone sample "StreamShelvesCallableSampleCallableStreamingServerEmpty" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -7974,7 +7974,7 @@ libraryClient.streamBooksCallable().serverStreamingCall(request, responseObserve
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "CallableServerStreaming"
+//     calling form: "CallableStreamingServer"
 //     valueSet "empty" ("Server streaming")
 //       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
 //       []

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -248,9 +248,9 @@ module.exports.v1 = gapic.v1;
 // Alias `module.exports` as `module.exports.default`, for future-proofing.
 module.exports.default = Object.assign({}, module.exports);
 
-============== file: src/samples/v1/discuss_book_sample_generic_prog.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookSampleGenericProg" ]
-//// STUB standalone sample "DiscussBookSampleGenericProg" /////
+============== file: src/samples/v1/discuss_book_sample_request_streaming_bidi_prog.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookSampleRequestStreamingBidiProg" ]
+//// STUB standalone sample "DiscussBookSampleRequestStreamingBidiProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -258,7 +258,7 @@ module.exports.default = Object.assign({}, module.exports);
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Generic"
+//     calling form "RequestStreamingBidi"
 //     valueSet "prog" ("Programming Books")
 //       description: "Testing calling forms: {Java:[CallableBidiStreaming]}"
 //       [name=BASIC]
@@ -284,9 +284,9 @@ stream.write(request);
 // FIXME: Insert here clean-up code.
 
 // [END full_sample]
-============== file: src/samples/v1/find_related_books_sample_generic_odyssey.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleGenericOdyssey" ]
-//// STUB standalone sample "FindRelatedBooksSampleGenericOdyssey" /////
+============== file: src/samples/v1/find_related_books_sample_request_async_paged_all_odyssey.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestAsyncPagedAllOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksSampleRequestAsyncPagedAllOdyssey" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -294,7 +294,7 @@ stream.write(request);
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Generic"
+//     calling form "RequestAsyncPagedAll"
 //     valueSet "odyssey" ("The Odyssey")
 //       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged]}"
 //       [names[0]=Odyssey, shelves[0]=Classics]
@@ -325,7 +325,33 @@ client.findRelatedBooks(request)
   .catch(err => {
     console.error(err);
   });
+*/
+// [END core_sample]
 
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/samples/v1/find_related_books_sample_request_async_paged_odyssey.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestAsyncPagedOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksSampleRequestAsyncPagedOdyssey" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form "RequestAsyncPaged"
+//     valueSet "odyssey" ("The Odyssey")
+//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged]}"
+//       [names[0]=Odyssey, shelves[0]=Classics]
+//     apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
 // Or obtain the paged response.
 var namesElement = 'Odyssey';
 var names = [namesElement];
@@ -364,9 +390,9 @@ client.findRelatedBooks(request, options)
 // FIXME: Insert here clean-up code.
 
 // [END full_sample]
-============== file: src/samples/v1/get_big_book_sample_generic_wap.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleGenericWap" ]
-//// STUB standalone sample "GetBigBookSampleGenericWap" /////
+============== file: src/samples/v1/get_big_book_sample_long_running_event_emitter_wap.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleLongRunningEventEmitterWap" ]
+//// STUB standalone sample "GetBigBookSampleLongRunningEventEmitterWap" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -374,7 +400,7 @@ client.findRelatedBooks(request, options)
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Generic"
+//     calling form "LongRunningEventEmitter"
 //     valueSet "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable]}"
 //       [name="War and Peace"]
@@ -385,31 +411,6 @@ client.findRelatedBooks(request, options)
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 /*
-var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-
-// Handle the operation using the promise pattern.
-client.getBigBook({name: formattedName})
-  .then(responses => {
-    var operation = responses[0];
-    var initialApiResponse = responses[1];
-
-    // Operation#promise starts polling for the completion of the LRO.
-    return operation.promise();
-  })
-  .then(responses => {
-    // The final result of the operation.
-    var result = responses[0];
-
-    // The metadata value of the completed operation.
-    var metadata = responses[1];
-
-    // The response of the api call returning the complete operation.
-    var finalApiResponse = responses[2];
-  })
-  .catch(err => {
-    console.error(err);
-  });
-
 var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
 
 // Handle the operation using the event emitter pattern.
@@ -444,9 +445,9 @@ client.getBigBook({name: formattedName})
 // FIXME: Insert here clean-up code.
 
 // [END full_sample]
-============== file: src/samples/v1/monolog_about_book_sample_generic_prog.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookSampleGenericProg" ]
-//// STUB standalone sample "MonologAboutBookSampleGenericProg" /////
+============== file: src/samples/v1/get_big_book_sample_long_running_promise_wap.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleLongRunningPromiseWap" ]
+//// STUB standalone sample "GetBigBookSampleLongRunningPromiseWap" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -454,7 +455,58 @@ client.getBigBook({name: formattedName})
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Generic"
+//     calling form "LongRunningPromise"
+//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable]}"
+//       [name="War and Peace"]
+//     apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
+
+// [START core_sample]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+
+// Handle the operation using the promise pattern.
+client.getBigBook({name: formattedName})
+  .then(responses => {
+    var operation = responses[0];
+    var initialApiResponse = responses[1];
+
+    // Operation#promise starts polling for the completion of the LRO.
+    return operation.promise();
+  })
+  .then(responses => {
+    // The final result of the operation.
+    var result = responses[0];
+
+    // The metadata value of the completed operation.
+    var metadata = responses[1];
+
+    // The response of the api call returning the complete operation.
+    var finalApiResponse = responses[2];
+  })
+  .catch(err => {
+    console.error(err);
+  });
+*/
+// [END core_sample]
+
+// FIXME: Insert here clean-up code.
+
+// [END full_sample]
+============== file: src/samples/v1/monolog_about_book_sample_request_streaming_client_prog.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookSampleRequestStreamingClientProg" ]
+//// STUB standalone sample "MonologAboutBookSampleRequestStreamingClientProg" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START full_sample]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//     calling form "RequestStreamingClient"
 //     valueSet "prog" ("Programming Books")
 //       description: "Testing calling forms: {Java:[CallableClientStreaming]}"
 //       [name=BASIC]
@@ -484,9 +536,9 @@ stream.write(request);
 // FIXME: Insert here clean-up code.
 
 // [END full_sample]
-============== file: src/samples/v1/publish_series_sample_generic_pi_version.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleGenericPiVersion" ]
-//// STUB standalone sample "PublishSeriesSampleGenericPiVersion" /////
+============== file: src/samples/v1/publish_series_sample_request_pi_version.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestPiVersion" ]
+//// STUB standalone sample "PublishSeriesSampleRequestPiVersion" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -494,7 +546,7 @@ stream.write(request);
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Generic"
+//     calling form "Request"
 //     valueSet "pi_version" ("Pi version")
 //       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
@@ -533,9 +585,9 @@ client.publishSeries(request)
 // FIXME: Insert here clean-up code.
 
 // [END full_sample]
-============== file: src/samples/v1/publish_series_sample_generic_second_edition.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleGenericSecondEdition" ]
-//// STUB standalone sample "PublishSeriesSampleGenericSecondEdition" /////
+============== file: src/samples/v1/publish_series_sample_request_second_edition.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestSecondEdition" ]
+//// STUB standalone sample "PublishSeriesSampleRequestSecondEdition" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -543,7 +595,7 @@ client.publishSeries(request)
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Generic"
+//     calling form "Request"
 //     valueSet "second_edition" ("Second edition")
 //       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 //       [edition=2]
@@ -578,9 +630,9 @@ client.publishSeries(request)
 // FIXME: Insert here clean-up code.
 
 // [END full_sample]
-============== file: src/samples/v1/stream_books_sample_generic_prog.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksSampleGenericProg" ]
-//// STUB standalone sample "StreamBooksSampleGenericProg" /////
+============== file: src/samples/v1/stream_books_sample_request_streaming_server_prog.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksSampleRequestStreamingServerProg" ]
+//// STUB standalone sample "StreamBooksSampleRequestStreamingServerProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -588,7 +640,7 @@ client.publishSeries(request)
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Generic"
+//     calling form "RequestStreamingServer"
 //     valueSet "prog" ("Programming Books")
 //       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
 //       [name=BASIC]
@@ -600,18 +652,18 @@ client.publishSeries(request)
 
 /*
 var name = 'BASIC';
-client.streamBooks({name: name}).on('data', response => {
-  // doThingsWith(response)
-});
+  client.streamBooks({name: name}).on('data', response => {
+      // doThingsWith(response)
+  });
 */
 // [END core_sample]
 
 // FIXME: Insert here clean-up code.
 
 // [END full_sample]
-============== file: src/samples/v1/stream_shelves_sample_generic_empty.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesSampleGenericEmpty" ]
-//// STUB standalone sample "StreamShelvesSampleGenericEmpty" /////
+============== file: src/samples/v1/stream_shelves_sample_request_streaming_server_empty.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesSampleRequestStreamingServerEmpty" ]
+//// STUB standalone sample "StreamShelvesSampleRequestStreamingServerEmpty" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -619,7 +671,7 @@ client.streamBooks({name: name}).on('data', response => {
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Generic"
+//     calling form "RequestStreamingServer"
 //     valueSet "empty" ("Server streaming")
 //       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
 //       []
@@ -631,9 +683,9 @@ client.streamBooks({name: name}).on('data', response => {
 
 /*
 
-client.streamShelves({}).on('data', response => {
-  // doThingsWith(response)
-});
+  client.streamShelves({}).on('data', response => {
+      // doThingsWith(response)
+  });
 */
 // [END core_sample]
 


### PR DESCRIPTION
- The logic for determining calling forms has been copied to the generator
- The standalone samples key off the calling form to call the correct
  sample-generating function (the routing is implemented here; the
  functions called at the moments as stubs are actually the in-code
  sample functions)

Also:
- CallingForm.java has the enum values listed in alphabetical order
  within each section
- The usage of calling forms in template files and in transformers
  follows the same order.

An upcoming PR will make the in-code samples also key off the
calling forms.