### PR TITLE
node: gax typescript fix

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -141,7 +141,7 @@
         };
       @end
       @if or(xapi.hasBatchingMethods, xapi.hasLongRunningOperations)
-        var protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
+        var protoFilesRoot = new gax.GoogleProtoFilesRoot();
         @join stub : xapi.stubs
           protoFilesRoot = protobuf.loadSync(
             @if xapi.fileHeader.hasVersion

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -3228,7 +3228,7 @@ class LibraryServiceClient {
       discussBook: new gax.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
       monologAboutBook: new gax.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
     };
-    var protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
+    var protoFilesRoot = new gax.GoogleProtoFilesRoot();
     protoFilesRoot = protobuf.loadSync(
       path.join(__dirname, '..', '..', 'protos', 'library.proto'),
       protoFilesRoot


### PR DESCRIPTION
One more fix related to #2070. Since google-gax TypeScript conversion `GoogleProtoFilesRoot` is now exported directly as `gax.GoogleProtoFilesRoot`, not as `gax.grpc.GoogleProtoFilesRoot` as before.