### PR TITLE
Updated to latest ruby GAX

### DIFF
--- a/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
+++ b/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
@@ -47,7 +47,7 @@ gax_version:
   php:
     lower: '0.32.0'
   ruby:
-    lower: '1.0'
+    lower: '1.3'
   java:
     lower: '1.27.0'
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -4811,7 +4811,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 0.8.0"
+  gem.add_dependency "google-gax", "~> 1.3"
   gem.add_dependency "google-some-other-package-v1", "~> 0.2.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -646,7 +646,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 0.8.0"
+  gem.add_dependency "google-gax", "~> 1.3"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rubocop", "~> 0.50.0"

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -501,7 +501,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 0.8.0"
+  gem.add_dependency "google-gax", "~> 1.3"
   gem.add_dependency "google-some-other-package-v1", "~> 0.2.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/src/test/java/com/google/api/codegen/testsrc/frozen_dependencies.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/frozen_dependencies.yaml
@@ -18,7 +18,7 @@ gax_version:
   php:
     lower: '0.6.*'
   ruby:
-    lower: '0.8.0'
+    lower: '1.3'
   java:
     lower: '1.0.0'
 


### PR DESCRIPTION
Changed GAX dependency to use the latest release. Does this require any updates in artman? I'm not sure how the `frozen_dependencies.yaml` works, which seems to control the output for the tests.

resolves #2133