### PR TITLE
Remove PHP experimental code warning

### DIFF
--- a/src/main/resources/com/google/api/codegen/php/client_impl.snip
+++ b/src/main/resources/com/google/api/codegen/php/client_impl.snip
@@ -25,10 +25,6 @@
      * https://github.com/google/googleapis/blob/master/{@xapiClass.protoFilename}
      * and updates to that file get reflected here through a refresh process.
      *
-     * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
-     * even though we intend the surface to be stable, we may make backwards incompatible changes
-     * if necessary.
-     *
      * @@experimental
      */
 @end
@@ -48,10 +44,6 @@
             {@""} * {@commentLine}
         @end
     @end
-     *
-     * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
-     * even though we intend the surface to be stable, we may make backwards incompatible changes
-     * if necessary.
      *
      * This class provides the ability to make remote calls to the backing service through method
      * calls that map to API methods. Sample code to get started:

--- a/src/main/resources/com/google/api/codegen/php/partial_veneer_client.snip
+++ b/src/main/resources/com/google/api/codegen/php/partial_veneer_client.snip
@@ -20,10 +20,6 @@
      * https://github.com/google/googleapis/blob/master/{@xapiClass.protoFilename}
      * and updates to that file get reflected here through a refresh process.
      *
-     * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
-     * even though we intend the surface to be stable, we may make backwards incompatible changes
-     * if necessary.
-     *
      * @@experimental
      */
 @end

--- a/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
@@ -44,10 +44,6 @@
  * https://github.com/google/googleapis/blob/master/library.proto
  * and updates to that file get reflected here through a refresh process.
  *
- * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
- * even though we intend the surface to be stable, we may make backwards incompatible changes
- * if necessary.
- *
  * @experimental
  */
 
@@ -134,10 +130,6 @@ use Google\Tagger\CustomNamespace\V1\LabelerGrpcClient;
  * This is [not a cloud link](http://www.google.com).
  *
  * Service comment may include special characters: <>&"`'&#64;.
- *
- * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
- * even though we intend the surface to be stable, we may make backwards incompatible changes
- * if necessary.
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods. Sample code to get started:
@@ -2180,10 +2172,6 @@ class LibraryServiceGapicClient
  * This file was generated from the file
  * https://github.com/google/googleapis/blob/master/library.proto
  * and updates to that file get reflected here through a refresh process.
- *
- * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
- * even though we intend the surface to be stable, we may make backwards incompatible changes
- * if necessary.
  *
  * @experimental
  */

--- a/src/test/java/com/google/api/codegen/testdata/php/php_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_longrunning.baseline
@@ -58,10 +58,6 @@
  * https://github.com/google/googleapis/blob/master/longrunning.proto
  * and updates to that file get reflected here through a refresh process.
  *
- * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
- * even though we intend the surface to be stable, we may make backwards incompatible changes
- * if necessary.
- *
  * @experimental
  */
 
@@ -95,10 +91,6 @@ use Google\Protobuf\GPBEmpty;
  * Google Cloud Pub/Sub API) to receive the response.  Any API service that
  * returns long-running operations should implement the `Operations` interface
  * so developers can have a consistent client experience.
- *
- * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
- * even though we intend the surface to be stable, we may make backwards incompatible changes
- * if necessary.
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods. Sample code to get started:
@@ -504,10 +496,6 @@ class OperationsGapicClient
  * This file was generated from the file
  * https://github.com/google/googleapis/blob/master/longrunning.proto
  * and updates to that file get reflected here through a refresh process.
- *
- * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
- * even though we intend the surface to be stable, we may make backwards incompatible changes
- * if necessary.
  *
  * @experimental
  */

--- a/src/test/java/com/google/api/codegen/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_no_path_templates.baseline
@@ -44,10 +44,6 @@
  * https://github.com/google/googleapis/blob/master/no_path_templates.proto
  * and updates to that file get reflected here through a refresh process.
  *
- * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
- * even though we intend the surface to be stable, we may make backwards incompatible changes
- * if necessary.
- *
  * @experimental
  */
 
@@ -68,10 +64,6 @@ use Google\Protobuf\GPBEmpty;
 
 /**
  * Service Description:
- *
- * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
- * even though we intend the surface to be stable, we may make backwards incompatible changes
- * if necessary.
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods. Sample code to get started:
@@ -270,10 +262,6 @@ class NoTemplatesApiServiceGapicClient
  * This file was generated from the file
  * https://github.com/google/googleapis/blob/master/no_path_templates.proto
  * and updates to that file get reflected here through a refresh process.
- *
- * EXPERIMENTAL: This client library class has not yet been declared GA (1.0). This means that
- * even though we intend the surface to be stable, we may make backwards incompatible changes
- * if necessary.
  *
  * @experimental
  */


### PR DESCRIPTION
As discussed with @tmatsuo, we want to remove the written warning, but keep the `@experimental` tags, which can be removed from specific APIs via generation scripts / tooling.