### PR TITLE
Update gax and common-protos generated versions

### DIFF
--- a/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
+++ b/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
@@ -49,17 +49,17 @@ gax_version:
   ruby:
     lower: '1.3'
   java:
-    lower: '1.27.0'
+    lower: '1.29.0'
 
 gax_grpc_version:
   csharp:
     lower: '2.3.0'
   java:
-    lower: '1.27.0'
+    lower: '1.29.0'
 
 gax_http_version:
   java:
-    lower: '0.44.0'
+    lower: '0.46.0'
 
 proto_version:
   python:
@@ -87,7 +87,7 @@ google-common-protos_version:
     name_override: googleapis-common-protos
     lower: '1.3.1'
   java:
-    lower: '1.11.0'
+    lower: '1.12.0'
 
 google-iam-v1_version:
   csharp:


### PR DESCRIPTION
The version of google-common-protos has been bumped to 1.2 in google-cloud-java.

~The gax-java versions will be bumped in https://github.com/GoogleCloudPlatform/google-cloud-java/pull/3439 (should wait for this to pass first).~ CI passed