### PR TITLE
Supporting same proto_deps structure as artman config

### DIFF
--- a/src/test/java/com/google/api/codegen/testsrc/library_pkg2.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_pkg2.yaml
@@ -4,8 +4,8 @@ artifact_type: GAPIC
 organization_name: google-cloud
 proto_path: google/library
 proto_deps:
-- google-common-protos
-- google-some-other-package-v1
-proto_test_deps:
-- google-some-test-package-v1
+- name: google-common-protos
+- name: google-some-other-package-v1
+test_proto_deps:
+- name: google-some-test-package-v1
 release_level: GA

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg2.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg2.yaml
@@ -4,8 +4,8 @@ artifact_type: GAPIC
 organization_name: google-cloud
 proto_path: google/multiple_services
 proto_deps:
-- google-common-protos
-- google-some-other-package-v1
-proto_test_deps:
-- google-some-test-package-v1
+- name: google-common-protos
+- name: google-some-other-package-v1
+test_proto_deps:
+- name: google-some-test-package-v1
 release_level: GA


### PR DESCRIPTION
- artman uses a structure with a key named `name` instead of just a list of dependency names
- artman uses `test_proto_deps` instead of `proto_test_deps`
