### PR TITLE
Adding dep version to fix logging_external_types

### DIFF
--- a/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
+++ b/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
@@ -103,6 +103,10 @@ google-iam-v1_version:
   java:
     lower: '0.12.0'
 
+google-appengine-v1_version:
+  java:
+    lower: '0.12.0'
+
 api_common_version:
   java:
     lower: '1.6.0'


### PR DESCRIPTION
Fixes the failure seen in this artman build:

https://circleci.com/gh/googleapis/artman/6524?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

cc @alexander-fenster 
