### PR TITLE
Add resource_name_treatment to protobuf-based configgen

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/mergers/MethodMerger.java
+++ b/src/main/java/com/google/api/codegen/configgen/mergers/MethodMerger.java
@@ -125,7 +125,16 @@ public class MethodMerger {
     ConfigNode prevNode = generateField(nameNode, method);
     prevNode = pageStreamingMerger.generatePageStreamingNode(prevNode, method);
     prevNode = retryMerger.generateRetryNamesNode(prevNode, method);
-    prevNode = generateFieldNamePatterns(prevNode, method, collectionNameMap);
+    ConfigNode fieldNamePatternsNode =
+        generateFieldNamePatterns(prevNode, method, collectionNameMap);
+    if (fieldNamePatternsNode != prevNode) {
+      prevNode = fieldNamePatternsNode;
+      ConfigNode resourceNameTreatmentNode =
+          FieldConfigNode.createStringPair(
+              NodeFinder.getNextLine(prevNode), "resource_name_treatment", "STATIC_TYPES");
+      prevNode.insertNext(resourceNameTreatmentNode);
+    }
+    prevNode = fieldNamePatternsNode;
     generateTimeout(prevNode, method);
     return methodNode;
   }

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -168,6 +168,7 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: ListShelves
     request_object_method: true
     page_streaming:
@@ -201,6 +202,7 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: MergeShelves
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -222,6 +224,7 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: CreateBook
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -243,6 +246,7 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: PublishSeries
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -283,6 +287,7 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: ListBooks
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -311,6 +316,7 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: DeleteBook
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -330,6 +336,7 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: UpdateBook
     # FIXME: Configure which fields are required.
     required_fields:
@@ -347,6 +354,7 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: MoveBook
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -368,6 +376,7 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: ListStrings
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -413,6 +422,7 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: GetBookFromArchive
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -432,6 +442,7 @@ interfaces:
       name: book
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: GetBookFromAnywhere
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -453,6 +464,7 @@ interfaces:
       name: book_path
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: GetBookFromAbsolutelyAnywhere
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -472,6 +484,7 @@ interfaces:
       name: book
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: UpdateBookIndex
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -495,6 +508,7 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: StreamShelves
     request_object_method: false
     # FIXME: Configure the retryable codes for this method.
@@ -605,6 +619,7 @@ interfaces:
       resource: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: GetBigBook
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -624,6 +639,7 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: GetBigNothing
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -643,6 +659,7 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: TestOptionalRequiredFlatteningParams
     # FIXME: Configure which fields are required.
     required_fields:
@@ -732,3 +749,4 @@ interfaces:
       resource: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES

--- a/src/test/java/com/google/api/codegen/testdata/longrunning_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/longrunning_config.baseline
@@ -165,6 +165,7 @@ interfaces:
       name: operation_path
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: DeleteOperation
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -184,6 +185,7 @@ interfaces:
       name: operation_path
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES
   - name: CancelOperation
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -203,3 +205,4 @@ interfaces:
       name: operation_path
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+    resource_name_treatment: STATIC_TYPES


### PR DESCRIPTION
If there are field name patterns, then also set a `resource_name_treatment` config value that defaults to `STATIC_TYPES`.

Resolves https://github.com/googleapis/gapic-generator/issues/2078