### PR TITLE
Assign and use the correct calling forms for Python samples

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
@@ -311,12 +311,13 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer 
   }
 
   private OptionalArrayMethodView createExampleApiMethodView(GapicMethodContext context) {
-    DynamicLangApiMethodTransformer apiMethodTransformer =
-        new DynamicLangApiMethodTransformer(
-            new PythonApiMethodParamTransformer(),
-            new InitCodeTransformer(new PythonImportSectionTransformer()));
+    PythonMethodViewGenerator methodViewGenerator =
+        new PythonMethodViewGenerator(
+            new DynamicLangApiMethodTransformer(
+                new PythonApiMethodParamTransformer(),
+                new InitCodeTransformer(new PythonImportSectionTransformer())));
 
-    return apiMethodTransformer.generateMethod(context);
+    return methodViewGenerator.generateOneApiMethod(context);
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/viewmodel/CallingForm.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/CallingForm.java
@@ -27,14 +27,15 @@ public enum CallingForm {
   //
   // [Method signature type][Request pattern][Response pattern][Idiomatic pattern]
 
-  Request, // Java, NodeJS
+  Request, // Java, NodeJS, Python
   RequestAsync,
   RequestAsyncPaged, // NodeJS
   RequestAsyncPagedAll, // NodeJS
-  RequestPaged, // Java
-  RequestStreamingBidi, // NodeJS
-  RequestStreamingClient, // NodeJS
-  RequestStreamingServer, // NodeJS
+  RequestPaged, // Java, Python
+  RequestPagedAll, // Python
+  RequestStreamingBidi, // NodeJS, Python
+  RequestStreamingClient, // NodeJS, Python
+  RequestStreamingServer, // NodeJS, Python
 
   Flattened, // Java
   FlattenedPaged, // Java
@@ -52,7 +53,7 @@ public enum CallingForm {
   LongRunningEventEmitter, // NodeJS
   LongRunningFlattened,
   LongRunningFlattenedAsync, // Java
-  LongRunningPromise, // NodeJS
+  LongRunningPromise, // NodeJS, Python
   LongRunningRequest,
   LongRunningRequestAsync, // Java
 

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -165,7 +165,7 @@
                     EXPERIMENTAL: This method interface might change in the future.
 
                 @end
-                {@exampleCode(apiMethod, apiMethod.initCode)}
+                {@exampleInCode(apiMethod, apiMethod.initCode)}
 
                 Args:
                     @join paramDoc : apiMethod.doc.paramDocs

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -1,46 +1,77 @@
 @extends "py/common.snip"
 
 # Generate brief code examples for method-level documentation.
-@snippet exampleCode(apiMethod, initCode)
+@snippet exampleInCode(apiMethod, initCode)
   Example:
-      @join line : util.getDocLines(sampleCode_(apiMethod, initCode))
+      @join line : util.getDocLines(incodeSamples(apiMethod))
           {@util.exampleLine(line)}
       @end
 @end
 
-# Generate code samples for standalone samples.
-@snippet sampleCode(apiMethod, initCode)
-      @join line : util.getDocLines(sampleCode_(apiMethod, initCode))
-          {@line}
+@snippet incodeSamples(apiMethod)
+    @join sample : apiMethod.samples on BREAK.add(BREAK).add(BREAK).add("# Alternatively:").add(BREAK)
+      @let firstSample = apiMethod.samples.get(0)
+        # Print the set-up code for the first sample, and for
+        # subsequent samples where the code differs from the first
+        @if or(and(sample.callingForm == firstSample.callingForm, \
+                    sample.valueSet.id == firstSample.valueSet.id), \
+               sampleSetupDiffers(firstSample, sample))
+          {@incodeSampleSetup(apiMethod, sample)}
+        @end
+
+        {@incodeSampleCall(apiMethod, sample)}
       @end
+    @end
 @end
 
-@snippet sampleCode_(apiMethod)
-  {@sampleCode_(apiMethod, apiMethod.initCode)}
+# This function returns true iff @incodeSampleSetup() would produce
+# different code for firstSample and secondSample.
+@snippet sampleSetupDiffers(firstSample, secondSample) horizontal
+  @if or(secondSample.initCode.importSection.appImports != firstSample.initCode.importSection.appImports, \
+         secondSample.initCode.lines != firstSample.initCode.lines)
+    sampleSetupDiffers: true
+  @end
 @end
 
-@snippet sampleCode_(apiMethod, initCode)
-  {@importList(initCode.importSection.appImports)}
+@snippet incodeSampleSetup(apiMethod, sample)
+  {@importList(sample.initCode.importSection.appImports)}
 
   client = {@apiMethod.apiModuleName}.{@apiMethod.apiClassName}()
 
-  @if initCode.lines
-    {@initCode(initCode)}
+  @if sample.initCode.lines
+    {@initCode(sample.initCode)}
 
-  @end
-  @switch apiMethod.type.toString
-  @case "OptionalArrayMethod"
-    {@optionalArrayMethodSampleCode(apiMethod, initCode)}
-  @case "LongRunningOptionalArrayMethod"
-    {@lroSampleCode(apiMethod, initCode)}
-  @case "PagedOptionalArrayMethod"
-    {@pagedOptionalArrayMethodSampleCode(apiMethod, initCode)}
-  @default
-    {@unhandledCase()}
   @end
 @end
 
-# Helper functions for sampleCode()
+@snippet incodeSample(apiMethod, sample)
+  {@incodeSampleSetup(apiMethod, sample)}
+  {@incodeSampleCall(apiMethod, sample)}
+@end
+
+# The structure of this should be parallel to that of standalone_sample.snip:@standaloneSample
+@snippet incodeSampleCall(apiMethod, sample)
+  @switch sample.callingForm
+  @case "Request"
+    {@optionalArrayMethodSampleCodeNonStreaming(apiMethod, sample.initCode)}
+  @case "RequestPaged"
+    {@pagedOptionalArrayMethodSampleCodePaged(apiMethod, sample.initCode)}
+  @case "RequestPagedAll"
+    {@pagedOptionalArrayMethodSampleCodeAll(apiMethod, sample.initCode)}
+  @case "RequestStreamingBidi"
+    {@optionalArrayMethodSampleCodeBidiStreaming(apiMethod, sample.initCode)}
+  @case "RequestStreamingClient"
+    {@optionalArrayMethodSampleCodeClientStreaming(apiMethod, sample.initCode)}
+  @case "RequestStreamingServer"
+    {@optionalArrayMethodSampleCodeServerStreaming(apiMethod, sample.initCode)}
+  @case "LongRunningPromise"
+    {@lroSampleCode(apiMethod, sample.initCode)}
+  @default
+    $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
+  @end
+@end
+
+# Helper functions
 
 # Generate argument initialization code for API call
 @snippet initCode(initCodeSpec)
@@ -128,30 +159,31 @@
   @end
 @end
 
-@private optionalArrayMethodSampleCodeNonStreaming(apiMethod, initCode)
+@snippet optionalArrayMethodSampleCodeNonStreaming(apiMethod, initCode)
   {@singularResponseSampleCode(apiMethod, initCode)}
 @end
 
-@private optionalArrayMethodSampleCodeServerStreaming(apiMethod, initCode)
+@snippet optionalArrayMethodSampleCodeServerStreaming(apiMethod, initCode)
   {@responseStreamingSampleCode(apiMethod, initCode)}
 @end
 
-@private optionalArrayMethodSampleCodeClientStreaming(apiMethod, initCode)
+@snippet optionalArrayMethodSampleCodeClientStreaming(apiMethod, initCode)
   requests = [request]
   {@singularResponseSampleCode(apiMethod, initCode)}
 @end
 
-@private optionalArrayMethodSampleCodeBidiStreaming(apiMethod, initCode)
+@snippet optionalArrayMethodSampleCodeBidiStreaming(apiMethod, initCode)
   requests = [request]
   {@responseStreamingSampleCode(apiMethod, initCode)}
 @end
 
-@private pagedOptionalArrayMethodSampleCode(apiMethod, initCode)
-
+@snippet pagedOptionalArrayMethodSampleCodeAll(apiMethod, initCode)
   @# Iterate over all results
   {@responseStreamingSampleCode(apiMethod, initCode)}
+@end
 
-  @# Or iterate over results one page at a time
+@snippet pagedOptionalArrayMethodSampleCodePaged(apiMethod, initCode)
+  @# Iterate over results one page at a time
   for page in {@pagedMethodCallSampleCode(apiMethod, initCode)}:
       for element in page:
           @# process element
@@ -172,7 +204,7 @@
   @end
 @end
 
-@private lroSampleCode(apiMethod, initCode)
+@snippet lroSampleCode(apiMethod, initCode)
   response = {@methodCallSampleCode(apiMethod, initCode)}
 
   def callback(operation_future):

--- a/src/main/resources/com/google/api/codegen/py/readme_common.snip
+++ b/src/main/resources/com/google/api/codegen/py/readme_common.snip
@@ -7,7 +7,7 @@
 
         .. code:: py
 
-            {@sampleCode_(method)}
+            {@incodeSample(method, method.samples.get(0))}
     @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -13,7 +13,7 @@
   @# [START full_sample]
 
   @# FIXME: Insert here boilerplate code not directly related to the method call itself.
-   
+
   @let apiMethod = sampleFile.libraryMethod
     @let sample = apiMethod.samples.get(0)
       @##     calling form "{@sample.callingForm.toString}"
@@ -26,7 +26,7 @@
 
       @# FIXME: Insert here code to prepare the request fields, make the call, process the response.
        
-      {@sampleCode(apiMethod, sample.initCode)}
+      {@standaloneSample(apiMethod, sample)}
       # TODO(pongad): Make this work on non-unary too.
       print(response)
       
@@ -37,4 +37,29 @@
     @end
   @end
   @# [END full_sample]
+@end
+
+# The structure of this should be parallel to that of method_sample.snip:@incodeSampleCall.
+#
+# FIXME: Replace the following function calls with calls to functions that emit full standalone samples. These stubs have been adapted from method_sample.snip
+@snippet standaloneSample(apiMethod, sample)
+  {@incodeSampleSetup(apiMethod, sample)}
+  @switch sample.callingForm
+  @case "Request"
+    {@optionalArrayMethodSampleCodeNonStreaming(apiMethod, sample.initCode)}
+  @case "RequestPaged"
+    {@pagedOptionalArrayMethodSampleCodePaged(apiMethod, sample.initCode)}
+  @case "RequestPagedAll"
+    {@pagedOptionalArrayMethodSampleCodeAll(apiMethod, sample.initCode)}
+  @case "RequestStreamingBidi"
+    {@optionalArrayMethodSampleCodeBidiStreaming(apiMethod, sample.initCode)}
+  @case "RequestStreamingClient"
+    {@optionalArrayMethodSampleCodeClientStreaming(apiMethod, sample.initCode)}
+  @case "RequestStreamingServer"
+    {@optionalArrayMethodSampleCodeServerStreaming(apiMethod, sample.initCode)}
+  @case "LongRunningPromise"
+    {@lroSampleCode(apiMethod, sample.initCode)}
+  @default
+    $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
+  @end
 @end

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -1337,13 +1337,15 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>>
             >>> # Iterate over all results
             >>> for element in client.list_shelves():
             ...     # process element
             ...     pass
             >>>
-            >>> # Or iterate over results one page at a time
+            >>>
+            >>> # Alternatively:
+            >>>
+            >>> # Iterate over results one page at a time
             >>> for page in client.list_shelves(options=CallOptions(page_token=INITIAL_PAGE)):
             ...     for element in page:
             ...         # process element
@@ -1717,13 +1719,15 @@ class LibraryServiceClient(object):
             >>> name = client.shelf_path('[SHELF_ID]')
             >>> filter_ = 'book-filter-string'
             >>>
-            >>>
             >>> # Iterate over all results
             >>> for element in client.list_books(name, filter=filter_):
             ...     # process element
             ...     pass
             >>>
-            >>> # Or iterate over results one page at a time
+            >>>
+            >>> # Alternatively:
+            >>>
+            >>> # Iterate over results one page at a time
             >>> for page in client.list_books(name, filter=filter_, options=CallOptions(page_token=INITIAL_PAGE)):
             ...     for element in page:
             ...         # process element
@@ -1975,13 +1979,15 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>>
             >>> # Iterate over all results
             >>> for element in client.list_strings():
             ...     # process element
             ...     pass
             >>>
-            >>> # Or iterate over results one page at a time
+            >>>
+            >>> # Alternatively:
+            >>>
+            >>> # Iterate over results one page at a time
             >>> for page in client.list_strings(options=CallOptions(page_token=INITIAL_PAGE)):
             ...     for element in page:
             ...         # process element
@@ -2558,13 +2564,15 @@ class LibraryServiceClient(object):
             >>> # TODO: Initialize ``shelves``:
             >>> shelves = []
             >>>
-            >>>
             >>> # Iterate over all results
             >>> for element in client.find_related_books(names, shelves):
             ...     # process element
             ...     pass
             >>>
-            >>> # Or iterate over results one page at a time
+            >>>
+            >>> # Alternatively:
+            >>>
+            >>> # Iterate over results one page at a time
             >>> for page in client.find_related_books(names, shelves, options=CallOptions(page_token=INITIAL_PAGE)):
             ...     for element in page:
             ...         # process element
@@ -3519,9 +3527,9 @@ def lint_setup_py(session):
     session.install('docutils', 'pygments')
     session.run(
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')
-============== file: samples/google/cloud/example/library_v1/gapic/discuss_book/discuss_book_sample_generic_prog.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookSampleGenericProg" ]
-#### STUB standalone sample "DiscussBookSampleGenericProg" #####
+============== file: samples/google/cloud/example/library_v1/gapic/discuss_book/discuss_book_sample_request_streaming_bidi_prog.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookSampleRequestStreamingBidiProg" ]
+#### STUB standalone sample "DiscussBookSampleRequestStreamingBidiProg" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -3532,7 +3540,7 @@ def lint_setup_py(session):
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "Generic"
+##     calling form "RequestStreamingBidi"
 ##     valueSet "prog" ("Programming Books")
 ##       description: "Testing calling forms: {Java:[CallableBidiStreaming]}"
 ##       [name=BASIC]
@@ -3560,9 +3568,9 @@ print(response)
 # FIXME: Insert here clean-up code.
 
 # [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/find_related_books/find_related_books_sample_generic_odyssey.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleGenericOdyssey" ]
-#### STUB standalone sample "FindRelatedBooksSampleGenericOdyssey" #####
+============== file: samples/google/cloud/example/library_v1/gapic/find_related_books/find_related_books_sample_request_paged_all_odyssey.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestPagedAllOdyssey" ]
+#### STUB standalone sample "FindRelatedBooksSampleRequestPagedAllOdyssey" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -3573,7 +3581,7 @@ print(response)
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "Generic"
+##     calling form "RequestPagedAll"
 ##     valueSet "odyssey" ("The Odyssey")
 ##       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged]}"
 ##       [names[0]=Odyssey, shelves[0]=Classics]
@@ -3592,13 +3600,50 @@ names = [names_element]
 shelves_element = 'Classics'
 shelves = [shelves_element]
 
-
 # Iterate over all results
 for element in client.find_related_books(names, shelves):
     # process element
     pass
+print(response)
 
-# Or iterate over results one page at a time
+# [END core_sample]
+
+# FIXME: Insert here clean-up code.
+
+# [END full_sample]
+============== file: samples/google/cloud/example/library_v1/gapic/find_related_books/find_related_books_sample_request_paged_odyssey.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestPagedOdyssey" ]
+#### STUB standalone sample "FindRelatedBooksSampleRequestPagedOdyssey" #####
+
+# FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+# To run with the published packaged, execute the following before running this code:
+#   pip install google-cloud-library
+
+# [START full_sample]
+
+# FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+##     calling form "RequestPaged"
+##     valueSet "odyssey" ("The Odyssey")
+##       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged]}"
+##       [names[0]=Odyssey, shelves[0]=Classics]
+##     apiMethod "find_related_books" of type "PagedOptionalArrayMethod"
+
+# [START core_sample]
+
+# FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+from google.cloud.example import library_v1
+
+client = library_v1.LibraryServiceClient()
+
+names_element = 'Odyssey'
+names = [names_element]
+shelves_element = 'Classics'
+shelves = [shelves_element]
+
+# Iterate over results one page at a time
 for page in client.find_related_books(names, shelves, options=CallOptions(page_token=INITIAL_PAGE)):
     for element in page:
         # process element
@@ -3610,9 +3655,9 @@ print(response)
 # FIXME: Insert here clean-up code.
 
 # [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/get_big_book/get_big_book_sample_generic_wap.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleGenericWap" ]
-#### STUB standalone sample "GetBigBookSampleGenericWap" #####
+============== file: samples/google/cloud/example/library_v1/gapic/get_big_book/get_big_book_sample_long_running_promise_wap.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleLongRunningPromiseWap" ]
+#### STUB standalone sample "GetBigBookSampleLongRunningPromiseWap" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -3623,7 +3668,7 @@ print(response)
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "Generic"
+##     calling form "LongRunningPromise"
 ##     valueSet "wap" ("GetBigBook: 'War and Peace'")
 ##       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable]}"
 ##       [name="War and Peace"]
@@ -3656,9 +3701,9 @@ print(response)
 # FIXME: Insert here clean-up code.
 
 # [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/monolog_about_book/monolog_about_book_sample_generic_prog.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookSampleGenericProg" ]
-#### STUB standalone sample "MonologAboutBookSampleGenericProg" #####
+============== file: samples/google/cloud/example/library_v1/gapic/monolog_about_book/monolog_about_book_sample_request_streaming_client_prog.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookSampleRequestStreamingClientProg" ]
+#### STUB standalone sample "MonologAboutBookSampleRequestStreamingClientProg" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -3669,7 +3714,7 @@ print(response)
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "Generic"
+##     calling form "RequestStreamingClient"
 ##     valueSet "prog" ("Programming Books")
 ##       description: "Testing calling forms: {Java:[CallableClientStreaming]}"
 ##       [name=BASIC]
@@ -3695,9 +3740,9 @@ print(response)
 # FIXME: Insert here clean-up code.
 
 # [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/publish_series/publish_series_sample_generic_pi_version.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleGenericPiVersion" ]
-#### STUB standalone sample "PublishSeriesSampleGenericPiVersion" #####
+============== file: samples/google/cloud/example/library_v1/gapic/publish_series/publish_series_sample_request_pi_version.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestPiVersion" ]
+#### STUB standalone sample "PublishSeriesSampleRequestPiVersion" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -3708,7 +3753,7 @@ print(response)
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "Generic"
+##     calling form "Request"
 ##     valueSet "pi_version" ("Pi version")
 ##       description: "callingFormCheck: pi_version java: Flattened Request Callable"
 ##       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
@@ -3738,9 +3783,9 @@ print(response)
 # FIXME: Insert here clean-up code.
 
 # [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/publish_series/publish_series_sample_generic_second_edition.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleGenericSecondEdition" ]
-#### STUB standalone sample "PublishSeriesSampleGenericSecondEdition" #####
+============== file: samples/google/cloud/example/library_v1/gapic/publish_series/publish_series_sample_request_second_edition.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestSecondEdition" ]
+#### STUB standalone sample "PublishSeriesSampleRequestSecondEdition" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -3751,7 +3796,7 @@ print(response)
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "Generic"
+##     calling form "Request"
 ##     valueSet "second_edition" ("Second edition")
 ##       description: "Testing calling forms: {Java:[Flattened, Request, Callable]}"
 ##       [edition=2]
@@ -3783,9 +3828,9 @@ print(response)
 # FIXME: Insert here clean-up code.
 
 # [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/stream_books/stream_books_sample_generic_prog.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksSampleGenericProg" ]
-#### STUB standalone sample "StreamBooksSampleGenericProg" #####
+============== file: samples/google/cloud/example/library_v1/gapic/stream_books/stream_books_sample_request_streaming_server_prog.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksSampleRequestStreamingServerProg" ]
+#### STUB standalone sample "StreamBooksSampleRequestStreamingServerProg" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -3796,7 +3841,7 @@ print(response)
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "Generic"
+##     calling form "RequestStreamingServer"
 ##     valueSet "prog" ("Programming Books")
 ##       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
 ##       [name=BASIC]
@@ -3822,9 +3867,9 @@ print(response)
 # FIXME: Insert here clean-up code.
 
 # [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/stream_shelves/stream_shelves_sample_generic_empty.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesSampleGenericEmpty" ]
-#### STUB standalone sample "StreamShelvesSampleGenericEmpty" #####
+============== file: samples/google/cloud/example/library_v1/gapic/stream_shelves/stream_shelves_sample_request_streaming_server_empty.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesSampleRequestStreamingServerEmpty" ]
+#### STUB standalone sample "StreamShelvesSampleRequestStreamingServerEmpty" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
@@ -3835,7 +3880,7 @@ print(response)
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "Generic"
+##     calling form "RequestStreamingServer"
 ##     valueSet "empty" ("Server streaming")
 ##       description: "Testing calling forms: {Java:[CallableServerStreaming]}"
 ##       []


### PR DESCRIPTION
* The logic for determining calling forms has been moved to the
  generator

* The standalone samples key off the calling form to call the correct
  sample-generating function (the routing is implemented here; the
  functions called at the moment as stubs are actually the in-code
  sample functions)

* The in-code samples are now also keyed off the calling forms