### PR TITLE
misc improvements to ProtoTypeRef

### DIFF
--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -144,8 +144,8 @@ public abstract class LongRunningConfig {
       return null;
     } else {
       return new AutoValue_LongRunningConfig(
-          new ProtoTypeRef(returnType),
-          new ProtoTypeRef(metadataType),
+          ProtoTypeRef.create(returnType),
+          ProtoTypeRef.create(metadataType),
           longRunningConfigProto.getImplementsDelete(),
           longRunningConfigProto.getImplementsCancel(),
           initialPollDelay,

--- a/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
@@ -115,7 +115,7 @@ public class ProtoApiModel implements ApiModel {
   public List<ProtoTypeRef> getAdditionalTypes() {
     return getTypes(protoModel)
         .stream()
-        .map(ProtoTypeRef::new)
+        .map(ProtoTypeRef::create)
         .collect(ImmutableList.toImmutableList());
   }
 

--- a/src/main/java/com/google/api/codegen/config/ProtoField.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoField.java
@@ -40,7 +40,7 @@ public class ProtoField implements FieldModel {
   public ProtoField(Field protoField) {
     Preconditions.checkNotNull(protoField);
     this.protoField = protoField;
-    this.protoTypeRef = new ProtoTypeRef(protoField.getType());
+    this.protoTypeRef = ProtoTypeRef.create(protoField.getType());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
@@ -48,8 +48,8 @@ public final class ProtoMethodModel implements MethodModel {
   public ProtoMethodModel(Method method) {
     Preconditions.checkNotNull(method);
     this.method = method;
-    this.inputType = new ProtoTypeRef(method.getInputType());
-    this.outputType = new ProtoTypeRef(method.getOutputType());
+    this.inputType = ProtoTypeRef.create(method.getInputType());
+    this.outputType = ProtoTypeRef.create(method.getOutputType());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -37,7 +37,7 @@ import java.util.Set;
  * Represents a node in an tree of objects to be initialized.
  */
 public class InitCodeNode {
-  private static final TypeModel INT_TYPE = new ProtoTypeRef(TypeRef.of(Type.TYPE_UINT64));
+  private static final TypeModel INT_TYPE = ProtoTypeRef.create(TypeRef.of(Type.TYPE_UINT64));
 
   private String key;
   private InitCodeLineType lineType;

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -387,7 +387,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
           "a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object";
     } else {
       returnTypeDoc =
-          getTypeNameDoc(typeTable, new ProtoTypeRef(methodConfig.getMethod().getOutputType()));
+          getTypeNameDoc(typeTable, ProtoTypeRef.create(methodConfig.getMethod().getOutputType()));
     }
     return returnTypeDoc;
   }

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -62,7 +62,7 @@ public class SampleInitCodeTest {
   private InitCodeContext.Builder getContextBuilder() {
     return InitCodeContext.newBuilder()
         .symbolTable(new SymbolTable())
-        .initObjectType(new ProtoTypeRef(method.getInputType()))
+        .initObjectType(ProtoTypeRef.create(method.getInputType()))
         .suggestedName(Name.from("request"));
   }
 


### PR DESCRIPTION
The main motivation is to make toString() more succinct so that
errors are easier to parse. This is fixed by using AutoValue.

Other changes:
- equals() was incorrect; fixed by AutoValue
- getFields() was not thread-safe; fixed by AutoValue
- some paths of validateValue() are more efficient