### PR TITLE
fix: list done as a keyword for Javascript

### DIFF
--- a/src/main/java/com/google/api/codegen/util/js/JSNameFormatter.java
+++ b/src/main/java/com/google/api/codegen/util/js/JSNameFormatter.java
@@ -102,11 +102,14 @@ public class JSNameFormatter implements NameFormatter {
 
   /**
    * A set of ECMAScript 2016 reserved words. See
-   * https://tc39.github.io/ecma262/2016/#sec-reserved-words
+   * https://tc39.github.io/ecma262/2016/#sec-reserved-words A notable exception here is `done`
+   * which is not reserved but is de facto standard for mocha tests, see
+   * https://mochajs.org/#asynchronous-code for details.
    */
   public static final ImmutableSet<String> RESERVED_IDENTIFIER_SET =
       ImmutableSet.<String>builder()
           .add(
+              "done",
               "break",
               "do",
               "in",


### PR DESCRIPTION
Fixes #2077 by listing `done`, which is de facto standard name for [Mocha callback](https://mochajs.org/#asynchronous-code), as a keyword for JavaScript.