### PR TITLE
Use native Python enums.

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/enum.snip
+++ b/src/main/resources/com/google/api/codegen/py/enum.snip
@@ -5,6 +5,8 @@
 
     {@moduleDocstring()}
 
+    import enum
+    
 
     {@enumConstants(view.elementDocs)}
 @end
@@ -36,7 +38,7 @@
 @end
 
 @private enumSection(enum)
-    class {@enum.name}(object):
+    class {@enum.name}(enum.IntEnum):
         {@enumComments(enum)}
         @join value : enum.values
             {@value.name} = {@value.number}

--- a/src/main/resources/com/google/api/codegen/py/setup.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/setup.py.snip
@@ -25,6 +25,7 @@ dependencies = [
         '{@packageDep.name} >= {@packageDep.versionBound.lower}, < {@packageDep.versionBound.upper}',
     @end
   @end
+  'enum34; python_version < "3.4"',
 ]
 
 

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -863,8 +863,10 @@ __all__ = (
 
 """Wrappers for protocol buffer enum types."""
 
+import enum
 
-class NullValue(object):
+
+class NullValue(enum.IntEnum):
     """
     ``NullValue`` is a singleton enumeration to represent the null value for the
     ``Value`` type union.
@@ -878,7 +880,7 @@ class NullValue(object):
 
 
 class FieldMask(object):
-    class Material(object):
+    class Material(enum.IntEnum):
         """
         Attributes:
           PAPIER_MACHE (int)
@@ -895,7 +897,7 @@ class FieldMask(object):
 
 
 class Book(object):
-    class Rating(object):
+    class Rating(enum.IntEnum):
         """
         Attributes:
           GOOD (int): GOOD enum description
@@ -906,7 +908,7 @@ class Book(object):
 
 
 class SomeMessage(object):
-    class Alignment(object):
+    class Alignment(enum.IntEnum):
         """
         Tests service with two enums of the same simple name
 
@@ -921,7 +923,7 @@ class SomeMessage(object):
 
 
 class SomeMessage2(object):
-    class Alignment(object):
+    class Alignment(enum.IntEnum):
         """
         Another enum with duplicated simple name
 
@@ -938,7 +940,7 @@ class SomeMessage2(object):
 
 
     class SomeMessage3(object):
-        class Alignment(object):
+        class Alignment(enum.IntEnum):
             """
             Tests Python nested enums
 
@@ -953,7 +955,7 @@ class SomeMessage2(object):
 
 
 class Comment(object):
-    class Stage(object):
+    class Stage(enum.IntEnum):
         """
         Attributes:
           UNSET (int)
@@ -968,7 +970,7 @@ class Comment(object):
 
 
 class TestOptionalRequiredFlatteningParamsRequest(object):
-    class InnerEnum(object):
+    class InnerEnum(enum.IntEnum):
         """
         For testing all types, plus resource-names, as required and optional.
 
@@ -3810,6 +3812,7 @@ dependencies = [
   'google-api-core[grpc] >= 1.1.0, < 2.0.0dev',
 
   'python-other-package >= 12.1.0, < 13.5.1',
+  'enum34; python_version < "3.4"',
 ]
 
 

--- a/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
@@ -1269,6 +1269,7 @@ dependencies = [
   'google-api-core[grpc] >= 1.1.0, < 2.0.0dev',
 
   'python-other-package >= 12.1.0, < 13.5.1',
+  'enum34; python_version < "3.4"',
 ]
 
 

--- a/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
@@ -1057,6 +1057,7 @@ dependencies = [
   'google-api-core[grpc] >= 1.1.0, < 2.0.0dev',
 
   'python-other-package >= 12.1.0, < 13.5.1',
+  'enum34; python_version < "3.4"',
 ]
 
 


### PR DESCRIPTION
This may have been shockingly easy. Fixes #1866.

Marking `do not merge` until I can appropriately test it.