### PR TITLE
Fix version regex

### DIFF
--- a/src/main/java/com/google/api/codegen/ruby/RubyUtil.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyUtil.java
@@ -22,8 +22,7 @@ import java.util.regex.Pattern;
 public class RubyUtil {
   private static final String LONGRUNNING_PACKAGE_NAME = "Google::Longrunning";
 
-  private static final Pattern IDENTIFIER_PATTERN =
-      Pattern.compile("(.+?)::([vV][\\D]*[0-9]+)(::.*)?");
+  private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("(.+?)::([vV].*[0-9]+)(::.*)?");
 
   public static boolean isLongrunning(String packageName) {
     return packageName.equals(LONGRUNNING_PACKAGE_NAME);


### PR DESCRIPTION
#2146 did not properly update the regex. Second correction to allow for versions like "V2beta2" vs "V2". 

fixes #2143