### PR TITLE
New createToolPaths task, add symlink to fatjar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,12 @@ task fatJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
   exclude 'META-INF/*.SF'
   exclude 'META-INF/*.DSA'
   exclude 'META-INF/*.RSA'
+
+  doLast {
+    Symlinks.createSymbolicLink(
+            "$buildDir/libs/gapic-generator-latest-fatjar.jar",
+            "$buildDir/libs/gapic-generator-${project.version}-fatjar.jar")
+  }
 }
 
 jacocoTestReport {
@@ -392,6 +398,8 @@ classes {
 //
 // Command line args can be passed to the tool as a comma-separated list:
 //   ./gradlew runCodeGen '-Pclargs=--arg1=val1,--arg2=val2,--arg3=val3'
+//
+// This task is deprecated - invoke GeneratorMain directly instead.
 task runCodeGen(type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
   main = 'com.google.api.codegen.GeneratorMain'
@@ -406,6 +414,8 @@ task runCodeGen(type: JavaExec) {
 //
 // Command line args can be passed to the tool as a comma-separated list:
 //   ./gradlew runDiscoCodeGen '-Pclargs=--arg1=val1,--arg2=val2,--arg3=val3'
+//
+// This task is deprecated - invoke GeneratorMain directly instead.
 task runDiscoCodeGen(type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
   main = 'com.google.api.codegen.GeneratorMain'
@@ -415,7 +425,30 @@ task runDiscoCodeGen(type: JavaExec) {
   }
 }
 
+// Task to build symlinks to tools related to code generation.
+// Symlinks will be placed under `build/toolpaths`.
+task createToolPaths {
+  doLast {
+    new File("$buildDir/toolpaths/").mkdirs()
+    DependencyResolver resolver = new DependencyResolver(project)
+
+    def protoGenGrpcJavaExe = resolver.resolveExecutable(
+            'io.grpc:protoc-gen-grpc-java:1.10.0')
+    Symlinks.createSymbolicLink("$buildDir/toolpaths/protoGenGrpcJavaExe", protoGenGrpcJavaExe)
+
+    def protobufJavaDir = resolver.extractArchive(
+            'com.google.protobuf:protobuf-java:' + protoVersion)
+    Symlinks.createSymbolicLink("$buildDir/toolpaths/protobufJavaDir", protobufJavaDir)
+
+    def googleJavaFormatJar = resolver.locateArchive(
+            'com.google.googlejavaformat:google-java-format:1.1:all-deps')
+    Symlinks.createSymbolicLink("$buildDir/toolpaths/googleJavaFormatJar", googleJavaFormatJar)
+  }
+}
+
 // Task to display the cache path of GRPC Java plugin
+//
+// This task is deprecated - use createToolPaths instead
 task showGrpcJavaPluginPath {
   doLast {
     DependencyResolver resolver = new DependencyResolver(project)
@@ -425,6 +458,8 @@ task showGrpcJavaPluginPath {
 }
 
 // Task to display the cache path of protobuf
+//
+// This task is deprecated - use createToolPaths instead
 task showProtobufPath() {
   doLast {
     DependencyResolver resolver = new DependencyResolver(project)
@@ -434,6 +469,8 @@ task showProtobufPath() {
 }
 
 // Task to display the cache path of Google Java formatter
+//
+// This task is deprecated - use createToolPaths instead
 task showJavaFormatterPath {
   doLast {
     DependencyResolver resolver = new DependencyResolver(project)
@@ -447,6 +484,8 @@ task showJavaFormatterPath {
 //
 // Command line args can be passed to the tool as a comma-separated list:
 //   ./gradlew runConfigGen '-Pclargs=--arg1=val1,--arg2=val2,--arg3=val3'
+//
+// This task is deprecated - invoke GeneratorMain directly instead.
 task runConfigGen(type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
   main = 'com.google.api.codegen.GeneratorMain'
@@ -461,6 +500,8 @@ task runConfigGen(type: JavaExec) {
 //
 // Command line args can be passed to the tool as a comma-separated list:
 //   ./gradlew runDiscoConfigGen '-Pclargs=--arg1=val1,--arg2=val2,--arg3=val3'
+//
+// This task is deprecated - invoke GeneratorMain directly instead.
 task runDiscoConfigGen(type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
   main = 'com.google.api.codegen.GeneratorMain'
@@ -475,6 +516,8 @@ task runDiscoConfigGen(type: JavaExec) {
 //
 // Command line args can be passed to the tool as a comma-separated list:
 //   ./gradlew runGrpcMetadataGen '-Pclargs=--arg1=val1,--arg2=val2,--arg3=val3'
+//
+// This task is deprecated - invoke GeneratorMain directly instead.
 task runGrpcMetadataGen(type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
   main = 'com.google.api.codegen.GeneratorMain'

--- a/buildSrc/src/main/groovy/DependencyResolver.groovy
+++ b/buildSrc/src/main/groovy/DependencyResolver.groovy
@@ -1,3 +1,17 @@
+/* Copyright 2016 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -17,14 +31,14 @@ class DependencyResolver {
 
   // Fetch and locate archives
   public String locateArchive(String dependency) {
-    Configuration config = setupConfig();
+    Configuration config = setupConfig(dependency);
     Dependency dep = project.dependencies.add(config.name, dependency)
     return config.fileCollection(dep).singleFile.toString();
   }
 
   // Fetch and locate executables
   public String resolveExecutable(String dependency) {
-    Configuration config = setupConfig();
+    Configuration config = setupConfig(dependency);
     def groupId, artifact, version
     (groupId, artifact, version) = dependency.split(":")
     def notation = [group: groupId,
@@ -53,8 +67,8 @@ class DependencyResolver {
     return output
   }
 
-  private Configuration setupConfig() {
-    Configuration config = project.configurations.create("DependencyResolver") {
+  private Configuration setupConfig(String uniqueSuffix) {
+    Configuration config = project.configurations.create("DependencyResolver-" + uniqueSuffix) {
       visible = false
       transitive = false
       extendsFrom = []

--- a/buildSrc/src/main/groovy/Symlinks.groovy
+++ b/buildSrc/src/main/groovy/Symlinks.groovy
@@ -1,0 +1,24 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class Symlinks {
+    static createSymbolicLink(String link, String target) {
+        def linkFile = new File(link)
+        linkFile.delete()
+        java.nio.file.Files.createSymbolicLink(
+                linkFile.toPath(),
+                new File(target).toPath())
+    }
+}


### PR DESCRIPTION
These features allow artman to invoke gradle just twice (once to build gapic-generator, a second time to cache the tool paths), and then avoid gradle completely after that. 
