### PR TITLE
Exclude all files in acceptance test directory

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/rubocop.yml.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/rubocop.yml.snip
@@ -6,7 +6,7 @@
       - "lib/google/**/*"
       - "Rakefile"
       - "test/**/*"
-      - "acceptance/**/*smoke_test.rb"
+      - "acceptance/**/*"
 
   Documentation:
     Enabled: false

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -20,7 +20,7 @@ AllCops:
     - "lib/google/**/*"
     - "Rakefile"
     - "test/**/*"
-    - "acceptance/**/*smoke_test.rb"
+    - "acceptance/**/*"
 
 Documentation:
   Enabled: false

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -20,7 +20,7 @@ AllCops:
     - "lib/google/**/*"
     - "Rakefile"
     - "test/**/*"
-    - "acceptance/**/*smoke_test.rb"
+    - "acceptance/**/*"
 
 Documentation:
   Enabled: false

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -20,7 +20,7 @@ AllCops:
     - "lib/google/**/*"
     - "Rakefile"
     - "test/**/*"
-    - "acceptance/**/*smoke_test.rb"
+    - "acceptance/**/*"
 
 Documentation:
   Enabled: false


### PR DESCRIPTION
Resolves #2186 by expanding the rubocop exclusions for the acceptance test directory.