### PR TITLE
python: fixing @oogle.com snip file error

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/setup.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/setup.py.snip
@@ -55,7 +55,7 @@ setuptools.setup(
     description=description,
     long_description=readme,
     author='Google LLC',
-    author_email='googleapis-packages@google.com',
+    author_email='googleapis-packages@@google.com',
     license='Apache 2.0',
     url='https://github.com/GoogleCloudPlatform/google-cloud-python',
     classifiers=[

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -3983,7 +3983,7 @@ setuptools.setup(
     description=description,
     long_description=readme,
     author='Google LLC',
-    author_email='googleapis-packages@oogle.com',
+    author_email='googleapis-packages@google.com',
     license='Apache 2.0',
     url='https://github.com/GoogleCloudPlatform/google-cloud-python',
     classifiers=[

--- a/src/test/java/com/google/api/codegen/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_multiple_services.baseline
@@ -1353,7 +1353,7 @@ setuptools.setup(
     description=description,
     long_description=readme,
     author='Google LLC',
-    author_email='googleapis-packages@oogle.com',
+    author_email='googleapis-packages@google.com',
     license='Apache 2.0',
     url='https://github.com/GoogleCloudPlatform/google-cloud-python',
     classifiers=[

--- a/src/test/java/com/google/api/codegen/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_no_path_templates.baseline
@@ -1116,7 +1116,7 @@ setuptools.setup(
     description=description,
     long_description=readme,
     author='Google LLC',
-    author_email='googleapis-packages@oogle.com',
+    author_email='googleapis-packages@google.com',
     license='Apache 2.0',
     url='https://github.com/GoogleCloudPlatform/google-cloud-python',
     classifiers=[


### PR DESCRIPTION
A funny error caused by incorrect usage of `@` character in the snip file.