### PR TITLE
setup output printing

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
@@ -1,0 +1,92 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer;
+
+import com.google.api.codegen.Accessor;
+import com.google.api.codegen.OutputSpec;
+import com.google.api.codegen.config.FieldModel;
+import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.TypeModel;
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class OutputTransformer {
+  private static final String RESPONSE_PLACEHOLDER = "$resp";
+
+  static List<OutputSpec> defaultOutputSpecs(MethodModel method) {
+    if (method.isOutputTypeEmpty()) {
+      return Collections.emptyList();
+    }
+    return Collections.singletonList(
+        OutputSpec.newBuilder()
+            .setPrint(OutputSpec.PrintStmt.newBuilder().setSpec("%s").addArgs(RESPONSE_PLACEHOLDER))
+            .build());
+  }
+
+  static OutputSpec toLanguage(OutputSpec config, MethodContext context) {
+    OutputSpec.Builder lang = OutputSpec.newBuilder();
+    switch (config.getStmtCase()) {
+      case LOOP:
+        throw new UnsupportedOperationException("loop not implemented yet");
+      case PRINT:
+        lang.setPrint(toLanguage(config.getPrint(), context));
+        break;
+    }
+    return lang.build();
+  }
+
+  private static OutputSpec.PrintStmt toLanguage(
+      OutputSpec.PrintStmt config, MethodContext context) {
+    return OutputSpec.PrintStmt.newBuilder()
+        .setSpec(context.getNamer().getPrintSpec(config.getSpec()))
+        .addAllArgsElems(
+            config
+                .getArgsList()
+                .stream()
+                .map(a -> accessor(a, context))
+                .collect(Collectors.toList()))
+        .build();
+  }
+
+  private static Accessor accessor(String config, MethodContext context) {
+    String[] configElems = config.split("\\.");
+    if (configElems.length == 0) {
+      return Accessor.getDefaultInstance();
+    }
+
+    Accessor.Builder accessor = Accessor.newBuilder();
+    TypeModel type;
+    if (configElems[0].equals(RESPONSE_PLACEHOLDER)) {
+      accessor.setVariable(context.getNamer().getSampleResponseVarName());
+      type = context.getMethodModel().getOutputType();
+    } else {
+      throw new UnsupportedOperationException("local variable not implemented yet");
+    }
+
+    for (int i = 1; i < configElems.length; i++) {
+      String fieldName = configElems[i];
+      FieldModel field =
+          Preconditions.checkNotNull(
+              type.getField(configElems[i]), "type %s does not have field %s", type, fieldName);
+      Preconditions.checkArgument(
+          !field.isRepeated() && !field.isMap(), "%s.%s is not scalar", type, fieldName);
+      type = field.getType();
+      accessor.addFields(context.getNamer().getFieldGetFunctionName(field));
+    }
+    return accessor.build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
@@ -52,19 +52,24 @@ class OutputTransformer {
           }
         };
 
-    OutputView.Builder view = OutputView.newBuilder();
+    OutputView view = null;
     if (config.hasLoop()) {
       once.run();
       throw new UnsupportedOperationException("loop not implemented yet");
     }
     if (config.getPrintCount() > 0) {
       once.run();
-      view.print(toView(config.getPrintList(), context, valueSet)).kind(OutputView.Kind.PRINT);
+      view = printView(config.getPrintList(), context, valueSet);
     }
-    return view.build();
+
+    return Preconditions.checkNotNull(
+        view,
+        "%s:%s: one field of OutputSpec must be set",
+        context.getMethodModel().getSimpleName(),
+        valueSet.getId());
   }
 
-  private static OutputView.PrintView toView(
+  private static OutputView.PrintView printView(
       List<String> config, MethodContext context, SampleValueSet valueSet) {
     Preconditions.checkArgument(
         !config.isEmpty(),

--- a/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
@@ -73,7 +73,7 @@ class OutputTransformer {
         valueSet.getId());
 
     return OutputView.PrintView.newBuilder()
-        .printSpec(context.getNamer().getPrintSpec(config.get(0), numSub))
+        .printSpec(context.getNamer().getPrintSpec(config.get(0)))
         .printArgs(
             config
                 .subList(1, config.size())

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -211,7 +211,7 @@ public class SampleTransformer {
                     ? initContext
                     : createInitCodeContext(
                         context, fieldConfigs, initCodeOutputType, valueSet.getParametersList()));
-        List<OutputSpec> outputs = valueSet.getOutputsList();
+        List<OutputSpec> outputs = valueSet.getOutputSpecsList();
         if (outputs.isEmpty()) {
           outputs = OutputTransformer.defaultOutputSpecs(context.getMethodModel());
         }

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -26,6 +26,7 @@ import com.google.api.codegen.viewmodel.ApiMethodView;
 import com.google.api.codegen.viewmodel.CallingForm;
 import com.google.api.codegen.viewmodel.InitCodeView;
 import com.google.api.codegen.viewmodel.MethodSampleView;
+import com.google.api.codegen.viewmodel.OutputView;
 import com.google.api.codegen.viewmodel.SampleValueSetView;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -214,17 +215,17 @@ public class SampleTransformer {
         if (outputs.isEmpty()) {
           outputs = OutputTransformer.defaultOutputSpecs(context.getMethodModel());
         }
-        outputs =
+        List<OutputView> outputViews =
             outputs
                 .stream()
-                .map(s -> OutputTransformer.toLanguage(s, context))
+                .map(s -> OutputTransformer.toView(s, context))
                 .collect(Collectors.toList());
         methodSampleViews.add(
             MethodSampleView.newBuilder()
                 .callingForm(form)
                 .valueSet(SampleValueSetView.of(valueSet))
                 .initCode(initCodeView)
-                .outputs(outputs)
+                .outputs(outputViews)
                 .build());
       }
     }

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -218,7 +218,7 @@ public class SampleTransformer {
         List<OutputView> outputViews =
             outputs
                 .stream()
-                .map(s -> OutputTransformer.toView(s, context))
+                .map(s -> OutputTransformer.toView(s, context, valueSet))
                 .collect(Collectors.toList());
         methodSampleViews.add(
             MethodSampleView.newBuilder()

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.transformer;
 
+import com.google.api.codegen.OutputSpec;
 import com.google.api.codegen.SampleValueSet;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.MethodConfig;
@@ -29,6 +30,7 @@ import com.google.api.codegen.viewmodel.SampleValueSetView;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A class that performs the transformations needed to generate the MethodSampleView for the
@@ -208,11 +210,21 @@ public class SampleTransformer {
                     ? initContext
                     : createInitCodeContext(
                         context, fieldConfigs, initCodeOutputType, valueSet.getParametersList()));
+        List<OutputSpec> outputs = valueSet.getOutputsList();
+        if (outputs.isEmpty()) {
+          outputs = OutputTransformer.defaultOutputSpecs(context.getMethodModel());
+        }
+        outputs =
+            outputs
+                .stream()
+                .map(s -> OutputTransformer.toLanguage(s, context))
+                .collect(Collectors.toList());
         methodSampleViews.add(
             MethodSampleView.newBuilder()
                 .callingForm(form)
                 .valueSet(SampleValueSetView.of(valueSet))
                 .initCode(initCodeView)
+                .outputs(outputs)
                 .build());
       }
     }

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -1584,6 +1584,15 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return getNotImplementedString("SurfaceNamer.getExampleFileName");
   }
 
+  /** Translate C-printf-spec into one expected by the language's format utilities. */
+  public String getPrintSpec(String spec) {
+    return getNotImplementedString("SurfaceNamer.getPrintSpec");
+  }
+
+  public String getSampleResponseVarName() {
+    return "response";
+  }
+
   /////////////////////////////////// Transport Protocol /////////////////////////////////////////
 
   public Name getTransportProtocolName(TransportProtocol protocol) {

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -453,4 +453,27 @@ public class PythonSurfaceNamer extends SurfaceNamer {
         throw new IllegalStateException("Invalid development status");
     }
   }
+
+  @Override
+  public String getPrintSpec(String spec) {
+    // Escaers don't work here. They only map from characters to strings.
+    StringBuilder sb = new StringBuilder();
+    int cursor = 0;
+    while (true) {
+      int p = spec.indexOf('%', cursor);
+      if (p < 0) {
+        return sb.append(spec, cursor, spec.length()).toString();
+      }
+      sb.append(spec, cursor, p);
+
+      if (spec.startsWith("%%", p)) {
+        sb.append('%');
+      } else if (spec.startsWith("%s", p)) {
+        sb.append("{}");
+      } else {
+        throw new IllegalArgumentException(String.format("bad format verb: %s", spec));
+      }
+      cursor = p + 2;
+    }
+  }
 }

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -456,7 +456,7 @@ public class PythonSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPrintSpec(String spec) {
-    // Escaers don't work here. They only map from characters to strings.
+    // com.google.common.escape.Escaper don't work here. They only map from characters to strings.
     StringBuilder sb = new StringBuilder();
     int cursor = 0;
     while (true) {

--- a/src/main/java/com/google/api/codegen/viewmodel/MethodSampleView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/MethodSampleView.java
@@ -14,7 +14,9 @@
  */
 package com.google.api.codegen.viewmodel;
 
+import com.google.api.codegen.OutputSpec;
 import com.google.auto.value.AutoValue;
+import java.util.List;
 
 /** A view model for methods samples. */
 @AutoValue
@@ -29,6 +31,8 @@ public abstract class MethodSampleView {
   /** The initialization code constructed from this samples value set and calling form. */
   public abstract InitCodeView initCode();
 
+  public abstract List<OutputSpec> outputs();
+
   public static Builder newBuilder() {
     return new AutoValue_MethodSampleView.Builder();
   }
@@ -40,6 +44,8 @@ public abstract class MethodSampleView {
     public abstract Builder callingForm(CallingForm val);
 
     public abstract Builder initCode(InitCodeView val);
+
+    public abstract Builder outputs(List<OutputSpec> val);
 
     public abstract MethodSampleView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/MethodSampleView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/MethodSampleView.java
@@ -14,7 +14,6 @@
  */
 package com.google.api.codegen.viewmodel;
 
-import com.google.api.codegen.OutputSpec;
 import com.google.auto.value.AutoValue;
 import java.util.List;
 
@@ -31,7 +30,8 @@ public abstract class MethodSampleView {
   /** The initialization code constructed from this samples value set and calling form. */
   public abstract InitCodeView initCode();
 
-  public abstract List<OutputSpec> outputs();
+  /** The response printing code. */
+  public abstract List<OutputView> outputs();
 
   public static Builder newBuilder() {
     return new AutoValue_MethodSampleView.Builder();
@@ -45,7 +45,7 @@ public abstract class MethodSampleView {
 
     public abstract Builder initCode(InitCodeView val);
 
-    public abstract Builder outputs(List<OutputSpec> val);
+    public abstract Builder outputs(List<OutputView> val);
 
     public abstract MethodSampleView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/OutputView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/OutputView.java
@@ -1,0 +1,85 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+@AutoValue
+public abstract class OutputView {
+
+  public enum Kind {
+    PRINT
+  }
+
+  public abstract Kind kind();
+
+  public abstract PrintView print();
+
+  public static Builder newBuilder() {
+    return new AutoValue_OutputView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder kind(Kind val);
+
+    public abstract Builder print(PrintView val);
+
+    public abstract OutputView build();
+  }
+
+  @AutoValue
+  public abstract static class PrintView {
+
+    public abstract String printSpec();
+
+    public abstract ImmutableList<PrintArgView> printArgs();
+
+    public static Builder newBuilder() {
+      return new AutoValue_OutputView_PrintView.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder printSpec(String val);
+
+      public abstract Builder printArgs(ImmutableList<PrintArgView> val);
+
+      public abstract PrintView build();
+    }
+  }
+
+  @AutoValue
+  public abstract static class PrintArgView {
+
+    public abstract String variable();
+
+    public abstract ImmutableList<String> accessors();
+
+    public static Builder newBuilder() {
+      return new AutoValue_OutputView_PrintArgView.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder variable(String val);
+
+      public abstract Builder accessors(ImmutableList<String> val);
+
+      public abstract PrintArgView build();
+    }
+  }
+}

--- a/src/main/java/com/google/api/codegen/viewmodel/OutputView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/OutputView.java
@@ -17,36 +17,24 @@ package com.google.api.codegen.viewmodel;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
-@AutoValue
-public abstract class OutputView {
+public interface OutputView {
 
   public enum Kind {
     PRINT
   }
 
-  public abstract Kind kind();
-
-  public abstract PrintView print();
-
-  public static Builder newBuilder() {
-    return new AutoValue_OutputView.Builder();
-  }
-
-  @AutoValue.Builder
-  public abstract static class Builder {
-    public abstract Builder kind(Kind val);
-
-    public abstract Builder print(PrintView val);
-
-    public abstract OutputView build();
-  }
+  Kind kind();
 
   @AutoValue
-  public abstract static class PrintView {
+  abstract class PrintView implements OutputView {
 
     public abstract String printSpec();
 
     public abstract ImmutableList<PrintArgView> printArgs();
+
+    public Kind kind() {
+      return Kind.PRINT;
+    }
 
     public static Builder newBuilder() {
       return new AutoValue_OutputView_PrintView.Builder();
@@ -63,7 +51,7 @@ public abstract class OutputView {
   }
 
   @AutoValue
-  public abstract static class PrintArgView {
+  abstract class PrintArgView {
 
     public abstract String variable();
 

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -346,7 +346,7 @@ message SampleValueSet {
   //   several placeholders.
   repeated string parameters = 4;
 
-  repeated OutputSpec outputs = 5;
+  repeated OutputSpec output_specs = 5;
 }
 
 // `SampleConfiguration` defines combinations of "calling forms"
@@ -660,26 +660,18 @@ message LongRunningConfigProto {
 }
 
 message OutputSpec {
-  message LoopStmt {
+  message LoopStatement {
     string collection = 1;
-    string var = 2;
+    string variable = 2;
     repeated OutputSpec body = 3;
   }
-  message PrintStmt {
-    string spec = 1;
-    repeated string args = 2;
 
-    // Internally used by gapic generator. Do not set this in configuration.
-    repeated Accessor argsElems = 100;
-  }
+  // Exactly one of the following should be set.
 
-  oneof stmt {
-    LoopStmt loop = 1;
-    PrintStmt print = 2;
-  }
-}
+  LoopStatement loop = 1;
 
-message Accessor {
-  string variable = 1;
-  repeated string fields = 2;
+  // example ["%s=%s", thing.variable, thing.value]
+  // field name is singular because the array
+  // represents one print statement.
+  repeated string print = 2;
 }

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -345,6 +345,8 @@ message SampleValueSet {
   //   a specially formatted string using `FIELD` as one of possibly
   //   several placeholders.
   repeated string parameters = 4;
+
+  repeated OutputSpec outputs = 5;
 }
 
 // `SampleConfiguration` defines combinations of "calling forms"
@@ -655,4 +657,29 @@ message LongRunningConfigProto {
 
   // Total polling timeout.
   uint64 total_poll_timeout_millis = 8;
+}
+
+message OutputSpec {
+  message LoopStmt {
+    string collection = 1;
+    string var = 2;
+    repeated OutputSpec body = 3;
+  }
+  message PrintStmt {
+    string spec = 1;
+    repeated string args = 2;
+
+    // Internally used by gapic generator. Do not set this in configuration.
+    repeated Accessor argsElems = 100;
+  }
+
+  oneof stmt {
+    LoopStmt loop = 1;
+    PrintStmt print = 2;
+  }
+}
+
+message Accessor {
+  string variable = 1;
+  repeated string fields = 2;
 }

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -69,7 +69,7 @@
   @join out : outs
     @switch out.kind
     @case "PRINT"
-      print('{@out.print.printSpec}'.format({@responseArgs(out.print.printArgs)}))
+      print('{@out.printSpec}'.format({@responseArgs(out.printArgs)}))
     @default
       $unhandledResponseForm: {@outs}
     @end

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -9,7 +9,7 @@
 
   @# To run with the published packaged, execute the following before running this code:
   @#   pip install {@sampleFile.gapicPackageName}
-   
+
   @# [START full_sample]
 
   @# FIXME: Insert here boilerplate code not directly related to the method call itself.
@@ -21,19 +21,19 @@
       @##       description: "{@sample.valueSet.description}"
       @##       {@sample.valueSet.parameters}
       @##     apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
-      
+
       @# [START core_sample]
 
       @# FIXME: Insert here code to prepare the request fields, make the call, process the response.
-       
+
       {@standaloneSample(apiMethod, sample)}
       # TODO(pongad): Make this work on non-unary too.
       print(response)
-      
+
       @# [END core_sample]
 
       @# FIXME: Insert here clean-up code.
-      
+
     @end
   @end
   @# [END full_sample]
@@ -47,6 +47,7 @@
   @switch sample.callingForm
   @case "Request"
     {@optionalArrayMethodSampleCodeNonStreaming(apiMethod, sample.initCode)}
+    {@printResponse(sample.outputs)}
   @case "RequestPaged"
     {@pagedOptionalArrayMethodSampleCodePaged(apiMethod, sample.initCode)}
   @case "RequestPagedAll"
@@ -61,5 +62,28 @@
     {@lroSampleCode(apiMethod, sample.initCode)}
   @default
     $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
+  @end
+@end
+
+@private printResponse(outs)
+  @join out : outs
+    @switch out.getStmtCase
+    @case "PRINT"
+      print('{@out.getPrint.getSpec}'{@responseArgs(out.getPrint.getArgsElemsList)})
+    @default
+      $unhandledResponseForm: {@outs}
+    @end
+  @end
+@end
+
+@private responseArgs(args)
+  @join arg : args on ""
+    , {@arg.getVariable}{@accessor(arg.getFieldsList)}
+  @end
+@end
+
+@private accessor(fields)
+  @join field : fields on ""
+    .{@field}
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -67,9 +67,9 @@
 
 @private printResponse(outs)
   @join out : outs
-    @switch out.getStmtCase
+    @switch out.kind
     @case "PRINT"
-      print('{@out.getPrint.getSpec}'{@responseArgs(out.getPrint.getArgsElemsList)})
+      print('{@out.print.printSpec}'.format({@responseArgs(out.print.printArgs)}))
     @default
       $unhandledResponseForm: {@outs}
     @end
@@ -77,13 +77,13 @@
 @end
 
 @private responseArgs(args)
-  @join arg : args on ""
-    , {@arg.getVariable}{@accessor(arg.getFieldsList)}
+  @join arg : args on ", "
+    {@arg.variable}{@accessor(arg.accessors)}
   @end
 @end
 
-@private accessor(fields)
-  @join field : fields on ""
+@private accessor(accessors)
+  @join field : accessors on ""
     .{@field}
   @end
 @end

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -3781,7 +3781,7 @@ series_string = 'xyz3141592654'
 series_uuid = {'series_string': series_string}
 
 response = client.publish_series(shelf, books, series_uuid)
-print('{}', response)
+print('{}'.format(response))
 print(response)
 
 # [END core_sample]
@@ -3827,7 +3827,7 @@ series_uuid = {}
 edition = 2
 
 response = client.publish_series(shelf, books, series_uuid, edition=edition)
-print('{}', response)
+print('{}'.format(response))
 print(response)
 
 # [END core_sample]

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -3781,6 +3781,7 @@ series_string = 'xyz3141592654'
 series_uuid = {'series_string': series_string}
 
 response = client.publish_series(shelf, books, series_uuid)
+print('{}', response)
 print(response)
 
 # [END core_sample]
@@ -3826,6 +3827,7 @@ series_uuid = {}
 edition = 2
 
 response = client.publish_series(shelf, books, series_uuid, edition=edition)
+print('{}', response)
 print(response)
 
 # [END core_sample]

--- a/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
@@ -256,7 +256,7 @@ interfaces:
       parameters:
       - edition=2
     samples:
-      in_code: 
+      in_code:
       - calling_forms: [callable]
         value_sets: [pi_version]
       api_explorer:
@@ -516,7 +516,7 @@ interfaces:
         value_sets: ".*"
       api_explorer:
       - calling_forms: ".*"
-        value_sets: ".*"    
+        value_sets: ".*"
   - name: StreamBooks
     request_object_method: false
     resource_name_treatment: STATIC_TYPES
@@ -547,7 +547,7 @@ interfaces:
         value_sets: ".*"
       api_explorer:
       - calling_forms: ".*"
-        value_sets: ".*"    
+        value_sets: ".*"
   - name: DiscussBook
     # required_fields makes a difference on sample code.
     required_fields:
@@ -647,7 +647,7 @@ interfaces:
         value_sets: odyssey
       api_explorer:
       - calling_forms: ".*"
-        value_sets: odyssey    
+        value_sets: odyssey
   - name: AddTag
     flattening:
       groups:


### PR DESCRIPTION
Examples need to be able to print specific fields in responses.
This PR sets up the structure to do this.

Currently formatted prints should work.
We can commit this now so that we can parallelize work.