### PR TITLE
Python: routing_header object called as method (actually module)

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -237,7 +237,7 @@
 
                     @if apiMethod.headerRequestParams
 
-                        routing_header = google.api_core.gapic_v1.routing_header(
+                        routing_header = google.api_core.gapic_v1.routing_header.to_grpc_metadata(
                             [{@routingHeader(apiMethod.headerRequestParams)}],
                         )
                         metadata.append(routing_header)

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -1558,7 +1558,7 @@ class LibraryServiceClient(object):
             book=book,
         )
 
-        routing_header = google.api_core.gapic_v1.routing_header(
+        routing_header = google.api_core.gapic_v1.routing_header.to_grpc_metadata(
             [('name', name), ('book.read', book.read)],
         )
         metadata.append(routing_header)


### PR DESCRIPTION
Resolves https://github.com/googleapis/gapic-generator/issues/2016.