### PR TITLE
Fix version regex and use lowercase symbols for versions

### DIFF
--- a/src/main/java/com/google/api/codegen/ruby/RubyUtil.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyUtil.java
@@ -22,7 +22,8 @@ import java.util.regex.Pattern;
 public class RubyUtil {
   private static final String LONGRUNNING_PACKAGE_NAME = "Google::Longrunning";
 
-  private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("(.+?)::([vV][0-9]+)(::.*)?");
+  private static final Pattern IDENTIFIER_PATTERN =
+      Pattern.compile("(.+?)::([vV][\\D]*[0-9]+)(::.*)?");
 
   public static boolean isLongrunning(String packageName) {
     return packageName.equals(LONGRUNNING_PACKAGE_NAME);

--- a/src/main/java/com/google/api/codegen/util/CommonRenderingUtil.java
+++ b/src/main/java/com/google/api/codegen/util/CommonRenderingUtil.java
@@ -112,9 +112,4 @@ public class CommonRenderingUtil {
   public static int toInt(String value) {
     return Integer.valueOf(value);
   }
-
-  /** Returns the lowercase version of the given text */
-  public static String lowercase(String value) {
-    return value.toLowerCase();
-  }
 }

--- a/src/main/java/com/google/api/codegen/util/CommonRenderingUtil.java
+++ b/src/main/java/com/google/api/codegen/util/CommonRenderingUtil.java
@@ -112,4 +112,9 @@ public class CommonRenderingUtil {
   public static int toInt(String value) {
     return Integer.valueOf(value);
   }
+
+  /** Returns the lowercase version of the given text */
+  public static String lowercase(String value) {
+    return value.toLowerCase();
+  }
 }

--- a/src/main/resources/com/google/api/codegen/ruby/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/method_sample.snip
@@ -26,7 +26,7 @@
   @case "Longrunning"
     {@apiMethod.apiVariableName} = {@apiMethod.versionAliasedApiClassName}.new
   @default
-    {@apiMethod.apiVariableName} = {@apiMethod.topLevelAliasedApiClassName}.new(version: :{@util.lowercase(apiMethod.apiVersion)})
+    {@apiMethod.apiVariableName} = {@apiMethod.topLevelAliasedApiClassName}.new(version: :{@apiMethod.apiVersion.toLowerCase})
   @end
 
   {@sampleCodeCore(apiMethod)}

--- a/src/main/resources/com/google/api/codegen/ruby/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/method_sample.snip
@@ -26,7 +26,7 @@
   @case "Longrunning"
     {@apiMethod.apiVariableName} = {@apiMethod.versionAliasedApiClassName}.new
   @default
-    {@apiMethod.apiVariableName} = {@apiMethod.topLevelAliasedApiClassName}.new(version: :{@apiMethod.apiVersion})
+    {@apiMethod.apiVariableName} = {@apiMethod.topLevelAliasedApiClassName}.new(version: :{@util.lowercase(apiMethod.apiVersion)})
   @end
 
   {@sampleCodeCore(apiMethod)}

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -781,7 +781,7 @@ module Library
   # ```rb
   # require "library"
   #
-  # library_service_client = Library.new(version: :V1)
+  # library_service_client = Library.new(version: :v1)
   # formatted_name = Library::V1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
   # optional_foo = ''
   # rating = :GOOD
@@ -3215,7 +3215,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #
       #   # TODO: Initialize +shelf+:
       #   shelf = {}
@@ -3256,7 +3256,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #
       #   # TODO: Initialize +options_+:
@@ -3297,7 +3297,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #
       #   # Iterate over all results.
       #   library_service_client.list_shelves.each do |element|
@@ -3331,7 +3331,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   library_service_client.delete_shelf(formatted_name)
 
@@ -3366,7 +3366,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   response = library_service_client.merge_shelves(formatted_name, formatted_other_shelf_name)
@@ -3403,7 +3403,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #
       #   # TODO: Initialize +book+:
@@ -3452,7 +3452,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #
       #   # TODO: Initialize +shelf+:
       #   shelf = {}
@@ -3497,7 +3497,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   response = library_service_client.get_book(formatted_name)
 
@@ -3539,7 +3539,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   filter = "book-filter-string"
       #
@@ -3585,7 +3585,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   library_service_client.delete_book(formatted_name)
 
@@ -3630,7 +3630,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # TODO: Initialize +book+:
@@ -3673,7 +3673,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   response = library_service_client.move_book(formatted_name, formatted_other_shelf_name)
@@ -3715,7 +3715,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #
       #   # Iterate over all results.
       #   library_service_client.list_strings.each do |element|
@@ -3759,7 +3759,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   comment = ''
       #   stage = :UNSET
@@ -3801,7 +3801,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
       #   response = library_service_client.get_book_from_archive(formatted_name)
 
@@ -3834,7 +3834,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   response = library_service_client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
@@ -3867,7 +3867,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   response = library_service_client.get_book_from_absolutely_anywhere(formatted_name)
 
@@ -3900,7 +3900,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   index_name = "default index"
       #
@@ -3938,7 +3938,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   library_service_client.stream_shelves.each do |element|
       #     # Process element.
       #   end
@@ -3963,7 +3963,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #
       #   # TODO: Initialize +name+:
       #   name = ''
@@ -4002,7 +4002,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #
       #   # TODO: Initialize +name+:
       #   name = ''
@@ -4038,7 +4038,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #
       #   # TODO: Initialize +name+:
       #   name = ''
@@ -4076,7 +4076,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #
       #   # TODO: Initialize +names_element+:
       #   names_element = ''
@@ -4132,7 +4132,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # TODO: Initialize +tag+:
@@ -4171,7 +4171,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # TODO: Initialize +label+:
@@ -4203,7 +4203,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # Register a callback during the method call.
@@ -4263,7 +4263,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # Register a callback during the method call.
@@ -4390,7 +4390,7 @@ module Library
       # @example
       #   require "library"
       #
-      #   library_service_client = Library.new(version: :V1)
+      #   library_service_client = Library.new(version: :v1)
       #
       #   # TODO: Initialize +required_singular_int32+:
       #   required_singular_int32 = 0

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -1103,7 +1103,7 @@ module Google
           # @example
           #   require "google/example"
           #
-          #   decrementer_service_client = Google::Example::Decrementer.new(version: :V1)
+          #   decrementer_service_client = Google::Example::Decrementer.new(version: :v1)
           #   decrementer_service_client.decrement
 
           def decrement options: nil, &block
@@ -1462,7 +1462,7 @@ module Google
           # @example
           #   require "google/example"
           #
-          #   incrementer_service_client = Google::Example::Incrementer.new(version: :V1)
+          #   incrementer_service_client = Google::Example::Incrementer.new(version: :v1)
           #   incrementer_service_client.increment
 
           def increment options: nil, &block


### PR DESCRIPTION
Fixes #2143 by updating the version regular expressions so it matches versions like "v1beta1" instead of only matching "v1". Also, update the version symbols used in the examples to be lower case.