### PR TITLE
Remove no-longer-used testing metadata from value set descriptions

### DIFF
--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -7277,7 +7277,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
 //     calling form: "CallableStreamingBidi"
 //     valueSet "prog" ("Programming Books")
-//       description: "Testing calling forms: {Java:[CallableStreamingBidi], NodeJS:[RequestStreamingBidi], Python:[RequestStreamingBidi]}"
+//       description: "Testing calling forms"
 //       [name=BASIC]
 //     apiMethod "discussBookCallable" of type "CallableMethod"
 
@@ -7316,7 +7316,7 @@ public class DiscussBookCallableSampleCallableStreamingBidiProg {
 
 //     calling form: "FlattenedPaged"
 //     valueSet "odyssey" ("The Odyssey")
-//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged], NodeJS:[RequestAsyncPaged, RequestAsyncPagedAll], Python:[RequestPaged, RequestPagedAll]}"
+//       description: "Testing calling forms"
 //       [names[0]=Odyssey, shelves[0]=Classics]
 //     apiMethod "findRelatedBooks" of type "PagedFlattenedMethod"
 
@@ -7353,7 +7353,7 @@ public class FindRelatedBooksSampleFlattenedPagedOdyssey {
 
 //     calling form: "RequestPaged"
 //     valueSet "odyssey" ("The Odyssey")
-//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged], NodeJS:[RequestAsyncPaged, RequestAsyncPagedAll], Python:[RequestPaged, RequestPagedAll]}"
+//       description: "Testing calling forms"
 //       [names[0]=Odyssey, shelves[0]=Classics]
 //     apiMethod "findRelatedBooks" of type "PagedRequestObjectMethod"
 
@@ -7392,7 +7392,7 @@ public class FindRelatedBooksSampleRequestPagedOdyssey {
 
 //     calling form: "CallableList"
 //     valueSet "odyssey" ("The Odyssey")
-//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged], NodeJS:[RequestAsyncPaged, RequestAsyncPagedAll], Python:[RequestPaged, RequestPagedAll]}"
+//       description: "Testing calling forms"
 //       [names[0]=Odyssey, shelves[0]=Classics]
 //     apiMethod "findRelatedBooksCallable" of type "UnpagedListCallableMethod"
 
@@ -7440,7 +7440,7 @@ public class FindRelatedBooksCallableSampleCallableListOdyssey {
 
 //     calling form: "CallablePaged"
 //     valueSet "odyssey" ("The Odyssey")
-//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged], NodeJS:[RequestAsyncPaged, RequestAsyncPagedAll], Python:[RequestPaged, RequestPagedAll]}"
+//       description: "Testing calling forms"
 //       [names[0]=Odyssey, shelves[0]=Classics]
 //     apiMethod "findRelatedBooksPagedCallable" of type "PagedCallableMethod"
 
@@ -7481,7 +7481,7 @@ public class FindRelatedBooksPagedCallableSampleCallablePagedOdyssey {
 
 //     calling form: "LongRunningFlattenedAsync"
 //     valueSet "wap" ("GetBigBook: 'War and Peace'")
-//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable], NodeJS:[LongRunningEventEmitter, LongRunningPromise], Python:[LongRunningPromise]}"
+//       description: "Testing calling forms"
 //       [name="War and Peace"]
 //     apiMethod "getBigBookAsync" of type "AsyncOperationFlattenedMethod"
 
@@ -7511,7 +7511,7 @@ public class GetBigBookAsyncSampleLongRunningFlattenedAsyncWap {
 
 //     calling form: "LongRunningRequestAsync"
 //     valueSet "wap" ("GetBigBook: 'War and Peace'")
-//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable], NodeJS:[LongRunningEventEmitter, LongRunningPromise], Python:[LongRunningPromise]}"
+//       description: "Testing calling forms"
 //       [name="War and Peace"]
 //     apiMethod "getBigBookAsync" of type "AsyncOperationRequestObjectMethod"
 
@@ -7544,7 +7544,7 @@ public class GetBigBookAsyncSampleLongRunningRequestAsyncWap {
 
 //     calling form: "Callable"
 //     valueSet "wap" ("GetBigBook: 'War and Peace'")
-//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable], NodeJS:[LongRunningEventEmitter, LongRunningPromise], Python:[LongRunningPromise]}"
+//       description: "Testing calling forms"
 //       [name="War and Peace"]
 //     apiMethod "getBigBookCallable" of type "CallableMethod"
 
@@ -7579,7 +7579,7 @@ public class GetBigBookCallableSampleCallableWap {
 
 //     calling form: "LongRunningCallable"
 //     valueSet "wap" ("GetBigBook: 'War and Peace'")
-//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable], NodeJS:[LongRunningEventEmitter, LongRunningPromise], Python:[LongRunningPromise]}"
+//       description: "Testing calling forms"
 //       [name="War and Peace"]
 //     apiMethod "getBigBookOperationCallable" of type "OperationCallableMethod"
 
@@ -7614,7 +7614,7 @@ public class GetBigBookOperationCallableSampleLongRunningCallableWap {
 
 //     calling form: "CallableStreamingClient"
 //     valueSet "prog" ("Programming Books")
-//       description: "Testing calling forms: {Java:[CallableStreamingClient], NodeJS:[RequestStreamingClient], Python:[RequestStreamingClient]}"
+//       description: "Testing calling forms"
 //       [name=BASIC]
 //     apiMethod "monologAboutBookCallable" of type "CallableMethod"
 
@@ -7667,7 +7667,7 @@ public class MonologAboutBookCallableSampleCallableStreamingClientProg {
 
 //     calling form: "Flattened"
 //     valueSet "pi_version" ("Pi version")
-//       description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+//       description: "Testing calling forms"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeries" of type "FlattenedMethod"
 
@@ -7706,7 +7706,7 @@ public class PublishSeriesSampleFlattenedPiVersion {
 
 //     calling form: "Flattened"
 //     valueSet "second_edition" ("Second edition")
-//       description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+//       description: "Testing calling forms"
 //       [edition=2]
 //     apiMethod "publishSeries" of type "FlattenedMethod"
 
@@ -7739,7 +7739,7 @@ public class PublishSeriesSampleFlattenedSecondEdition {
 
 //     calling form: "Request"
 //     valueSet "pi_version" ("Pi version")
-//       description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+//       description: "Testing calling forms"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeries" of type "RequestObjectMethod"
 
@@ -7782,7 +7782,7 @@ public class PublishSeriesSampleRequestPiVersion {
 
 //     calling form: "Request"
 //     valueSet "second_edition" ("Second edition")
-//       description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+//       description: "Testing calling forms"
 //       [edition=2]
 //     apiMethod "publishSeries" of type "RequestObjectMethod"
 
@@ -7821,7 +7821,7 @@ public class PublishSeriesSampleRequestSecondEdition {
 
 //     calling form: "Callable"
 //     valueSet "pi_version" ("Pi version")
-//       description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+//       description: "Testing calling forms"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeriesCallable" of type "CallableMethod"
 
@@ -7866,7 +7866,7 @@ public class PublishSeriesCallableSampleCallablePiVersion {
 
 //     calling form: "Callable"
 //     valueSet "second_edition" ("Second edition")
-//       description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+//       description: "Testing calling forms"
 //       [edition=2]
 //     apiMethod "publishSeriesCallable" of type "CallableMethod"
 
@@ -7907,7 +7907,7 @@ public class PublishSeriesCallableSampleCallableSecondEdition {
 
 //     calling form: "CallableStreamingServer"
 //     valueSet "prog" ("Programming Books")
-//       description: "Testing calling forms: {Java:[CallableStreamingServer], NodeJS:[RequestStreamingServer], Python:[RequestStreamingServer]}"
+//       description: "Testing calling forms"
 //       [name=BASIC]
 //     apiMethod "streamBooksCallable" of type "CallableMethod"
 
@@ -7944,7 +7944,7 @@ public class StreamBooksCallableSampleCallableStreamingServerProg {
 
 //     calling form: "CallableStreamingServer"
 //     valueSet "empty" ("Server streaming")
-//       description: "Testing calling forms: {Java:[CallableStreamingServer], NodeJS:[RequestStreamingServer], Python:[RequestStreamingServer]}"
+//       description: "Testing calling forms"
 //       []
 //     apiMethod "streamShelvesCallable" of type "CallableMethod"
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -260,7 +260,7 @@ module.exports.default = Object.assign({}, module.exports);
 
 //     calling form "RequestStreamingBidi"
 //     valueSet "prog" ("Programming Books")
-//       description: "Testing calling forms: {Java:[CallableStreamingBidi], NodeJS:[RequestStreamingBidi], Python:[RequestStreamingBidi]}"
+//       description: "Testing calling forms"
 //       [name=BASIC]
 //     apiMethod "discussBook" of type "OptionalArrayMethod"
 
@@ -296,7 +296,7 @@ stream.write(request);
 
 //     calling form "RequestAsyncPagedAll"
 //     valueSet "odyssey" ("The Odyssey")
-//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged], NodeJS:[RequestAsyncPaged, RequestAsyncPagedAll], Python:[RequestPaged, RequestPagedAll]}"
+//       description: "Testing calling forms"
 //       [names[0]=Odyssey, shelves[0]=Classics]
 //     apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
 
@@ -343,7 +343,7 @@ client.findRelatedBooks(request)
 
 //     calling form "RequestAsyncPaged"
 //     valueSet "odyssey" ("The Odyssey")
-//       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged], NodeJS:[RequestAsyncPaged, RequestAsyncPagedAll], Python:[RequestPaged, RequestPagedAll]}"
+//       description: "Testing calling forms"
 //       [names[0]=Odyssey, shelves[0]=Classics]
 //     apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
 
@@ -402,7 +402,7 @@ client.findRelatedBooks(request, options)
 
 //     calling form "LongRunningEventEmitter"
 //     valueSet "wap" ("GetBigBook: 'War and Peace'")
-//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable], NodeJS:[LongRunningEventEmitter, LongRunningPromise], Python:[LongRunningPromise]}"
+//       description: "Testing calling forms"
 //       [name="War and Peace"]
 //     apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
 
@@ -457,7 +457,7 @@ client.getBigBook({name: formattedName})
 
 //     calling form "LongRunningPromise"
 //     valueSet "wap" ("GetBigBook: 'War and Peace'")
-//       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable], NodeJS:[LongRunningEventEmitter, LongRunningPromise], Python:[LongRunningPromise]}"
+//       description: "Testing calling forms"
 //       [name="War and Peace"]
 //     apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
 
@@ -508,7 +508,7 @@ client.getBigBook({name: formattedName})
 
 //     calling form "RequestStreamingClient"
 //     valueSet "prog" ("Programming Books")
-//       description: "Testing calling forms: {Java:[CallableStreamingClient], NodeJS:[RequestStreamingClient], Python:[RequestStreamingClient]}"
+//       description: "Testing calling forms"
 //       [name=BASIC]
 //     apiMethod "monologAboutBook" of type "OptionalArrayMethod"
 
@@ -548,7 +548,7 @@ stream.write(request);
 
 //     calling form "Request"
 //     valueSet "pi_version" ("Pi version")
-//       description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+//       description: "Testing calling forms"
 //       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 //     apiMethod "publishSeries" of type "OptionalArrayMethod"
 
@@ -597,7 +597,7 @@ client.publishSeries(request)
 
 //     calling form "Request"
 //     valueSet "second_edition" ("Second edition")
-//       description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+//       description: "Testing calling forms"
 //       [edition=2]
 //     apiMethod "publishSeries" of type "OptionalArrayMethod"
 
@@ -642,7 +642,7 @@ client.publishSeries(request)
 
 //     calling form "RequestStreamingServer"
 //     valueSet "prog" ("Programming Books")
-//       description: "Testing calling forms: {Java:[CallableStreamingServer], NodeJS:[RequestStreamingServer], Python:[RequestStreamingServer]}"
+//       description: "Testing calling forms"
 //       [name=BASIC]
 //     apiMethod "streamBooks" of type "OptionalArrayMethod"
 
@@ -673,7 +673,7 @@ var name = 'BASIC';
 
 //     calling form "RequestStreamingServer"
 //     valueSet "empty" ("Server streaming")
-//       description: "Testing calling forms: {Java:[CallableStreamingServer], NodeJS:[RequestStreamingServer], Python:[RequestStreamingServer]}"
+//       description: "Testing calling forms"
 //       []
 //     apiMethod "streamShelves" of type "OptionalArrayMethod"
 

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -3547,7 +3547,7 @@ def lint_setup_py(session):
 
 ##     calling form "RequestStreamingBidi"
 ##     valueSet "prog" ("Programming Books")
-##       description: "Testing calling forms: {Java:[CallableStreamingBidi], NodeJS:[RequestStreamingBidi], Python:[RequestStreamingBidi]}"
+##       description: "Testing calling forms"
 ##       [name=BASIC]
 ##     apiMethod "discuss_book" of type "OptionalArrayMethod"
 
@@ -3588,7 +3588,7 @@ print(response)
 
 ##     calling form "RequestPagedAll"
 ##     valueSet "odyssey" ("The Odyssey")
-##       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged], NodeJS:[RequestAsyncPaged, RequestAsyncPagedAll], Python:[RequestPaged, RequestPagedAll]}"
+##       description: "Testing calling forms"
 ##       [names[0]=Odyssey, shelves[0]=Classics]
 ##     apiMethod "find_related_books" of type "PagedOptionalArrayMethod"
 
@@ -3631,7 +3631,7 @@ print(response)
 
 ##     calling form "RequestPaged"
 ##     valueSet "odyssey" ("The Odyssey")
-##       description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged], NodeJS:[RequestAsyncPaged, RequestAsyncPagedAll], Python:[RequestPaged, RequestPagedAll]}"
+##       description: "Testing calling forms"
 ##       [names[0]=Odyssey, shelves[0]=Classics]
 ##     apiMethod "find_related_books" of type "PagedOptionalArrayMethod"
 
@@ -3675,7 +3675,7 @@ print(response)
 
 ##     calling form "LongRunningPromise"
 ##     valueSet "wap" ("GetBigBook: 'War and Peace'")
-##       description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable], NodeJS:[LongRunningEventEmitter, LongRunningPromise], Python:[LongRunningPromise]}"
+##       description: "Testing calling forms"
 ##       [name="War and Peace"]
 ##     apiMethod "get_big_book" of type "LongRunningOptionalArrayMethod"
 
@@ -3721,7 +3721,7 @@ print(response)
 
 ##     calling form "RequestStreamingClient"
 ##     valueSet "prog" ("Programming Books")
-##       description: "Testing calling forms: {Java:[CallableStreamingClient], NodeJS:[RequestStreamingClient], Python:[RequestStreamingClient]}"
+##       description: "Testing calling forms"
 ##       [name=BASIC]
 ##     apiMethod "monolog_about_book" of type "OptionalArrayMethod"
 
@@ -3760,7 +3760,7 @@ print(response)
 
 ##     calling form "Request"
 ##     valueSet "pi_version" ("Pi version")
-##       description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+##       description: "Testing calling forms"
 ##       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 ##     apiMethod "publish_series" of type "OptionalArrayMethod"
 
@@ -3803,7 +3803,7 @@ print(response)
 
 ##     calling form "Request"
 ##     valueSet "second_edition" ("Second edition")
-##       description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+##       description: "Testing calling forms"
 ##       [edition=2]
 ##     apiMethod "publish_series" of type "OptionalArrayMethod"
 
@@ -3848,7 +3848,7 @@ print(response)
 
 ##     calling form "RequestStreamingServer"
 ##     valueSet "prog" ("Programming Books")
-##       description: "Testing calling forms: {Java:[CallableStreamingServer], NodeJS:[RequestStreamingServer], Python:[RequestStreamingServer]}"
+##       description: "Testing calling forms"
 ##       [name=BASIC]
 ##     apiMethod "stream_books" of type "OptionalArrayMethod"
 
@@ -3887,7 +3887,7 @@ print(response)
 
 ##     calling form "RequestStreamingServer"
 ##     valueSet "empty" ("Server streaming")
-##       description: "Testing calling forms: {Java:[CallableStreamingServer], NodeJS:[RequestStreamingServer], Python:[RequestStreamingServer]}"
+##       description: "Testing calling forms"
 ##       []
 ##     apiMethod "stream_shelves" of type "OptionalArrayMethod"
 

--- a/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
@@ -243,7 +243,7 @@ interfaces:
       # callingFormCheck: pi_version py: Request
     - id: pi_version
       title: "Pi version"
-      description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+      description: "Testing calling forms"
       parameters:
       - shelf.name=Math
       - series_uuid.series_string=xyz3141592654
@@ -252,7 +252,7 @@ interfaces:
       # callingFormCheck: second_edition py: Request
     - id: second_edition
       title: "Second edition"
-      description: "Testing calling forms: {Java:[Flattened, Request, Callable], NodeJS:[Request], Python:[Request]}"
+      description: "Testing calling forms"
       parameters:
       - edition=2
     samples:
@@ -506,7 +506,7 @@ interfaces:
       # callingFormCheck: empty py: RequestStreamingServer
     - id: empty
       title: "Server streaming"
-      description: "Testing calling forms: {Java:[CallableStreamingServer], NodeJS:[RequestStreamingServer], Python:[RequestStreamingServer]}"
+      description: "Testing calling forms"
     samples:
       in_code:
       - calling_forms: ".*"
@@ -535,7 +535,7 @@ interfaces:
       # callingFormCheck: prog py: RequestStreamingServer
     - id: prog
       title: "Programming Books"
-      description: "Testing calling forms: {Java:[CallableStreamingServer], NodeJS:[RequestStreamingServer], Python:[RequestStreamingServer]}"
+      description: "Testing calling forms"
       parameters:
         - name=BASIC
     samples:
@@ -562,7 +562,7 @@ interfaces:
       # callingFormCheck: prog py: RequestStreamingBidi
     - id: prog
       title: "Programming Books"
-      description: "Testing calling forms: {Java:[CallableStreamingBidi], NodeJS:[RequestStreamingBidi], Python:[RequestStreamingBidi]}"
+      description: "Testing calling forms"
       parameters:
         - name=BASIC
     samples:
@@ -589,7 +589,7 @@ interfaces:
       # callingFormCheck: prog py: RequestStreamingClient
     - id: prog
       title: "Programming Books"
-      description: "Testing calling forms: {Java:[CallableStreamingClient], NodeJS:[RequestStreamingClient], Python:[RequestStreamingClient]}"
+      description: "Testing calling forms"
       parameters:
         - name=BASIC
     samples:
@@ -634,7 +634,7 @@ interfaces:
       # callingFormCheck: odyssey py: RequestPaged RequestPagedAll
     - id: odyssey
       title: "The Odyssey"
-      description: "Testing calling forms: {Java:[FlattenedPaged, RequestPaged, CallableList, CallablePaged], NodeJS:[RequestAsyncPaged, RequestAsyncPagedAll], Python:[RequestPaged, RequestPagedAll]}"
+      description: "Testing calling forms"
       parameters:
       - names[0]=Odyssey
       - shelves[0]=Classics
@@ -719,7 +719,7 @@ interfaces:
       # callingFormCheck: wap py: LongRunningPromise
     - id: wap
       title: "GetBigBook: 'War and Peace'"
-      description: "Testing calling forms: {Java:[LongRunningFlattenedAsync, LongRunningRequestAsync, Callable, LongRunningCallable], NodeJS:[LongRunningEventEmitter, LongRunningPromise], Python:[LongRunningPromise]}"
+      description: "Testing calling forms"
       parameters:
       - name="War and Peace"
     samples:


### PR DESCRIPTION
#2049 #2050 and #2057 made it so that the calling form test metadata is now in yaml comments, so we no longer have to regenerate all baselines every time we configure a new calling form for a language.

This change removes the now-unused (and hence misleading and confusing) metadata from the various value set descriptions.