### PR TITLE
Ruby: Fix issue with importing additional types declared in yaml file

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -234,10 +234,8 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
       if (type instanceof ProtoTypeRef) {
         ProtoTypeRef t = (ProtoTypeRef) type;
         String name =
-            namer.getVersionIndexFileImportName()
-                + "/"
-                + namer.getProtoFileImportName(
-                    t.getProtoType().getMessageType().getFile().getSimpleName());
+            namer.getProtoFileImportName(
+                t.getProtoType().getMessageType().getFile().getSimpleName());
         requireTypes.add(name);
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -719,7 +719,7 @@ end
 # limitations under the License.
 
 require "library/v1/library_service_client"
-require "library/v1/errors_pb"
+require "errors_pb"
 
 # rubocop:disable LineLength
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -719,7 +719,7 @@ end
 # limitations under the License.
 
 require "library/v1/library_service_client"
-require "library/v1/errors_pb"
+require "errors_pb"
 
 # rubocop:disable LineLength
 


### PR DESCRIPTION
## What
Fixed a bug where additionally imported protobuf types were imported correctly. This error was due to the fact that the test protos are simply located at the top level of the protodir causing the previous implementation to erroneously prepend the import path with the package path.