### PR TITLE
Reorder auth env vars

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -293,15 +293,15 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer<Proto
     List<String> apiSpecificPathEnvVars =
         ImmutableList.of(
             namer.inittedConstantName(
-                Name.lowerCamel(sanitizedShortName.split(" ")).join("keyfile")),
+                Name.lowerCamel(sanitizedShortName.split(" ")).join("credentials")),
             namer.inittedConstantName(
-                Name.lowerCamel(sanitizedShortName.split(" ")).join("credentials")));
+                Name.lowerCamel(sanitizedShortName.split(" ")).join("keyfile")));
     List<String> apiSpecificJsonEnvVars =
         ImmutableList.of(
             namer.inittedConstantName(
-                Name.lowerCamel(sanitizedShortName.split(" ")).join("keyfile").join("json")),
+                Name.lowerCamel(sanitizedShortName.split(" ")).join("credentials").join("json")),
             namer.inittedConstantName(
-                Name.lowerCamel(sanitizedShortName.split(" ")).join("credentials").join("json")));
+                Name.lowerCamel(sanitizedShortName.split(" ")).join("keyfile").join("json")));
 
     List<String> pathEnvVars =
         ImmutableList.<String>builder()

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -921,13 +921,13 @@ module Library
         "https://www.googleapis.com/auth/cloud-platform",
         "https://www.googleapis.com/auth/library"
       ].freeze
-      PATH_ENV_VARS = %w(LIBRARY_KEYFILE
-                         LIBRARY_CREDENTIALS
+      PATH_ENV_VARS = %w(LIBRARY_CREDENTIALS
+                         LIBRARY_KEYFILE
                          GOOGLE_CLOUD_CREDENTIALS
                          GOOGLE_CLOUD_KEYFILE
                          GCLOUD_KEYFILE)
-      JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON
-                         LIBRARY_CREDENTIALS_JSON
+      JSON_ENV_VARS = %w(LIBRARY_CREDENTIALS_JSON
+                         LIBRARY_KEYFILE_JSON
                          GOOGLE_CLOUD_CREDENTIALS_JSON
                          GOOGLE_CLOUD_KEYFILE_JSON
                          GCLOUD_KEYFILE_JSON)

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -907,13 +907,13 @@ module Google
         class Credentials < Google::Auth::Credentials
           SCOPE = [
           ].freeze
-          PATH_ENV_VARS = %w(MULTIPLE_SERVICES_KEYFILE
-                             MULTIPLE_SERVICES_CREDENTIALS
+          PATH_ENV_VARS = %w(MULTIPLE_SERVICES_CREDENTIALS
+                             MULTIPLE_SERVICES_KEYFILE
                              GOOGLE_CLOUD_CREDENTIALS
                              GOOGLE_CLOUD_KEYFILE
                              GCLOUD_KEYFILE)
-          JSON_ENV_VARS = %w(MULTIPLE_SERVICES_KEYFILE_JSON
-                             MULTIPLE_SERVICES_CREDENTIALS_JSON
+          JSON_ENV_VARS = %w(MULTIPLE_SERVICES_CREDENTIALS_JSON
+                             MULTIPLE_SERVICES_KEYFILE_JSON
                              GOOGLE_CLOUD_CREDENTIALS_JSON
                              GOOGLE_CLOUD_KEYFILE_JSON
                              GCLOUD_KEYFILE_JSON)


### PR DESCRIPTION
Fixes #2182 by reordering the ENV variables to be consistent with the `GOOGLE_CLOUD_*` ordering.