### PR TITLE
Provide sample_code_init_fields to samples via sample_value_sets; apply to NodeJS

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -21,6 +21,7 @@ import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.SampleSpec.SampleType;
+import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.viewmodel.ApiMethodDocView;
 import com.google.api.codegen.viewmodel.CallingForm;
@@ -71,6 +72,7 @@ public class DynamicLangApiMethodTransformer {
 
   public OptionalArrayMethodView generateRequestMethod(
       GapicMethodContext context,
+      InitCodeContext initContext,
       boolean packageHasMultipleServices,
       List<CallingForm> callingForms) {
     MethodModel method = context.getMethodModel();
@@ -79,13 +81,15 @@ public class DynamicLangApiMethodTransformer {
 
     apiMethod.type(ClientMethodType.OptionalArrayMethod);
 
-    generateMethodCommon(context, packageHasMultipleServices, method, apiMethod, callingForms);
+    generateMethodCommon(
+        context, initContext, packageHasMultipleServices, method, apiMethod, callingForms);
 
     return apiMethod.build();
   }
 
   public OptionalArrayMethodView generateLongRunningMethod(
       GapicMethodContext context,
+      InitCodeContext initContext,
       boolean packageHasMultipleServices,
       List<CallingForm> callingForms) {
     MethodModel method = context.getMethodModel();
@@ -95,13 +99,15 @@ public class DynamicLangApiMethodTransformer {
     apiMethod.longRunningView(lroTransformer.generateDetailView(context));
     apiMethod.type(ClientMethodType.LongRunningOptionalArrayMethod);
 
-    generateMethodCommon(context, packageHasMultipleServices, method, apiMethod, callingForms);
+    generateMethodCommon(
+        context, initContext, packageHasMultipleServices, method, apiMethod, callingForms);
 
     return apiMethod.build();
   }
 
   public OptionalArrayMethodView generatePagedStreamingMethod(
       GapicMethodContext context,
+      InitCodeContext initContext,
       boolean packageHasMultipleServices,
       List<CallingForm> callingForms) {
     MethodModel method = context.getMethodModel();
@@ -111,7 +117,8 @@ public class DynamicLangApiMethodTransformer {
     apiMethod.pageStreamingView(
         pageStreamingTransformer.generateDescriptor(context.getSurfaceInterfaceContext(), method));
 
-    generateMethodCommon(context, packageHasMultipleServices, method, apiMethod, callingForms);
+    generateMethodCommon(
+        context, initContext, packageHasMultipleServices, method, apiMethod, callingForms);
 
     return apiMethod.build();
   }
@@ -135,13 +142,19 @@ public class DynamicLangApiMethodTransformer {
     }
 
     generateMethodCommon(
-        context, packageHasMultipleServices, method, apiMethod, Arrays.asList(CallingForm.Generic));
+        context,
+        null,
+        packageHasMultipleServices,
+        method,
+        apiMethod,
+        Arrays.asList(CallingForm.Generic));
 
     return apiMethod.build();
   }
 
   private void generateMethodCommon(
       GapicMethodContext context,
+      InitCodeContext initContext,
       boolean packageHasMultipleServices,
       MethodModel method,
       OptionalArrayMethodView.Builder apiMethod,
@@ -215,6 +228,7 @@ public class DynamicLangApiMethodTransformer {
     sampleTransformer.generateSamples(
         apiMethod,
         context,
+        initContext,
         context.getMethodConfig().getRequiredFieldConfigs(),
         initCodeOutputType,
         initCodeContext ->

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSamplesTransformer.java
@@ -45,12 +45,11 @@ import java.util.List;
 public class NodeJSGapicSamplesTransformer implements ModelToViewTransformer {
 
   private static final String STANDALONE_SAMPLE_TEMPLATE_FILENAME = "nodejs/standalone_sample.snip";
-  private static final SampleType sampleType = SampleType.STANDALONE;
 
   private final GapicCodePathMapper pathMapper;
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
       new DynamicLangApiMethodTransformer(
-          new NodeJSApiMethodParamTransformer(), new InitCodeTransformer(), sampleType);
+          new NodeJSApiMethodParamTransformer(), new InitCodeTransformer(), SampleType.STANDALONE);
   private final NodeJSMethodViewGenerator methodGenerator =
       new NodeJSMethodViewGenerator(apiMethodTransformer);
   private final PackageMetadataConfig packageConfig;

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
@@ -22,6 +22,7 @@ import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.nodejs.NodeJSUtils;
@@ -45,7 +46,6 @@ import com.google.api.codegen.util.testing.ValueProducer;
 import com.google.api.codegen.viewmodel.ClientMethodType;
 import com.google.api.codegen.viewmodel.FileHeaderView;
 import com.google.api.codegen.viewmodel.ImportSectionView;
-import com.google.api.codegen.viewmodel.InitCodeView;
 import com.google.api.codegen.viewmodel.OptionalArrayMethodView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.codegen.viewmodel.testing.ClientTestClassView;
@@ -255,19 +255,18 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
 
   private OptionalArrayMethodView createSmokeTestCaseApiMethodView(
       GapicMethodContext context, boolean packageHasMultipleServices) {
-    OptionalArrayMethodView initialApiMethodView =
-        new DynamicLangApiMethodTransformer(new NodeJSApiMethodParamTransformer())
-            .generateMethod(context, packageHasMultipleServices);
+    OptionalArrayMethodView apiMethodView =
+        new NodeJSMethodViewGenerator(
+                new DynamicLangApiMethodTransformer(
+                    new NodeJSApiMethodParamTransformer(),
+                    new InitCodeTransformer(),
+                    SampleType.IN_CODE))
+            .generateOneApiMethod(
+                context,
+                testCaseTransformer.createSmokeTestInitContext(context),
+                packageHasMultipleServices);
 
-    OptionalArrayMethodView.Builder apiMethodView = initialApiMethodView.toBuilder();
-
-    InitCodeTransformer initCodeTransformer = new InitCodeTransformer();
-    InitCodeView initCodeView =
-        initCodeTransformer.generateInitCode(
-            context, testCaseTransformer.createSmokeTestInitContext(context));
-    apiMethodView.initCode(initCodeView);
-    apiMethodView.packageName("../src");
-    return apiMethodView.build();
+    return apiMethodView.toBuilder().packageName("../src").build();
   }
 
   private GapicInterfaceContext createContext(

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -22,6 +22,7 @@ import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.LongRunningConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
+import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.config.TypeModel;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
@@ -32,6 +33,7 @@ import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
 import com.google.api.codegen.transformer.GapicMethodContext;
 import com.google.api.codegen.transformer.GrpcStubTransformer;
+import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.PageStreamingTransformer;
@@ -70,7 +72,8 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
   private final FileHeaderTransformer fileHeaderTransformer =
       new FileHeaderTransformer(new NodeJSImportSectionTransformer());
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
-      new DynamicLangApiMethodTransformer(new NodeJSApiMethodParamTransformer());
+      new DynamicLangApiMethodTransformer(
+          new NodeJSApiMethodParamTransformer(), new InitCodeTransformer(), SampleType.IN_CODE);
   private final NodeJSMethodViewGenerator methodGenerator =
       new NodeJSMethodViewGenerator(apiMethodTransformer);
   private final ServiceTransformer serviceTransformer = new ServiceTransformer();

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSMethodViewGenerator.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSMethodViewGenerator.java
@@ -16,7 +16,7 @@
 package com.google.api.codegen.transformer.nodejs;
 
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
-import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.transformer.DynamicLangApiMethodTransformer;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
 import com.google.api.codegen.transformer.GapicMethodContext;
@@ -25,6 +25,7 @@ import com.google.api.codegen.viewmodel.OptionalArrayMethodView;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Contains the common logic for generating view models for GAPIC surface methods. This is used in
@@ -43,49 +44,59 @@ public class NodeJSMethodViewGenerator {
       GapicInterfaceContext context, boolean packageHasMultipleServices) {
     ImmutableList.Builder<OptionalArrayMethodView> apiMethodsAndSamples = ImmutableList.builder();
 
-    for (MethodModel method : context.getSupportedMethods()) {
-      GapicMethodContext methodContext = context.asDynamicMethodContext(method);
-      OptionalArrayMethodView methodView;
-      if (methodContext.getMethodConfig().isPageStreaming()) {
-        methodView =
-            clientMethodTransformer.generatePagedStreamingMethod(
-                methodContext,
-                packageHasMultipleServices,
-                Arrays.asList(CallingForm.RequestAsyncPaged, CallingForm.RequestAsyncPagedAll));
-      } else if (methodContext.getMethodConfig().isLongRunningOperation()) {
-        methodView =
-            clientMethodTransformer.generateLongRunningMethod(
-                methodContext,
-                packageHasMultipleServices,
-                Arrays.asList(CallingForm.LongRunningPromise, CallingForm.LongRunningEventEmitter));
-      } else {
-        List<CallingForm> callingForms;
-        GrpcStreamingType streamingType = methodContext.getMethodConfig().getGrpcStreamingType();
-        switch (streamingType) {
-          case BidiStreaming:
-            callingForms = Arrays.asList(CallingForm.RequestStreamingBidi);
-            break;
-          case ClientStreaming:
-            callingForms = Arrays.asList(CallingForm.RequestStreamingClient);
-            break;
-          case ServerStreaming:
-            callingForms = Arrays.asList(CallingForm.RequestStreamingServer);
-            break;
-          case NonStreaming:
-            callingForms = Arrays.asList(CallingForm.Request);
-            break;
-          default:
-            throw new IllegalArgumentException(
-                "unhandled grpcStreamingType: " + streamingType.toString());
-        }
-        methodView =
-            clientMethodTransformer.generateRequestMethod(
-                methodContext, packageHasMultipleServices, callingForms);
+    return context
+        .getSupportedMethods()
+        .stream()
+        .map(
+            methodModel ->
+                generateOneApiMethod(
+                    context.asDynamicMethodContext(methodModel), null, packageHasMultipleServices))
+        .collect((Collectors.toList()));
+  }
+
+  public OptionalArrayMethodView generateOneApiMethod(
+      GapicMethodContext methodContext,
+      InitCodeContext initContext,
+      boolean packageHasMultipleServices) {
+    OptionalArrayMethodView methodView;
+    if (methodContext.getMethodConfig().isPageStreaming()) {
+      methodView =
+          clientMethodTransformer.generatePagedStreamingMethod(
+              methodContext,
+              initContext,
+              packageHasMultipleServices,
+              Arrays.asList(CallingForm.RequestAsyncPagedAll, CallingForm.RequestAsyncPaged));
+    } else if (methodContext.getMethodConfig().isLongRunningOperation()) {
+      methodView =
+          clientMethodTransformer.generateLongRunningMethod(
+              methodContext,
+              initContext,
+              packageHasMultipleServices,
+              Arrays.asList(CallingForm.LongRunningPromise, CallingForm.LongRunningEventEmitter));
+    } else {
+      List<CallingForm> callingForms;
+      GrpcStreamingType streamingType = methodContext.getMethodConfig().getGrpcStreamingType();
+      switch (streamingType) {
+        case BidiStreaming:
+          callingForms = Arrays.asList(CallingForm.RequestStreamingBidi);
+          break;
+        case ClientStreaming:
+          callingForms = Arrays.asList(CallingForm.RequestStreamingClient);
+          break;
+        case ServerStreaming:
+          callingForms = Arrays.asList(CallingForm.RequestStreamingServer);
+          break;
+        case NonStreaming:
+          callingForms = Arrays.asList(CallingForm.Request);
+          break;
+        default:
+          throw new IllegalArgumentException(
+              "unhandled grpcStreamingType: " + streamingType.toString());
       }
-
-      apiMethodsAndSamples.add(methodView);
+      methodView =
+          clientMethodTransformer.generateRequestMethod(
+              methodContext, initContext, packageHasMultipleServices, callingForms);
     }
-
-    return apiMethodsAndSamples.build();
+    return methodView;
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -22,6 +22,7 @@ import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.ProductConfig;
+import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.config.VersionBound;
 import com.google.api.codegen.nodejs.NodeJSUtils;
 import com.google.api.codegen.transformer.DynamicLangApiMethodTransformer;
@@ -39,7 +40,6 @@ import com.google.api.codegen.util.testing.StandardValueProducer;
 import com.google.api.codegen.util.testing.ValueProducer;
 import com.google.api.codegen.viewmodel.ApiMethodView;
 import com.google.api.codegen.viewmodel.ImportSectionView;
-import com.google.api.codegen.viewmodel.InitCodeView;
 import com.google.api.codegen.viewmodel.OptionalArrayMethodView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.codegen.viewmodel.metadata.PackageDependencyView;
@@ -155,19 +155,17 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
 
   private OptionalArrayMethodView createExampleApiMethodView(
       GapicMethodContext context, boolean packageHasMultipleServices) {
-    OptionalArrayMethodView initialApiMethodView =
-        new DynamicLangApiMethodTransformer(new NodeJSApiMethodParamTransformer())
-            .generateMethod(context, packageHasMultipleServices);
-
-    OptionalArrayMethodView.Builder apiMethodView = initialApiMethodView.toBuilder();
-
-    InitCodeTransformer initCodeTransformer = new InitCodeTransformer();
-    InitCodeView initCodeView =
-        initCodeTransformer.generateInitCode(
-            context, testCaseTransformer.createSmokeTestInitContext(context));
-    apiMethodView.initCode(initCodeView);
-
-    return apiMethodView.build();
+    OptionalArrayMethodView apiMethodView =
+        new NodeJSMethodViewGenerator(
+                new DynamicLangApiMethodTransformer(
+                    new NodeJSApiMethodParamTransformer(),
+                    new InitCodeTransformer(),
+                    SampleType.IN_CODE))
+            .generateOneApiMethod(
+                context,
+                testCaseTransformer.createSmokeTestInitContext(context),
+                packageHasMultipleServices);
+    return apiMethodView;
   }
 
   private List<ViewModel> generateMetadataViews(

--- a/src/main/resources/com/google/api/codegen/nodejs/README.md.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/README.md.snip
@@ -13,7 +13,7 @@
   @join method : methods on BREAK
     @#### {@method.apiClassName}
     ```js
-     {@decorateSampleCodeUnversioned(method, sampleCode(method, method.initCode))}
+     {@decorateSampleCodeUnversioned(method, @incodeSamples(method, empty()))}
     ```
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -400,7 +400,7 @@
 @end
 
 @private decorateSampleCodeSegment(method)
-  @let coreSampleCode = sampleCode\(method, method.initCode), \
+  @let coreSampleCode = incodeSamples\(method, empty()), \
       finalSampleCode = decorateSampleCode(method, coreSampleCode)
     @if finalSampleCode
       {@finalSampleCode}

--- a/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
@@ -24,27 +24,51 @@
     {@coreSampleCode}
 @end
 
-@snippet sampleCode(apiMethod, init)
-    {@sampleCode(apiMethod, init, empty())}
-@end
-
 @snippet empty()
 @end
 
-# TODO(vchudnov-g): When we implement in-code samples, the switch
-# statement below will switch on the callingfrom selected for the
-# sample (as happens now in standalone_sample.snip).
-@snippet sampleCode(apiMethod, init, additionalCallback)
-    @switch apiMethod.type.toString
-    @case "OptionalArrayMethod"
-        {@optionalArrayMethodSampleCode(apiMethod, init, additionalCallback)}
-    @case "LongRunningOptionalArrayMethod"
-        {@lroSampleCode(apiMethod, init, additionalCallback)}
-    @case "PagedOptionalArrayMethod"
-        {@pagedOptionalArrayMethodSampleCode(apiMethod, init, additionalCallback)}
-    @default
-        $unhandledCase: {@apiMethod.type.toString}$
+@snippet incodeSamples(apiMethod, additionalCallback)
+    @join sample : apiMethod.samples
+      {@oneIncodeSample(apiMethod, sample, additionalCallback)}
+
     @end
+@end
+
+
+# The structure of this should be parallel to that of standalone_sample.snip:@standaloneSample
+@snippet oneIncodeSample(apiMethod, sample, additionalCallback)
+  @switch sample.callingForm
+  @case "Request"
+    @if apiMethod.hasReturnValue
+      {@methodCallSampleCodeWithReturnValue(apiMethod, sample.initCode, additionalCallback)}
+    @else
+      {@methodCallSampleCodeWithoutReturnValue(apiMethod, sample.initCode, additionalCallback)}
+    @end
+  @case "RequestAsyncPaged"
+    {@methodCallSampleCodeForPagedResponse(apiMethod, sample.initCode, additionalCallback)}
+  @case "RequestAsyncPagedAll"
+    {@methodCallSampleCodeForPagedResponseIterative(apiMethod, sample.initCode, additionalCallback)}
+  @case "RequestStreamingBidi"
+    {@bidiStreamingSampleCode(apiMethod, sample.initCode, additionalCallback)}
+  @case "RequestStreamingClient"
+    {@clientStreamingSampleCode(apiMethod, sample.initCode, additionalCallback)}
+  @case "RequestStreamingServer"
+    {@initCode(apiMethod, sample.initCode)}
+    {@methodCallSampleCode(apiMethod, sample.initCode)}.on('data', response => {
+      @if additionalCallback
+        console.log(response);
+        {@additionalCallback}();
+      @else
+        // doThingsWith(response)
+      @end
+    });
+  @case "LongRunningEventEmitter"
+    {@methodCallSampleCodeLongrunningEventEmitter(apiMethod, sample.initCode, additionalCallback)}
+  @case "LongRunningPromise"
+    {@methodCallSampleCodeLongrunningPromise(apiMethod, sample.initCode, additionalCallback)}
+  @default
+    $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$    
+  @end
 @end
 
 @snippet sampleCodePageStreaming(apiMethod, init)

--- a/src/main/resources/com/google/api/codegen/nodejs/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/smoke_test.snip
@@ -38,7 +38,7 @@
     @else
         {@smokeTestBody(smokeTest, \
             "successfully makes a call to the service", \
-            {@sampleCode(smokeTest.apiMethod, smokeTest.apiMethod.initCode, mochaCompletedCallback()))}}
+            {@incodeSamples(smokeTest.apiMethod, mochaCompletedCallback()))}}
       @end
     @case "PagedOptionalArrayMethod"
         {@smokeTestBody(smokeTest, \

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -36,6 +36,8 @@
    // [END full_sample]
 @end
 
+# The structure of this should be parallel to that of method_sample.snip:@incodeSample
+#
 # FIXME: Replace the following function calls with calls to functions that emit full standalone samples. These stubs have been adapted from method_sample.snip
 @snippet standaloneSample(apiMethod, sample)
   @switch sample.callingForm

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -52,6 +52,7 @@ $ npm install --save @google-cloud/library
    .catch(err => {
      console.error(err);
    });
+
 ```
 
 ### Next Steps
@@ -164,6 +165,7 @@ describe('LibraryServiceSmokeTest', () => {
       })
       .then(done)
       .catch(done);
+
   });
 });
 
@@ -3019,6 +3021,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   createShelf(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3078,6 +3081,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getShelf(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3160,6 +3164,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   listShelves(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3249,6 +3254,7 @@ class LibraryServiceClient {
    * client.deleteShelf({name: formattedName}).catch(err => {
    *   console.error(err);
    * });
+   *
    */
   deleteShelf(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3304,6 +3310,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   mergeShelves(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3359,6 +3366,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   createBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3435,6 +3443,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   publishSeries(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3481,6 +3490,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3587,6 +3597,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   listBooks(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3687,6 +3698,7 @@ class LibraryServiceClient {
    * client.deleteBook({name: formattedName}).catch(err => {
    *   console.error(err);
    * });
+   *
    */
   deleteBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3752,6 +3764,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   updateBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3805,6 +3818,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   moveBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3894,6 +3908,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   listStrings(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4000,6 +4015,7 @@ class LibraryServiceClient {
    * client.addComments(request).catch(err => {
    *   console.error(err);
    * });
+   *
    */
   addComments(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4046,6 +4062,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBookFromArchive(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4100,6 +4117,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBookFromAnywhere(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4146,6 +4164,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBookFromAbsolutelyAnywhere(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4196,6 +4215,7 @@ class LibraryServiceClient {
    * client.updateBookIndex(request).catch(err => {
    *   console.error(err);
    * });
+   *
    */
   updateBookIndex(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4231,6 +4251,7 @@ class LibraryServiceClient {
    * client.streamShelves({}).on('data', response => {
    *   // doThingsWith(response)
    * });
+   *
    */
   streamShelves(request, options) {
     options = options || {};
@@ -4266,6 +4287,7 @@ class LibraryServiceClient {
    * client.streamBooks({name: name}).on('data', response => {
    *   // doThingsWith(response)
    * });
+   *
    */
   streamBooks(request, options) {
     options = options || {};
@@ -4302,6 +4324,7 @@ class LibraryServiceClient {
    * };
    * // Write request objects.
    * stream.write(request);
+   *
    */
   discussBook(options) {
     options = options || {};
@@ -4344,6 +4367,7 @@ class LibraryServiceClient {
    * };
    * // Write request objects.
    * stream.write(request);
+   *
    */
   monologAboutBook(options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4448,6 +4472,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   findRelatedBooks(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4564,6 +4589,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   addTag(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4619,6 +4645,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   addLabel(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4709,6 +4736,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBigBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4799,6 +4827,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBigNothing(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -4968,6 +4997,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   testOptionalRequiredFlatteningParams(request, options, callback) {
     if (options instanceof Function && callback === undefined) {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -52,6 +52,7 @@ $ npm install --save @google-cloud/library
    .catch(err => {
      console.error(err);
    });
+
 ```
 
 ### Next Steps
@@ -164,6 +165,7 @@ describe('LibraryServiceSmokeTest', () => {
       })
       .then(done)
       .catch(done);
+
   });
 });
 
@@ -1120,6 +1122,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   createShelf(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1179,6 +1182,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getShelf(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1261,6 +1265,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   listShelves(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1350,6 +1355,7 @@ class LibraryServiceClient {
    * client.deleteShelf({name: formattedName}).catch(err => {
    *   console.error(err);
    * });
+   *
    */
   deleteShelf(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1405,6 +1411,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   mergeShelves(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1460,6 +1467,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   createBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1536,6 +1544,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   publishSeries(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1582,6 +1591,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1688,6 +1698,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   listBooks(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1788,6 +1799,7 @@ class LibraryServiceClient {
    * client.deleteBook({name: formattedName}).catch(err => {
    *   console.error(err);
    * });
+   *
    */
   deleteBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1853,6 +1865,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   updateBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1906,6 +1919,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   moveBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -1995,6 +2009,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   listStrings(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -2101,6 +2116,7 @@ class LibraryServiceClient {
    * client.addComments(request).catch(err => {
    *   console.error(err);
    * });
+   *
    */
   addComments(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -2147,6 +2163,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBookFromArchive(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -2201,6 +2218,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBookFromAnywhere(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -2247,6 +2265,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBookFromAbsolutelyAnywhere(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -2297,6 +2316,7 @@ class LibraryServiceClient {
    * client.updateBookIndex(request).catch(err => {
    *   console.error(err);
    * });
+   *
    */
   updateBookIndex(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -2332,6 +2352,7 @@ class LibraryServiceClient {
    * client.streamShelves({}).on('data', response => {
    *   // doThingsWith(response)
    * });
+   *
    */
   streamShelves(request, options) {
     options = options || {};
@@ -2367,6 +2388,7 @@ class LibraryServiceClient {
    * client.streamBooks({name: name}).on('data', response => {
    *   // doThingsWith(response)
    * });
+   *
    */
   streamBooks(request, options) {
     options = options || {};
@@ -2403,6 +2425,7 @@ class LibraryServiceClient {
    * };
    * // Write request objects.
    * stream.write(request);
+   *
    */
   discussBook(options) {
     options = options || {};
@@ -2445,6 +2468,7 @@ class LibraryServiceClient {
    * };
    * // Write request objects.
    * stream.write(request);
+   *
    */
   monologAboutBook(options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -2549,6 +2573,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   findRelatedBooks(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -2665,6 +2690,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   addTag(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -2720,6 +2746,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   addLabel(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -2810,6 +2837,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBigBook(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -2900,6 +2928,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   getBigNothing(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -3069,6 +3098,7 @@ class LibraryServiceClient {
    *   .catch(err => {
    *     console.error(err);
    *   });
+   *
    */
   testOptionalRequiredFlatteningParams(request, options, callback) {
     if (options instanceof Function && callback === undefined) {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -366,6 +366,7 @@ class DecrementerServiceClient {
    * client.decrement({}).catch(err => {
    *   console.error(err);
    * });
+   *
    */
   decrement(request, options, callback) {
     if (options instanceof Function && callback === undefined) {
@@ -596,6 +597,7 @@ class IncrementerServiceClient {
    * client.increment({}).catch(err => {
    *   console.error(err);
    * });
+   *
    */
   increment(request, options, callback) {
     if (options instanceof Function && callback === undefined) {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -300,6 +300,7 @@ class NoTemplatesApiServiceClient {
    * client.increment({}).catch(err => {
    *   console.error(err);
    * });
+   *
    */
   increment(request, options, callback) {
     if (options instanceof Function && callback === undefined) {


### PR DESCRIPTION
For backward compatibility, `sample_init_fields` remains the source of
truth for `IN_CODE` samples for the moment. `sample_init_fields` is
now copied to the in-code sample view model so that as languages adopt
samplegen, those language's templates can stop depending on
`method.initCode`. Once all languages have done this mgration, we can
remove `method.initCode`

- Do the copying from `sample_init_fields` in `SampleTransformer`
- Make NodeJSPackageMetadataTransformer and
  NodeJSGapicSurfaceTestTransformer use NodeJSMethodViewGenerator
- Make the NodeJS in-code samples use the sample-configured init fields