### PR TITLE
Ruby: Fix a bug where where the top level entry did not work

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -104,7 +104,7 @@
     AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
       .select { |file| File.directory?(file) }
       .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
-      .select { |dir| File.exist?(dir + "{@index.postVersionDirPath}.rb") }
+      .select { |dir| File.exist?(File.join(dir, "{@index.postVersionDirPath}.rb")) }
       .map { |dir| File.basename(dir) }
 
   @default

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -672,7 +672,7 @@ module Library
   AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
     .select { |file| File.directory?(file) }
     .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
-    .select { |dir| File.exist?(dir + ".rb") }
+    .select { |dir| File.exist?(File.join(dir, ".rb")) }
     .map { |dir| File.basename(dir) }
 
   ##

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -589,7 +589,7 @@ module Google
     AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
       .select { |file| File.directory?(file) }
       .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
-      .select { |dir| File.exist?(dir + "foo.rb") }
+      .select { |dir| File.exist?(File.join(dir, "foo.rb")) }
       .map { |dir| File.basename(dir) }
 
     module Incrementer


### PR DESCRIPTION
The original implementation assumed that the dir would end with a '/' but sometimes it doesn't depending on the system. By using the `File.join`, assumption will no longer be needed.