### PR TITLE
Python: fix issue where proto submodules would not be tracked.

### DIFF
--- a/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_multiple_services.baseline
@@ -1206,6 +1206,8 @@ import sys
 from google.api_core.protobuf_helpers import get_messages
 
 from google.api import http_pb2
+from google.cloud.example_v1.proto import other_shared_type_pb2
+from google.cloud.example_v1.proto.bar import different_submodule_pb2
 from google.cloud.example_v1.proto.foo import multiple_services_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import empty_pb2
@@ -1213,6 +1215,8 @@ from google.protobuf import empty_pb2
 
 names = []
 for module in (http_pb2,
+               other_shared_type_pb2,
+               different_submodule_pb2,
                multiple_services_pb2,
                descriptor_pb2,
                empty_pb2,):

--- a/src/test/java/com/google/api/codegen/testsrc/different_submodule.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/different_submodule.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package google.cloud.example.v1.bar;
+
+message OtherType {}

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services.proto
@@ -4,8 +4,10 @@ syntax = "proto3";
 
 package google.cloud.example.v1.foo;
 
+import "different_submodule.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
+import "other_shared_type.proto";
 
 option java_multiple_files = true;
 option java_outer_classname = "ExampleProto";


### PR DESCRIPTION
# What
My prior commit made it such that the submodules of the interface that follow the version are imported correctly. For example if an interface is in package `a.b.v1.c` the python package would be converted to `a.b_v1.protos.c`. This solution worked for protos that were located in `a.b.v1.c` but not for protos that were located in `a.b_v1.d` in which the pb2 file would be imported from `a.b_v1.protos.c` rather than `a.b_v1.protos.d`.

This makes it such that the different submodules would be imported correctly. 

For protos that are not part of the interface parent package (`a.b.v1`) they will simply be imported from the top level of the proto python package (`a.b_v1.proto`).
