### PR TITLE
Add PHP type hints for constructor and optional args

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/php/PhpApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpApiMethodParamTransformer.java
@@ -42,6 +42,7 @@ public class PhpApiMethodParamTransformer implements ApiMethodParamTransformer {
     optionalArgs.name(context.getNamer().localVarName(Name.from("optional", "args")));
     optionalArgs.defaultValue(
         context.getTypeTable().getSnippetZeroValueAndSaveNicknameFor(arrayType));
+    optionalArgs.typeHint("array");
     methodParams.add(optionalArgs.build());
 
     return methodParams.build();

--- a/src/main/java/com/google/api/codegen/viewmodel/DynamicLangDefaultableParamView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/DynamicLangDefaultableParamView.java
@@ -15,12 +15,20 @@
 package com.google.api.codegen.viewmodel;
 
 import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class DynamicLangDefaultableParamView {
   public abstract String name();
 
   public abstract String defaultValue();
+
+  @Nullable
+  public abstract String typeHint();
+
+  public boolean hasTypeHint() {
+    return typeHint() != null && !typeHint().isEmpty();
+  }
 
   public static Builder newBuilder() {
     return new AutoValue_DynamicLangDefaultableParamView.Builder();
@@ -31,6 +39,8 @@ public abstract class DynamicLangDefaultableParamView {
     public abstract Builder name(String name);
 
     public abstract Builder defaultValue(String value);
+
+    public abstract Builder typeHint(String value);
 
     public abstract DynamicLangDefaultableParamView build();
   }

--- a/src/main/resources/com/google/api/codegen/php/client_impl.snip
+++ b/src/main/resources/com/google/api/codegen/php/client_impl.snip
@@ -372,7 +372,7 @@
      * @@throws ValidationException
      * @@experimental
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
@@ -503,10 +503,18 @@
 @private paramList(params)
     @join param : params on ", "
         @if param.defaultValue
-            ${@param.name} = {@param.defaultValue}
+            {@paramName(param)} = {@param.defaultValue}
         @else
-            ${@param.name}
+            {@paramName(param)}
         @end
+    @end
+@end
+
+@private paramName(param)
+    @if param.hasTypeHint
+        {@param.typeHint} ${@param.name}
+    @else
+        ${@param.name}
     @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/php/client_impl.snip
+++ b/src/main/resources/com/google/api/codegen/php/client_impl.snip
@@ -503,14 +503,14 @@
 @private paramList(params)
     @join param : params on ", "
         @if param.defaultValue
-            {@paramName(param)} = {@param.defaultValue}
+            {@paramDeclaration(param)} = {@param.defaultValue}
         @else
-            {@paramName(param)}
+            {@paramDeclaration(param)}
         @end
     @end
 @end
 
-@private paramName(param)
+@private paramDeclaration(param)
     @if param.hasTypeHint
         {@param.typeHint} ${@param.name}
     @else

--- a/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
@@ -483,7 +483,7 @@ class LibraryServiceGapicClient
      * @throws ValidationException
      * @experimental
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
@@ -520,7 +520,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function createShelf($shelf, $optionalArgs = [])
+    public function createShelf($shelf, array $optionalArgs = [])
     {
         $request = new CreateShelfRequest();
         $request->setShelf($shelf);
@@ -567,7 +567,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function getShelf($name, $options, $optionalArgs = [])
+    public function getShelf($name, $options, array $optionalArgs = [])
     {
         $request = new GetShelfRequest();
         $request->setName($name);
@@ -632,7 +632,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function listShelves($optionalArgs = [])
+    public function listShelves(array $optionalArgs = [])
     {
         $request = new ListShelvesRequest();
         if (isset($optionalArgs['pageToken'])) {
@@ -674,7 +674,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function deleteShelf($name, $optionalArgs = [])
+    public function deleteShelf($name, array $optionalArgs = [])
     {
         $request = new DeleteShelfRequest();
         $request->setName($name);
@@ -720,7 +720,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function mergeShelves($name, $otherShelfName, $optionalArgs = [])
+    public function mergeShelves($name, $otherShelfName, array $optionalArgs = [])
     {
         $request = new MergeShelvesRequest();
         $request->setName($name);
@@ -765,7 +765,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function createBook($name, $book, $optionalArgs = [])
+    public function createBook($name, $book, array $optionalArgs = [])
     {
         $request = new CreateBookRequest();
         $request->setName($name);
@@ -826,7 +826,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function publishSeries($shelf, $books, $seriesUuid, $optionalArgs = [])
+    public function publishSeries($shelf, $books, $seriesUuid, array $optionalArgs = [])
     {
         $request = new PublishSeriesRequest();
         $request->setShelf($shelf);
@@ -876,7 +876,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function getBook($name, $optionalArgs = [])
+    public function getBook($name, array $optionalArgs = [])
     {
         $request = new GetBookRequest();
         $request->setName($name);
@@ -942,7 +942,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function listBooks($name, $optionalArgs = [])
+    public function listBooks($name, array $optionalArgs = [])
     {
         $request = new ListBooksRequest();
         $request->setName($name);
@@ -991,7 +991,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function deleteBook($name, $optionalArgs = [])
+    public function deleteBook($name, array $optionalArgs = [])
     {
         $request = new DeleteBookRequest();
         $request->setName($name);
@@ -1041,7 +1041,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function updateBook($name, $book, $optionalArgs = [])
+    public function updateBook($name, $book, array $optionalArgs = [])
     {
         $request = new UpdateBookRequest();
         $request->setName($name);
@@ -1095,7 +1095,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function moveBook($name, $otherShelfName, $optionalArgs = [])
+    public function moveBook($name, $otherShelfName, array $optionalArgs = [])
     {
         $request = new MoveBookRequest();
         $request->setName($name);
@@ -1159,7 +1159,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function listStrings($optionalArgs = [])
+    public function listStrings(array $optionalArgs = [])
     {
         $request = new ListStringsRequest();
         if (isset($optionalArgs['name'])) {
@@ -1216,7 +1216,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function addComments($name, $comments, $optionalArgs = [])
+    public function addComments($name, $comments, array $optionalArgs = [])
     {
         $request = new AddCommentsRequest();
         $request->setName($name);
@@ -1259,7 +1259,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function getBookFromArchive($name, $optionalArgs = [])
+    public function getBookFromArchive($name, array $optionalArgs = [])
     {
         $request = new GetBookFromArchiveRequest();
         $request->setName($name);
@@ -1304,7 +1304,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function getBookFromAnywhere($name, $altBookName, $optionalArgs = [])
+    public function getBookFromAnywhere($name, $altBookName, array $optionalArgs = [])
     {
         $request = new GetBookFromAnywhereRequest();
         $request->setName($name);
@@ -1347,7 +1347,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function getBookFromAbsolutelyAnywhere($name, $optionalArgs = [])
+    public function getBookFromAbsolutelyAnywhere($name, array $optionalArgs = [])
     {
         $request = new GetBookFromAbsolutelyAnywhereRequest();
         $request->setName($name);
@@ -1392,7 +1392,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function updateBookIndex($name, $indexName, $indexMap, $optionalArgs = [])
+    public function updateBookIndex($name, $indexName, $indexMap, array $optionalArgs = [])
     {
         $request = new UpdateBookIndexRequest();
         $request->setName($name);
@@ -1437,7 +1437,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function streamShelves($optionalArgs = [])
+    public function streamShelves(array $optionalArgs = [])
     {
         $request = new StreamShelvesRequest();
 
@@ -1481,7 +1481,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function streamBooks($name, $optionalArgs = [])
+    public function streamBooks($name, array $optionalArgs = [])
     {
         $request = new StreamBooksRequest();
         $request->setName($name);
@@ -1548,7 +1548,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function discussBook($optionalArgs = [])
+    public function discussBook(array $optionalArgs = [])
     {
         return $this->startCall(
             'DiscussBook',
@@ -1600,7 +1600,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function monologAboutBook($optionalArgs = [])
+    public function monologAboutBook(array $optionalArgs = [])
     {
         return $this->startCall(
             'MonologAboutBook',
@@ -1664,7 +1664,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function findRelatedBooks($names, $shelves, $optionalArgs = [])
+    public function findRelatedBooks($names, $shelves, array $optionalArgs = [])
     {
         $request = new FindRelatedBooksRequest();
         $request->setNames($names);
@@ -1717,7 +1717,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function addTag($resource, $tag, $optionalArgs = [])
+    public function addTag($resource, $tag, array $optionalArgs = [])
     {
         $request = new AddTagRequest();
         $request->setResource($resource);
@@ -1764,7 +1764,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function addLabel($resource, $label, $optionalArgs = [])
+    public function addLabel($resource, $label, array $optionalArgs = [])
     {
         $request = new AddLabelRequest();
         $request->setResource($resource);
@@ -1834,7 +1834,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function getBigBook($name, $optionalArgs = [])
+    public function getBigBook($name, array $optionalArgs = [])
     {
         $request = new GetBookRequest();
         $request->setName($name);
@@ -1899,7 +1899,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function getBigNothing($name, $optionalArgs = [])
+    public function getBigNothing($name, array $optionalArgs = [])
     {
         $request = new GetBookRequest();
         $request->setName($name);
@@ -2028,7 +2028,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $requiredSingularResourceName, $requiredSingularResourceNameOneof, $requiredSingularResourceNameCommon, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $requiredRepeatedResourceName, $requiredRepeatedResourceNameOneof, $requiredRepeatedResourceNameCommon, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap, $optionalArgs = [])
+    public function testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $requiredSingularResourceName, $requiredSingularResourceNameOneof, $requiredSingularResourceNameCommon, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $requiredRepeatedResourceName, $requiredRepeatedResourceNameOneof, $requiredRepeatedResourceNameCommon, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap, array $optionalArgs = [])
     {
         $request = new TestOptionalRequiredFlatteningParamsRequest();
         $request->setRequiredSingularInt32($requiredSingularInt32);

--- a/src/test/java/com/google/api/codegen/testdata/php/php_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_longrunning.baseline
@@ -216,7 +216,7 @@ class OperationsGapicClient
      * @throws ValidationException
      * @experimental
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
@@ -261,7 +261,7 @@ class OperationsGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function getOperation($name, $optionalArgs = [])
+    public function getOperation($name, array $optionalArgs = [])
     {
         $request = new GetOperationRequest();
         $request->setName($name);
@@ -338,7 +338,7 @@ class OperationsGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function listOperations($name, $filter, $optionalArgs = [])
+    public function listOperations($name, $filter, array $optionalArgs = [])
     {
         $request = new ListOperationsRequest();
         $request->setName($name);
@@ -402,7 +402,7 @@ class OperationsGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function cancelOperation($name, $optionalArgs = [])
+    public function cancelOperation($name, array $optionalArgs = [])
     {
         $request = new CancelOperationRequest();
         $request->setName($name);
@@ -453,7 +453,7 @@ class OperationsGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function deleteOperation($name, $optionalArgs = [])
+    public function deleteOperation($name, array $optionalArgs = [])
     {
         $request = new DeleteOperationRequest();
         $request->setName($name);

--- a/src/test/java/com/google/api/codegen/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_no_path_templates.baseline
@@ -189,7 +189,7 @@ class NoTemplatesApiServiceGapicClient
      * @throws ValidationException
      * @experimental
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
@@ -234,7 +234,7 @@ class NoTemplatesApiServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function increment($optionalArgs = [])
+    public function increment(array $optionalArgs = [])
     {
         $request = new IncrementRequest();
 


### PR DESCRIPTION
Add type hints for array arguments in constructor and methods. cc @dwsupplee @jdpedrie