### PR TITLE
Python: submodules fix.

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/mergers/LanguageSettingsMerger.java
+++ b/src/main/java/com/google/api/codegen/configgen/mergers/LanguageSettingsMerger.java
@@ -188,14 +188,19 @@ public class LanguageSettingsMerger {
       }
       List<String> names = Splitter.on(DEFAULT_PACKAGE_SEPARATOR).splitToList(packageName);
       LinkedList<String> collector = new LinkedList<>();
+      boolean found = false;
       for (String n : names) {
         if (VersionMatcher.isVersion(n)) {
           collector.add(String.format("%s_%s", collector.removeLast(), n));
+          collector.add("gapic");
+          found = true;
         } else {
           collector.add(n);
         }
       }
-      collector.add("gapic");
+      if (!found) {
+        collector.add("gapic");
+      }
       return Joiner.on('.').join(collector);
     }
   }

--- a/src/main/java/com/google/api/codegen/configgen/transformer/LanguageTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/LanguageTransformer.java
@@ -175,14 +175,19 @@ public class LanguageTransformer {
       }
       List<String> names = Splitter.on(DEFAULT_PACKAGE_SEPARATOR).splitToList(packageName);
       LinkedList<String> collector = new LinkedList<>();
+      boolean found = false;
       for (String n : names) {
         if (VersionMatcher.isVersion(n)) {
           collector.add(String.format("%s_%s", collector.removeLast(), n));
+          collector.add("gapic");
+          found = true;
         } else {
           collector.add(n);
         }
       }
-      collector.add("gapic");
+      if (!found) {
+        collector.add("gapic");
+      }
       return Joiner.on('.').join(collector);
     }
   }

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonModelTypeNameConverter.java
@@ -28,9 +28,11 @@ import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.ProtoElement;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -96,11 +98,20 @@ public class PythonModelTypeNameConverter extends ModelTypeNameConverter {
 
   public PythonModelTypeNameConverter(String implicitPackageName) {
     typeNameConverter = new PythonTypeTable(implicitPackageName);
-    if (implicitPackageName.endsWith(".gapic")) {
-      protoNamespace = implicitPackageName.replace(".gapic", ".proto");
-    } else {
-      protoNamespace = String.format("%s.proto", implicitPackageName);
+    List<String> names = new ArrayList<>();
+    boolean found = false;
+    for (String n : ImmutableList.copyOf(implicitPackageName.split("\\.")).reverse()) {
+      if (n.equals("gapic") && !found) {
+        names.add(0, "proto");
+        found = true;
+      } else {
+        names.add(0, n);
+      }
     }
+    if (!found) {
+      names.add("proto");
+    }
+    protoNamespace = Joiner.on(".").join(names);
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/testdata/multiple_services_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/multiple_services_config.baseline
@@ -9,7 +9,7 @@ language_settings:
   java:
     package_name: com.google.cloud.example.v1.foo
   python:
-    package_name: google.cloud.example_v1.foo.gapic
+    package_name: google.cloud.example_v1.gapic.foo
   go:
     package_name: google.golang.org/google/cloud/example/v1/foo
   csharp:

--- a/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
@@ -790,8 +790,8 @@ __all__ = (
 from __future__ import absolute_import
 
 from google.cloud.example_v1 import types
-from google.cloud.example_v1.foo.gapic import decrementer_service_client
-from google.cloud.example_v1.foo.gapic import incrementer_service_client
+from google.cloud.example_v1.gapic.foo import decrementer_service_client
+from google.cloud.example_v1.gapic.foo import incrementer_service_client
 
 
 class IncrementerServiceClient(incrementer_service_client.IncrementerServiceClient):
@@ -806,11 +806,11 @@ __all__ = (
     'IncrementerServiceClient',
     'DecrementerServiceClient',
 )
-============== file: google/cloud/example_v1/foo/__init__.py ==============
+============== file: google/cloud/example_v1/gapic/__init__.py ==============
 
-============== file: google/cloud/example_v1/foo/gapic/__init__.py ==============
+============== file: google/cloud/example_v1/gapic/foo/__init__.py ==============
 
-============== file: google/cloud/example_v1/foo/gapic/decrementer_service_client.py ==============
+============== file: google/cloud/example_v1/gapic/foo/decrementer_service_client.py ==============
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -834,9 +834,9 @@ import google.api_core.gapic_v1.config
 import google.api_core.gapic_v1.method
 import google.api_core.grpc_helpers
 
-from google.cloud.example_v1.foo.gapic import decrementer_service_client_config
-from google.cloud.example_v1.foo.proto import multiple_services_pb2
-from google.cloud.example_v1.foo.proto import multiple_services_pb2_grpc
+from google.cloud.example_v1.gapic.foo import decrementer_service_client_config
+from google.cloud.example_v1.proto.foo import multiple_services_pb2
+from google.cloud.example_v1.proto.foo import multiple_services_pb2_grpc
 from google.protobuf import empty_pb2
 
 
@@ -961,7 +961,7 @@ class DecrementerServiceClient(object):
         request = multiple_services_pb2.DecrementRequest()
         self._decrement(request, retry=retry, timeout=timeout, metadata=metadata)
 
-============== file: google/cloud/example_v1/foo/gapic/decrementer_service_client_config.py ==============
+============== file: google/cloud/example_v1/gapic/foo/decrementer_service_client_config.py ==============
 config = {
   "interfaces": {
     "google.cloud.example.v1.foo.DecrementerService": {
@@ -976,7 +976,7 @@ config = {
   }
 }
 
-============== file: google/cloud/example_v1/foo/gapic/incrementer_service_client.py ==============
+============== file: google/cloud/example_v1/gapic/foo/incrementer_service_client.py ==============
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1000,9 +1000,9 @@ import google.api_core.gapic_v1.config
 import google.api_core.gapic_v1.method
 import google.api_core.grpc_helpers
 
-from google.cloud.example_v1.foo.gapic import incrementer_service_client_config
-from google.cloud.example_v1.foo.proto import multiple_services_pb2
-from google.cloud.example_v1.foo.proto import multiple_services_pb2_grpc
+from google.cloud.example_v1.gapic.foo import incrementer_service_client_config
+from google.cloud.example_v1.proto.foo import multiple_services_pb2
+from google.cloud.example_v1.proto.foo import multiple_services_pb2_grpc
 from google.protobuf import empty_pb2
 
 
@@ -1127,7 +1127,7 @@ class IncrementerServiceClient(object):
         request = multiple_services_pb2.IncrementRequest()
         self._increment(request, retry=retry, timeout=timeout, metadata=metadata)
 
-============== file: google/cloud/example_v1/foo/gapic/incrementer_service_client_config.py ==============
+============== file: google/cloud/example_v1/gapic/foo/incrementer_service_client_config.py ==============
 config = {
   "interfaces": {
     "google.cloud.example.v1.foo.IncrementerService": {
@@ -1164,7 +1164,7 @@ import sys
 from google.api_core.protobuf_helpers import get_messages
 
 from google.api import http_pb2
-from google.cloud.example_v1.foo.proto import multiple_services_pb2
+from google.cloud.example_v1.proto.foo import multiple_services_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import empty_pb2
 
@@ -1339,7 +1339,7 @@ setuptools.setup(
 import pytest
 
 from google.cloud import example_v1
-from google.cloud.example_v1.foo.proto import multiple_services_pb2
+from google.cloud.example_v1.proto.foo import multiple_services_pb2
 from google.protobuf import empty_pb2
 
 
@@ -1422,7 +1422,7 @@ class TestDecrementerServiceClient(object):
 import pytest
 
 from google.cloud import example_v1
-from google.cloud.example_v1.foo.proto import multiple_services_pb2
+from google.cloud.example_v1.proto.foo import multiple_services_pb2
 from google.protobuf import empty_pb2
 
 

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services_gapic.yaml
@@ -4,7 +4,7 @@ language_settings:
   java:
     package_name: com.google.gcloud.example
   python:
-    package_name: google.cloud.example_v1.foo.gapic
+    package_name: google.cloud.example_v1.gapic.foo
   ruby:
     package_name: Google::Example::V1::Foo
     release_level: GA


### PR DESCRIPTION
# What
My prior commit fixed the transformation of the proto package `a.b.v1.c` to the client package `a.b_v1.c.gapic`. This was incorrect. artman actually copies the proto paths to mirror the location of the `gapic` package. With my previous commit, this would cause the proto subdirectories to get repeated. For example `a.b.v1.c` would transform into `a.b_v1.c.gapic` and artman would copy the protos into `a.b.v1.c.protos.c` (notice the repetition of `c`). 

This change makes it such that the repetition is not made. For the example above, `a.b.v1.c` would transform int `a.b_v1.gapic.c` and the protos would be copied over into `a.b_v1.proto.c`. This keeps the proto and the gapic subdirectories mirrored.

Luckily enough, this change will not require any updates to artman.