### PR TITLE
node: use GCLOUD_PROJECT as an env var name for smoke tests

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/smoke_test.snip
@@ -17,10 +17,10 @@
 @private smokeTest(smokeTest)
   describe('{@smokeTest.name}', () => {
     @if smokeTest.requireProjectId
-      if (!process.env.SMOKE_TEST_PROJECT) {
-        throw new Error("Usage: SMOKE_TEST_PROJECT=<project_id> node #{$0}");
+      if (!process.env.GCLOUD_PROJECT) {
+        throw new Error("Usage: GCLOUD_PROJECT=<project_id> node #{$0}");
       }
-      var projectId = process.env.SMOKE_TEST_PROJECT;
+      var projectId = process.env.GCLOUD_PROJECT;
 
     @end
     @switch smokeTest.apiMethod.type.toString

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -130,10 +130,10 @@ $ npm install --save @google-cloud/library
 'use strict';
 
 describe('LibraryServiceSmokeTest', () => {
-  if (!process.env.SMOKE_TEST_PROJECT) {
-    throw new Error("Usage: SMOKE_TEST_PROJECT=<project_id> node #{$0}");
+  if (!process.env.GCLOUD_PROJECT) {
+    throw new Error("Usage: GCLOUD_PROJECT=<project_id> node #{$0}");
   }
-  var projectId = process.env.SMOKE_TEST_PROJECT;
+  var projectId = process.env.GCLOUD_PROJECT;
 
   it('successfully makes a call to the service', done => {
     const library = require('../src');


### PR DESCRIPTION
Currently, the generated smoke tests use `SMOKE_TEST_PROJECT` variable to get the project name. Since we use `GCLOUD_PROJECT` everywhere else (in system tests and samples tests), let's change smoke tests to use `GCLOUD_PROJECT` as well.