### PR TITLE
Ensure version number only is captured by second group

### DIFF
--- a/src/main/java/com/google/api/codegen/ruby/RubyUtil.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyUtil.java
@@ -22,7 +22,8 @@ import java.util.regex.Pattern;
 public class RubyUtil {
   private static final String LONGRUNNING_PACKAGE_NAME = "Google::Longrunning";
 
-  private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("(.+?)::([vV].*[0-9]+)(::.*)?");
+  private static final Pattern IDENTIFIER_PATTERN =
+      Pattern.compile("(.+?)::([vV][^:]*[0-9]+)(::.*)?");
 
   public static boolean isLongrunning(String packageName) {
     return packageName.equals(LONGRUNNING_PACKAGE_NAME);

--- a/src/test/java/com/google/api/codegen/ruby/RubyUtilTest.java
+++ b/src/test/java/com/google/api/codegen/ruby/RubyUtilTest.java
@@ -76,4 +76,24 @@ public class RubyUtilTest {
             ImmutableList.of("Lorem ipsum dolor sit amet", " ", "consectetur adipiscing elit"));
     Truth.assertThat(sentence).isEqualTo("Lorem ipsum dolor sit amet");
   }
+
+  @Test
+  public void testHasMajorVersion() {
+    Truth.assertThat(RubyUtil.hasMajorVersion("One::Two::Three::V1")).isTrue();
+  }
+
+  @Test
+  public void testHasMajorVersion_notVersion() {
+    Truth.assertThat(RubyUtil.hasMajorVersion("One::Two::Three::Version")).isFalse();
+  }
+
+  @Test
+  public void testHasMajorVersion_pointVersion() {
+    Truth.assertThat(RubyUtil.hasMajorVersion("One::Two::Three::V1p2beta4")).isTrue();
+  }
+
+  @Test
+  public void testHasMajorVersion_alphaVersion() {
+    Truth.assertThat(RubyUtil.hasMajorVersion("One::Two::Three::V9alpha4")).isTrue();
+  }
 }


### PR DESCRIPTION
#2146 and #2153 both updated the regex used for identifying the version component of namespaces in the templates, but the first was too narrow and the second was too broad (https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/2197).

This change should cause `one::two::version::v1` to have a top level namespace of `one::two::version` instead of `one::two`.