### PR TITLE
go: don't overwrite the List requests

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -394,7 +394,10 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
               .put(
                   ImportContext.CLIENT,
                   ImportKind.PAGE_STREAM,
-                  ImmutableList.<String>of("math;;;", "google.golang.org/api/iterator;;;"))
+                  ImmutableList.<String>of(
+                      "math;;;",
+                      "google.golang.org/api/iterator;;;",
+                      "github.com/golang/protobuf/proto;;;"))
               .put(
                   ImportContext.EXAMPLE,
                   ImportKind.PAGE_STREAM,

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -247,6 +247,7 @@
         {@mergeMetadata(method)}
         opts = {@mergeOptions(method.settingsGetterName)}
         it := &{@method.responseTypeName}{}
+        req = proto.Clone(req).({@method.serviceRequestTypeName})
         it.InternalFetch = func(pageSize int, pageToken string) ([]{@method.listMethod.resourceTypeName}, string, error) {
             var resp {@method.serviceResponseTypeName}
             req.PageToken = pageToken

--- a/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
@@ -148,6 +148,7 @@ import (
     "cloud.google.com/go/internal/version"
     "cloud.google.com/go/longrunning"
     lroauto "cloud.google.com/go/longrunning/autogen"
+    "github.com/golang/protobuf/proto"
     gax "github.com/googleapis/gax-go"
     "golang.org/x/net/context"
     "google.golang.org/api/iterator"
@@ -376,6 +377,7 @@ func (c *LibClient) ListShelves(ctx context.Context, req *librarypb.ListShelvesR
     ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.ListShelves[0:len(c.CallOptions.ListShelves):len(c.CallOptions.ListShelves)], opts...)
     it := &ShelfIterator{}
+    req = proto.Clone(req).(*librarypb.ListShelvesRequest)
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Shelf, string, error) {
         var resp *librarypb.ListShelvesResponse
         req.PageToken = pageToken
@@ -490,6 +492,7 @@ func (c *LibClient) ListBooks(ctx context.Context, req *librarypb.ListBooksReque
     ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.ListBooks[0:len(c.CallOptions.ListBooks):len(c.CallOptions.ListBooks)], opts...)
     it := &BookIterator{}
+    req = proto.Clone(req).(*librarypb.ListBooksRequest)
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Book, string, error) {
         var resp *librarypb.ListBooksResponse
         req.PageToken = pageToken
@@ -569,6 +572,7 @@ func (c *LibClient) ListStrings(ctx context.Context, req *librarypb.ListStringsR
     ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.ListStrings[0:len(c.CallOptions.ListStrings):len(c.CallOptions.ListStrings)], opts...)
     it := &StringIterator{}
+    req = proto.Clone(req).(*librarypb.ListStringsRequest)
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
         var resp *librarypb.ListStringsResponse
         req.PageToken = pageToken
@@ -744,6 +748,7 @@ func (c *LibClient) FindRelatedBooks(ctx context.Context, req *librarypb.FindRel
     ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.FindRelatedBooks[0:len(c.CallOptions.FindRelatedBooks):len(c.CallOptions.FindRelatedBooks)], opts...)
     it := &StringIterator{}
+    req = proto.Clone(req).(*librarypb.FindRelatedBooksRequest)
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
         var resp *librarypb.FindRelatedBooksResponse
         req.PageToken = pageToken


### PR DESCRIPTION
In list calls, the iterator might make multiple RPCs with different page token to fetch items. Previously, we use the request object the user supplied and change its `PageToken` field in place. This behavior is probably unexpected and certainly unintentional.

This PR fixes the problem by making a copy of the request object for the iterator's own use and never modify the one the user passes in.

This is technically a breaking change: people might be counting on the request being modified, but this seems extremely unlikely.