### PR TITLE
go: don't generate empty LRO Metadata()

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/LongRunningTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/LongRunningTransformer.java
@@ -39,6 +39,7 @@ public class LongRunningTransformer {
         .clientReturnTypeName(clientReturnTypeName)
         .operationPayloadTypeName(operationPayloadTypeName)
         .isEmptyOperation(lroConfig.getReturnType().isEmptyType())
+        .isEmptyMetadata(lroConfig.getMetadataType().isEmptyType())
         .metadataTypeName(metadataTypeName)
         .implementsDelete(lroConfig.implementsDelete())
         .implementsCancel(lroConfig.implementsCancel())

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -240,6 +240,7 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
               .clientReturnTypeName("")
               .operationPayloadTypeName(context.getImportTypeTable().getFullNameFor(returnType))
               .isEmptyOperation(lroConfig.getReturnType().isEmptyType())
+              .isEmptyMetadata(lroConfig.getMetadataType().isEmptyType())
               .metadataTypeName(context.getImportTypeTable().getFullNameFor(metadataType))
               .implementsCancel(true)
               .implementsDelete(true)

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -243,6 +243,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
               .clientReturnTypeName("")
               .operationPayloadTypeName(context.getImportTypeTable().getFullNameFor(returnType))
               .isEmptyOperation(lroConfig.getReturnType().isEmptyType())
+              .isEmptyMetadata(lroConfig.getMetadataType().isEmptyType())
               .metadataTypeName(context.getImportTypeTable().getFullNameFor(metadataType))
               .implementsCancel(true)
               .implementsDelete(true)

--- a/src/main/java/com/google/api/codegen/viewmodel/LongRunningOperationDetailView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/LongRunningOperationDetailView.java
@@ -28,6 +28,8 @@ public abstract class LongRunningOperationDetailView {
 
   public abstract boolean isEmptyOperation();
 
+  public abstract boolean isEmptyMetadata();
+
   public abstract String metadataTypeName();
 
   public abstract boolean implementsDelete();
@@ -60,6 +62,8 @@ public abstract class LongRunningOperationDetailView {
     public abstract Builder operationPayloadTypeName(String val);
 
     public abstract Builder isEmptyOperation(boolean val);
+
+    public abstract Builder isEmptyMetadata(boolean val);
 
     public abstract Builder metadataTypeName(String val);
 

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -1,4 +1,5 @@
 @extends "go/header.snip"
+@extends "common.snip"
 
 @snippet generate(view)
     {@headerComment(view.fileHeader)}
@@ -348,9 +349,7 @@
         }
 
         // Poll fetches the latest state of the long-running operation.
-        //
-        // Poll also fetches the latest metadata, which can be retrieved by Metadata.
-        //
+        {@pollMetadataDoc(lro)}
         // If Poll fails, the error is returned and op is unmodified. If Poll succeeds and
         // the operation has completed with failure, the error is returned and op.Done will return true.
         // If Poll succeeds and the operation has completed successfully, op.Done will return true.
@@ -370,9 +369,7 @@
         }
 
         // Poll fetches the latest state of the long-running operation.
-        //
-        // Poll also fetches the latest metadata, which can be retrieved by Metadata.
-        //
+        {@pollMetadataDoc(lro)}
         // If Poll fails, the error is returned and op is unmodified. If Poll succeeds and
         // the operation has completed with failure, the error is returned and op.Done will return true.
         // If Poll succeeds and the operation has completed successfully,
@@ -390,19 +387,21 @@
         }
     @end
 
-    // Metadata returns metadata associated with the long-running operation.
-    // Metadata itself does not contact the server, but Poll does.
-    // To get the latest metadata, call this method after a successful call to Poll.
-    // If the metadata is not available, the returned metadata and error are both nil.
-    func (op *{@lro.clientReturnTypeName}) Metadata() (*{@lro.metadataTypeName}, error) {
-        var meta {@lro.metadataTypeName}
-        if err := op.lro.Metadata(&meta); err == longrunning.ErrNoMetadata {
-            return nil, nil
-        } else if err != nil {
-            return nil, err
+    @if not(lro.isEmptyMetadata)
+        // Metadata returns metadata associated with the long-running operation.
+        // Metadata itself does not contact the server, but Poll does.
+        // To get the latest metadata, call this method after a successful call to Poll.
+        // If the metadata is not available, the returned metadata and error are both nil.
+        func (op *{@lro.clientReturnTypeName}) Metadata() (*{@lro.metadataTypeName}, error) {
+            var meta {@lro.metadataTypeName}
+            if err := op.lro.Metadata(&meta); err == longrunning.ErrNoMetadata {
+                return nil, nil
+            } else if err != nil {
+                return nil, err
+            }
+            return &meta, nil
         }
-        return &meta, nil
-    }
+    @end
 
     // Done reports whether the long-running operation has completed.
     func (op *{@lro.clientReturnTypeName}) Done() bool {
@@ -433,6 +432,16 @@
         func (op *{@lro.clientReturnTypeName}) Delete(ctx context.Context, opts ...gax.CallOption) error {
             return op.lro.Delete(ctx, opts...)
         }
+    @end
+@end
+
+@private pollMetadataDoc(lro)
+    @if lro.isEmptyMetadata
+        //
+    @else
+        //
+        // Poll also fetches the latest metadata, which can be retrieved by Metadata.
+        //
     @end
 @end
 


### PR DESCRIPTION
Most methods we generate have signatures like this:

  func (*Client) Method(context.Context, *pb.Request) (*pb.Response, error)

If the response is an empty type, it's not terribly useful, so we drop
it, making the signature:

  func (*Client) Method(context.Context, *pb.Request) error

Since we never write the name of the Empty type,
we have a special logic to never import the "emptypb" package
so we don't get the imported-but-not-used error.

The problem is that if a long-running operation has an Empty metadata,
we still create the

  func (*Operation) Metadata() (*emptypb.Empty, error)

method. This does not compile, because now we're using emptypb without
importing.

The solution is to simply not generating the Metadata() method at all,
since it doesn't contain any useful information anyway.