### PR TITLE
Initialize init tree forward

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ ext {
     commonsLang: 'org.apache.commons:commons-lang3:3.6',
     commonsCli: 'commons-cli:commons-cli:1.4',
     gson: 'com.google.code.gson:gson:2.3',
-    guava: 'com.google.guava:guava:25.0-jre',
+    guava: 'com.google.guava:guava:26.0-jre',
     jacksonAnnotations: 'com.fasterxml.jackson.core:jackson-annotations:2.9.0',
     jacksonCore: 'com.fasterxml.jackson.core:jackson-core:2.9.0',
     jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.9.0',
@@ -78,7 +78,8 @@ ext {
     // Testing
     junit: 'junit:junit:4.12',
     mockito: 'org.mockito:mockito-core:2.+',
-    truth: 'com.google.truth:truth:0.40',
+    truth: 'com.google.truth:truth:0.42',
+    truth8: 'com.google.truth.extensions:truth-java8-extension:0.42',
     toolsFxTesting: 'com.google.api:api-compiler:0.0.6:testing',
     junitParams: 'pl.pragmatists:JUnitParams:1.1.1',
 
@@ -117,6 +118,7 @@ dependencies {
 
   testCompile libraries.junit,
     libraries.truth,
+    libraries.truth8,
     libraries.toolsFxTesting,
     libraries.mockito,
     libraries.commonProtos,

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -141,7 +141,7 @@ public class FieldStructureParser {
 
   /**
    * Parses the path found in {@code scanner} and descend the tree rooted at {@code root}. If
-   * children specified by the path does not exist, they are created.
+   * children specified by the path do not exist, they are created.
    */
   private static InitCodeNode parsePath(InitCodeNode root, Scanner scanner) {
     Preconditions.checkArgument(

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -28,10 +28,12 @@ import java.util.Map;
 public class FieldStructureParser {
   private static final String PROJECT_ID_TOKEN = "$PROJECT_ID";
 
+  /** Update {@code root} with configuration in {@code initFieldConfigString}. */
   public static void parse(InitCodeNode root, String initFieldConfigString) {
     parse(root, initFieldConfigString, ImmutableMap.<String, InitValueConfig>of());
   }
 
+  /** Update {@code root} with configuration in {@code initFieldConfigString}. */
   public static void parse(
       InitCodeNode root,
       String initFieldConfigString,
@@ -84,14 +86,14 @@ public class FieldStructureParser {
     InitCodeNode parent = parsePath(root, scanner);
 
     int fieldNamePos = config.length();
-    int token = scanner.last();
+    int token = scanner.lastToken();
 
     String entityName = null;
     if (token == '%') {
       fieldNamePos = scanner.pos() - 1;
       Preconditions.checkArgument(
           scanner.scan() == Scanner.IDENT, "expected ident after '%': %s", config);
-      entityName = scanner.token();
+      entityName = scanner.tokenStr();
       token = scanner.scan();
     }
 
@@ -137,10 +139,14 @@ public class FieldStructureParser {
     return root;
   }
 
+  /**
+   * Parses the path found in {@code scanner} and descend the tree rooted at {@code root}. If
+   * children specified by the path does not exist, they are created.
+   */
   private static InitCodeNode parsePath(InitCodeNode root, Scanner scanner) {
     Preconditions.checkArgument(
         scanner.scan() == Scanner.IDENT, "expected root identifier: %s", scanner.input());
-    InitCodeNode parent = root.mergeChild(InitCodeNode.create(scanner.token()));
+    InitCodeNode parent = root.mergeChild(InitCodeNode.create(scanner.tokenStr()));
     int token;
 
     while (true) {
@@ -156,14 +162,14 @@ public class FieldStructureParser {
               "expected identifier after '.': %s",
               scanner.input());
           parent.setLineType(InitCodeLineType.StructureInitLine);
-          parent = parent.mergeChild(InitCodeNode.create(scanner.token()));
+          parent = parent.mergeChild(InitCodeNode.create(scanner.tokenStr()));
           break;
 
         case '[':
           Preconditions.checkArgument(
               scanner.scan() == Scanner.INT, "expected number after '[': %s", scanner.input());
           parent.setLineType(InitCodeLineType.ListInitLine);
-          parent = parent.mergeChild(InitCodeNode.create(scanner.token()));
+          parent = parent.mergeChild(InitCodeNode.create(scanner.tokenStr()));
 
           Preconditions.checkArgument(
               scanner.scan() == ']', "expected closing ']': %s", scanner.input());
@@ -190,6 +196,6 @@ public class FieldStructureParser {
         token == Scanner.INT || token == Scanner.IDENT || token == Scanner.STRING,
         "invalid value: %s",
         scanner.input());
-    return scanner.token();
+    return scanner.tokenStr();
   }
 }

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -66,8 +66,7 @@ public class FieldStructureParser {
   }
 
   // Parses `config` to construct the `InitCodeNode` it specifies. `config` must be a valid
-  // config
-  // satisfying the eBNF grammar below:
+  // config satisfying the eBNF grammar below:
   //
   // config = path ['%' ident] ['=' value];
   // path = ident pathElem*

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -131,11 +131,8 @@ public class FieldStructureParser {
                 .build(),
             initValueConfigMap);
     if (valueConfig != null) {
-      // System.err.println("old: " + parent.getInitValueConfig());
-      // System.err.println("new: " + valueConfig);
       parent.updateInitValueConfig(
           InitCodeNode.mergeInitValueConfig(parent.getInitValueConfig(), valueConfig));
-      // System.err.println("result: " + parent.getInitValueConfig());
       parent.setLineType(InitCodeLineType.SimpleInitLine);
     }
     return root;

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -28,15 +28,15 @@ import java.util.Map;
 public class FieldStructureParser {
   private static final String PROJECT_ID_TOKEN = "$PROJECT_ID";
 
-  public static InitCodeNode parse(InitCodeNode root, String initFieldConfigString) {
-    return parse(root, initFieldConfigString, ImmutableMap.<String, InitValueConfig>of());
+  public static void parse(InitCodeNode root, String initFieldConfigString) {
+    parse(root, initFieldConfigString, ImmutableMap.<String, InitValueConfig>of());
   }
 
-  public static InitCodeNode parse(
+  public static void parse(
       InitCodeNode root,
       String initFieldConfigString,
       Map<String, InitValueConfig> initValueConfigMap) {
-    return parseConfig(root, initFieldConfigString, initValueConfigMap);
+    parseConfig(root, initFieldConfigString, initValueConfigMap);
   }
 
   private static InitValueConfig createInitValueConfig(

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -25,11 +25,11 @@ import com.google.api.codegen.util.SymbolTable;
 import com.google.api.codegen.util.testing.TestValueGenerator;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -242,17 +242,10 @@ public class InitCodeNode {
 
   static InitValueConfig mergeInitValueConfig(
       InitValueConfig oldConfig, InitValueConfig newConfig) {
-    HashMap<String, InitValue> collectionValues = new HashMap<>();
     if (oldConfig.hasSimpleInitialValue()
         && newConfig.hasSimpleInitialValue()
         && !oldConfig.getInitialValue().equals(newConfig.getInitialValue())) {
       throw new IllegalArgumentException("Inconsistent init values");
-    }
-    if (oldConfig.hasFormattingConfigInitialValues()) {
-      collectionValues.putAll(oldConfig.getResourceNameBindingValues());
-    }
-    if (newConfig.hasFormattingConfigInitialValues()) {
-      collectionValues.putAll(newConfig.getResourceNameBindingValues());
     }
     return InitValueConfig.newBuilder()
         .setApiWrapperName(
@@ -261,7 +254,11 @@ public class InitCodeNode {
             firstNotNull(
                 oldConfig.getSingleResourceNameConfig(), newConfig.getSingleResourceNameConfig()))
         .setInitialValue(firstNotNull(oldConfig.getInitialValue(), newConfig.getInitialValue()))
-        .setResourceNameBindingValues(collectionValues)
+        .setResourceNameBindingValues(
+            ImmutableMap.<String, InitValue>builder()
+                .putAll(oldConfig.getResourceNameBindingValues())
+                .putAll(newConfig.getResourceNameBindingValues())
+                .build())
         .build();
   }
 
@@ -435,9 +432,5 @@ public class InitCodeNode {
    */
   private static void validateValue(TypeModel type, String value) {
     type.validateValue(value);
-  }
-
-  public String toString() {
-    return String.format("InitCodeNode{%s}", initValueConfig);
   }
 }

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -162,8 +162,9 @@ public class InitCodeNode {
     return new InitCodeNode("root", InitCodeLineType.StructureInitLine, InitValueConfig.create());
   }
 
-  /*
-   * Constructs a tree of objects to be initialized using the provided context, and returns the root.
+  /**
+   * Constructs a tree of objects to be initialized using the provided context, and returns the
+   * root.
    */
   public static InitCodeNode createTree(InitCodeContext context) {
     Preconditions.checkArgument(

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -206,7 +206,6 @@ public class InitCodeNode {
       initStack.addAll(node.children.values());
       initOrder.add(node);
     }
-    System.err.println("initOrder: " + Lists.reverse(initOrder));
     return Lists.reverse(initOrder);
   }
 
@@ -252,7 +251,22 @@ public class InitCodeNode {
     if (newConfig.hasFormattingConfigInitialValues()) {
       collectionValues.putAll(newConfig.getResourceNameBindingValues());
     }
-    return oldConfig.withInitialCollectionValues(collectionValues);
+    return InitValueConfig.newBuilder()
+        .setApiWrapperName(
+            firstNotNull(oldConfig.getApiWrapperName(), newConfig.getApiWrapperName()))
+        .setSingleResourceNameConfig(
+            firstNotNull(
+                oldConfig.getSingleResourceNameConfig(), newConfig.getSingleResourceNameConfig()))
+        .setInitialValue(firstNotNull(oldConfig.getInitialValue(), newConfig.getInitialValue()))
+        .setResourceNameBindingValues(collectionValues)
+        .build();
+  }
+
+  private static <T> T firstNotNull(T a, T b) {
+    if (a != null) {
+      return a;
+    }
+    return b;
   }
 
   private void resolveNamesAndTypes(

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -184,8 +184,6 @@ public class InitCodeNode {
 
     for (String initFieldConfigString : context.initFieldConfigStrings()) {
       FieldStructureParser.parse(root, initFieldConfigString, context.initValueConfigMap());
-      // root.mergeChild(
-      //     FieldStructureParser.parse(initFieldConfigString, context.initValueConfigMap()));
     }
 
     for (InitCodeNode node : context.additionalInitCodeNodes()) {
@@ -263,10 +261,7 @@ public class InitCodeNode {
   }
 
   private static <T> T firstNotNull(T a, T b) {
-    if (a != null) {
-      return a;
-    }
-    return b;
+    return a != null ? a : b;
   }
 
   private void resolveNamesAndTypes(

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -157,6 +157,10 @@ public class InitCodeNode {
     return InitCodeNode.createWithChildren(key, InitCodeLineType.ListInitLine, child);
   }
 
+  public static InitCodeNode newRoot() {
+    return new InitCodeNode("root", InitCodeLineType.StructureInitLine, InitValueConfig.create());
+  }
+
   /*
    * Constructs a tree of objects to be initialized using the provided context, and returns the root
    */
@@ -164,8 +168,7 @@ public class InitCodeNode {
     Preconditions.checkArgument(
         context.initFields() != null || context.outputType() != InitCodeOutputType.FieldList,
         "init field array is not set for flattened method");
-    InitCodeNode root =
-        new InitCodeNode("root", InitCodeLineType.StructureInitLine, InitValueConfig.create());
+    InitCodeNode root = newRoot();
 
     if (context.initFields() != null) {
       for (FieldModel field : context.initFields()) {

--- a/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
@@ -17,8 +17,6 @@ package com.google.api.codegen.metacode;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
-import java.util.HashMap;
-import java.util.Map;
 import javax.annotation.Nullable;
 
 /** InitValueConfig configures the initial value of an initialized variable. */
@@ -44,7 +42,7 @@ public abstract class InitValueConfig {
   public static InitValueConfig create(
       String apiWrapperName,
       SingleResourceNameConfig singleResourceNameConfig,
-      Map<String, InitValue> resourceNameBindingValues) {
+      ImmutableMap<String, InitValue> resourceNameBindingValues) {
     return newBuilder()
         .setApiWrapperName(apiWrapperName)
         .setSingleResourceNameConfig(singleResourceNameConfig)
@@ -61,7 +59,7 @@ public abstract class InitValueConfig {
   @Nullable
   public abstract InitValue getInitialValue();
 
-  public abstract Map<String, InitValue> getResourceNameBindingValues();
+  public abstract ImmutableMap<String, InitValue> getResourceNameBindingValues();
 
   public abstract Builder toBuilder();
 
@@ -77,21 +75,14 @@ public abstract class InitValueConfig {
 
     public abstract Builder setInitialValue(InitValue val);
 
-    public abstract Builder setResourceNameBindingValues(Map<String, InitValue> val);
+    public abstract Builder setResourceNameBindingValues(ImmutableMap<String, InitValue> val);
 
     public abstract InitValueConfig build();
   }
 
   /** Creates an updated InitValueConfig with the provided value. */
   public InitValueConfig withInitialCollectionValue(String entityName, InitValue value) {
-    HashMap<String, InitValue> resourceNameBindingValues = new HashMap<>();
-    resourceNameBindingValues.put(entityName, value);
-    return withInitialCollectionValues(resourceNameBindingValues);
-  }
-
-  public InitValueConfig withInitialCollectionValues(
-      Map<String, InitValue> resourceNameBindingValues) {
-    return toBuilder().setResourceNameBindingValues(resourceNameBindingValues).build();
+    return toBuilder().setResourceNameBindingValues(ImmutableMap.of(entityName, value)).build();
   }
 
   public boolean isEmpty() {
@@ -100,10 +91,6 @@ public abstract class InitValueConfig {
 
   public boolean hasFormattingConfig() {
     return getSingleResourceNameConfig() != null;
-  }
-
-  public boolean hasFormattingConfigInitialValues() {
-    return !getResourceNameBindingValues().isEmpty();
   }
 
   public boolean hasSimpleInitialValue() {

--- a/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.metacode;
 
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -60,13 +61,12 @@ public abstract class InitValueConfig {
   @Nullable
   public abstract InitValue getInitialValue();
 
-  @Nullable
   public abstract Map<String, InitValue> getResourceNameBindingValues();
 
   public abstract Builder toBuilder();
 
   public static Builder newBuilder() {
-    return new AutoValue_InitValueConfig.Builder();
+    return new AutoValue_InitValueConfig.Builder().setResourceNameBindingValues(ImmutableMap.of());
   }
 
   @AutoValue.Builder
@@ -89,6 +89,11 @@ public abstract class InitValueConfig {
     return withInitialCollectionValues(resourceNameBindingValues);
   }
 
+  public InitValueConfig withInitialCollectionValues(
+      Map<String, InitValue> resourceNameBindingValues) {
+    return toBuilder().setResourceNameBindingValues(resourceNameBindingValues).build();
+  }
+
   public boolean isEmpty() {
     return getSingleResourceNameConfig() == null;
   }
@@ -98,7 +103,7 @@ public abstract class InitValueConfig {
   }
 
   public boolean hasFormattingConfigInitialValues() {
-    return getResourceNameBindingValues() != null && !getResourceNameBindingValues().isEmpty();
+    return !getResourceNameBindingValues().isEmpty();
   }
 
   public boolean hasSimpleInitialValue() {

--- a/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
@@ -25,24 +25,30 @@ import javax.annotation.Nullable;
 public abstract class InitValueConfig {
 
   public static InitValueConfig create() {
-    return new AutoValue_InitValueConfig(null, null, null, null);
+    return newBuilder().build();
   }
 
   public static InitValueConfig createWithValue(InitValue value) {
-    return new AutoValue_InitValueConfig(null, null, value, null);
+    return newBuilder().setInitialValue(value).build();
   }
 
   public static InitValueConfig create(
       String apiWrapperName, SingleResourceNameConfig singleResourceNameConfig) {
-    return new AutoValue_InitValueConfig(apiWrapperName, singleResourceNameConfig, null, null);
+    return newBuilder()
+        .setApiWrapperName(apiWrapperName)
+        .setSingleResourceNameConfig(singleResourceNameConfig)
+        .build();
   }
 
   public static InitValueConfig create(
       String apiWrapperName,
       SingleResourceNameConfig singleResourceNameConfig,
       Map<String, InitValue> resourceNameBindingValues) {
-    return new AutoValue_InitValueConfig(
-        apiWrapperName, singleResourceNameConfig, null, resourceNameBindingValues);
+    return newBuilder()
+        .setApiWrapperName(apiWrapperName)
+        .setSingleResourceNameConfig(singleResourceNameConfig)
+        .setResourceNameBindingValues(resourceNameBindingValues)
+        .build();
   }
 
   @Nullable
@@ -57,17 +63,30 @@ public abstract class InitValueConfig {
   @Nullable
   public abstract Map<String, InitValue> getResourceNameBindingValues();
 
+  public abstract Builder toBuilder();
+
+  public static Builder newBuilder() {
+    return new AutoValue_InitValueConfig.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setApiWrapperName(String val);
+
+    public abstract Builder setSingleResourceNameConfig(SingleResourceNameConfig val);
+
+    public abstract Builder setInitialValue(InitValue val);
+
+    public abstract Builder setResourceNameBindingValues(Map<String, InitValue> val);
+
+    public abstract InitValueConfig build();
+  }
+
   /** Creates an updated InitValueConfig with the provided value. */
   public InitValueConfig withInitialCollectionValue(String entityName, InitValue value) {
     HashMap<String, InitValue> resourceNameBindingValues = new HashMap<>();
     resourceNameBindingValues.put(entityName, value);
     return withInitialCollectionValues(resourceNameBindingValues);
-  }
-
-  public InitValueConfig withInitialCollectionValues(
-      Map<String, InitValue> resourceNameBindingValues) {
-    return new AutoValue_InitValueConfig(
-        getApiWrapperName(), getSingleResourceNameConfig(), null, resourceNameBindingValues);
   }
 
   public boolean isEmpty() {

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -583,8 +583,7 @@ public class InitCodeTransformer {
           context
               .getTypeTable()
               .renderValueAsString("[" + Name.anyLower(entityName).toUpperUnderscore() + "]");
-      if (initValueConfig.hasFormattingConfigInitialValues()
-          && initValueConfig.getResourceNameBindingValues().containsKey(entityName)) {
+      if (initValueConfig.getResourceNameBindingValues().containsKey(entityName)) {
         InitValue initValue = initValueConfig.getResourceNameBindingValues().get(entityName);
         switch (initValue.getType()) {
           case Variable:

--- a/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
@@ -144,7 +144,7 @@ class OutputTransformer {
         context.getMethodModel().getSimpleName(),
         valueSet.getId(),
         definition.input());
-    String identifier = definition.token();
+    String identifier = definition.tokenStr();
 
     Preconditions.checkArgument(
         definition.scan() == '=',
@@ -202,7 +202,7 @@ class OutputTransformer {
         context.getMethodModel().getSimpleName(),
         valueSet.getId(),
         config.input());
-    String baseIdentifier = config.token();
+    String baseIdentifier = config.tokenStr();
 
     TypeModel type;
     if (baseIdentifier.equals(RESPONSE_PLACEHOLDER)) {
@@ -254,7 +254,7 @@ class OutputTransformer {
             context.getMethodModel().getSimpleName(),
             valueSet.getId(),
             config.input());
-        String fieldName = config.token();
+        String fieldName = config.tokenStr();
         FieldModel field =
             Preconditions.checkNotNull(
                 type.getField(fieldName),

--- a/src/main/java/com/google/api/codegen/util/Scanner.java
+++ b/src/main/java/com/google/api/codegen/util/Scanner.java
@@ -62,7 +62,7 @@ public class Scanner {
 
   private final String input;
   private int loc;
-  private String token = "";
+  private String tokenStr = "";
   private int last;
 
   public Scanner(String input) {
@@ -70,7 +70,7 @@ public class Scanner {
   }
 
   public int scan() {
-    token = "";
+    tokenStr = "";
     int codePoint;
 
     while (true) {
@@ -95,7 +95,7 @@ public class Scanner {
 
         if (!escaped && codePoint == '"') {
           loc += Character.charCount(codePoint);
-          token = sb.toString();
+          tokenStr = sb.toString();
           return last = STRING;
         }
         if (!escaped && codePoint == '\\') {
@@ -133,10 +133,10 @@ public class Scanner {
         loc += Character.charCount(codePoint);
       }
 
-      token = input.substring(start, loc);
-      if (input.codePointCount(start, loc) > 1 && token.startsWith("0")) {
+      tokenStr = input.substring(start, loc);
+      if (input.codePointCount(start, loc) > 1 && tokenStr.startsWith("0")) {
         throw new IllegalArgumentException(
-            String.format("leading zero not allowed: %s: %s", token, input));
+            String.format("leading zero not allowed: %s: %s", tokenStr, input));
       }
       return last = INT;
     }
@@ -150,12 +150,12 @@ public class Scanner {
         if (loc >= input.length()) {
           Preconditions.checkArgument(
               valid, "identifier needs a letter or underscore after '$': %s", input);
-          token = input.substring(start);
+          tokenStr = input.substring(start);
           return last = IDENT;
         }
         codePoint = input.codePointAt(loc);
         if (valid && !identFollow(codePoint)) {
-          token = input.substring(start, loc);
+          tokenStr = input.substring(start, loc);
           return last = IDENT;
         }
         Preconditions.checkArgument(
@@ -176,7 +176,7 @@ public class Scanner {
   }
 
   public String tokenStr() {
-    return token;
+    return tokenStr;
   }
 
   public String input() {

--- a/src/main/java/com/google/api/codegen/util/Scanner.java
+++ b/src/main/java/com/google/api/codegen/util/Scanner.java
@@ -171,7 +171,11 @@ public class Scanner {
     return last = codePoint;
   }
 
-  public String token() {
+  public int lastToken() {
+    return last;
+  }
+
+  public String tokenStr() {
     return token;
   }
 
@@ -181,10 +185,6 @@ public class Scanner {
 
   public int pos() {
     return loc;
-  }
-
-  public int last() {
-    return last;
   }
 
   private static boolean digit(int codePoint) {

--- a/src/main/java/com/google/api/codegen/util/Scanner.java
+++ b/src/main/java/com/google/api/codegen/util/Scanner.java
@@ -63,6 +63,7 @@ public class Scanner {
   private final String input;
   private int loc;
   private String token = "";
+  private int last;
 
   public Scanner(String input) {
     this.input = input;
@@ -74,7 +75,7 @@ public class Scanner {
 
     while (true) {
       if (loc >= input.length()) {
-        return EOF;
+        return last = EOF;
       }
       codePoint = input.codePointAt(loc);
       if (!Character.isWhitespace(codePoint)) {
@@ -95,7 +96,7 @@ public class Scanner {
         if (!escaped && codePoint == '"') {
           loc += Character.charCount(codePoint);
           token = sb.toString();
-          return STRING;
+          return last = STRING;
         }
         if (!escaped && codePoint == '\\') {
           escaped = true;
@@ -137,7 +138,7 @@ public class Scanner {
         throw new IllegalArgumentException(
             String.format("leading zero not allowed: %s: %s", token, input));
       }
-      return INT;
+      return last = INT;
     }
 
     if (identLead(codePoint) || codePoint == '$') {
@@ -150,12 +151,12 @@ public class Scanner {
           Preconditions.checkArgument(
               valid, "identifier needs a letter or underscore after '$': %s", input);
           token = input.substring(start);
-          return IDENT;
+          return last = IDENT;
         }
         codePoint = input.codePointAt(loc);
         if (valid && !identFollow(codePoint)) {
           token = input.substring(start, loc);
-          return IDENT;
+          return last = IDENT;
         }
         Preconditions.checkArgument(
             valid || identLead(codePoint),
@@ -167,7 +168,7 @@ public class Scanner {
     }
     // Consume and return the next character
     loc += Character.charCount(codePoint);
-    return codePoint;
+    return last = codePoint;
   }
 
   public String token() {
@@ -180,6 +181,10 @@ public class Scanner {
 
   public int pos() {
     return loc;
+  }
+
+  public int last() {
+    return last;
   }
 
   private static boolean digit(int codePoint) {

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -14,6 +14,8 @@
  */
 package com.google.api.codegen.metacode;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.api.codegen.config.ProtoTypeRef;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
@@ -24,8 +26,8 @@ import com.google.api.tools.framework.model.stages.Merged;
 import com.google.api.tools.framework.model.testing.TestConfig;
 import com.google.api.tools.framework.model.testing.TestDataLocator;
 import com.google.api.tools.framework.setup.StandardSetup;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.truth.Truth;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -66,80 +68,102 @@ public class SampleInitCodeTest {
         .suggestedName(Name.from("request"));
   }
 
-  // @Test
-  // public void testSimpleField() throws Exception {
-  //   String fieldSpec = "myfield";
+  @Test
+  public void testSimpleField() throws Exception {
+    String fieldSpec = "myfield";
 
-  //   InitCodeNode expectedStructure = InitCodeNode.create("myfield");
+    InitCodeNode expectedStructure = InitCodeNode.newRoot();
+    expectedStructure.mergeChild(InitCodeNode.create("myfield"));
 
-  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  // }
+    InitCodeNode actualStructure = InitCodeNode.newRoot();
+    FieldStructureParser.parse(actualStructure, fieldSpec);
 
-  // @Test
-  // public void testEmbeddedField() throws Exception {
-  //   String fieldSpec = "myobj.myfield";
+    assertNodeEqual(actualStructure, expectedStructure);
+  }
 
-  //   InitCodeNode innerStructure = InitCodeNode.create("myfield");
-  //   InitCodeNode expectedStructure =
-  //       InitCodeNode.createWithChildren(
-  //           "myobj", InitCodeLineType.StructureInitLine, innerStructure);
+  @Test
+  public void testEmbeddedField() throws Exception {
+    String fieldSpec = "myobj.myfield";
 
-  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  // }
+    InitCodeNode innerStructure = InitCodeNode.create("myfield");
+    InitCodeNode outerStructure =
+        InitCodeNode.createWithChildren(
+            "myobj", InitCodeLineType.StructureInitLine, innerStructure);
+    InitCodeNode expectedStructure = InitCodeNode.newRoot();
+    expectedStructure.mergeChild(outerStructure);
 
-  // @Test
-  // public void testListField() throws Exception {
-  //   String fieldSpec = "mylist[0]";
+    InitCodeNode actualStructure = InitCodeNode.newRoot();
+    FieldStructureParser.parse(actualStructure, fieldSpec);
 
-  //   InitCodeNode innerStructure = InitCodeNode.create("0");
-  //   InitCodeNode expectedStructure =
-  //       InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerStructure);
+    assertNodeEqual(actualStructure, expectedStructure);
+  }
 
-  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  // }
+  @Test
+  public void testListField() throws Exception {
+    String fieldSpec = "mylist[0]";
 
-  // @Test
-  // public void testMapField() throws Exception {
-  //   String fieldSpec = "mymap{key}";
+    InitCodeNode innerStructure = InitCodeNode.create("0");
+    InitCodeNode outerStructure =
+        InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerStructure);
+    InitCodeNode expectedStructure = InitCodeNode.newRoot();
+    expectedStructure.mergeChild(outerStructure);
 
-  //   InitCodeNode innerStructure = InitCodeNode.create("key");
-  //   InitCodeNode expectedStructure =
-  //       InitCodeNode.createWithChildren("mymap", InitCodeLineType.MapInitLine, innerStructure);
+    InitCodeNode actualStructure = InitCodeNode.newRoot();
+    FieldStructureParser.parse(actualStructure, fieldSpec);
 
-  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  // }
+    assertNodeEqual(actualStructure, expectedStructure);
+  }
 
-  // @Test
-  // public void testNestedListField() throws Exception {
-  //   String fieldSpec = "mylist[0][0]";
+  @Test
+  public void testMapField() throws Exception {
+    String fieldSpec = "mymap{key}";
 
-  //   InitCodeNode innerList = InitCodeNode.create("0");
-  //   InitCodeNode outerList =
-  //       InitCodeNode.createWithChildren("0", InitCodeLineType.ListInitLine, innerList);
-  //   InitCodeNode expectedStructure =
-  //       InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, outerList);
+    InitCodeNode innerStructure = InitCodeNode.create("key");
+    InitCodeNode outerStructure =
+        InitCodeNode.createWithChildren("mymap", InitCodeLineType.MapInitLine, innerStructure);
+    InitCodeNode expectedStructure = InitCodeNode.newRoot();
+    expectedStructure.mergeChild(outerStructure);
 
-  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  // }
+    InitCodeNode actualStructure = InitCodeNode.newRoot();
+    FieldStructureParser.parse(actualStructure, fieldSpec);
 
-  // @Test
-  // public void testFormattedField() throws Exception {
-  //   String fieldSpec = "name%entity";
+    assertNodeEqual(actualStructure, expectedStructure);
+  }
 
-  //   HashMap<String, InitValueConfig> initValueMap = new HashMap<>();
-  //   InitValueConfig initValueConfig = InitValueConfig.create("test-api", null);
-  //   initValueMap.put("name", initValueConfig);
+  @Test
+  public void testNestedListField() throws Exception {
+    String fieldSpec = "mylist[0][0]";
 
-  //   InitCodeNode expectedStructure = InitCodeNode.createWithValue("name", initValueConfig);
+    InitCodeNode innerList = InitCodeNode.create("0");
+    InitCodeNode outerList =
+        InitCodeNode.createWithChildren("0", InitCodeLineType.ListInitLine, innerList);
+    InitCodeNode outerStructure =
+        InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, outerList);
+    InitCodeNode expectedStructure = InitCodeNode.newRoot();
+    expectedStructure.mergeChild(outerStructure);
 
-  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec, initValueMap);
-  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  // }
+    InitCodeNode actualStructure = InitCodeNode.newRoot();
+    FieldStructureParser.parse(actualStructure, fieldSpec);
+
+    assertNodeEqual(actualStructure, expectedStructure);
+  }
+
+  @Test
+  public void testFormattedField() throws Exception {
+    String fieldSpec = "name%entity";
+
+    InitValueConfig initValueConfig = InitValueConfig.create("test-api", null);
+    InitCodeNode outerStructure = InitCodeNode.createWithValue("name", initValueConfig);
+
+    InitCodeNode expectedStructure = InitCodeNode.newRoot();
+    expectedStructure.mergeChild(outerStructure);
+
+    InitCodeNode actualStructure = InitCodeNode.newRoot();
+    FieldStructureParser.parse(
+        actualStructure, fieldSpec, ImmutableMap.of("name", initValueConfig));
+
+    assertNodeEqual(actualStructure, expectedStructure);
+  }
 
   @Test
   public void testFormattedFieldWithValues() throws Exception {
@@ -160,13 +184,12 @@ public class SampleInitCodeTest {
             .initValueConfigMap(initValueMap)
             .build();
     InitCodeNode actualStructure = InitCodeNode.createTree(context);
-    Truth.assertThat(actualStructure.getChildren().isEmpty()).isFalse();
+    assertThat(actualStructure.getChildren().isEmpty()).isFalse();
     InitCodeNode actualFormattedFieldNode = actualStructure.getChildren().get("formatted_field");
-    Truth.assertThat(actualFormattedFieldNode.getInitValueConfig()).isNotNull();
-    Truth.assertThat(
-            actualFormattedFieldNode.getInitValueConfig().hasFormattingConfigInitialValues())
+    assertThat(actualFormattedFieldNode.getInitValueConfig()).isNotNull();
+    assertThat(actualFormattedFieldNode.getInitValueConfig().hasFormattingConfigInitialValues())
         .isTrue();
-    Truth.assertThat(
+    assertThat(
             actualFormattedFieldNode
                 .getInitValueConfig()
                 .getResourceNameBindingValues()
@@ -174,72 +197,92 @@ public class SampleInitCodeTest {
         .isTrue();
   }
 
-  // @Test
-  // public void testNestedMixedField() throws Exception {
-  //   String fieldSpec = "mylist[0]{key}";
+  @Test
+  public void testNestedMixedField() throws Exception {
+    String fieldSpec = "mylist[0]{key}";
 
-  //   InitCodeNode innerMap = InitCodeNode.create("key");
-  //   InitCodeNode innerList =
-  //       InitCodeNode.createWithChildren("0", InitCodeLineType.MapInitLine, innerMap);
-  //   InitCodeNode expectedStructure =
-  //       InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
+    InitCodeNode innerMap = InitCodeNode.create("key");
+    InitCodeNode innerList =
+        InitCodeNode.createWithChildren("0", InitCodeLineType.MapInitLine, innerMap);
+    InitCodeNode outerStructure =
+        InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
 
-  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  // }
+    InitCodeNode expectedStructure = InitCodeNode.newRoot();
+    expectedStructure.mergeChild(outerStructure);
 
-  // @Test
-  // public void testAssignment() throws Exception {
-  //   String fieldSpec = "myfield=\"default\"";
+    InitCodeNode actualStructure = InitCodeNode.newRoot();
+    FieldStructureParser.parse(actualStructure, fieldSpec);
 
-  //   InitCodeNode expectedStructure =
-  //       InitCodeNode.createWithValue(
-  //           "myfield", InitValueConfig.createWithValue(InitValue.createLiteral("default")));
+    assertNodeEqual(actualStructure, expectedStructure);
+  }
 
-  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  // }
+  @Test
+  public void testAssignment() throws Exception {
+    String fieldSpec = "myfield=\"default\"";
 
-  // @Test
-  // public void testListEmbeddedField() throws Exception {
-  //   String fieldSpec = "mylist[0].myfield";
+    InitCodeNode outerStructure =
+        InitCodeNode.createWithValue(
+            "myfield", InitValueConfig.createWithValue(InitValue.createLiteral("default")));
 
-  //   InitCodeNode innerStructure = InitCodeNode.create("myfield");
-  //   InitCodeNode innerList =
-  //       InitCodeNode.createWithChildren("0", InitCodeLineType.StructureInitLine, innerStructure);
-  //   InitCodeNode expectedStructure =
-  //       InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
+    InitCodeNode expectedStructure = InitCodeNode.newRoot();
+    expectedStructure.mergeChild(outerStructure);
 
-  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  // }
+    InitCodeNode actualStructure = InitCodeNode.newRoot();
+    FieldStructureParser.parse(actualStructure, fieldSpec);
 
-  // @Test
-  // public void testEmbeddedFieldList() throws Exception {
-  //   String fieldSpec = "myfield.mylist[0]";
+    assertNodeEqual(actualStructure, expectedStructure);
+  }
 
-  //   InitCodeNode innerList = InitCodeNode.create("0");
-  //   InitCodeNode innerStructure =
-  //       InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
-  //   InitCodeNode expectedStructure =
-  //       InitCodeNode.createWithChildren(
-  //           "myfield", InitCodeLineType.StructureInitLine, innerStructure);
+  @Test
+  public void testListEmbeddedField() throws Exception {
+    String fieldSpec = "mylist[0].myfield";
 
-  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  // }
+    InitCodeNode innerStructure = InitCodeNode.create("myfield");
+    InitCodeNode innerList =
+        InitCodeNode.createWithChildren("0", InitCodeLineType.StructureInitLine, innerStructure);
+    InitCodeNode outerStructure =
+        InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
 
-  // @Test(expected = IllegalArgumentException.class)
-  // public void testFormattedFieldBadField() throws Exception {
-  //   String fieldSpec = "name%entity";
-  //   FieldStructureParser.parse(fieldSpec);
-  // }
+    InitCodeNode expectedStructure = InitCodeNode.newRoot();
+    expectedStructure.mergeChild(outerStructure);
 
-  // @Test(expected = IllegalArgumentException.class)
-  // public void testFormattedFieldBadFieldWithValue() throws Exception {
-  //   String fieldSpec = "name%entity=test";
-  //   FieldStructureParser.parse(fieldSpec);
-  // }
+    InitCodeNode actualStructure = InitCodeNode.newRoot();
+    FieldStructureParser.parse(actualStructure, fieldSpec);
+
+    assertNodeEqual(actualStructure, expectedStructure);
+  }
+
+  @Test
+  public void testEmbeddedFieldList() throws Exception {
+    String fieldSpec = "myfield.mylist[0]";
+
+    InitCodeNode innerList = InitCodeNode.create("0");
+    InitCodeNode innerStructure =
+        InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
+    InitCodeNode outerStructure =
+        InitCodeNode.createWithChildren(
+            "myfield", InitCodeLineType.StructureInitLine, innerStructure);
+
+    InitCodeNode expectedStructure = InitCodeNode.newRoot();
+    expectedStructure.mergeChild(outerStructure);
+
+    InitCodeNode actualStructure = InitCodeNode.newRoot();
+    FieldStructureParser.parse(actualStructure, fieldSpec);
+
+    assertNodeEqual(actualStructure, expectedStructure);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFormattedFieldBadField() throws Exception {
+    String fieldSpec = "name%entity";
+    FieldStructureParser.parse(InitCodeNode.newRoot(), fieldSpec);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFormattedFieldBadFieldWithValue() throws Exception {
+    String fieldSpec = "name%entity=test";
+    FieldStructureParser.parse(InitCodeNode.newRoot(), fieldSpec);
+  }
 
   @Test(expected = IllegalArgumentException.class)
   public void testListFieldBadIndex() throws Exception {
@@ -309,7 +352,7 @@ public class SampleInitCodeTest {
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
     }
-    Truth.assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
   }
 
   @Test
@@ -324,7 +367,7 @@ public class SampleInitCodeTest {
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
     }
-    Truth.assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
   }
 
   @Test
@@ -341,7 +384,7 @@ public class SampleInitCodeTest {
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
     }
-    Truth.assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
   }
 
   @Test
@@ -366,7 +409,7 @@ public class SampleInitCodeTest {
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
     }
-    Truth.assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
   }
 
   @Test
@@ -382,7 +425,7 @@ public class SampleInitCodeTest {
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
     }
-    Truth.assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
   }
 
   @Test
@@ -397,7 +440,7 @@ public class SampleInitCodeTest {
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
     }
-    Truth.assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
   }
 
   @Test
@@ -412,30 +455,19 @@ public class SampleInitCodeTest {
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
     }
-    Truth.assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
   }
 
-  private static boolean checkEquals(InitCodeNode first, InitCodeNode second) {
-    if (first == second) {
-      return true;
+  private static void assertNodeEqual(InitCodeNode a, InitCodeNode b) {
+    assertThat(a.getKey()).isEqualTo(b.getKey());
+    assertThat(a.getLineType()).isEqualTo(b.getLineType());
+    assertThat(a.getInitValueConfig()).isEqualTo(b.getInitValueConfig());
+    assertThat(a.getType()).isEqualTo(b.getType());
+    assertThat(a.getIdentifier()).isEqualTo(b.getIdentifier());
+
+    assertThat(a.getChildren().keySet()).isEqualTo(b.getChildren().keySet());
+    for (String key : a.getChildren().keySet()) {
+      assertNodeEqual(a.getChildren().get(key), b.getChildren().get(key));
     }
-    if (!(first.getKey().equals(second.getKey())
-        && first.getLineType().equals(second.getLineType())
-        && first.getInitValueConfig().equals(second.getInitValueConfig())
-        && first.getChildren().keySet().equals(second.getChildren().keySet())
-        && (first.getType() == null
-            ? second.getType() == null
-            : first.getType().equals(second.getType()))
-        && (first.getIdentifier() == null
-            ? second.getIdentifier() == null
-            : first.getIdentifier().equals(second.getIdentifier())))) {
-      return false;
-    }
-    for (String key : first.getChildren().keySet()) {
-      if (!checkEquals(first.getChildren().get(key), second.getChildren().get(key))) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -30,7 +30,6 @@ import com.google.api.tools.framework.setup.StandardSetup;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
@@ -170,27 +169,22 @@ public class SampleInitCodeTest {
     List<String> fieldSpecs =
         Arrays.asList("formatted_field%entity1=test1", "formatted_field%entity2=test2");
 
-    HashMap<String, InitValueConfig> initValueMap = new HashMap<>();
     InitValueConfig initValueConfig = InitValueConfig.create("test-api", null);
-    initValueMap.put("formatted_field", initValueConfig);
-
-    HashMap<String, InitValue> expectedCollectionValues = new HashMap<>();
-    expectedCollectionValues.put("entity1", InitValue.createLiteral("test1"));
-    expectedCollectionValues.put("entity2", InitValue.createLiteral("test2"));
 
     InitCodeContext context =
         getContextBuilder()
             .initFieldConfigStrings(fieldSpecs)
-            .initValueConfigMap(initValueMap)
+            .initValueConfigMap(ImmutableMap.of("formatted_field", initValueConfig))
             .build();
     InitCodeNode actualStructure = InitCodeNode.createTree(context);
     assertThat(actualStructure.getChildren().isEmpty()).isFalse();
     InitCodeNode actualFormattedFieldNode = actualStructure.getChildren().get("formatted_field");
-    assertThat(actualFormattedFieldNode.getInitValueConfig()).isNotNull();
-    assertThat(actualFormattedFieldNode.getInitValueConfig().hasFormattingConfigInitialValues())
-        .isTrue();
     assertThat(actualFormattedFieldNode.getInitValueConfig().getResourceNameBindingValues())
-        .isEqualTo(expectedCollectionValues);
+        .containsExactly(
+            "entity1",
+            InitValue.createLiteral("test1"),
+            "entity2",
+            InitValue.createLiteral("test2"));
   }
 
   @Test
@@ -375,14 +369,12 @@ public class SampleInitCodeTest {
         Arrays.asList(
             "formatted_field%entity1", "formatted_field%entity2", "formatted_field%entity3");
 
-    HashMap<String, InitValueConfig> initValueMap = new HashMap<>();
     InitValueConfig initValueConfig = InitValueConfig.create("test-api", null);
-    initValueMap.put("formatted_field", initValueConfig);
 
     InitCodeContext context =
         getContextBuilder()
             .initFieldConfigStrings(fieldSpecs)
-            .initValueConfigMap(initValueMap)
+            .initValueConfigMap(ImmutableMap.of("formatted_field", initValueConfig))
             .build();
     InitCodeNode rootNode = InitCodeNode.createTree(context);
     assertThat(rootNode.listInInitializationOrder().stream().map(node -> node.getKey()))

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.metacode;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 
 import com.google.api.codegen.config.ProtoTypeRef;
 import com.google.api.codegen.util.Name;
@@ -28,7 +29,6 @@ import com.google.api.tools.framework.model.testing.TestDataLocator;
 import com.google.api.tools.framework.setup.StandardSetup;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -189,12 +189,8 @@ public class SampleInitCodeTest {
     assertThat(actualFormattedFieldNode.getInitValueConfig()).isNotNull();
     assertThat(actualFormattedFieldNode.getInitValueConfig().hasFormattingConfigInitialValues())
         .isTrue();
-    assertThat(
-            actualFormattedFieldNode
-                .getInitValueConfig()
-                .getResourceNameBindingValues()
-                .equals(expectedCollectionValues))
-        .isTrue();
+    assertThat(actualFormattedFieldNode.getInitValueConfig().getResourceNameBindingValues())
+        .isEqualTo(expectedCollectionValues);
   }
 
   @Test
@@ -343,31 +339,22 @@ public class SampleInitCodeTest {
     List<String> fieldSpecs =
         Arrays.asList("mylist", "myfield", "secondfield", "stringmap", "intmap");
 
-    List<String> expectedKeyList =
-        Lists.newArrayList("mylist", "myfield", "secondfield", "stringmap", "intmap", "root");
-
     InitCodeNode rootNode =
         InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
-    List<String> actualKeyList = new ArrayList<>();
-    for (InitCodeNode node : rootNode.listInInitializationOrder()) {
-      actualKeyList.add(node.getKey());
-    }
-    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(rootNode.listInInitializationOrder().stream().map(node -> node.getKey()))
+        .containsExactly("mylist", "myfield", "secondfield", "stringmap", "intmap", "root")
+        .inOrder();
   }
 
   @Test
   public void testMultipleListEntries() throws Exception {
     List<String> fieldSpecs = Arrays.asList("mylist[0]", "mylist[1]");
 
-    List<String> expectedKeyList = Arrays.asList("0", "1", "mylist", "root");
-
     InitCodeNode rootNode =
         InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
-    List<String> actualKeyList = new ArrayList<>();
-    for (InitCodeNode node : rootNode.listInInitializationOrder()) {
-      actualKeyList.add(node.getKey());
-    }
-    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(rootNode.listInInitializationOrder().stream().map(node -> node.getKey()))
+        .containsExactly("0", "1", "mylist", "root")
+        .inOrder();
   }
 
   @Test
@@ -375,16 +362,11 @@ public class SampleInitCodeTest {
     List<String> fieldSpecs =
         Arrays.asList("stringmap{\"key1\"}", "stringmap{\"key2\"}", "intmap{123}", "intmap{456}");
 
-    List<String> expectedKeyList =
-        Arrays.asList("key1", "key2", "stringmap", "123", "456", "intmap", "root");
-
     InitCodeNode rootNode =
         InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
-    List<String> actualKeyList = new ArrayList<>();
-    for (InitCodeNode node : rootNode.listInInitializationOrder()) {
-      actualKeyList.add(node.getKey());
-    }
-    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(rootNode.listInInitializationOrder().stream().map(node -> node.getKey()))
+        .containsExactly("key1", "key2", "stringmap", "123", "456", "intmap", "root")
+        .inOrder();
   }
 
   @Test
@@ -392,8 +374,6 @@ public class SampleInitCodeTest {
     List<String> fieldSpecs =
         Arrays.asList(
             "formatted_field%entity1", "formatted_field%entity2", "formatted_field%entity3");
-
-    List<String> expectedKeyList = Arrays.asList("formatted_field", "root");
 
     HashMap<String, InitValueConfig> initValueMap = new HashMap<>();
     InitValueConfig initValueConfig = InitValueConfig.create("test-api", null);
@@ -405,57 +385,42 @@ public class SampleInitCodeTest {
             .initValueConfigMap(initValueMap)
             .build();
     InitCodeNode rootNode = InitCodeNode.createTree(context);
-    List<String> actualKeyList = new ArrayList<>();
-    for (InitCodeNode node : rootNode.listInInitializationOrder()) {
-      actualKeyList.add(node.getKey());
-    }
-    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(rootNode.listInInitializationOrder().stream().map(node -> node.getKey()))
+        .containsExactly("formatted_field", "root")
+        .inOrder();
   }
 
   @Test
   public void testListEmbeddedMultipleFields() throws Exception {
     List<String> fieldSpecs = Arrays.asList("mylist[0].subfield", "mylist[0].subsecondfield");
 
-    List<String> expectedKeyList =
-        Arrays.asList("subfield", "subsecondfield", "0", "mylist", "root");
-
     InitCodeNode rootNode =
         InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
-    List<String> actualKeyList = new ArrayList<>();
-    for (InitCodeNode node : rootNode.listInInitializationOrder()) {
-      actualKeyList.add(node.getKey());
-    }
-    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(rootNode.listInInitializationOrder().stream().map(node -> node.getKey()))
+        .containsExactly("subfield", "subsecondfield", "0", "mylist", "root")
+        .inOrder();
   }
 
   @Test
   public void testCompoundingStructure() throws Exception {
     List<String> fieldSpecs = Arrays.asList("myfield", "myfield.subfield");
 
-    List<String> expectedKeyList = Arrays.asList("subfield", "myfield", "root");
-
     InitCodeNode rootNode =
         InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
-    List<String> actualKeyList = new ArrayList<>();
-    for (InitCodeNode node : rootNode.listInInitializationOrder()) {
-      actualKeyList.add(node.getKey());
-    }
-    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(rootNode.listInInitializationOrder().stream().map(node -> node.getKey()))
+        .containsExactly("subfield", "myfield", "root")
+        .inOrder();
   }
 
   @Test
   public void testCompoundingStructureList() throws Exception {
     List<String> fieldSpecs = Arrays.asList("mylist", "mylist[0]", "mylist[0].subfield");
 
-    List<String> expectedKeyList = Arrays.asList("subfield", "0", "mylist", "root");
-
     InitCodeNode rootNode =
         InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
-    List<String> actualKeyList = new ArrayList<>();
-    for (InitCodeNode node : rootNode.listInInitializationOrder()) {
-      actualKeyList.add(node.getKey());
-    }
-    assertThat(actualKeyList.equals(expectedKeyList)).isTrue();
+    assertThat(rootNode.listInInitializationOrder().stream().map(node -> node.getKey()))
+        .containsExactly("subfield", "0", "mylist", "root")
+        .inOrder();
   }
 
   private static void assertNodeEqual(InitCodeNode a, InitCodeNode b) {

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -66,80 +66,80 @@ public class SampleInitCodeTest {
         .suggestedName(Name.from("request"));
   }
 
-  @Test
-  public void testSimpleField() throws Exception {
-    String fieldSpec = "myfield";
+  // @Test
+  // public void testSimpleField() throws Exception {
+  //   String fieldSpec = "myfield";
 
-    InitCodeNode expectedStructure = InitCodeNode.create("myfield");
+  //   InitCodeNode expectedStructure = InitCodeNode.create("myfield");
 
-    InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-    Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  }
+  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
+  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
+  // }
 
-  @Test
-  public void testEmbeddedField() throws Exception {
-    String fieldSpec = "myobj.myfield";
+  // @Test
+  // public void testEmbeddedField() throws Exception {
+  //   String fieldSpec = "myobj.myfield";
 
-    InitCodeNode innerStructure = InitCodeNode.create("myfield");
-    InitCodeNode expectedStructure =
-        InitCodeNode.createWithChildren(
-            "myobj", InitCodeLineType.StructureInitLine, innerStructure);
+  //   InitCodeNode innerStructure = InitCodeNode.create("myfield");
+  //   InitCodeNode expectedStructure =
+  //       InitCodeNode.createWithChildren(
+  //           "myobj", InitCodeLineType.StructureInitLine, innerStructure);
 
-    InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-    Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  }
+  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
+  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
+  // }
 
-  @Test
-  public void testListField() throws Exception {
-    String fieldSpec = "mylist[0]";
+  // @Test
+  // public void testListField() throws Exception {
+  //   String fieldSpec = "mylist[0]";
 
-    InitCodeNode innerStructure = InitCodeNode.create("0");
-    InitCodeNode expectedStructure =
-        InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerStructure);
+  //   InitCodeNode innerStructure = InitCodeNode.create("0");
+  //   InitCodeNode expectedStructure =
+  //       InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerStructure);
 
-    InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-    Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  }
+  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
+  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
+  // }
 
-  @Test
-  public void testMapField() throws Exception {
-    String fieldSpec = "mymap{key}";
+  // @Test
+  // public void testMapField() throws Exception {
+  //   String fieldSpec = "mymap{key}";
 
-    InitCodeNode innerStructure = InitCodeNode.create("key");
-    InitCodeNode expectedStructure =
-        InitCodeNode.createWithChildren("mymap", InitCodeLineType.MapInitLine, innerStructure);
+  //   InitCodeNode innerStructure = InitCodeNode.create("key");
+  //   InitCodeNode expectedStructure =
+  //       InitCodeNode.createWithChildren("mymap", InitCodeLineType.MapInitLine, innerStructure);
 
-    InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-    Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  }
+  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
+  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
+  // }
 
-  @Test
-  public void testNestedListField() throws Exception {
-    String fieldSpec = "mylist[0][0]";
+  // @Test
+  // public void testNestedListField() throws Exception {
+  //   String fieldSpec = "mylist[0][0]";
 
-    InitCodeNode innerList = InitCodeNode.create("0");
-    InitCodeNode outerList =
-        InitCodeNode.createWithChildren("0", InitCodeLineType.ListInitLine, innerList);
-    InitCodeNode expectedStructure =
-        InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, outerList);
+  //   InitCodeNode innerList = InitCodeNode.create("0");
+  //   InitCodeNode outerList =
+  //       InitCodeNode.createWithChildren("0", InitCodeLineType.ListInitLine, innerList);
+  //   InitCodeNode expectedStructure =
+  //       InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, outerList);
 
-    InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-    Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  }
+  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
+  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
+  // }
 
-  @Test
-  public void testFormattedField() throws Exception {
-    String fieldSpec = "name%entity";
+  // @Test
+  // public void testFormattedField() throws Exception {
+  //   String fieldSpec = "name%entity";
 
-    HashMap<String, InitValueConfig> initValueMap = new HashMap<>();
-    InitValueConfig initValueConfig = InitValueConfig.create("test-api", null);
-    initValueMap.put("name", initValueConfig);
+  //   HashMap<String, InitValueConfig> initValueMap = new HashMap<>();
+  //   InitValueConfig initValueConfig = InitValueConfig.create("test-api", null);
+  //   initValueMap.put("name", initValueConfig);
 
-    InitCodeNode expectedStructure = InitCodeNode.createWithValue("name", initValueConfig);
+  //   InitCodeNode expectedStructure = InitCodeNode.createWithValue("name", initValueConfig);
 
-    InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec, initValueMap);
-    Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  }
+  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec, initValueMap);
+  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
+  // }
 
   @Test
   public void testFormattedFieldWithValues() throws Exception {
@@ -174,72 +174,72 @@ public class SampleInitCodeTest {
         .isTrue();
   }
 
-  @Test
-  public void testNestedMixedField() throws Exception {
-    String fieldSpec = "mylist[0]{key}";
+  // @Test
+  // public void testNestedMixedField() throws Exception {
+  //   String fieldSpec = "mylist[0]{key}";
 
-    InitCodeNode innerMap = InitCodeNode.create("key");
-    InitCodeNode innerList =
-        InitCodeNode.createWithChildren("0", InitCodeLineType.MapInitLine, innerMap);
-    InitCodeNode expectedStructure =
-        InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
+  //   InitCodeNode innerMap = InitCodeNode.create("key");
+  //   InitCodeNode innerList =
+  //       InitCodeNode.createWithChildren("0", InitCodeLineType.MapInitLine, innerMap);
+  //   InitCodeNode expectedStructure =
+  //       InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
 
-    InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-    Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  }
+  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
+  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
+  // }
 
-  @Test
-  public void testAssignment() throws Exception {
-    String fieldSpec = "myfield=\"default\"";
+  // @Test
+  // public void testAssignment() throws Exception {
+  //   String fieldSpec = "myfield=\"default\"";
 
-    InitCodeNode expectedStructure =
-        InitCodeNode.createWithValue(
-            "myfield", InitValueConfig.createWithValue(InitValue.createLiteral("default")));
+  //   InitCodeNode expectedStructure =
+  //       InitCodeNode.createWithValue(
+  //           "myfield", InitValueConfig.createWithValue(InitValue.createLiteral("default")));
 
-    InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-    Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  }
+  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
+  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
+  // }
 
-  @Test
-  public void testListEmbeddedField() throws Exception {
-    String fieldSpec = "mylist[0].myfield";
+  // @Test
+  // public void testListEmbeddedField() throws Exception {
+  //   String fieldSpec = "mylist[0].myfield";
 
-    InitCodeNode innerStructure = InitCodeNode.create("myfield");
-    InitCodeNode innerList =
-        InitCodeNode.createWithChildren("0", InitCodeLineType.StructureInitLine, innerStructure);
-    InitCodeNode expectedStructure =
-        InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
+  //   InitCodeNode innerStructure = InitCodeNode.create("myfield");
+  //   InitCodeNode innerList =
+  //       InitCodeNode.createWithChildren("0", InitCodeLineType.StructureInitLine, innerStructure);
+  //   InitCodeNode expectedStructure =
+  //       InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
 
-    InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-    Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  }
+  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
+  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
+  // }
 
-  @Test
-  public void testEmbeddedFieldList() throws Exception {
-    String fieldSpec = "myfield.mylist[0]";
+  // @Test
+  // public void testEmbeddedFieldList() throws Exception {
+  //   String fieldSpec = "myfield.mylist[0]";
 
-    InitCodeNode innerList = InitCodeNode.create("0");
-    InitCodeNode innerStructure =
-        InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
-    InitCodeNode expectedStructure =
-        InitCodeNode.createWithChildren(
-            "myfield", InitCodeLineType.StructureInitLine, innerStructure);
+  //   InitCodeNode innerList = InitCodeNode.create("0");
+  //   InitCodeNode innerStructure =
+  //       InitCodeNode.createWithChildren("mylist", InitCodeLineType.ListInitLine, innerList);
+  //   InitCodeNode expectedStructure =
+  //       InitCodeNode.createWithChildren(
+  //           "myfield", InitCodeLineType.StructureInitLine, innerStructure);
 
-    InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
-    Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
-  }
+  //   InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
+  //   Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
+  // }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testFormattedFieldBadField() throws Exception {
-    String fieldSpec = "name%entity";
-    FieldStructureParser.parse(fieldSpec);
-  }
+  // @Test(expected = IllegalArgumentException.class)
+  // public void testFormattedFieldBadField() throws Exception {
+  //   String fieldSpec = "name%entity";
+  //   FieldStructureParser.parse(fieldSpec);
+  // }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testFormattedFieldBadFieldWithValue() throws Exception {
-    String fieldSpec = "name%entity=test";
-    FieldStructureParser.parse(fieldSpec);
-  }
+  // @Test(expected = IllegalArgumentException.class)
+  // public void testFormattedFieldBadFieldWithValue() throws Exception {
+  //   String fieldSpec = "name%entity=test";
+  //   FieldStructureParser.parse(fieldSpec);
+  // }
 
   @Test(expected = IllegalArgumentException.class)
   public void testListFieldBadIndex() throws Exception {

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -381,7 +381,7 @@ public class SampleInitCodeTest {
             .initValueConfigMap(ImmutableMap.of("formatted_field", initValueConfig))
             .build();
     InitCodeNode rootNode = InitCodeNode.createTree(context);
-    List<InitCodeNode> initOrder =rootNode.listInInitializationOrder();
+    List<InitCodeNode> initOrder = rootNode.listInInitializationOrder();
     assertThat(initOrder.stream().map(node -> node.getKey()))
         .containsExactly("formatted_field", "root")
         .inOrder();

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -67,12 +67,14 @@ public class SampleInitCodeTest {
         .suggestedName(Name.from("request"));
   }
 
+  // TODO(pongad): Consider using createTree everywhere.
+
   @Test
   public void testSimpleField() throws Exception {
     String fieldSpec = "myfield";
 
     InitCodeNode expectedStructure = InitCodeNode.newRoot();
-    expectedStructure.mergeChild(InitCodeNode.create("myfield"));
+    expectedStructure.mergeChild(InitCodeNode.create(fieldSpec));
 
     InitCodeNode actualStructure = InitCodeNode.newRoot();
     FieldStructureParser.parse(actualStructure, fieldSpec);
@@ -264,12 +266,14 @@ public class SampleInitCodeTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testFormattedFieldBadField() throws Exception {
+    // Error because `name` is not configured to be a resource name field.
     String fieldSpec = "name%entity";
     FieldStructureParser.parse(InitCodeNode.newRoot(), fieldSpec);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testFormattedFieldBadFieldWithValue() throws Exception {
+    // Error because `name` is not configured to be a resource name field.
     String fieldSpec = "name%entity=test";
     FieldStructureParser.parse(InitCodeNode.newRoot(), fieldSpec);
   }
@@ -377,7 +381,8 @@ public class SampleInitCodeTest {
             .initValueConfigMap(ImmutableMap.of("formatted_field", initValueConfig))
             .build();
     InitCodeNode rootNode = InitCodeNode.createTree(context);
-    assertThat(rootNode.listInInitializationOrder().stream().map(node -> node.getKey()))
+    List<InitCodeNode> initOrder =rootNode.listInInitializationOrder();
+    assertThat(initOrder.stream().map(node -> node.getKey()))
         .containsExactly("formatted_field", "root")
         .inOrder();
   }

--- a/src/test/java/com/google/api/codegen/util/ScannerTest.java
+++ b/src/test/java/com/google/api/codegen/util/ScannerTest.java
@@ -24,22 +24,22 @@ public class ScannerTest {
     Scanner scanner = new Scanner("$abc =   def123 + 456 + \"xyz\";");
 
     assertThat(scanner.scan()).isEqualTo(Scanner.IDENT);
-    assertThat(scanner.token()).isEqualTo("$abc");
+    assertThat(scanner.tokenStr()).isEqualTo("$abc");
 
     assertThat(scanner.scan()).isEqualTo('=');
 
     assertThat(scanner.scan()).isEqualTo(Scanner.IDENT);
-    assertThat(scanner.token()).isEqualTo("def123");
+    assertThat(scanner.tokenStr()).isEqualTo("def123");
 
     assertThat(scanner.scan()).isEqualTo('+');
 
     assertThat(scanner.scan()).isEqualTo(Scanner.INT);
-    assertThat(scanner.token()).isEqualTo("456");
+    assertThat(scanner.tokenStr()).isEqualTo("456");
 
     assertThat(scanner.scan()).isEqualTo('+');
 
     assertThat(scanner.scan()).isEqualTo(Scanner.STRING);
-    assertThat(scanner.token()).isEqualTo("xyz");
+    assertThat(scanner.tokenStr()).isEqualTo("xyz");
 
     assertThat(scanner.scan()).isEqualTo(';');
 
@@ -54,10 +54,10 @@ public class ScannerTest {
       Scanner scanner = new Scanner("$a$b$");
 
       assertThat(scanner.scan()).isEqualTo(Scanner.IDENT);
-      assertThat(scanner.token()).isEqualTo("$a");
+      assertThat(scanner.tokenStr()).isEqualTo("$a");
 
       assertThat(scanner.scan()).isEqualTo(Scanner.IDENT);
-      assertThat(scanner.token()).isEqualTo("$b");
+      assertThat(scanner.tokenStr()).isEqualTo("$b");
 
       assertThrow(() -> scanner.scan());
     }
@@ -66,7 +66,7 @@ public class ScannerTest {
       Scanner scanner = new Scanner("a$$b");
 
       assertThat(scanner.scan()).isEqualTo(Scanner.IDENT);
-      assertThat(scanner.token()).isEqualTo("a");
+      assertThat(scanner.tokenStr()).isEqualTo("a");
 
       assertThrow(() -> scanner.scan());
     }
@@ -75,7 +75,7 @@ public class ScannerTest {
       Scanner scanner = new Scanner("a$");
 
       assertThat(scanner.scan()).isEqualTo(Scanner.IDENT);
-      assertThat(scanner.token()).isEqualTo("a");
+      assertThat(scanner.tokenStr()).isEqualTo("a");
 
       assertThrow(() -> scanner.scan());
     }
@@ -87,10 +87,10 @@ public class ScannerTest {
       Scanner scanner = new Scanner("123 456");
 
       assertThat(scanner.scan()).isEqualTo(Scanner.INT);
-      assertThat(scanner.token()).isEqualTo("123");
+      assertThat(scanner.tokenStr()).isEqualTo("123");
 
       assertThat(scanner.scan()).isEqualTo(Scanner.INT);
-      assertThat(scanner.token()).isEqualTo("456");
+      assertThat(scanner.tokenStr()).isEqualTo("456");
 
       assertThat(scanner.scan()).isEqualTo(Scanner.EOF);
     }
@@ -103,7 +103,7 @@ public class ScannerTest {
       Scanner scanner = new Scanner("0");
 
       assertThat(scanner.scan()).isEqualTo(Scanner.INT);
-      assertThat(scanner.token()).isEqualTo("0");
+      assertThat(scanner.tokenStr()).isEqualTo("0");
 
       assertThat(scanner.scan()).isEqualTo(Scanner.EOF);
     }


### PR DESCRIPTION
Instead of creating lists then merging them, we create and populate only one tree. The current implementation creates a lot of temporary objects. I decided to leave it be for now because the PR is already quite large. We can fix this up later if needed.