### PR TITLE
Add gRPC interceptor support

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -72,6 +72,9 @@
   @# The default port of the service.
   DEFAULT_SERVICE_PORT = {@xapiClass.servicePort}
 
+  @# The default set of gRPC interceptors.
+  GRPC_INTERCEPTORS = []
+
   DEFAULT_TIMEOUT = 30
   @if xapiClass.hasPageStreamingMethods
 
@@ -109,6 +112,7 @@
   @if xapiClass.hasLongRunningOperations
     class OperationsClient < Google::Longrunning::OperationsClient
       self::SERVICE_ADDRESS = {@xapiClass.name}::SERVICE_ADDRESS
+      self::GRPC_INTERCEPTORS = {@xapiClass.name}::GRPC_INTERCEPTORS
     end
   @end
 @end
@@ -198,6 +202,7 @@
     @# Allow overriding the service path/port in subclasses.
     service_path = self.class::SERVICE_ADDRESS
     port = self.class::DEFAULT_SERVICE_PORT
+    interceptors = self.class::GRPC_INTERCEPTORS
     @join stub : xapiClass.stubs
       @@{@stub.name} = Google::Gax::Grpc.create_stub(
         service_path,
@@ -206,6 +211,7 @@
         channel: channel,
         updater_proc: updater_proc,
         scopes: scopes,
+        interceptors: interceptors,
         &{@stub.fullyQualifiedType}.method(:new)
       )
     @end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -2665,6 +2665,9 @@ module Library
       # The default port of the service.
       DEFAULT_SERVICE_PORT = 443
 
+      # The default set of gRPC interceptors.
+      GRPC_INTERCEPTORS = []
+
       DEFAULT_TIMEOUT = 30
 
       PAGE_DESCRIPTORS = {
@@ -2714,6 +2717,7 @@ module Library
 
       class OperationsClient < Google::Longrunning::OperationsClient
         self::SERVICE_ADDRESS = LibraryServiceClient::SERVICE_ADDRESS
+        self::GRPC_INTERCEPTORS = LibraryServiceClient::GRPC_INTERCEPTORS
       end
 
       SHELF_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
@@ -2901,6 +2905,7 @@ module Library
         # Allow overriding the service path/port in subclasses.
         service_path = self.class::SERVICE_ADDRESS
         port = self.class::DEFAULT_SERVICE_PORT
+        interceptors = self.class::GRPC_INTERCEPTORS
         @library_service_stub = Google::Gax::Grpc.create_stub(
           service_path,
           port,
@@ -2908,6 +2913,7 @@ module Library
           channel: channel,
           updater_proc: updater_proc,
           scopes: scopes,
+          interceptors: interceptors,
           &Google::Example::Library::V1::LibraryService::Stub.method(:new)
         )
         @labeler_stub = Google::Gax::Grpc.create_stub(
@@ -2917,6 +2923,7 @@ module Library
           channel: channel,
           updater_proc: updater_proc,
           scopes: scopes,
+          interceptors: interceptors,
           &Google::Tagger::V1::Labeler::Stub.method(:new)
         )
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -901,6 +901,9 @@ module Library
       # The default port of the service.
       DEFAULT_SERVICE_PORT = 443
 
+      # The default set of gRPC interceptors.
+      GRPC_INTERCEPTORS = []
+
       DEFAULT_TIMEOUT = 30
 
       PAGE_DESCRIPTORS = {
@@ -950,6 +953,7 @@ module Library
 
       class OperationsClient < Google::Longrunning::OperationsClient
         self::SERVICE_ADDRESS = LibraryServiceClient::SERVICE_ADDRESS
+        self::GRPC_INTERCEPTORS = LibraryServiceClient::GRPC_INTERCEPTORS
       end
 
       SHELF_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
@@ -1137,6 +1141,7 @@ module Library
         # Allow overriding the service path/port in subclasses.
         service_path = self.class::SERVICE_ADDRESS
         port = self.class::DEFAULT_SERVICE_PORT
+        interceptors = self.class::GRPC_INTERCEPTORS
         @library_service_stub = Google::Gax::Grpc.create_stub(
           service_path,
           port,
@@ -1144,6 +1149,7 @@ module Library
           channel: channel,
           updater_proc: updater_proc,
           scopes: scopes,
+          interceptors: interceptors,
           &Google::Example::Library::V1::LibraryService::Stub.method(:new)
         )
         @labeler_stub = Google::Gax::Grpc.create_stub(
@@ -1153,6 +1159,7 @@ module Library
           channel: channel,
           updater_proc: updater_proc,
           scopes: scopes,
+          interceptors: interceptors,
           &Google::Tagger::V1::Labeler::Stub.method(:new)
         )
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -829,6 +829,9 @@ module Google
       # The default port of the service.
       DEFAULT_SERVICE_PORT = 443
 
+      # The default set of gRPC interceptors.
+      GRPC_INTERCEPTORS = []
+
       DEFAULT_TIMEOUT = 30
 
       PAGE_DESCRIPTORS = {
@@ -937,6 +940,7 @@ module Google
         # Allow overriding the service path/port in subclasses.
         service_path = self.class::SERVICE_ADDRESS
         port = self.class::DEFAULT_SERVICE_PORT
+        interceptors = self.class::GRPC_INTERCEPTORS
         @operations_stub = Google::Gax::Grpc.create_stub(
           service_path,
           port,
@@ -944,6 +948,7 @@ module Google
           channel: channel,
           updater_proc: updater_proc,
           scopes: scopes,
+          interceptors: interceptors,
           &Google::Longrunning::Operations::Stub.method(:new)
         )
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -871,6 +871,9 @@ module Google
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
 
+          # The default set of gRPC interceptors.
+          GRPC_INTERCEPTORS = []
+
           DEFAULT_TIMEOUT = 30
 
           # The scopes needed to make gRPC calls to all of the methods defined in
@@ -969,6 +972,7 @@ module Google
             # Allow overriding the service path/port in subclasses.
             service_path = self.class::SERVICE_ADDRESS
             port = self.class::DEFAULT_SERVICE_PORT
+            interceptors = self.class::GRPC_INTERCEPTORS
             @decrementer_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
               port,
@@ -976,6 +980,7 @@ module Google
               channel: channel,
               updater_proc: updater_proc,
               scopes: scopes,
+              interceptors: interceptors,
               &Google::Cloud::Example::V1::Foo::DecrementerService::Stub.method(:new)
             )
 
@@ -1073,6 +1078,9 @@ module Google
 
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
+
+          # The default set of gRPC interceptors.
+          GRPC_INTERCEPTORS = []
 
           DEFAULT_TIMEOUT = 30
 
@@ -1172,6 +1180,7 @@ module Google
             # Allow overriding the service path/port in subclasses.
             service_path = self.class::SERVICE_ADDRESS
             port = self.class::DEFAULT_SERVICE_PORT
+            interceptors = self.class::GRPC_INTERCEPTORS
             @incrementer_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
               port,
@@ -1179,6 +1188,7 @@ module Google
               channel: channel,
               updater_proc: updater_proc,
               scopes: scopes,
+              interceptors: interceptors,
               &Google::Cloud::Example::V1::Foo::IncrementerService::Stub.method(:new)
             )
 


### PR DESCRIPTION
Add support for enabling custom gRPC interceptors via a subclass hook (`GRPC_INTERCEPTORS` following the pattern from `SERVICE_ADDRESS`, etc.)

Associated GAX change: https://github.com/googleapis/gax-ruby/pull/127/files