### PR TITLE
prune some dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,10 +66,8 @@ ext {
     commonProtos: 'com.google.api.grpc:grpc-google-common-protos:1.0.5',
     commonsLang: 'org.apache.commons:commons-lang3:3.6',
     commonsCli: 'commons-cli:commons-cli:1.4',
-    grpcCore: 'io.grpc:grpc-core:1.0.1',
     gson: 'com.google.code.gson:gson:2.3',
     guava: 'com.google.guava:guava:25.0-jre',
-    guice: 'com.google.inject:guice:4.0',
     jacksonAnnotations: 'com.fasterxml.jackson.core:jackson-annotations:2.9.0',
     jacksonCore: 'com.fasterxml.jackson.core:jackson-core:2.9.0',
     jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.9.0',
@@ -89,7 +87,7 @@ ext {
     protoc:  'com.google.protobuf:protoc:' + protoVersion,
 
     // Formatter
-    javaFomatter: 'com.google.googlejavaformat:google-java-format:1.1'
+    javaFormatter: 'com.google.googlejavaformat:google-java-format:1.6'
   ]
 }
 
@@ -105,13 +103,12 @@ dependencies {
     libraries.commonmark,
     libraries.commonsCli,
     libraries.commonsLang,
-    libraries.grpcCore,
     libraries.gson,
     libraries.guava,
     libraries.jacksonAnnotations,
     libraries.jacksonCore,
     libraries.jacksonDatabind,
-    libraries.javaFomatter,
+    libraries.javaFormatter,
     libraries.jsr305,
     libraries.protobuf,
     libraries.snakeyaml,


### PR DESCRIPTION
Newer versions of java formatter reduces the number of dependencies they
need. This should reduce CI run time.