### PR TITLE
Add additional env vars for credentials

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -73,9 +73,10 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer<Proto
   private static final String CREDENTIALS_CLASS_TEMPLATE_FILE = "ruby/credentials.snip";
   // This assumes the api is a google-cloud api.
   private static final List<String> DEFAULT_PATH_ENV_VARS =
-      ImmutableList.of("GOOGLE_CLOUD_KEYFILE", "GCLOUD_KEYFILE");
+      ImmutableList.of("GOOGLE_CLOUD_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE", "GCLOUD_KEYFILE");
   private static final List<String> DEFAULT_JSON_ENV_VARS =
-      ImmutableList.of("GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON");
+      ImmutableList.of(
+          "GOOGLE_CLOUD_CREDENTIALS_JSON", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON");
   private static final List<String> DEFAULT_PATHS =
       ImmutableList.of("~/.config/gcloud/application_default_credentials.json");
 
@@ -289,20 +290,27 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer<Proto
 
     String sanitizedShortName = packageConfig.shortName().replaceAll("[^A-Za-z0-9]", " ");
     Name.lowerCamel(sanitizedShortName.split(" "));
-    String apiSpecificPathEnvVar =
-        namer.inittedConstantName(Name.lowerCamel(sanitizedShortName.split(" ")).join("keyfile"));
-    String apiSpecificJsonEnvVar =
-        namer.inittedConstantName(
-            Name.lowerCamel(sanitizedShortName.split(" ")).join("keyfile").join("json"));
+    List<String> apiSpecificPathEnvVars =
+        ImmutableList.of(
+            namer.inittedConstantName(
+                Name.lowerCamel(sanitizedShortName.split(" ")).join("keyfile")),
+            namer.inittedConstantName(
+                Name.lowerCamel(sanitizedShortName.split(" ")).join("credentials")));
+    List<String> apiSpecificJsonEnvVars =
+        ImmutableList.of(
+            namer.inittedConstantName(
+                Name.lowerCamel(sanitizedShortName.split(" ")).join("keyfile").join("json")),
+            namer.inittedConstantName(
+                Name.lowerCamel(sanitizedShortName.split(" ")).join("credentials").join("json")));
 
     List<String> pathEnvVars =
         ImmutableList.<String>builder()
-            .add(apiSpecificPathEnvVar)
+            .addAll(apiSpecificPathEnvVars)
             .addAll(DEFAULT_PATH_ENV_VARS)
             .build();
     List<String> jsonEnvVars =
         ImmutableList.<String>builder()
-            .add(apiSpecificJsonEnvVar)
+            .addAll(apiSpecificJsonEnvVars)
             .addAll(DEFAULT_JSON_ENV_VARS)
             .build();
 

--- a/src/main/resources/com/google/api/codegen/ruby/credentials.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/credentials.snip
@@ -37,7 +37,7 @@
 @end
 
 @private wordArrayStrings(strings)
-  @join string : strings on " "
+  @join string : strings on " ".add(BREAK)
     {@string}
   @end
 @end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -921,8 +921,16 @@ module Library
         "https://www.googleapis.com/auth/cloud-platform",
         "https://www.googleapis.com/auth/library"
       ].freeze
-      PATH_ENV_VARS = %w(LIBRARY_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
-      JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
+      PATH_ENV_VARS = %w(LIBRARY_KEYFILE
+                         LIBRARY_CREDENTIALS
+                         GOOGLE_CLOUD_CREDENTIALS
+                         GOOGLE_CLOUD_KEYFILE
+                         GCLOUD_KEYFILE)
+      JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON
+                         LIBRARY_CREDENTIALS_JSON
+                         GOOGLE_CLOUD_CREDENTIALS_JSON
+                         GOOGLE_CLOUD_KEYFILE_JSON
+                         GCLOUD_KEYFILE_JSON)
       DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
     end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -907,8 +907,16 @@ module Google
         class Credentials < Google::Auth::Credentials
           SCOPE = [
           ].freeze
-          PATH_ENV_VARS = %w(MULTIPLE_SERVICES_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
-          JSON_ENV_VARS = %w(MULTIPLE_SERVICES_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
+          PATH_ENV_VARS = %w(MULTIPLE_SERVICES_KEYFILE
+                             MULTIPLE_SERVICES_CREDENTIALS
+                             GOOGLE_CLOUD_CREDENTIALS
+                             GOOGLE_CLOUD_KEYFILE
+                             GCLOUD_KEYFILE)
+          JSON_ENV_VARS = %w(MULTIPLE_SERVICES_KEYFILE_JSON
+                             MULTIPLE_SERVICES_CREDENTIALS_JSON
+                             GOOGLE_CLOUD_CREDENTIALS_JSON
+                             GOOGLE_CLOUD_KEYFILE_JSON
+                             GCLOUD_KEYFILE_JSON)
           DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
         end
       end


### PR DESCRIPTION
Add back some additional env settings that were in manual clients, as per: https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1830