### PR TITLE
Enable naive server streaming retries.

### DIFF
--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangStubSettingsView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangStubSettingsView.java
@@ -51,15 +51,13 @@ public abstract class StaticLangStubSettingsView {
     return unaryCallSettings;
   }
 
-  /**
-   * ApiCalls that send exactly one request. This includes unary and server streaming apis.
-   */
+  /** ApiCalls that send exactly one request. This includes unary and server streaming apis. */
   public List<ApiCallSettingsView> unaryRequestCallSettings() {
     ArrayList<ApiCallSettingsView> retryableCallSettings = new ArrayList<>();
     for (ApiCallSettingsView settingsView : callSettings()) {
       if (settingsView.type().serviceMethodType() == ServiceMethodType.UnaryMethod
           || settingsView.type().serviceMethodType()
-          == ServiceMethodType.GrpcServerStreamingMethod) {
+              == ServiceMethodType.GrpcServerStreamingMethod) {
         retryableCallSettings.add(settingsView);
       }
     }

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangStubSettingsView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangStubSettingsView.java
@@ -52,7 +52,7 @@ public abstract class StaticLangStubSettingsView {
   }
 
   /** ApiCalls that send exactly one request. This includes unary and server streaming apis. */
-  public List<ApiCallSettingsView> unaryRequestCallSettings() {
+  public List<ApiCallSettingsView> singleRequestRpcCallSettings() {
     ArrayList<ApiCallSettingsView> retryableCallSettings = new ArrayList<>();
     for (ApiCallSettingsView settingsView : callSettings()) {
       if (settingsView.type().serviceMethodType() == ServiceMethodType.UnaryMethod

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangStubSettingsView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangStubSettingsView.java
@@ -51,6 +51,21 @@ public abstract class StaticLangStubSettingsView {
     return unaryCallSettings;
   }
 
+  /**
+   * ApiCalls that send exactly one request. This includes unary and server streaming apis.
+   */
+  public List<ApiCallSettingsView> unaryRequestCallSettings() {
+    ArrayList<ApiCallSettingsView> retryableCallSettings = new ArrayList<>();
+    for (ApiCallSettingsView settingsView : callSettings()) {
+      if (settingsView.type().serviceMethodType() == ServiceMethodType.UnaryMethod
+          || settingsView.type().serviceMethodType()
+          == ServiceMethodType.GrpcServerStreamingMethod) {
+        retryableCallSettings.add(settingsView);
+      }
+    }
+    return retryableCallSettings;
+  }
+
   public List<ApiCallSettingsView> longRunningCallSettings() {
     ArrayList<ApiCallSettingsView> unaryCallSettings = new ArrayList<>();
     for (ApiCallSettingsView settingsView : callSettings()) {

--- a/src/main/resources/com/google/api/codegen/java/stub_settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/stub_settings.snip
@@ -507,7 +507,7 @@
   }
 
   private static Builder initDefaults(Builder builder) {
-    @join settings : xsettingsClass.unaryRequestCallSettings
+    @join settings : xsettingsClass.singleRequestRpcCallSettings
       {@""}
       # batching settings
       @switch settings.type

--- a/src/main/resources/com/google/api/codegen/java/stub_settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/stub_settings.snip
@@ -507,7 +507,7 @@
   }
 
   private static Builder initDefaults(Builder builder) {
-    @join settings : xsettingsClass.unaryCallSettings
+    @join settings : xsettingsClass.unaryRequestCallSettings
       {@""}
       # batching settings
       @switch settings.type

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -6870,6 +6870,14 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.streamShelvesSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.streamBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       builder.findRelatedBooksSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));


### PR DESCRIPTION
This enables retries that were added to gax in
https://github.com/googleapis/gax-java/pull/463.
Server streaming api can be treated the same as unary apis before the
first response is received. Allowing GAPIC clients to automatically
retry RPCs. This PR exposes the retry settings that were configured in
gapic yaml file to the java stub settings.

This will affect the codegen for 3 clients:
- firestore - will enable retries for batchGetDocuments & runQuery.
  Which will bring its behavior closer to the golang client
- bigtable - the handwritten overlay will overwrite these settings
- spanner - doesn't currently use gapic client, so will ignore the new
  settings

ping @schmidt-sebastian (for firestore behavior change)