### PR TITLE
Improve page streaming heuristic

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/ProtoPageStreamingTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/ProtoPageStreamingTransformer.java
@@ -71,17 +71,14 @@ public class ProtoPageStreamingTransformer implements PageStreamingTransformer {
         continue;
       }
 
-      if (resourcesField != null) {
-        helper.error(
-            ((ProtoMethodModel) method).getProtoMethod().getLocation(),
-            "Page streaming resources field could not be heuristically determined for "
-                + "method '%s'%n",
-            method.getSimpleName());
-        return null;
-      }
-
-      resourcesField = field.getSimpleName();
+      return field.getSimpleName();
     }
-    return resourcesField;
+
+    helper.error(
+        ((ProtoMethodModel) method).getProtoMethod().getLocation(),
+        "Page streaming resources field could not be heuristically determined for "
+            + "method '%s'%n",
+        method.getSimpleName());
+    return null;
   }
 }

--- a/src/main/java/com/google/api/codegen/configgen/ProtoPageStreamingTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/ProtoPageStreamingTransformer.java
@@ -65,13 +65,11 @@ public class ProtoPageStreamingTransformer implements PageStreamingTransformer {
   }
 
   private String getResourcesFieldName(MethodModel method, ConfigHelper helper) {
-    String resourcesField = null;
     for (FieldModel field : method.getOutputFields()) {
-      if (!field.isRepeated()) {
-        continue;
+      // Return the first repeated field.
+      if (field.isRepeated()) {
+        return field.getSimpleName();
       }
-
-      return field.getSimpleName();
     }
 
     helper.error(


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator/issues/2090.

All current protos in googleapis follow a convention where the very first repeated field in a List[Resource]Response message is the page streaming object, so this PR uses that as a heuristic.

I've run this PR on all artman_*.yaml configs in googleapis that have a `gapic_config` target, and they all succeed. Therefore, this fixes https://circleci.com/gh/googleapis/googleapis/1312, where the `gapic_config` target fails on the monitoring API.
For whatever reason, this also fixes the `gapic_config` target for the bigtableadmin API that had been chronically failing in the googleapis smoke test (see it exempt from the smoke test [here](https://github.com/googleapis/artman/blob/e1fd2255ccfe8f500f2b0d4637e8f6278669590c/test/smoketest_artman.py#L42)).