### PR TITLE
Enabling separate code-only generation for C#

### DIFF
--- a/src/main/java/com/google/api/codegen/ArtifactType.java
+++ b/src/main/java/com/google/api/codegen/ArtifactType.java
@@ -18,6 +18,14 @@ public enum ArtifactType {
   GAPIC_CONFIG,
   DISCOGAPIC_CONFIG,
 
+  // Generates only the code for the client
+  // Only supported by a subset of languages so far
+  GAPIC_CODE,
+
+  // Generates only the packaging files for the client
+  // Only supported by a subset of languages so far
+  GAPIC_PACKAGE,
+
   // This will be split into GAPIC and GAPIC_PACKAGE
   LEGACY_GAPIC_AND_PACKAGE,
   // This will be split into DISCOGAPIC and DISCOGAPIC_PACKAGE

--- a/src/main/java/com/google/api/codegen/GeneratorMain.java
+++ b/src/main/java/com/google/api/codegen/GeneratorMain.java
@@ -143,8 +143,14 @@ public class GeneratorMain {
       case GAPIC_CONFIG:
         gapicConfigGeneratorMain(args);
         break;
+      case GAPIC_CODE:
+        gapicGeneratorMain(artifactType, args);
+        break;
+      case GAPIC_PACKAGE:
+        gapicGeneratorMain(artifactType, args);
+        break;
       case LEGACY_GAPIC_AND_PACKAGE:
-        gapicGeneratorMain(args);
+        gapicGeneratorMain(artifactType, args);
         break;
       case DISCOGAPIC_CONFIG:
         discoGapicConfigGeneratorMain(args);
@@ -190,7 +196,7 @@ public class GeneratorMain {
     System.exit(exitCode);
   }
 
-  public static void gapicGeneratorMain(String[] args) throws Exception {
+  public static void gapicGeneratorMain(ArtifactType artifactType, String[] args) throws Exception {
     Options options = new Options();
     options.addOption("h", "help", false, "show usage");
     options.addOption(DESCRIPTOR_SET_OPTION);
@@ -247,7 +253,7 @@ public class GeneratorMain {
           GapicGeneratorApp.ENABLED_ARTIFACTS,
           Lists.newArrayList(cl.getOptionValues(enabledArtifactsOption.getLongOpt())));
     }
-    GapicGeneratorApp codeGen = new GapicGeneratorApp(toolOptions);
+    GapicGeneratorApp codeGen = new GapicGeneratorApp(toolOptions, artifactType);
     int exitCode = codeGen.run();
     System.exit(exitCode);
   }

--- a/src/main/java/com/google/api/codegen/discogapic/DiscoGapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/discogapic/DiscoGapicGeneratorApp.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.discogapic;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.codegen.ArtifactType;
 import com.google.api.codegen.ConfigProto;
 import com.google.api.codegen.common.CodeGenerator;
 import com.google.api.codegen.common.GeneratedResult;
@@ -32,6 +33,7 @@ import com.google.api.codegen.configgen.MessageGenerator;
 import com.google.api.codegen.configgen.nodes.ConfigNode;
 import com.google.api.codegen.discovery.DiscoveryNode;
 import com.google.api.codegen.discovery.Document;
+import com.google.api.codegen.gapic.ArtifactFlags;
 import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.SimpleDiagCollector;
 import com.google.api.tools.framework.tools.ToolOptions;
@@ -157,8 +159,10 @@ public class DiscoGapicGeneratorApp {
 
     GapicProductConfig productConfig = GapicProductConfig.create(model, configProto, language);
 
+    ArtifactFlags artifactFlags =
+        new ArtifactFlags(enabledArtifacts, ArtifactType.LEGACY_DISCOGAPIC_AND_PACKAGE);
     return DiscoGapicGeneratorFactory.create(
-        language, model, productConfig, packageConfig, enabledArtifacts);
+        language, model, productConfig, packageConfig, artifactFlags);
   }
 
   public int run() throws Exception {

--- a/src/main/java/com/google/api/codegen/discogapic/DiscoGapicGeneratorFactory.java
+++ b/src/main/java/com/google/api/codegen/discogapic/DiscoGapicGeneratorFactory.java
@@ -25,9 +25,9 @@ import com.google.api.codegen.discogapic.transformer.java.JavaDiscoGapicRequestT
 import com.google.api.codegen.discogapic.transformer.java.JavaDiscoGapicResourceNameToViewTransformer;
 import com.google.api.codegen.discogapic.transformer.java.JavaDiscoGapicSchemaToViewTransformer;
 import com.google.api.codegen.discogapic.transformer.java.JavaDiscoGapicSurfaceTransformer;
+import com.google.api.codegen.gapic.ArtifactFlags;
 import com.google.api.codegen.gapic.CommonGapicCodePathMapper;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
-import com.google.api.codegen.gapic.GapicGeneratorFactory;
 import com.google.api.codegen.rendering.CommonSnippetSetRunner;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.java.JavaGapicPackageTransformer;
@@ -47,13 +47,13 @@ public class DiscoGapicGeneratorFactory {
       DiscoApiModel model,
       GapicProductConfig productConfig,
       PackageMetadataConfig packageConfig,
-      List<String> enabledArtifacts) {
+      ArtifactFlags artifactFlags) {
 
     ArrayList<CodeGenerator<?>> generators = new ArrayList<>();
 
     // Please keep the following IDs in alphabetical order
     if (language.equals(JAVA)) {
-      if (GapicGeneratorFactory.enableSurfaceGenerator(enabledArtifacts)) {
+      if (artifactFlags.surfaceGeneratorEnabled()) {
         GapicCodePathMapper javaPathMapper =
             CommonGapicCodePathMapper.newBuilder()
                 .setPrefix("src/main/java")
@@ -86,7 +86,7 @@ public class DiscoGapicGeneratorFactory {
         generators.add(metadataGenerator);
       }
 
-      if (GapicGeneratorFactory.enableTestGenerator(enabledArtifacts)) {
+      if (artifactFlags.testGeneratorEnabled()) {
         GapicCodePathMapper javaTestPathMapper =
             CommonGapicCodePathMapper.newBuilder()
                 .setPrefix("src/test/java")

--- a/src/main/java/com/google/api/codegen/gapic/ArtifactFlags.java
+++ b/src/main/java/com/google/api/codegen/gapic/ArtifactFlags.java
@@ -1,0 +1,54 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.gapic;
+
+import com.google.api.codegen.ArtifactType;
+import java.util.List;
+
+public class ArtifactFlags {
+  public static final String ARTIFACT_SURFACE = "surface";
+  public static final String ARTIFACT_TEST = "test";
+  public static final String ARTIFACT_SAMPLES = "samples";
+
+  private List<String> enabledArtifacts;
+  private ArtifactType artifactType;
+
+  public ArtifactFlags(List<String> enabledArtifacts, ArtifactType artifactType) {
+    this.enabledArtifacts = enabledArtifacts;
+    this.artifactType = artifactType;
+  }
+
+  public boolean surfaceGeneratorEnabled() {
+    return enabledArtifacts.isEmpty() || enabledArtifacts.contains(ARTIFACT_SURFACE);
+  }
+
+  public boolean testGeneratorEnabled() {
+    return enabledArtifacts.isEmpty() || enabledArtifacts.contains(ARTIFACT_TEST);
+  }
+
+  public boolean sampleGeneratorEnabled() {
+    return enabledArtifacts.contains(ARTIFACT_SAMPLES);
+  }
+
+  public boolean codeFilesEnabled() {
+    return artifactType == ArtifactType.LEGACY_GAPIC_AND_PACKAGE
+        || artifactType == ArtifactType.GAPIC_CODE;
+  }
+
+  public boolean packagingFilesEnabled() {
+    return artifactType == ArtifactType.LEGACY_GAPIC_AND_PACKAGE
+        || artifactType == ArtifactType.GAPIC_PACKAGE;
+  }
+}

--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.gapic;
 
+import com.google.api.codegen.ArtifactType;
 import com.google.api.codegen.ConfigProto;
 import com.google.api.codegen.advising.Adviser;
 import com.google.api.codegen.common.CodeGenerator;
@@ -83,9 +84,12 @@ public class GapicGeneratorApp extends ToolDriverBase {
           "Names of adviser rules to suppress warnings for.",
           ImmutableList.of());
 
+  private ArtifactType artifactType;
+
   /** Constructs a code generator api based on given options. */
-  public GapicGeneratorApp(ToolOptions options) {
+  public GapicGeneratorApp(ToolOptions options, ArtifactType artifactType) {
     super(options);
+    this.artifactType = artifactType;
   }
 
   @Override
@@ -155,9 +159,9 @@ public class GapicGeneratorApp extends ToolDriverBase {
     }
 
     String outputPath = options.get(OUTPUT_FILE);
+    ArtifactFlags artifactFlags = new ArtifactFlags(options.get(ENABLED_ARTIFACTS), artifactType);
     List<CodeGenerator<?>> generators =
-        GapicGeneratorFactory.create(
-            language, model, productConfig, packageConfig, options.get(ENABLED_ARTIFACTS));
+        GapicGeneratorFactory.create(language, model, productConfig, packageConfig, artifactFlags);
     ImmutableMap.Builder<String, Object> outputFiles = ImmutableMap.builder();
     ImmutableSet.Builder<String> executables = ImmutableSet.builder();
     for (CodeGenerator<?> generator : generators) {

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpBasicPackageTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpBasicPackageTransformer.java
@@ -30,7 +30,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 /* Transforms a ProtoApiModel into the smoke tests of an API for C#. */
 public class CSharpBasicPackageTransformer implements ModelToViewTransformer<ProtoApiModel> {
@@ -47,7 +47,7 @@ public class CSharpBasicPackageTransformer implements ModelToViewTransformer<Pro
   private final GapicCodePathMapper pathMapper;
   private final String templateFilename;
   private final String fileBaseSuffix;
-  private final Function<GapicInterfaceContext, Boolean> shouldGenerateFn;
+  private final Predicate<GapicInterfaceContext> shouldGenerateFn;
   private final CSharpCommonTransformer csharpCommonTransformer = new CSharpCommonTransformer();
   private final FileHeaderTransformer fileHeaderTransformer =
       new FileHeaderTransformer(new StandardImportSectionTransformer());
@@ -56,7 +56,7 @@ public class CSharpBasicPackageTransformer implements ModelToViewTransformer<Pro
       GapicCodePathMapper pathMapper,
       String templateFilename,
       String fileBaseSuffix,
-      Function<GapicInterfaceContext, Boolean> shouldGenerateFn) {
+      Predicate<GapicInterfaceContext> shouldGenerateFn) {
     this.pathMapper = pathMapper;
     this.templateFilename = templateFilename;
     this.fileBaseSuffix = fileBaseSuffix;
@@ -81,7 +81,7 @@ public class CSharpBasicPackageTransformer implements ModelToViewTransformer<Pro
         pathMapper, UNITTEST_CSPROJ_TEMPLATE_FILENAME, ".Tests.csproj", parameter -> true);
   }
 
-  private static Function<GapicInterfaceContext, Boolean> shouldGenSmokeTestPackage() {
+  private static Predicate<GapicInterfaceContext> shouldGenSmokeTestPackage() {
     return parameter -> parameter.getInterfaceConfig().getSmokeTestConfig() != null;
   }
 
@@ -98,7 +98,7 @@ public class CSharpBasicPackageTransformer implements ModelToViewTransformer<Pro
               csharpCommonTransformer.createTypeTable(namer.getPackageName(), ALIAS_MODE),
               namer,
               new CSharpFeatureConfig());
-      if (shouldGenerateFn.apply(context)) {
+      if (shouldGenerateFn.test(context)) {
         surfaceDocs.add(generateCsproj(context));
       }
     }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpBasicPackageTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpBasicPackageTransformer.java
@@ -1,0 +1,123 @@
+/* Copyright 2017 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer.csharp;
+
+import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.InterfaceModel;
+import com.google.api.codegen.config.ProtoApiModel;
+import com.google.api.codegen.gapic.GapicCodePathMapper;
+import com.google.api.codegen.transformer.FileHeaderTransformer;
+import com.google.api.codegen.transformer.GapicInterfaceContext;
+import com.google.api.codegen.transformer.ModelToViewTransformer;
+import com.google.api.codegen.transformer.StandardImportSectionTransformer;
+import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.util.csharp.CSharpAliasMode;
+import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.api.codegen.viewmodel.metadata.SimpleInitFileView;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+/* Transforms a ProtoApiModel into the smoke tests of an API for C#. */
+public class CSharpBasicPackageTransformer implements ModelToViewTransformer<ProtoApiModel> {
+
+  private static final String SMOKETEST_CSPROJ_TEMPLATE_FILENAME =
+      "csharp/gapic_smoketest_csproj.snip";
+  private static final String SNIPPETS_CSPROJ_TEMPLATE_FILENAME =
+      "csharp/gapic_snippets_csproj.snip";
+  private static final String UNITTEST_CSPROJ_TEMPLATE_FILENAME =
+      "csharp/gapic_unittest_csproj.snip";
+
+  private static final CSharpAliasMode ALIAS_MODE = CSharpAliasMode.MessagesOnly;
+
+  private final GapicCodePathMapper pathMapper;
+  private final String templateFilename;
+  private final String fileBaseSuffix;
+  private final Function<GapicInterfaceContext, Boolean> shouldGenerateFn;
+  private final CSharpCommonTransformer csharpCommonTransformer = new CSharpCommonTransformer();
+  private final FileHeaderTransformer fileHeaderTransformer =
+      new FileHeaderTransformer(new StandardImportSectionTransformer());
+
+  private CSharpBasicPackageTransformer(
+      GapicCodePathMapper pathMapper,
+      String templateFilename,
+      String fileBaseSuffix,
+      Function<GapicInterfaceContext, Boolean> shouldGenerateFn) {
+    this.pathMapper = pathMapper;
+    this.templateFilename = templateFilename;
+    this.fileBaseSuffix = fileBaseSuffix;
+    this.shouldGenerateFn = shouldGenerateFn;
+  }
+
+  public static CSharpBasicPackageTransformer forSmokeTests(GapicCodePathMapper pathMapper) {
+    return new CSharpBasicPackageTransformer(
+        pathMapper,
+        SMOKETEST_CSPROJ_TEMPLATE_FILENAME,
+        ".SmokeTests.csproj",
+        shouldGenSmokeTestPackage());
+  }
+
+  public static CSharpBasicPackageTransformer forSnippets(GapicCodePathMapper pathMapper) {
+    return new CSharpBasicPackageTransformer(
+        pathMapper, SNIPPETS_CSPROJ_TEMPLATE_FILENAME, ".Snippets.csproj", parameter -> true);
+  }
+
+  public static CSharpBasicPackageTransformer forUnitTests(GapicCodePathMapper pathMapper) {
+    return new CSharpBasicPackageTransformer(
+        pathMapper, UNITTEST_CSPROJ_TEMPLATE_FILENAME, ".Tests.csproj", parameter -> true);
+  }
+
+  private static Function<GapicInterfaceContext, Boolean> shouldGenSmokeTestPackage() {
+    return parameter -> parameter.getInterfaceConfig().getSmokeTestConfig() != null;
+  }
+
+  @Override
+  public List<ViewModel> transform(ProtoApiModel model, GapicProductConfig productConfig) {
+    List<ViewModel> surfaceDocs = new ArrayList<>();
+    SurfaceNamer namer = new CSharpSurfaceNamer(productConfig.getPackageName(), ALIAS_MODE);
+
+    for (InterfaceModel apiInterface : model.getInterfaces()) {
+      GapicInterfaceContext context =
+          GapicInterfaceContext.create(
+              apiInterface,
+              productConfig,
+              csharpCommonTransformer.createTypeTable(namer.getPackageName(), ALIAS_MODE),
+              namer,
+              new CSharpFeatureConfig());
+      if (shouldGenerateFn.apply(context)) {
+        surfaceDocs.add(generateCsproj(context));
+      }
+    }
+
+    return surfaceDocs;
+  }
+
+  @Override
+  public List<String> getTemplateFileNames() {
+    return Arrays.asList(templateFilename);
+  }
+
+  private SimpleInitFileView generateCsproj(GapicInterfaceContext context) {
+    GapicProductConfig productConfig = context.getProductConfig();
+    String outputPath =
+        pathMapper.getOutputPath(context.getInterface().getFullName(), productConfig);
+    return SimpleInitFileView.create(
+        templateFilename,
+        outputPath + File.separator + productConfig.getPackageName() + fileBaseSuffix,
+        fileHeaderTransformer.generateFileHeader(context));
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientPackageTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientPackageTransformer.java
@@ -1,0 +1,140 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer.csharp;
+
+import com.google.api.codegen.common.TargetLanguage;
+import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.InterfaceModel;
+import com.google.api.codegen.config.PackageMetadataConfig;
+import com.google.api.codegen.config.ProtoApiModel;
+import com.google.api.codegen.gapic.GapicCodePathMapper;
+import com.google.api.codegen.transformer.FileHeaderTransformer;
+import com.google.api.codegen.transformer.GapicInterfaceContext;
+import com.google.api.codegen.transformer.ModelToViewTransformer;
+import com.google.api.codegen.transformer.PackageMetadataNamer;
+import com.google.api.codegen.transformer.PackageMetadataTransformer;
+import com.google.api.codegen.transformer.StandardImportSectionTransformer;
+import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.util.csharp.CSharpAliasMode;
+import com.google.api.codegen.viewmodel.PackageInfoView;
+import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.api.codegen.viewmodel.metadata.PackageMetadataView;
+import com.google.api.tools.framework.model.Model;
+import com.google.common.base.Splitter;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CSharpGapicClientPackageTransformer implements ModelToViewTransformer<ProtoApiModel> {
+  private static final String CSPROJ_TEMPLATE_FILENAME = "csharp/gapic_csproj.snip";
+
+  private static final CSharpAliasMode ALIAS_MODE = CSharpAliasMode.Global;
+
+  private final GapicCodePathMapper pathMapper;
+  private final PackageMetadataConfig packageMetadataConfig;
+  private final CSharpCommonTransformer csharpCommonTransformer = new CSharpCommonTransformer();
+  private final FileHeaderTransformer fileHeaderTransformer =
+      new FileHeaderTransformer(new StandardImportSectionTransformer());
+  private final PackageMetadataTransformer metadataTransformer = new PackageMetadataTransformer();
+
+  public CSharpGapicClientPackageTransformer(
+      GapicCodePathMapper pathMapper, PackageMetadataConfig packageMetadataConfig) {
+    this.pathMapper = pathMapper;
+    this.packageMetadataConfig = packageMetadataConfig;
+  }
+
+  @Override
+  public List<ViewModel> transform(ProtoApiModel model, GapicProductConfig productConfig) {
+    List<ViewModel> surfaceDocs = new ArrayList<>();
+    SurfaceNamer namer = new CSharpSurfaceNamer(productConfig.getPackageName(), ALIAS_MODE);
+    CSharpFeatureConfig featureConfig = new CSharpFeatureConfig();
+
+    InterfaceModel lastApiInterface = null;
+    for (InterfaceModel apiInterface : model.getInterfaces()) {
+      lastApiInterface = apiInterface;
+    }
+
+    GapicInterfaceContext context =
+        GapicInterfaceContext.create(
+            lastApiInterface,
+            productConfig,
+            csharpCommonTransformer.createTypeTable(productConfig.getPackageName(), ALIAS_MODE),
+            namer,
+            featureConfig);
+    surfaceDocs.add(generateCsProjView(context));
+
+    return surfaceDocs;
+  }
+
+  @Override
+  public List<String> getTemplateFileNames() {
+    return Arrays.asList(CSPROJ_TEMPLATE_FILENAME);
+  }
+
+  private PackageInfoView generateCsProjView(GapicInterfaceContext context) {
+    Model model = context.getModel();
+    GapicProductConfig productConfig = context.getProductConfig();
+    PackageInfoView.Builder view = PackageInfoView.newBuilder();
+    view.templateFileName(CSPROJ_TEMPLATE_FILENAME);
+    String outputPath =
+        pathMapper.getOutputPath(context.getInterface().getFullName(), productConfig);
+    view.outputPath(outputPath + File.separator + productConfig.getPackageName() + ".csproj");
+    view.fileHeader(fileHeaderTransformer.generateFileHeader(context));
+    view.serviceTitle(model.getServiceConfig().getTitle());
+    view.serviceDescription(model.getServiceConfig().getDocumentation().getSummary().trim());
+    view.domainLayerLocation(productConfig.getDomainLayerLocation());
+    view.authScopes(new ArrayList<>()); // Unused in C#
+    view.releaseLevel(productConfig.getReleaseLevel());
+    String versionSuffix;
+    switch (productConfig.getReleaseLevel()) {
+      case ALPHA:
+        versionSuffix = "-alpha01";
+        break;
+      case BETA:
+        versionSuffix = "-beta01";
+        break;
+      default:
+        versionSuffix = "";
+        break;
+    }
+    view.version("1.0.0" + versionSuffix);
+    String tags = "";
+    for (String tag : Splitter.on('.').split(productConfig.getPackageName())) {
+      if (tag.matches("[vV][\\d.]+")) {
+        break;
+      }
+      tags += ";" + tag;
+    }
+    view.tags(tags.isEmpty() ? "" : tags.substring(1));
+    view.packageMetadata(generatePackageMetadataView(context));
+    view.serviceDocs(new ArrayList<>());
+    return view.build();
+  }
+
+  private PackageMetadataView generatePackageMetadataView(GapicInterfaceContext context) {
+    String outputPath =
+        pathMapper.getOutputPath(context.getInterface().getFullName(), context.getProductConfig());
+    return metadataTransformer
+        .generateMetadataView(
+            new PackageMetadataNamer(),
+            packageMetadataConfig,
+            context.getApiModel(),
+            CSPROJ_TEMPLATE_FILENAME,
+            outputPath,
+            TargetLanguage.CSHARP)
+        .build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientPackageTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientPackageTransformer.java
@@ -16,9 +16,9 @@ package com.google.api.codegen.transformer.csharp;
 
 import com.google.api.codegen.common.TargetLanguage;
 import com.google.api.codegen.config.GapicProductConfig;
-import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.ProtoApiModel;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
@@ -62,14 +62,14 @@ public class CSharpGapicClientPackageTransformer implements ModelToViewTransform
     SurfaceNamer namer = new CSharpSurfaceNamer(productConfig.getPackageName(), ALIAS_MODE);
     CSharpFeatureConfig featureConfig = new CSharpFeatureConfig();
 
-    InterfaceModel lastApiInterface = null;
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
-      lastApiInterface = apiInterface;
+    List<ProtoInterfaceModel> apiInterfaces = model.getInterfaces();
+    if (apiInterfaces.isEmpty()) {
+      return surfaceDocs;
     }
 
     GapicInterfaceContext context =
         GapicInterfaceContext.create(
-            lastApiInterface,
+            apiInterfaces.get(apiInterfaces.size() - 1),
             productConfig,
             csharpCommonTransformer.createTypeTable(productConfig.getPackageName(), ALIAS_MODE),
             namer,

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
@@ -81,7 +81,7 @@ import java.util.stream.Collectors;
 /* Transforms a ProtoApiModel into the standard GAPIC library for C#. */
 public class CSharpGapicClientTransformer implements ModelToViewTransformer<ProtoApiModel> {
 
-  private static final String XAPI_TEMPLATE_FILENAME = "csharp/gapic_client.snip";
+  private static final String API_TEMPLATE_FILENAME = "csharp/gapic_client.snip";
   private static final String RESOURCENAMES_TEMPLATE_FILENAME = "csharp/gapic_resourcenames.snip";
 
   private static final CSharpAliasMode ALIAS_MODE = CSharpAliasMode.Global;
@@ -138,7 +138,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer<Prot
 
   @Override
   public List<String> getTemplateFileNames() {
-    return Arrays.asList(XAPI_TEMPLATE_FILENAME, RESOURCENAMES_TEMPLATE_FILENAME);
+    return Arrays.asList(API_TEMPLATE_FILENAME, RESOURCENAMES_TEMPLATE_FILENAME);
   }
 
   private StaticLangResourceNamesView generateResourceNamesView(GapicInterfaceContext context) {
@@ -253,7 +253,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer<Prot
     StaticLangApiAndSettingsFileView.Builder fileView =
         StaticLangApiAndSettingsFileView.newBuilder();
 
-    fileView.templateFileName(XAPI_TEMPLATE_FILENAME);
+    fileView.templateFileName(API_TEMPLATE_FILENAME);
 
     fileView.api(generateApiClass(context));
     fileView.settings(generateSettingsClass(context));

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSmokeTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSmokeTestTransformer.java
@@ -50,8 +50,6 @@ import java.util.List;
 public class CSharpGapicSmokeTestTransformer implements ModelToViewTransformer<ProtoApiModel> {
 
   private static final String SMOKETEST_SNIPPETS_TEMPLATE_FILENAME = "csharp/gapic_smoketest.snip";
-  private static final String SMOKETEST_CSPROJ_TEMPLATE_FILENAME =
-      "csharp/gapic_smoketest_csproj.snip";
 
   private static final CSharpAliasMode ALIAS_MODE = CSharpAliasMode.MessagesOnly;
 
@@ -85,7 +83,6 @@ public class CSharpGapicSmokeTestTransformer implements ModelToViewTransformer<P
       SmokeTestClassView smokeTests = generateSmokeTest(context);
       if (smokeTests != null) {
         surfaceDocs.add(smokeTests);
-        surfaceDocs.add(generateSmokeTestCsproj(context));
       }
     }
 
@@ -94,7 +91,7 @@ public class CSharpGapicSmokeTestTransformer implements ModelToViewTransformer<P
 
   @Override
   public List<String> getTemplateFileNames() {
-    return Arrays.asList(SMOKETEST_SNIPPETS_TEMPLATE_FILENAME, SMOKETEST_CSPROJ_TEMPLATE_FILENAME);
+    return Arrays.asList(SMOKETEST_SNIPPETS_TEMPLATE_FILENAME);
   }
 
   private SmokeTestClassView generateSmokeTest(GapicInterfaceContext context) {
@@ -108,17 +105,6 @@ public class CSharpGapicSmokeTestTransformer implements ModelToViewTransformer<P
     String outputPath =
         pathMapper.getOutputPath(context.getInterface().getFullName(), context.getProductConfig());
     builder.outputPath(outputPath + File.separator + name + ".g.cs");
-    return builder.build();
-  }
-
-  private SmokeTestClassView generateSmokeTestCsproj(GapicInterfaceContext context) {
-    SmokeTestClassView.Builder builder = generateSmokeTestViewBuilder(context);
-    GapicProductConfig productConfig = context.getProductConfig();
-    String outputPath =
-        pathMapper.getOutputPath(context.getInterface().getFullName(), productConfig);
-    builder.outputPath(
-        outputPath + File.separator + productConfig.getPackageName() + ".SmokeTests.csproj");
-    builder.templateFileName(SMOKETEST_CSPROJ_TEMPLATE_FILENAME);
     return builder.build();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
@@ -54,8 +54,6 @@ import java.util.List;
 public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer<ProtoApiModel> {
 
   private static final String SNIPPETS_TEMPLATE_FILENAME = "csharp/gapic_snippets.snip";
-  private static final String SNIPPETS_CSPROJ_TEMPLATE_FILENAME =
-      "csharp/gapic_snippets_csproj.snip";
 
   private static final CSharpAliasMode ALIAS_MODE = CSharpAliasMode.MessagesOnly;
 
@@ -88,9 +86,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer<Pr
       csharpCommonTransformer.addCommonImports(context);
       context.getImportTypeTable().saveNicknameFor("Google.Protobuf.Bytestring");
       context.getImportTypeTable().saveNicknameFor("System.Linq.__import__");
-      SnippetsFileView snippets = generateSnippets(context);
       surfaceDocs.add(generateSnippets(context));
-      surfaceDocs.add(generateSnippetsCsProj(context));
     }
 
     return surfaceDocs;
@@ -98,27 +94,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer<Pr
 
   @Override
   public List<String> getTemplateFileNames() {
-    return Arrays.asList(SNIPPETS_TEMPLATE_FILENAME, SNIPPETS_CSPROJ_TEMPLATE_FILENAME);
-  }
-
-  private SnippetsFileView generateSnippetsCsProj(GapicInterfaceContext context) {
-    SurfaceNamer namer = context.getNamer();
-    String name = namer.getApiSnippetsClassName(context.getInterfaceConfig());
-    SnippetsFileView.Builder snippetsBuilder = SnippetsFileView.newBuilder();
-    GapicProductConfig productConfig = context.getProductConfig();
-
-    snippetsBuilder.templateFileName(SNIPPETS_CSPROJ_TEMPLATE_FILENAME);
-    String outputPath =
-        pathMapper.getOutputPath(context.getInterface().getFullName(), context.getProductConfig());
-    snippetsBuilder.outputPath(
-        outputPath + File.separator + productConfig.getPackageName() + ".Snippets.csproj");
-    snippetsBuilder.name(name);
-    snippetsBuilder.snippetMethods(new ArrayList<StaticLangApiMethodSnippetView>());
-
-    // must be done as the last step to catch all imports
-    snippetsBuilder.fileHeader(fileHeaderTransformer.generateFileHeader(context));
-
-    return snippetsBuilder.build();
+    return Arrays.asList(SNIPPETS_TEMPLATE_FILENAME);
   }
 
   private SnippetsFileView generateSnippets(GapicInterfaceContext context) {

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicUnitTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicUnitTestTransformer.java
@@ -57,8 +57,6 @@ import java.util.List;
 public class CSharpGapicUnitTestTransformer implements ModelToViewTransformer<ProtoApiModel> {
 
   private static final String UNITTEST_SNIPPETS_TEMPLATE_FILENAME = "csharp/gapic_unittest.snip";
-  private static final String UNITTEST_CSPROJ_TEMPLATE_FILENAME =
-      "csharp/gapic_unittest_csproj.snip";
 
   private static final CSharpAliasMode ALIAS_MODE = CSharpAliasMode.MessagesOnly;
 
@@ -97,7 +95,6 @@ public class CSharpGapicUnitTestTransformer implements ModelToViewTransformer<Pr
         typeTable.saveNicknameFor("Google.LongRunning.Operations");
       }
       surfaceDocs.add(generateUnitTest(context));
-      surfaceDocs.add(generateUnitTestCsproj(context));
     }
 
     return surfaceDocs;
@@ -105,18 +102,7 @@ public class CSharpGapicUnitTestTransformer implements ModelToViewTransformer<Pr
 
   @Override
   public List<String> getTemplateFileNames() {
-    return Arrays.asList(UNITTEST_SNIPPETS_TEMPLATE_FILENAME, UNITTEST_CSPROJ_TEMPLATE_FILENAME);
-  }
-
-  private ClientTestFileView generateUnitTestCsproj(GapicInterfaceContext context) {
-    ClientTestFileView.Builder builder = generateUnitTestBuilder(context);
-    GapicProductConfig productConfig = context.getProductConfig();
-    String outputPath =
-        pathMapper.getOutputPath(context.getInterface().getFullName(), productConfig);
-    builder.outputPath(
-        outputPath + File.separator + productConfig.getPackageName() + ".Tests.csproj");
-    builder.templateFileName(UNITTEST_CSPROJ_TEMPLATE_FILENAME);
-    return builder.build();
+    return Arrays.asList(UNITTEST_SNIPPETS_TEMPLATE_FILENAME);
   }
 
   private ClientTestFileView generateUnitTest(GapicInterfaceContext context) {

--- a/src/test/java/com/google/api/codegen/GapicTestBase2.java
+++ b/src/test/java/com/google/api/codegen/GapicTestBase2.java
@@ -23,6 +23,7 @@ import com.google.api.codegen.config.DependenciesConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.PackagingConfig;
+import com.google.api.codegen.gapic.ArtifactFlags;
 import com.google.api.codegen.gapic.GapicGeneratorFactory;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.Model;
@@ -123,14 +124,12 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
     Model model = Model.create(Service.getDefaultInstance());
     GapicProductConfig productConfig = GapicProductConfig.createDummyInstance();
     PackageMetadataConfig packageConfig = PackageMetadataConfig.createDummyPackageMetadataConfig();
+    ArtifactFlags artifactFlags =
+        new ArtifactFlags(
+            Arrays.asList("surface", "test", "samples"), ArtifactType.LEGACY_GAPIC_AND_PACKAGE);
 
     List<CodeGenerator<?>> generators =
-        GapicGeneratorFactory.create(
-            language,
-            model,
-            productConfig,
-            packageConfig,
-            Arrays.asList("surface", "test", "samples"));
+        GapicGeneratorFactory.create(language, model, productConfig, packageConfig, artifactFlags);
 
     List<String> snippetNames = new ArrayList<>();
     for (CodeGenerator<?> generator : generators) {
@@ -171,10 +170,11 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
     if (hasSmokeTestConfig(productConfig)) {
       enabledArtifacts.addAll(Arrays.asList("surface", "test", "samples"));
     }
+    ArtifactFlags artifactFlags =
+        new ArtifactFlags(enabledArtifacts, ArtifactType.LEGACY_GAPIC_AND_PACKAGE);
 
     List<CodeGenerator<?>> generators =
-        GapicGeneratorFactory.create(
-            language, model, productConfig, packageConfig, enabledArtifacts);
+        GapicGeneratorFactory.create(language, model, productConfig, packageConfig, artifactFlags);
 
     // Don't run any generators we're not testing.
     ArrayList<CodeGenerator<?>> testedGenerators = new ArrayList<>();

--- a/src/test/java/com/google/api/codegen/gapic/GapicGeneratorAppTest.java
+++ b/src/test/java/com/google/api/codegen/gapic/GapicGeneratorAppTest.java
@@ -17,6 +17,7 @@ package com.google.api.codegen.gapic;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.api.codegen.ArtifactType;
 import com.google.api.tools.framework.snippet.Doc;
 import com.google.api.tools.framework.tools.ToolOptions;
 import com.google.common.collect.Maps;
@@ -41,7 +42,8 @@ public class GapicGeneratorAppTest {
 
     // Verify that files are outputed to a directory.
     String outputDir = tempDir.getRoot().getPath();
-    GapicGeneratorApp generator = new GapicGeneratorApp(ToolOptions.create());
+    GapicGeneratorApp generator =
+        new GapicGeneratorApp(ToolOptions.create(), ArtifactType.LEGACY_GAPIC_AND_PACKAGE);
     generator.writeCodeGenOutput(outputFiles, outputDir);
     generator.setOutputFilesPermissions(Collections.singleton("tmp3"), outputDir);
     assertTrue((new File(outputDir, "tmp.txt")).exists());


### PR DESCRIPTION
This enables a command like this:

```
java -cp ../gapic-generator/build/libs/gapic-generator-latest-fatjar.jar \
  com.google.api.codegen.GeneratorMain GAPIC_CODE \
  --descriptor_set=artman-genfiles/google-cloud-pubsub-v1.desc \
  --output=artman-genfiles/csharp/google-cloud-pubsub \
  --language=csharp \
  --service_yaml=google/pubsub/pubsub.yaml \
  --gapic_yaml=google/pubsub/v1/pubsub_gapic.yaml
```

This will only output code files (*.cs), omitting *.csproj files. 

To output only *.csproj files, use GAPIC_PACKAGE instead of GAPIC_CODE. 
