### PR TITLE
turn callingFormCheck into comment

### DIFF
--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -7715,7 +7715,7 @@ requestObserver.onNext(request);
 
 //     calling form: "Flattened"
 //     valueSet "pi_version" ("Pi version")
-//       description: "callingFormCheck: pi_version java: Flattened Request Callable"
+//       description: "Pi version description"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeries" of type "FlattenedMethod"
 
@@ -7785,7 +7785,7 @@ PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, editi
 
 //     calling form: "Request"
 //     valueSet "pi_version" ("Pi version")
-//       description: "callingFormCheck: pi_version java: Flattened Request Callable"
+//       description: "Pi version description"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeries" of type "RequestObjectMethod"
 
@@ -7865,7 +7865,7 @@ PublishSeriesResponse response = libraryClient.publishSeries(request);
 
 //     calling form: "Callable"
 //     valueSet "pi_version" ("Pi version")
-//       description: "callingFormCheck: pi_version java: Flattened Request Callable"
+//       description: "Pi version description"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeriesCallable" of type "CallableMethod"
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -548,7 +548,7 @@ stream.write(request);
 
 //     calling form "Request"
 //     valueSet "pi_version" ("Pi version")
-//       description: "callingFormCheck: pi_version java: Flattened Request Callable"
+//       description: "Pi version description"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeries" of type "OptionalArrayMethod"
 

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -3710,7 +3710,7 @@ print(response)
 
 ##     calling form "Generic"
 ##     valueSet "pi_version" ("Pi version")
-##       description: "callingFormCheck: pi_version java: Flattened Request Callable"
+##       description: "Pi version description"
 ##       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 ##     apiMethod "publish_series" of type "OptionalArrayMethod"
 

--- a/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
@@ -238,10 +238,10 @@ interfaces:
     sample_code_init_fields:
     - series_uuid.series_string=foobar
     sample_value_sets:
+      # callingFormCheck: pi_version java: Flattened Request Callable
     - id: pi_version
       title: "Pi version"
-      description: >
-        callingFormCheck: pi_version java: Flattened Request Callable
+      description: "Pi version description"
       parameters:
       - shelf.name=Math
       - series_uuid.series_string=xyz3141592654

--- a/testutils/check-calling-form-in-baseline/main.go
+++ b/testutils/check-calling-form-in-baseline/main.go
@@ -39,8 +39,9 @@ run of whitespaces. To check for multiple languages or value sets, simply write 
 multiple times. The '#' makes the line a YAML comment, so that it can be inserted without
 affecting the meaning of the file.
 
-NOTE: It is regretable that we have to write valueSetID twice, once in YAML "id" field,
-and again in the comment. One may hope this will improve in the future.
+NOTE: It is regretable that we have to write valueSetID twice, once in the YAML "id" field,
+and again in the comment. We would like to improve this in the future, but this will require
+the additional complexity of parsing the YAML.
 `
 
 func main() {

--- a/testutils/check-calling-form-in-baseline/main.go
+++ b/testutils/check-calling-form-in-baseline/main.go
@@ -32,15 +32,15 @@ const usage = `Reads calling forms from gapic_yaml_file and makes sure each is u
 some *.baseline file in dir.
 The line specifying the calling form is in the format:
 
-  callingFormCheck: <valueSetID> <language>: <callingForm1> <callingForm2> ...
+  # callingFormCheck: <valueSetID> <language>: <callingForm1> <callingForm2> ...
 
-The string "callingFormCheck" must start the line, preceded only by a possibly empty
+The string "# callingFormCheck" must start the line, preceded only by a possibly empty
 run of whitespaces. To check for multiple languages or value sets, simply write the line
-multiple times. Hint: YAML files allow multi-line string literals like
+multiple times. The '#' makes the line a YAML comment, so that it can be inserted without
+affecting the meaning of the file.
 
-  sometext: >
-    callingFormCheck: valud_id java: form1 form2
-    callingFormCheck: another_value_id python: formSpam formEgg formHam
+NOTE: It is regretable that we have to write valueSetID twice, once in YAML "id" field,
+and again in the comment. One may hope this will improve in the future.
 `
 
 func main() {
@@ -127,7 +127,7 @@ func (s checkConfigSlice) Less(i, j int) bool {
 	return s[i].form < s[j].form
 }
 
-var checkPrefix = "callingFormCheck:"
+var checkPrefix = "# callingFormCheck:"
 
 // readChecks reads r for callingFormCheck lines as described in command's usage
 // and returns the set of the checkConfigs to be verified in the baselines.

--- a/testutils/check-calling-form-in-baseline/main_test.go
+++ b/testutils/check-calling-form-in-baseline/main_test.go
@@ -21,9 +21,10 @@ import (
 
 func TestReadChecks(t *testing.T) {
 	const checkFile = `
-callingFormCheck: set1 java: foo bar
- callingFormCheck: set2 go: zip zap
-# callingFormCheck: ignored because: not at line start
+# callingFormCheck: set1 java: foo bar
+ # callingFormCheck: set2 go: zip zap
+callingFormCheck: ignored because no hash
+sometext # callingFormCheck: ignored because: not at line start
 unrelated line
 `
 	checks, err := readChecks(strings.NewReader(checkFile))


### PR DESCRIPTION
This makes it easier to add new languages,
as baselines won't have to change.

Updates #2044.