### PR TITLE
Use pandoc for Python doc comment reformatting.

### DIFF
--- a/src/main/java/com/google/api/codegen/util/CommentPatterns.java
+++ b/src/main/java/com/google/api/codegen/util/CommentPatterns.java
@@ -29,7 +29,6 @@ public final class CommentPatterns {
   public static final Pattern PROTO_LINK_PATTERN =
       Pattern.compile("\\[([^\\]]+)\\]\\[([A-Za-z_][A-Za-z_.0-9]*)?\\]");
   public static final Pattern HEADLINE_PATTERN = Pattern.compile("^#+", Pattern.MULTILINE);
-  public static final Pattern CODE_BLOCK_PATTERN = Pattern.compile("\\s{4}.*");
   public static final Pattern UNORDERED_LIST_PATTERN = Pattern.compile("^\\s*[\\*\\+\\-]\\s+");
   public static final Pattern INDENT_PATTERN = Pattern.compile("^\\s*");
 }

--- a/src/test/java/com/google/api/codegen/ProtoDocumentLinkTest.java
+++ b/src/test/java/com/google/api/codegen/ProtoDocumentLinkTest.java
@@ -83,15 +83,15 @@ public class ProtoDocumentLinkTest {
 
     // Cloud link may contain special character '$'
     Truth.assertThat(commentReformatter.reformat("[cloud docs!](/library/example/link)"))
-        .isEqualTo("`cloud docs! <https://cloud.google.com/library/example/link>`_");
+        .isEqualTo("`cloud docs! <https://cloud.google.com/library/example/link>`__");
     Truth.assertThat(commentReformatter.reformat("[cloud docs!](/library/example/link$)"))
-        .isEqualTo("`cloud docs! <https://cloud.google.com/library/example/link$>`_");
+        .isEqualTo("`cloud docs! <https://cloud.google.com/library/example/link$>`__");
 
     // Absolute link may contain special character '$'
     Truth.assertThat(commentReformatter.reformat("[not a cloud link](http://www.google.com)"))
-        .isEqualTo("`not a cloud link <http://www.google.com>`_");
+        .isEqualTo("`not a cloud link <http://www.google.com>`__");
     Truth.assertThat(commentReformatter.reformat("[not a cloud link](http://www.google.com$)"))
-        .isEqualTo("`not a cloud link <http://www.google.com$>`_");
+        .isEqualTo("`not a cloud link <http://www.google.com$>`__");
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -868,10 +868,10 @@ import enum
 
 class NullValue(enum.IntEnum):
     """
-    ``NullValue`` is a singleton enumeration to represent the null value for the
-    ``Value`` type union.
+    ``NullValue`` is a singleton enumeration to represent the null value for
+    the ``Value`` type union.
 
-     The JSON representation for ``NullValue`` is JSON ``null``.
+    The JSON representation for ``NullValue`` is JSON ``null``.
 
     Attributes:
       NULL_VALUE (int): Null value.
@@ -901,7 +901,7 @@ class Book(object):
         """
         Attributes:
           GOOD (int): GOOD enum description
-          BAD (int): Enum description with special characters: <>&\"``'@.
+          BAD (int): Enum description with special characters: <>&"\`'@.
         """
         GOOD = 0
         BAD = 1
@@ -1034,20 +1034,21 @@ _GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
 
 class LibraryServiceClient(object):
     """
-    This API represents a simple digital library.  It lets you manage Shelf
+    This API represents a simple digital library. It lets you manage Shelf
     resources and Book resources in the library. It defines the following
     resource model:
 
-    - The API has a collection of ``Shelf``
-      resources, named ``bookShelves/*``
+    -  The API has a collection of ``Shelf`` resources, named
+       ``bookShelves/*``
 
-    - Each Shelf has a collection of ``Book``
-      resources, named ``bookShelves/*/books/*``
+    -  Each Shelf has a collection of ``Book`` resources, named
+       ``bookShelves/*/books/*``
 
-    Check out `cloud docs! <https://cloud.google.com/library/example/link>`_.
-    This is `not a cloud link <http://www.google.com>`_.
+    Check out `cloud
+    docs! <https://cloud.google.com/library/example/link>`__. This is `not a
+    cloud link <http://www.google.com>`__.
 
-    Service comment may include special characters: <>&\"``'@.
+    Service comment may include special characters: <>&"\`'@.
     """
 
     SERVICE_ADDRESS = 'library-example.googleapis.com:443'
@@ -1208,8 +1209,8 @@ class LibraryServiceClient(object):
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):
         """
-        Creates a shelf, and returns the new Shelf.
-        RPC method comment may include special characters: <>&\"``'@.
+        Creates a shelf, and returns the new Shelf. RPC method comment may
+        include special characters: <>&"\`'@.
 
         Example:
             >>> from google.cloud.example import library_v1
@@ -2335,8 +2336,8 @@ class LibraryServiceClient(object):
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):
         """
-        Test server streaming
-        gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+        Test server streaming gRPC streaming methods don't have an HTTP
+        equivalent and don't need to have the google.api.http option.
 
         Example:
             >>> from google.cloud.example import library_v1
@@ -2384,8 +2385,9 @@ class LibraryServiceClient(object):
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):
         """
-        Test server streaming, non-paged responses.
-        gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+        Test server streaming, non-paged responses. gRPC streaming methods don't
+        have an HTTP equivalent and don't need to have the google.api.http
+        option.
 
         Example:
             >>> from google.cloud.example import library_v1
@@ -2440,8 +2442,8 @@ class LibraryServiceClient(object):
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):
         """
-        Test bidi-streaming.
-        gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+        Test bidi-streaming. gRPC streaming methods don't have an HTTP
+        equivalent and don't need to have the google.api.http option.
 
         EXPERIMENTAL: This method interface might change in the future.
 
@@ -2498,8 +2500,8 @@ class LibraryServiceClient(object):
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):
         """
-        Test client streaming.
-        gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+        Test client streaming. gRPC streaming methods don't have an HTTP
+        equivalent and don't need to have the google.api.http option.
 
         EXPERIMENTAL: This method interface might change in the future.
 
@@ -2659,8 +2661,8 @@ class LibraryServiceClient(object):
             >>> response = client.add_tag(resource, tag)
 
         Args:
-            resource (str): REQUIRED: The resource which the tag is being added to.
-                Resource is usually specified as a path, such as,
+            resource (str): REQUIRED: The resource which the tag is being added to. Resource is
+                usually specified as a path, such as,
                 projects/{project}/zones/{zone}/disks/{disk}.
             tag (str): REQUIRED: The tag to add.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
@@ -2719,8 +2721,8 @@ class LibraryServiceClient(object):
             >>> response = client.add_label(resource, label)
 
         Args:
-            resource (str): REQUIRED: The resource which the label is being added to.
-                Resource is usually specified as a path, such as,
+            resource (str): REQUIRED: The resource which the label is being added to. Resource is
+                usually specified as a path, such as,
                 projects/{project}/zones/{zone}/disks/{disk}.
             label (str): REQUIRED: The label to add.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used

--- a/src/test/java/com/google/api/codegen/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_no_path_templates.baseline
@@ -895,11 +895,8 @@ class NoTemplatesAPIServiceClient(object):
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):
         """
-        Increments something.
-        Sometimes the comments are indented, but Sphinx doesn't like that. So
-        in Python we trim all
-        leading
-        and trailing
+        Increments something. Sometimes the comments are indented, but Sphinx
+        doesn't like that. So in Python we trim all leading and trailing
         whitespace.
 
         Example:


### PR DESCRIPTION
Fixes #1587 

Java has no pandoc library that accepts strings, so the pandoc command is used directly with `InputStream`s and `OutputStream`s.

Formatting is stricter than most client libraries in googleapis might expect, and more closely follows strict markdown spec. (Though pandoc markdown is used.)