### PR TITLE
Ruby: Fix version selection for packages with no submodule.

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -104,7 +104,11 @@
     AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
       .select { |file| File.directory?(file) }
       .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
-      .select { |dir| File.exist?(File.join(dir, "{@index.postVersionDirPath}.rb")) }
+      @if index.postVersionDirPath
+        .select { |dir| File.exist?(File.join(dir, "{@index.postVersionDirPath}.rb")) }
+      @else
+        .select { |dir| File.exist?(dir + ".rb")) }
+      @end
       .map { |dir| File.basename(dir) }
 
   @default

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -672,7 +672,7 @@ module Library
   AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
     .select { |file| File.directory?(file) }
     .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
-    .select { |dir| File.exist?(File.join(dir, ".rb")) }
+    .select { |dir| File.exist?(dir + ".rb")) }
     .map { |dir| File.basename(dir) }
 
   ##


### PR DESCRIPTION
Resolves #2174 