### PR TITLE
Revert PR #2083 (default STATIC_TYPES in configgen)

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/mergers/MethodMerger.java
+++ b/src/main/java/com/google/api/codegen/configgen/mergers/MethodMerger.java
@@ -125,16 +125,7 @@ public class MethodMerger {
     ConfigNode prevNode = generateField(nameNode, method);
     prevNode = pageStreamingMerger.generatePageStreamingNode(prevNode, method);
     prevNode = retryMerger.generateRetryNamesNode(prevNode, method);
-    ConfigNode fieldNamePatternsNode =
-        generateFieldNamePatterns(prevNode, method, collectionNameMap);
-    if (fieldNamePatternsNode != prevNode) {
-      prevNode = fieldNamePatternsNode;
-      ConfigNode resourceNameTreatmentNode =
-          FieldConfigNode.createStringPair(
-              NodeFinder.getNextLine(prevNode), "resource_name_treatment", "STATIC_TYPES");
-      prevNode.insertNext(resourceNameTreatmentNode);
-    }
-    prevNode = fieldNamePatternsNode;
+    prevNode = generateFieldNamePatterns(prevNode, method, collectionNameMap);
     generateTimeout(prevNode, method);
     return methodNode;
   }

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -168,7 +168,6 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: ListShelves
     request_object_method: true
     page_streaming:
@@ -202,7 +201,6 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: MergeShelves
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -224,7 +222,6 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: CreateBook
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -246,7 +243,6 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: PublishSeries
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -287,7 +283,6 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: ListBooks
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -316,7 +311,6 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: DeleteBook
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -336,7 +330,6 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: UpdateBook
     # FIXME: Configure which fields are required.
     required_fields:
@@ -354,7 +347,6 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: MoveBook
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -376,7 +368,6 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: ListStrings
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -422,7 +413,6 @@ interfaces:
       name: book_shelf
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: GetBookFromArchive
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -442,7 +432,6 @@ interfaces:
       name: book
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: GetBookFromAnywhere
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -464,7 +453,6 @@ interfaces:
       name: book_path
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: GetBookFromAbsolutelyAnywhere
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -484,7 +472,6 @@ interfaces:
       name: book
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: UpdateBookIndex
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -508,7 +495,6 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: StreamShelves
     request_object_method: false
     # FIXME: Configure the retryable codes for this method.
@@ -619,7 +605,6 @@ interfaces:
       resource: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: GetBigBook
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -639,7 +624,6 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: GetBigNothing
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -659,7 +643,6 @@ interfaces:
       name: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: TestOptionalRequiredFlatteningParams
     # FIXME: Configure which fields are required.
     required_fields:
@@ -749,4 +732,3 @@ interfaces:
       resource: book_2
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES

--- a/src/test/java/com/google/api/codegen/testdata/longrunning_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/longrunning_config.baseline
@@ -165,7 +165,6 @@ interfaces:
       name: operation_path
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: DeleteOperation
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -185,7 +184,6 @@ interfaces:
       name: operation_path
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES
   - name: CancelOperation
     # FIXME: Configure which groups of fields should be flattened into method
     # params.
@@ -205,4 +203,3 @@ interfaces:
       name: operation_path
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-    resource_name_treatment: STATIC_TYPES


### PR DESCRIPTION
Reverts https://github.com/googleapis/gapic-generator/pull/2083, which had broke smoke test generation in artman.