### PR TITLE
"Parse" the whole init config left-to-right

### DIFF
--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -63,7 +63,7 @@ public class FieldStructureParser {
     return valueConfig;
   }
 
-  // Parses `pathconfig` to construct the `InitCodeNode` it specifies. `config` must be a valid
+  // Parses `config` to construct the `InitCodeNode` it specifies. `config` must be a valid
   // config
   // satisfying the eBNF grammar below:
   //
@@ -148,8 +148,7 @@ public class FieldStructureParser {
 
       // TODO(pongad): Quote the RHS of existing configs, and once that's done use 'parseValue' here
       // (`String valueString = parseValue(scanner)`). For now we are preserving the previous
-      // behavior,
-      // where everything on the right of the equal sign is a string.
+      // behavior, where everything on the right of the equal sign is a string.
       String valueString = config.substring(scanner.pos());
 
       if (valueString.contains(InitFieldConfig.RANDOM_TOKEN)) {

--- a/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
@@ -37,29 +37,19 @@ public abstract class InitFieldConfig {
   @Nullable
   public abstract InitValue value();
 
-  /*
-   * Parses the given config string and returns the corresponding object.
-   */
-  public static InitFieldConfig from(String initFieldConfigString) {
-    String fieldName = null;
-    String entityName = null;
-    InitValue value = null;
+  public static Builder newBuilder() {
+    return new AutoValue_InitFieldConfig.Builder();
+  }
 
-    String[] equalsParts = initFieldConfigString.split("[=]");
-    if (equalsParts.length > 2) {
-      throw new IllegalArgumentException("Inconsistent: found multiple '=' characters");
-    } else if (equalsParts.length == 2) {
-      value = parseValueString(equalsParts[1]);
-    }
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder fieldPath(String val);
 
-    String[] fieldSpecs = equalsParts[0].split("[%]");
-    fieldName = fieldSpecs[0];
-    if (fieldSpecs.length == 2) {
-      entityName = fieldSpecs[1];
-    } else if (fieldSpecs.length > 2) {
-      throw new IllegalArgumentException("Inconsistent: found multiple '%' characters");
-    }
-    return new AutoValue_InitFieldConfig(fieldName, entityName, value);
+    public abstract Builder entityName(String val);
+
+    public abstract Builder value(InitValue val);
+
+    public abstract InitFieldConfig build();
   }
 
   public boolean hasSimpleInitValue() {
@@ -72,19 +62,5 @@ public abstract class InitFieldConfig {
 
   public boolean hasFormattedInitValue() {
     return entityName() != null && value() != null;
-  }
-
-  private static InitValue parseValueString(String valueString) {
-    InitValue initValue = InitValue.createLiteral(valueString);
-    if (valueString.contains(RANDOM_TOKEN)) {
-      initValue = InitValue.createRandom(valueString);
-    } else if (valueString.contains(PROJECT_ID_TOKEN)) {
-      if (!valueString.equals(PROJECT_ID_TOKEN)) {
-        throw new IllegalArgumentException("Inconsistent: found project ID as a substring ");
-      }
-      valueString = PROJECT_ID_VARIABLE_NAME;
-      initValue = InitValue.createVariable(valueString);
-    }
-    return initValue;
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -29,6 +29,7 @@ import com.google.api.codegen.transformer.ImportTypeTable;
 import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.ModelTypeFormatterImpl;
 import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.util.CommonRenderingUtil;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
 import com.google.api.codegen.util.go.GoCommentReformatter;
@@ -441,7 +442,11 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String injectRandomStringGeneratorCode(String randomString) {
-    return randomString.replace(
-        InitFieldConfig.RANDOM_TOKEN, "\" + strconv.FormatInt(time.Now().UnixNano(), 10) + \"");
+    randomString =
+        CommonRenderingUtil.stripQuotes(randomString)
+            .replace(
+                InitFieldConfig.RANDOM_TOKEN,
+                "\" + strconv.FormatInt(time.Now().UnixNano(), 10) + \"");
+    return "\"" + randomString + "\"";
   }
 }

--- a/src/main/java/com/google/api/codegen/util/Scanner.java
+++ b/src/main/java/com/google/api/codegen/util/Scanner.java
@@ -176,6 +176,10 @@ public class Scanner {
     return input;
   }
 
+  public int pos() {
+    return loc;
+  }
+
   private static boolean digit(int codePoint) {
     return codePoint >= '0' && codePoint <= '9';
   }


### PR DESCRIPTION
This will let us incrementally create initialization tree later.
The tree-descending code can then be used to work with sample
parameters.

The use of field name as a map key is regrettable. This can be fixed
later.

The RHS being arbitrary string is also regrettable. We'll migrate
slowly.