### PR TITLE
Support custom region tags in samples

### DIFF
--- a/src/main/java/com/google/api/codegen/config/SampleSpec.java
+++ b/src/main/java/com/google/api/codegen/config/SampleSpec.java
@@ -22,10 +22,8 @@ import com.google.api.codegen.util.Name;
 import com.google.api.codegen.viewmodel.CallingForm;
 import com.google.auto.value.AutoValue;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
@@ -85,11 +83,10 @@ public class SampleSpec {
     sampleConfiguration = methodConfigProto.getSamples();
     valueSets = methodConfigProto.getSampleValueSetsList();
 
-    HashMap<String, SampleValueSet> setMap = new HashMap<>();
+    HashSet<String> ids = new HashSet<>();
     for (SampleValueSet valueSet : valueSets) {
       String id = valueSet.getId();
-      SampleValueSet oldSet = setMap.put(id, valueSet);
-      if (oldSet != null) {
+      if (!ids.add(id)) {
         throw new IllegalArgumentException(
             String.format(
                 "in method \"%s\": duplicate value set id: \"%s\"",
@@ -138,14 +135,12 @@ public class SampleSpec {
 
     // Construct a `ValueSetAndTags` for each sample specified in each element of `matchingSamples`.
     List<ValueSetAndTags> result = new ArrayList<>();
-    Set<String> generated = new HashSet<>();
     for (SampleValueSet vset : valueSets) {
       for (SampleTypeConfiguration sample : matchingSamples) {
         for (String valueSetExpression : sample.getValueSetsList()) {
           if (expressionMatchesId(valueSetExpression, vset.getId())) {
             result.add(
                 ValueSetAndTags.newBuilder().values(vset).regionTag(sample.getRegionTag()).build());
-            generated.add(vset.getId());
           }
         }
       }

--- a/src/main/java/com/google/api/codegen/config/SampleSpec.java
+++ b/src/main/java/com/google/api/codegen/config/SampleSpec.java
@@ -18,25 +18,30 @@ import com.google.api.codegen.MethodConfigProto;
 import com.google.api.codegen.SampleConfiguration;
 import com.google.api.codegen.SampleConfiguration.SampleTypeConfiguration;
 import com.google.api.codegen.SampleValueSet;
+import com.google.api.codegen.util.Name;
 import com.google.api.codegen.viewmodel.CallingForm;
-import com.google.api.codegen.viewmodel.ClientMethodType;
-import com.google.common.collect.ImmutableList;
+import com.google.auto.value.AutoValue;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
- * Class SampleSpec stores the sample specification for a given method, and provides methods to
- * easily access them by calling form and sample type.
+ * Class {@code SampleSpec} stores the sample specification for a given method, and provides methods
+ * to easily access them by calling form and sample type.
  */
 public class SampleSpec {
 
-  /** A reference to the Sample Configuration from which the other fields are derived. */
+  /** A reference to the {@code SampleConfiguration} from which the other fields are derived. */
   private final SampleConfiguration sampleConfiguration;
 
-  /** All the SampleValueSets defined for this method. */
+  /** All the {@code SampleValueSets} defined for this method. */
   private final List<SampleValueSet> valueSets;
 
+  /** Whether samples have been specified (ie. need to be emitted) for this method. */
   private final boolean specified;
 
   /** The various types of supported samples. */
@@ -46,16 +51,49 @@ public class SampleSpec {
     EXPLORER,
   }
 
+  /**
+   * A class used by {@code getMatchingValueSets} to return a value set needed to generate a sample
+   * for a given method, sample type, and calling form, together with region tag that should be used
+   * in that sample.
+   */
+  @AutoValue
+  public abstract static class ValueSetAndTags {
+
+    public abstract SampleValueSet values();
+
+    /** Returns the region tag prefix to be used for this sample. */
+    @Nullable
+    public abstract String regionTag();
+
+    public static Builder newBuilder() {
+      return new AutoValue_SampleSpec_ValueSetAndTags.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+      public abstract Builder values(SampleValueSet sets);
+
+      public abstract Builder regionTag(String tag);
+
+      public abstract ValueSetAndTags build();
+    }
+  }
+
   public SampleSpec(MethodConfigProto methodConfigProto) {
     specified = methodConfigProto.hasSamples();
     sampleConfiguration = methodConfigProto.getSamples();
     valueSets = methodConfigProto.getSampleValueSetsList();
 
-    HashSet<String> ids = new HashSet<>();
+    HashMap<String, SampleValueSet> setMap = new HashMap<>();
     for (SampleValueSet valueSet : valueSets) {
       String id = valueSet.getId();
-      if (!ids.add(id)) {
-        throw new IllegalArgumentException("SampleSpec: duplicate element: " + id);
+      SampleValueSet oldSet = setMap.put(id, valueSet);
+      if (oldSet != null) {
+        throw new IllegalArgumentException(
+            String.format(
+                "in method \"%s\": duplicate value set id: \"%s\"",
+                methodConfigProto.getName(), id));
       }
     }
   }
@@ -76,23 +114,18 @@ public class SampleSpec {
     return id.matches(expression);
   }
 
-  public List<SampleValueSet> getMatchingValueSets(
-      ClientMethodType methodForm, SampleType sampleType) {
-    return getMatchingValueSets(CallingForm.Generic, sampleType);
-  }
-
   /**
    * Returns the SampleValueSets that were specified for this methodForm and sampleType.
    *
-   * @param methodForm The calling form for which value sets are requestd
+   * @param methodForm The calling form for which value sets are requested
    * @param sampleType The sample type for which value sets are requested
    * @return A set of SampleValueSets for methodForm andSampleType
    */
-  public List<SampleValueSet> getMatchingValueSets(CallingForm methodForm, SampleType sampleType) {
-    String methodFormString = methodForm.toString();
+  public List<ValueSetAndTags> getMatchingValueSets(CallingForm methodForm, SampleType sampleType) {
+    String methodFormString = Name.anyCamel(methodForm.toString()).toLowerUnderscore();
 
-    // Get the value set expressions configured for this calling form.
-    List<String> valueSetExpressions =
+    // Get the `SampleTypeConfigs` configured for this `methodForm`.
+    List<SampleTypeConfiguration> matchingSamples =
         getConfigFor(sampleType)
             .stream()
             .filter(
@@ -101,21 +134,26 @@ public class SampleSpec {
                         .getCallingFormsList()
                         .stream()
                         .anyMatch(expression -> expressionMatchesId(expression, methodFormString)))
-            .flatMap(sampleConfig -> sampleConfig.getValueSetsList().stream())
             .collect(Collectors.toList());
 
-    // Return the value sets corresponding to the selected value set expressions.
-    return valueSets
-        .stream()
-        .filter(
-            valueSet ->
-                valueSetExpressions
-                    .stream()
-                    .anyMatch(expression -> expressionMatchesId(expression, valueSet.getId())))
-        .collect(ImmutableList.toImmutableList());
+    // Construct a `ValueSetAndTags` for each sample specified in each element of `matchingSamples`.
+    List<ValueSetAndTags> result = new ArrayList<>();
+    Set<String> generated = new HashSet<>();
+    for (SampleValueSet vset : valueSets) {
+      for (SampleTypeConfiguration sample : matchingSamples) {
+        for (String valueSetExpression : sample.getValueSetsList()) {
+          if (expressionMatchesId(valueSetExpression, vset.getId())) {
+            result.add(
+                ValueSetAndTags.newBuilder().values(vset).regionTag(sample.getRegionTag()).build());
+            generated.add(vset.getId());
+          }
+        }
+      }
+    }
+    return result;
   }
 
-  /** Returns the single SampleTypeConfiguration for the specified sampleType. */
+  /** Returns the single {@code SampleTypeConfiguration} for the specified {@code sampleType}. */
   private List<SampleTypeConfiguration> getConfigFor(SampleType sampleType) {
     switch (sampleType) {
       case STANDALONE:

--- a/src/main/java/com/google/api/codegen/transformer/SampleFileRegistry.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleFileRegistry.java
@@ -1,0 +1,103 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer;
+
+import com.google.auto.value.AutoValue;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@code SampleFileRegistry} is used to verify that the samples we generate with different
+ * parameters have different paths, so they don't clobber each other.
+ */
+public class SampleFileRegistry {
+
+  Map<String, SampleInfo> files = new HashMap<>();
+
+  /**
+   * Adds a file with the given parameters to the registry. If a file with the given {@code path}
+   * previously existed in the registry and any of the parameters don't match, throws an exception
+   * describing the conflict.
+   */
+  public void addFile(
+      String path, String method, String callingForm, String valueSet, String regionTag) {
+    SampleInfo previous = files.get(path);
+    if (previous == null) {
+      files.put(
+          path,
+          SampleInfo.newBuilder()
+              .path(path)
+              .method(method)
+              .callingForm(callingForm)
+              .valueSet(valueSet)
+              .regionTag(regionTag)
+              .build());
+    } else if (!(previous.path().equals(path)
+        && previous.method().equals(method)
+        && previous.callingForm().equals(callingForm)
+        && previous.valueSet().equals(valueSet)
+        && previous.regionTag().equals(regionTag))) {
+      throw new IllegalArgumentException(
+          String.format(
+              "conflicting configurations for sample \"%s\":\n"
+                  + "%s\n%s\n"
+                  + "  {method:\"%s\", calling form:\"%s\", value set:\"%s\", region tag:\"%s\"}\n"
+                  + "  {method:\"%s\", calling form:\"%s\", value set:\"%s\", region tag:\"%s\"}\n",
+              path,
+              previous.path(),
+              path,
+              previous.method(),
+              previous.callingForm(),
+              previous.valueSet(),
+              previous.regionTag(),
+              method,
+              callingForm,
+              valueSet,
+              regionTag));
+    }
+  }
+
+  @AutoValue
+  public abstract static class SampleInfo {
+    public abstract String path();
+
+    public abstract String method();
+
+    public abstract String callingForm();
+
+    public abstract String valueSet();
+
+    public abstract String regionTag();
+
+    public static SampleInfo.Builder newBuilder() {
+      return new AutoValue_SampleFileRegistry_SampleInfo.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract SampleInfo.Builder path(String value);
+
+      public abstract SampleInfo.Builder method(String value);
+
+      public abstract SampleInfo.Builder callingForm(String value);
+
+      public abstract SampleInfo.Builder valueSet(String value);
+
+      public abstract SampleInfo.Builder regionTag(String value);
+
+      public abstract SampleInfo build();
+    }
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/SampleFileRegistry.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleFileRegistry.java
@@ -24,7 +24,7 @@ import java.util.Map;
  */
 public class SampleFileRegistry {
 
-  Map<String, SampleInfo> files = new HashMap<>();
+  private final Map<String, SampleInfo> files = new HashMap<>();
 
   /**
    * Adds a file with the given parameters to the registry. If a file with the given {@code path}
@@ -33,39 +33,22 @@ public class SampleFileRegistry {
    */
   public void addFile(
       String path, String method, String callingForm, String valueSet, String regionTag) {
+    SampleInfo current =
+        SampleInfo.newBuilder()
+            .path(path)
+            .method(method)
+            .callingForm(callingForm)
+            .valueSet(valueSet)
+            .regionTag(regionTag)
+            .build();
     SampleInfo previous = files.get(path);
     if (previous == null) {
-      files.put(
-          path,
-          SampleInfo.newBuilder()
-              .path(path)
-              .method(method)
-              .callingForm(callingForm)
-              .valueSet(valueSet)
-              .regionTag(regionTag)
-              .build());
-    } else if (!(previous.path().equals(path)
-        && previous.method().equals(method)
-        && previous.callingForm().equals(callingForm)
-        && previous.valueSet().equals(valueSet)
-        && previous.regionTag().equals(regionTag))) {
+      files.put(path, current);
+    } else if (!current.equals(previous)) {
       throw new IllegalArgumentException(
           String.format(
-              "conflicting configurations for sample \"%s\":\n"
-                  + "%s\n%s\n"
-                  + "  {method:\"%s\", calling form:\"%s\", value set:\"%s\", region tag:\"%s\"}\n"
-                  + "  {method:\"%s\", calling form:\"%s\", value set:\"%s\", region tag:\"%s\"}\n",
-              path,
-              previous.path(),
-              path,
-              previous.method(),
-              previous.callingForm(),
-              previous.valueSet(),
-              previous.regionTag(),
-              method,
-              callingForm,
-              valueSet,
-              regionTag));
+              "conflicting configurations for sample \"%s\":\n  %s\n  %s",
+              path, previous.toString(), current.toString()));
     }
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -29,6 +29,7 @@ import com.google.api.codegen.viewmodel.InitCodeView;
 import com.google.api.codegen.viewmodel.MethodSampleView;
 import com.google.api.codegen.viewmodel.SampleValueSetView;
 import com.google.common.base.CaseFormat;
+import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -246,11 +247,11 @@ public class SampleTransformer {
    * Creates a region tag from the spec, replacing any {@code %m}, {@code %c}, and {@code %v}
    * placeholders with the method name, calling form name, and value set id, respectively.
    */
-  private String regionTagFromSpec(
+  private static String regionTagFromSpec(
       String spec, String methodName, CallingForm callingForm, String valueSetId) {
     final String DEFAULT_REGION_SPEC = "sample";
 
-    if (spec == null || spec.isEmpty()) {
+    if (Strings.isNullOrEmpty(spec)) {
       spec = DEFAULT_REGION_SPEC;
     }
     return spec.replace("%m", CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, methodName))

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -19,6 +19,7 @@ import com.google.api.codegen.SampleValueSet;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.SampleSpec.SampleType;
+import com.google.api.codegen.config.SampleSpec.ValueSetAndTags;
 import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.util.Name;
@@ -27,6 +28,7 @@ import com.google.api.codegen.viewmodel.CallingForm;
 import com.google.api.codegen.viewmodel.InitCodeView;
 import com.google.api.codegen.viewmodel.MethodSampleView;
 import com.google.api.codegen.viewmodel.SampleValueSetView;
+import com.google.common.base.CaseFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -175,7 +177,7 @@ public class SampleTransformer {
     for (CallingForm form : callingForms) {
       MethodConfig methodConfig = context.getMethodConfig();
 
-      List<SampleValueSet> matchingValueSets =
+      List<ValueSetAndTags> matchingValueSets =
           methodConfig.getSampleSpec().getMatchingValueSets(form, sampleType);
 
       // For backwards compatibility in the configs, we need to use sample_code_init_fields instead
@@ -195,35 +197,65 @@ public class SampleTransformer {
       if (id != null) {
         matchingValueSets =
             Collections.singletonList(
-                SampleValueSet.newBuilder()
-                    .addAllParameters(methodConfig.getSampleCodeInitFields())
-                    .setId(id)
-                    .setDescription("value set imported from sample_code_init_fields")
-                    .setTitle("Sample Values")
+                ValueSetAndTags.newBuilder()
+                    .values(
+                        SampleValueSet.newBuilder()
+                            .addAllParameters(methodConfig.getSampleCodeInitFields())
+                            .setId(id)
+                            .setDescription("value set imported from sample_code_init_fields")
+                            .setTitle("Sample Values")
+                            .build())
+                    .regionTag("")
                     .build());
       }
 
-      for (SampleValueSet valueSet : matchingValueSets) {
+      for (ValueSetAndTags valueSet : matchingValueSets) {
         InitCodeView initCodeView =
             sampleGenerator.generate(
                 initContext != null
                     ? initContext
                     : createInitCodeContext(
-                        context, fieldConfigs, initCodeOutputType, valueSet.getParametersList()));
-        List<OutputSpec> outputs = valueSet.getOutputSpecsList();
+                        context,
+                        fieldConfigs,
+                        initCodeOutputType,
+                        valueSet.values().getParametersList()));
+        List<OutputSpec> outputs = valueSet.values().getOutputSpecsList();
         if (outputs.isEmpty()) {
           outputs = OutputTransformer.defaultOutputSpecs(context.getMethodModel());
         }
+
         methodSampleViews.add(
             MethodSampleView.newBuilder()
                 .callingForm(form)
-                .valueSet(SampleValueSetView.of(valueSet))
+                .valueSet(SampleValueSetView.of(valueSet.values()))
                 .initCode(initCodeView)
-                .outputs(OutputTransformer.toViews(outputs, context, valueSet))
+                .outputs(OutputTransformer.toViews(outputs, context, valueSet.values()))
+                .regionTag(
+                    regionTagFromSpec(
+                        valueSet.regionTag(),
+                        context.getMethodModel().getSimpleName(),
+                        form,
+                        valueSet.values().getId()))
                 .build());
       }
     }
     return methodSampleViews;
+  }
+
+  /**
+   * Creates a region tag from the spec, replacing any {@code %m}, {@code %c}, and {@code %v}
+   * placeholders with the method name, calling form name, and value set id, respectively.
+   */
+  private String regionTagFromSpec(
+      String spec, String methodName, CallingForm callingForm, String valueSetId) {
+    final String DEFAULT_REGION_SPEC = "sample";
+
+    if (spec == null || spec.isEmpty()) {
+      spec = DEFAULT_REGION_SPEC;
+    }
+    return spec.replace("%m", CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, methodName))
+        .replace("%c", callingForm.toLowerCamel())
+        .replace("%v", valueSetId);
   }
 
   private InitCodeContext createInitCodeContext(

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -779,15 +779,10 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /**
-   * The name of the class that holds a sample for an API method, calling form, and value set id.
+   * The name of the class that holds a sample for an API method, constructed from {@code parts}.
    */
-  public String getApiSampleClassName(String methodName, String callingForm, String values) {
-    return publicClassName(
-        Name.anyCamel(
-            methodName,
-            "sample",
-            Name.anyCamel(callingForm).toUpperCamel(),
-            Name.anyLower(values).toUpperCamel()));
+  public String getApiSampleClassName(String... parts) {
+    return publicClassName(Name.anyLower(parts));
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -114,16 +114,6 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiSampleClassName(String methodName, String callingForm, String values) {
-    return publicClassName(
-        Name.anyLower(
-            Name.anyLower(methodName).toLowerUnderscore(),
-            "sample",
-            Name.anyCamel(callingForm).toLowerUnderscore(),
-            Name.anyLower(values).toLowerUnderscore()));
-  }
-
-  @Override
   public String getApiSampleFileName(String className) {
     return Name.anyCamel(className).toLowerUnderscore() + ".js";
   }

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
@@ -31,6 +31,7 @@ import com.google.api.codegen.transformer.GapicMethodContext;
 import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
+import com.google.api.codegen.transformer.SampleFileRegistry;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.py.PythonTypeTable;
 import com.google.api.codegen.viewmodel.DynamicLangSampleView;
@@ -137,6 +138,7 @@ public class PythonGapicSamplesTransformer implements ModelToViewTransformer<Pro
   private List<ViewModel> generateSampleClasses(GapicInterfaceContext context) {
     ImmutableList.Builder<ViewModel> viewModels = new ImmutableList.Builder<>();
     SurfaceNamer namer = context.getNamer();
+    SampleFileRegistry generatedSamples = new SampleFileRegistry();
 
     List<OptionalArrayMethodView> allmethods = methodGenerator.generateApiMethods(context);
 
@@ -146,10 +148,12 @@ public class PythonGapicSamplesTransformer implements ModelToViewTransformer<Pro
           pathMapper.getSamplesOutputPath(
               context.getInterfaceModel().getFullName(), context.getProductConfig(), method.name());
       for (MethodSampleView methodSample : method.samples()) {
-        String className =
-            namer.getApiSampleClassName(
-                method.name(), methodSample.callingForm().toString(), methodSample.valueSet().id());
+        String callingForm = methodSample.callingForm().toLowerCamel();
+        String valueSet = methodSample.valueSet().id();
+        String className = namer.getApiSampleClassName(method.name(), callingForm, valueSet);
         String sampleOutputPath = subPath + File.separator + namer.getApiSampleFileName(className);
+        generatedSamples.addFile(
+            sampleOutputPath, method.name(), callingForm, valueSet, methodSample.regionTag());
         viewModels.add(
             sampleClassBuilder
                 .templateFileName(STANDALONE_SAMPLE_TEMPLATE_FILENAME)

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -148,16 +148,6 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiSampleClassName(String methodName, String callingForm, String values) {
-    return publicClassName(
-        Name.anyLower(
-            methodName,
-            "sample",
-            Name.anyCamel(callingForm).toLowerUnderscore(),
-            Name.anyLower(values).toLowerUnderscore()));
-  }
-
-  @Override
   public String getApiSampleFileName(String className) {
     return Name.anyCamel(className).toLowerUnderscore() + ".py";
   }

--- a/src/main/java/com/google/api/codegen/util/Name.java
+++ b/src/main/java/com/google/api/codegen/util/Name.java
@@ -56,7 +56,17 @@ public class Name {
     try {
       name = Name.from(pieces);
     } catch (IllegalArgumentException e) {
-      name = Name.lowerCamel(pieces);
+      try {
+        name = Name.lowerCamel(pieces);
+      } catch (IllegalArgumentException ex) {
+        String msg = "[";
+        for (String p : pieces) {
+          msg += String.format("\"%s\", ", p);
+        }
+        msg += "]\n";
+        throw new IllegalArgumentException(
+            "Name: identifiers are not all either lower-underscore or lower-camel: " + msg);
+      }
     }
     return name;
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/CallingForm.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/CallingForm.java
@@ -14,6 +14,8 @@
  */
 package com.google.api.codegen.viewmodel;
 
+import com.google.common.base.CaseFormat;
+
 /**
  * The different calling forms we wish to illustrate in samples. Not every method type will have
  * every calling form, and a calling form for a given method type need not be applicable to every
@@ -61,5 +63,14 @@ public enum CallingForm {
 
   // Used only if code does not yet support deciding on one of the other ones. The goal is to have
   // this value never set.
-  Generic
+  Generic;
+
+  /**
+   * Returns the {@code String} representation of this enum, but in lower camelcase.
+   *
+   * @return the lower camelcase name of this enum value
+   */
+  public String toLowerCamel() {
+    return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, toString());
+  }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/MethodSampleView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/MethodSampleView.java
@@ -33,6 +33,9 @@ public abstract class MethodSampleView {
   /** The response printing code. */
   public abstract List<OutputView> outputs();
 
+  /** The region tag to be used for this sample. */
+  public abstract String regionTag();
+
   public static Builder newBuilder() {
     return new AutoValue_MethodSampleView.Builder();
   }
@@ -46,6 +49,8 @@ public abstract class MethodSampleView {
     public abstract Builder initCode(InitCodeView val);
 
     public abstract Builder outputs(List<OutputView> val);
+
+    public abstract Builder regionTag(String val);
 
     public abstract MethodSampleView build();
   }

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -376,6 +376,16 @@ message SampleConfiguration {
     // matching. In particular, the expression "*" will
     // match all IDs.
     repeated string value_sets = 2;
+
+    // The region tag value to be used inside each of these particular
+    // samples to bracket off (in language-specific comments)
+    // important areas of the sample. A region tag value can only
+    // consist of word characters (letters, numbers, or underscores)
+    // as well as the special tokens "%m", "%c", and "%v" (no quotes)
+    // which get replaced by each sample's method name, calling form,
+    // and value set, respectively. If not specified, `region_tag`
+    // defaults to "sample".
+    string region_tag = 3;
   }
 
   // The configuration for in-code samples, which appear in the format
@@ -389,6 +399,11 @@ message SampleConfiguration {
   // generated language. If this field is not specified, a stand-alone
   // sample is generated for every combination of calling form and
   // `MethodConfigProto.sample_value_sets`, if the latter is defined.
+  //
+  // If multiple samples configured here would result in files
+  // clobbering each other (ie. two files with the same path but not
+  // with identical calling forms, value sets, and region tags), an
+  // exception is raised.
   repeated SampleTypeConfiguration standalone = 2;
 
   // The configuration for user-parametrized samples ("API explorer
@@ -398,6 +413,11 @@ message SampleConfiguration {
   // specified, an explorer sample is generated for every combination
   // of calling form and `MethodConfigProto.sample_value_sets`, if the
   // latter is defined.
+  //
+  // If multiple samples configured here would result in files
+  // clobbering each other (ie. two files with the same path but not
+  // with identical calling forms, value sets, and region tags), an
+  // exception is raised.
   repeated SampleTypeConfiguration api_explorer = 3;
 }
 

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -7,34 +7,36 @@
 
   // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
    
-  // [START full_sample]
-
-  // FIXME: Insert here boilerplate code not directly related to the method call itself.
-       
   @let apiMethod = sampleFile.classView.libraryMethod, \
        sample = apiMethod.samples.get(0)
-    //     calling form: "{@sample.callingForm.toString}"
-    //     valueSet "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
+    // [START {@sample.regionTag}]
+
+    // FIXME: Insert here boilerplate code not directly related to the method call itself.
+       
+    //      calling form: "{@sample.callingForm.toString}"
+    //        region tag: "{@sample.regionTag}"
+    //         className: "{@sampleFile.classView.name}"
+    //          valueSet: "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
     //       description: "{@sample.valueSet.description}"
-    //       {@sample.valueSet.parameters}
-    //     apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
+    //        {@sample.valueSet.parameters}
+    //      apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
 
     // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
     public class {@sampleFile.classView.name} {
       public static void main(String[] args) {
-        // [START core_sample]
+        // [START {@sample.regionTag}_core]
         @let coreSampleCode = generateSample(apiMethod, sample.callingForm, sample.initCode)
           {@methodLines(coreSampleCode)}
         @end
-        // [END core_sample]
+        // [END {@sample.regionTag}_core]
       }
     }
 
     // FIXME: Insert here clean-up code.
 
+    // [END {@sample.regionTag}]
   @end
-  // [END full_sample]
 @end
 
 # adapted from main.snip:apiMethods(xapiClass) and its dependencies

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -8,32 +8,34 @@
 
    // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
    
-   // [START full_sample]
-
-   // FIXME: Insert here boilerplate code not directly related to the method call itself.
-       
   @let apiMethod = sampleFile.libraryMethod
      @let sample = apiMethod.samples.get(0)
-       //     calling form "{@sample.callingForm.toString}"
-       //     valueSet "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
-       //       description: "{@sample.valueSet.description}"
-       //       {@sample.valueSet.parameters}
-       //     apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
+       // [START {@sample.regionTag}]
 
-       // [START core_sample]
+       // FIXME: Insert here boilerplate code not directly related to the method call itself.
+       
+       //      calling form: "{@sample.callingForm.toString}"
+       //        region tag: "{@sample.regionTag}"
+       //         className: "{@sampleFile.className}"
+       //          valueSet: "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
+       //       description: "{@sample.valueSet.description}"
+       //        {@sample.valueSet.parameters}
+       //      apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
+
+       // [START {@sample.regionTag}_core]
 
        // FIXME: Insert here code to prepare the request fields, make the call, process the response.
        
        /*
        {@standaloneSample(apiMethod, sample)}
        */
-       // [END core_sample]
+       // [END {@sample.regionTag}_core]
 
        // FIXME: Insert here clean-up code.
        
+       // [END {@sample.regionTag}]
      @end
    @end
-   // [END full_sample]
 @end
 
 # The structure of this should be parallel to that of method_sample.snip:@incodeSample

--- a/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
@@ -6,33 +6,35 @@
     //// STUB standalone sample "{@sampleFile.className}" /////
 
     // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-     
-    // [START full_sample]
 
-    // FIXME: Insert here boilerplate code not directly related to the method call itself.
-             
     @let apiMethod = sampleFile.libraryMethod
         @let sample = apiMethod.samples.get(0)
-        //     calling form "{@sample.callingForm.toString}"
-        //     valueSet "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
-        //       description: "{@sample.valueSet.description}"
-        //       {@sample.valueSet.parameters}
-        //     apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
+        // [START {@sample.regionTag}]
 
-        // [START core_sample]
+        // FIXME: Insert here boilerplate code not directly related to the method call itself.
+    
+        //      calling form: "{@sample.callingForm.toString}"
+        //        region tag: "{@sample.regionTag}"
+        //         className: "{@sampleFile.className}"
+        //          valueSet: "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
+        //       description: "{@sample.valueSet.description}"
+        //        {@sample.valueSet.parameters}
+        //      apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
+
+        // [START {@sample.regionTag}_core]
 
         // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
         /*
         {@standaloneSample(sampleFile, apiMethod, sample)}
         */
-        // [END core_sample]
+        // [END {@sample.regionTag}_core]
 
         // FIXME: Insert here clean-up code.
              
+        // [END {@sample.regionTag}]
         @end
     @end
-    // [END full_sample]
 @end
 
 # The structure of this should be parallel to that of method_sample.snip:@incodeSampleCall

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -10,31 +10,33 @@
   @# To run with the published packaged, execute the following before running this code:
   @#   pip install {@sampleFile.gapicPackageName}
 
-  @# [START full_sample]
-
-  @# FIXME: Insert here boilerplate code not directly related to the method call itself.
-
   @let apiMethod = sampleFile.libraryMethod
     @let sample = apiMethod.samples.get(0)
-      @##     calling form "{@sample.callingForm.toString}"
-      @##     valueSet "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
-      @##       description: "{@sample.valueSet.description}"
+      @# [START {@sample.regionTag}]
+
+      @# FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+      @##     calling form: "{@sample.callingForm.toString}"
+      @##       region tag: "{@sample.regionTag}"
+      @##        className: "{@sampleFile.className}"
+      @##         valueSet: "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
+      @##      description: "{@sample.valueSet.description}"
       @##       {@sample.valueSet.parameters}
       @##     apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
 
-      @# [START core_sample]
+      @# [END {@sample.regionTag}_core]
 
       @# FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
       {@standaloneSample(apiMethod, sample)}
 
-      @# [END core_sample]
+      @# [END {@sample.regionTag}_core]
 
       @# FIXME: Insert here clean-up code.
 
+      @# [END {@sample.regionTag}]
     @end
   @end
-  @# [END full_sample]
 @end
 
 # The structure of this should be parallel to that of method_sample.snip:@incodeSampleCall.

--- a/src/test/java/com/google/api/codegen/config/SampleSpecTest.java
+++ b/src/test/java/com/google/api/codegen/config/SampleSpecTest.java
@@ -21,8 +21,9 @@ import com.google.api.codegen.SampleConfiguration;
 import com.google.api.codegen.SampleConfiguration.SampleTypeConfiguration;
 import com.google.api.codegen.SampleValueSet;
 import com.google.api.codegen.config.SampleSpec.SampleType;
-import com.google.api.codegen.viewmodel.ClientMethodType;
+import com.google.api.codegen.viewmodel.CallingForm;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.Test;
 
 public class SampleSpecTest {
@@ -75,7 +76,11 @@ public class SampleSpecTest {
             .build();
     SampleSpec sampleSpec = new SampleSpec(methodConfigProto);
     final List<SampleValueSet> matchingValues =
-        sampleSpec.getMatchingValueSets(ClientMethodType.CallableMethod, SampleType.STANDALONE);
+        sampleSpec
+            .getMatchingValueSets(CallingForm.Request, SampleType.STANDALONE)
+            .stream()
+            .map(vsat -> vsat.values())
+            .collect(Collectors.toList());
     assertThat(matchingValues).containsExactly(valueSetAlice, valueSetAlison).inOrder();
   }
 
@@ -101,8 +106,7 @@ public class SampleSpecTest {
                             .addCallingForms(".*")))
             .build();
     SampleSpec sampleSpec = new SampleSpec(methodConfigProto);
-    assertThat(
-            sampleSpec.getMatchingValueSets(ClientMethodType.CallableMethod, SampleType.STANDALONE))
-        .hasSize(2);
+    assertThat(sampleSpec.getMatchingValueSets(CallingForm.Request, SampleType.STANDALONE))
+        .hasSize(3);
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -7240,27 +7240,29 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     }
   }
 }
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/discussbookcallable/DiscussBookCallableSampleCallableStreamingBidiProg.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookCallableSampleCallableStreamingBidiProg" ]
-//// STUB standalone sample "DiscussBookCallableSampleCallableStreamingBidiProg" /////
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/discussbookcallable/DiscussBookCallableCallableStreamingBidiProg.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookCallableCallableStreamingBidiProg" ]
+//// STUB standalone sample "DiscussBookCallableCallableStreamingBidiProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START turing_prog_callable_streaming_bidi]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "CallableStreamingBidi"
-//     valueSet "prog" ("Programming Books")
+//      calling form: "CallableStreamingBidi"
+//        region tag: "turing_prog_callable_streaming_bidi"
+//         className: "DiscussBookCallableCallableStreamingBidiProg"
+//          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//       [name=BASIC]
-//     apiMethod "discussBookCallable" of type "CallableMethod"
+//        [name=BASIC]
+//      apiMethod "discussBookCallable" of type "CallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class DiscussBookCallableSampleCallableStreamingBidiProg {
+public class DiscussBookCallableCallableStreamingBidiProg {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START turing_prog_callable_streaming_bidi_core]
     BidiStream<DiscussBookRequest, Comment> bidiStream =
         libraryClient.discussBookCallable().call();
 
@@ -7272,34 +7274,36 @@ public class DiscussBookCallableSampleCallableStreamingBidiProg {
     for (Comment response : bidiStream) {
       // Do something when receive a response
     }
-    // [END core_sample]
+    // [END turing_prog_callable_streaming_bidi_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbooks/FindRelatedBooksSampleFlattenedPagedOdyssey.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleFlattenedPagedOdyssey" ]
-//// STUB standalone sample "FindRelatedBooksSampleFlattenedPagedOdyssey" /////
+// [END turing_prog_callable_streaming_bidi]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbooks/FindRelatedBooksFlattenedPagedOdyssey.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksFlattenedPagedOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksFlattenedPagedOdyssey" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "FlattenedPaged"
-//     valueSet "odyssey" ("The Odyssey")
+//      calling form: "FlattenedPaged"
+//        region tag: "sample"
+//         className: "FindRelatedBooksFlattenedPagedOdyssey"
+//          valueSet: "odyssey" ("The Odyssey")
 //       description: "Testing calling forms"
-//       [names[0]=Odyssey, shelves[0]=Classics]
-//     apiMethod "findRelatedBooks" of type "PagedFlattenedMethod"
+//        [names[0]=Odyssey, shelves[0]=Classics]
+//      apiMethod "findRelatedBooks" of type "PagedFlattenedMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class FindRelatedBooksSampleFlattenedPagedOdyssey {
+public class FindRelatedBooksFlattenedPagedOdyssey {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     String namesElement = "Odyssey";
     List<String> names = Arrays.asList(namesElement);
     String shelvesElement = "Classics";
@@ -7309,34 +7313,36 @@ public class FindRelatedBooksSampleFlattenedPagedOdyssey {
     for (ShelfBookName element : future.get().iterateAllAsShelfBookName()) {
       // doThingsWith(element);
     }
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbooks/FindRelatedBooksSampleRequestPagedOdyssey.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestPagedOdyssey" ]
-//// STUB standalone sample "FindRelatedBooksSampleRequestPagedOdyssey" /////
+// [END sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbooks/FindRelatedBooksRequestPagedOdyssey.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestPagedOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksRequestPagedOdyssey" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "RequestPaged"
-//     valueSet "odyssey" ("The Odyssey")
+//      calling form: "RequestPaged"
+//        region tag: "sample"
+//         className: "FindRelatedBooksRequestPagedOdyssey"
+//          valueSet: "odyssey" ("The Odyssey")
 //       description: "Testing calling forms"
-//       [names[0]=Odyssey, shelves[0]=Classics]
-//     apiMethod "findRelatedBooks" of type "PagedRequestObjectMethod"
+//        [names[0]=Odyssey, shelves[0]=Classics]
+//      apiMethod "findRelatedBooks" of type "PagedRequestObjectMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class FindRelatedBooksSampleRequestPagedOdyssey {
+public class FindRelatedBooksRequestPagedOdyssey {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     List<ShelfBookName> names = Arrays.asList(namesElement);
     ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
@@ -7348,34 +7354,36 @@ public class FindRelatedBooksSampleRequestPagedOdyssey {
     for (ShelfBookName element : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
       // doThingsWith(element);
     }
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbookscallable/FindRelatedBooksCallableSampleCallableListOdyssey.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksCallableSampleCallableListOdyssey" ]
-//// STUB standalone sample "FindRelatedBooksCallableSampleCallableListOdyssey" /////
+// [END sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbookscallable/FindRelatedBooksCallableCallableListOdyssey.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksCallableCallableListOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksCallableCallableListOdyssey" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "CallableList"
-//     valueSet "odyssey" ("The Odyssey")
+//      calling form: "CallableList"
+//        region tag: "sample"
+//         className: "FindRelatedBooksCallableCallableListOdyssey"
+//          valueSet: "odyssey" ("The Odyssey")
 //       description: "Testing calling forms"
-//       [names[0]=Odyssey, shelves[0]=Classics]
-//     apiMethod "findRelatedBooksCallable" of type "UnpagedListCallableMethod"
+//        [names[0]=Odyssey, shelves[0]=Classics]
+//      apiMethod "findRelatedBooksCallable" of type "UnpagedListCallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class FindRelatedBooksCallableSampleCallableListOdyssey {
+public class FindRelatedBooksCallableCallableListOdyssey {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     List<ShelfBookName> names = Arrays.asList(namesElement);
     ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
@@ -7396,34 +7404,36 @@ public class FindRelatedBooksCallableSampleCallableListOdyssey {
         break;
       }
     }
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbookspagedcallable/FindRelatedBooksPagedCallableSampleCallablePagedOdyssey.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksPagedCallableSampleCallablePagedOdyssey" ]
-//// STUB standalone sample "FindRelatedBooksPagedCallableSampleCallablePagedOdyssey" /////
+// [END sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/findrelatedbookspagedcallable/FindRelatedBooksPagedCallableCallablePagedOdyssey.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksPagedCallableCallablePagedOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksPagedCallableCallablePagedOdyssey" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "CallablePaged"
-//     valueSet "odyssey" ("The Odyssey")
+//      calling form: "CallablePaged"
+//        region tag: "sample"
+//         className: "FindRelatedBooksPagedCallableCallablePagedOdyssey"
+//          valueSet: "odyssey" ("The Odyssey")
 //       description: "Testing calling forms"
-//       [names[0]=Odyssey, shelves[0]=Classics]
-//     apiMethod "findRelatedBooksPagedCallable" of type "PagedCallableMethod"
+//        [names[0]=Odyssey, shelves[0]=Classics]
+//      apiMethod "findRelatedBooksPagedCallable" of type "PagedCallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class FindRelatedBooksPagedCallableSampleCallablePagedOdyssey {
+public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     List<ShelfBookName> names = Arrays.asList(namesElement);
     ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
@@ -7437,97 +7447,103 @@ public class FindRelatedBooksPagedCallableSampleCallablePagedOdyssey {
     for (ShelfBookName element : future.get().iterateAllAsShelfBookName()) {
       // doThingsWith(element);
     }
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookasync/GetBigBookAsyncSampleLongRunningFlattenedAsyncWap.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookAsyncSampleLongRunningFlattenedAsyncWap" ]
-//// STUB standalone sample "GetBigBookAsyncSampleLongRunningFlattenedAsyncWap" /////
+// [END sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookasync/GetBigBookAsyncLongRunningFlattenedAsyncWap.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookAsyncLongRunningFlattenedAsyncWap" ]
+//// STUB standalone sample "GetBigBookAsyncLongRunningFlattenedAsyncWap" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START hopper]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "LongRunningFlattenedAsync"
-//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//      calling form: "LongRunningFlattenedAsync"
+//        region tag: "hopper"
+//         className: "GetBigBookAsyncLongRunningFlattenedAsyncWap"
+//          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//       [name="War and Peace"]
-//     apiMethod "getBigBookAsync" of type "AsyncOperationFlattenedMethod"
+//        [name="War and Peace"]
+//      apiMethod "getBigBookAsync" of type "AsyncOperationFlattenedMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class GetBigBookAsyncSampleLongRunningFlattenedAsyncWap {
+public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START hopper_core]
     ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     Book response = libraryClient.getBigBookAsync(name.toString()).get();
-    // [END core_sample]
+    // [END hopper_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookasync/GetBigBookAsyncSampleLongRunningRequestAsyncWap.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookAsyncSampleLongRunningRequestAsyncWap" ]
-//// STUB standalone sample "GetBigBookAsyncSampleLongRunningRequestAsyncWap" /////
+// [END hopper]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookasync/GetBigBookAsyncLongRunningRequestAsyncWap.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookAsyncLongRunningRequestAsyncWap" ]
+//// STUB standalone sample "GetBigBookAsyncLongRunningRequestAsyncWap" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START hopper]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "LongRunningRequestAsync"
-//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//      calling form: "LongRunningRequestAsync"
+//        region tag: "hopper"
+//         className: "GetBigBookAsyncLongRunningRequestAsyncWap"
+//          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//       [name="War and Peace"]
-//     apiMethod "getBigBookAsync" of type "AsyncOperationRequestObjectMethod"
+//        [name="War and Peace"]
+//      apiMethod "getBigBookAsync" of type "AsyncOperationRequestObjectMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class GetBigBookAsyncSampleLongRunningRequestAsyncWap {
+public class GetBigBookAsyncLongRunningRequestAsyncWap {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START hopper_core]
     ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     GetBookRequest request = GetBookRequest.newBuilder()
       .setName(name.toString())
       .build();
     Book response = libraryClient.getBigBookAsync(request).get();
-    // [END core_sample]
+    // [END hopper_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookcallable/GetBigBookCallableSampleCallableWap.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookCallableSampleCallableWap" ]
-//// STUB standalone sample "GetBigBookCallableSampleCallableWap" /////
+// [END hopper]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookcallable/GetBigBookCallableCallableWap.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookCallableCallableWap" ]
+//// STUB standalone sample "GetBigBookCallableCallableWap" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START hopper]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "Callable"
-//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//      calling form: "Callable"
+//        region tag: "hopper"
+//         className: "GetBigBookCallableCallableWap"
+//          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//       [name="War and Peace"]
-//     apiMethod "getBigBookCallable" of type "CallableMethod"
+//        [name="War and Peace"]
+//      apiMethod "getBigBookCallable" of type "CallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class GetBigBookCallableSampleCallableWap {
+public class GetBigBookCallableCallableWap {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START hopper_core]
     ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     GetBookRequest request = GetBookRequest.newBuilder()
       .setName(name.toString())
@@ -7535,34 +7551,36 @@ public class GetBigBookCallableSampleCallableWap {
     ApiFuture<Operation> future = libraryClient.getBigBookCallable().futureCall(request);
     // Do something
     Operation response = future.get();
-    // [END core_sample]
+    // [END hopper_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookoperationcallable/GetBigBookOperationCallableSampleLongRunningCallableWap.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookOperationCallableSampleLongRunningCallableWap" ]
-//// STUB standalone sample "GetBigBookOperationCallableSampleLongRunningCallableWap" /////
+// [END hopper]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/getbigbookoperationcallable/GetBigBookOperationCallableLongRunningCallableWap.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookOperationCallableLongRunningCallableWap" ]
+//// STUB standalone sample "GetBigBookOperationCallableLongRunningCallableWap" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START hopper]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "LongRunningCallable"
-//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//      calling form: "LongRunningCallable"
+//        region tag: "hopper"
+//         className: "GetBigBookOperationCallableLongRunningCallableWap"
+//          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//       [name="War and Peace"]
-//     apiMethod "getBigBookOperationCallable" of type "OperationCallableMethod"
+//        [name="War and Peace"]
+//      apiMethod "getBigBookOperationCallable" of type "OperationCallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class GetBigBookOperationCallableSampleLongRunningCallableWap {
+public class GetBigBookOperationCallableLongRunningCallableWap {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START hopper_core]
     ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     GetBookRequest request = GetBookRequest.newBuilder()
       .setName(name.toString())
@@ -7570,34 +7588,36 @@ public class GetBigBookOperationCallableSampleLongRunningCallableWap {
     OperationFuture<Operation> future = libraryClient.getBigBookOperationCallable().futureCall(request);
     // Do something
     Book response = future.get();
-    // [END core_sample]
+    // [END hopper_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/monologaboutbookcallable/MonologAboutBookCallableSampleCallableStreamingClientProg.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookCallableSampleCallableStreamingClientProg" ]
-//// STUB standalone sample "MonologAboutBookCallableSampleCallableStreamingClientProg" /////
+// [END hopper]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/monologaboutbookcallable/MonologAboutBookCallableCallableStreamingClientProg.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookCallableCallableStreamingClientProg" ]
+//// STUB standalone sample "MonologAboutBookCallableCallableStreamingClientProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "CallableStreamingClient"
-//     valueSet "prog" ("Programming Books")
+//      calling form: "CallableStreamingClient"
+//        region tag: "sample"
+//         className: "MonologAboutBookCallableCallableStreamingClientProg"
+//          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//       [name=BASIC]
-//     apiMethod "monologAboutBookCallable" of type "CallableMethod"
+//        [name=BASIC]
+//      apiMethod "monologAboutBookCallable" of type "CallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class MonologAboutBookCallableSampleCallableStreamingClientProg {
+public class MonologAboutBookCallableCallableStreamingClientProg {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     ApiStreamObserver<Comment> responseObserver =
         new ApiStreamObserver<Comment>() {
           @Override
@@ -7623,34 +7643,36 @@ public class MonologAboutBookCallableSampleCallableStreamingClientProg {
       .setName(name)
       .build();
     requestObserver.onNext(request);
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesSampleFlattenedPiVersion.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleFlattenedPiVersion" ]
-//// STUB standalone sample "PublishSeriesSampleFlattenedPiVersion" /////
+// [END sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesFlattenedPiVersion.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesFlattenedPiVersion" ]
+//// STUB standalone sample "PublishSeriesFlattenedPiVersion" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "Flattened"
-//     valueSet "pi_version" ("Pi version")
+//      calling form: "Flattened"
+//        region tag: "sample"
+//         className: "PublishSeriesFlattenedPiVersion"
+//          valueSet: "pi_version" ("Pi version")
 //       description: "Testing calling forms"
-//       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
-//     apiMethod "publishSeries" of type "FlattenedMethod"
+//        [shelf.name=Math, series_uuid.series_string=xyz3141592654]
+//      apiMethod "publishSeries" of type "FlattenedMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class PublishSeriesSampleFlattenedPiVersion {
+public class PublishSeriesFlattenedPiVersion {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     String name = "Math";
     Shelf shelf = Shelf.newBuilder()
       .setName(name)
@@ -7662,67 +7684,71 @@ public class PublishSeriesSampleFlattenedPiVersion {
       .setSeriesString(seriesString)
       .build();
     PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesSampleFlattenedSecondEdition.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleFlattenedSecondEdition" ]
-//// STUB standalone sample "PublishSeriesSampleFlattenedSecondEdition" /////
+// [END sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesFlattenedSecondEdition.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesFlattenedSecondEdition" ]
+//// STUB standalone sample "PublishSeriesFlattenedSecondEdition" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "Flattened"
-//     valueSet "second_edition" ("Second edition")
+//      calling form: "Flattened"
+//        region tag: "sample"
+//         className: "PublishSeriesFlattenedSecondEdition"
+//          valueSet: "second_edition" ("Second edition")
 //       description: "Testing calling forms"
-//       [edition=2]
-//     apiMethod "publishSeries" of type "FlattenedMethod"
+//        [edition=2]
+//      apiMethod "publishSeries" of type "FlattenedMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class PublishSeriesSampleFlattenedSecondEdition {
+public class PublishSeriesFlattenedSecondEdition {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
     int edition = 2;
     SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
     PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesSampleRequestPiVersion.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestPiVersion" ]
-//// STUB standalone sample "PublishSeriesSampleRequestPiVersion" /////
+// [END sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesRequestPiVersion.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestPiVersion" ]
+//// STUB standalone sample "PublishSeriesRequestPiVersion" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "Request"
-//     valueSet "pi_version" ("Pi version")
+//      calling form: "Request"
+//        region tag: "sample"
+//         className: "PublishSeriesRequestPiVersion"
+//          valueSet: "pi_version" ("Pi version")
 //       description: "Testing calling forms"
-//       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
-//     apiMethod "publishSeries" of type "RequestObjectMethod"
+//        [shelf.name=Math, series_uuid.series_string=xyz3141592654]
+//      apiMethod "publishSeries" of type "RequestObjectMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class PublishSeriesSampleRequestPiVersion {
+public class PublishSeriesRequestPiVersion {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     String name = "Math";
     Shelf shelf = Shelf.newBuilder()
       .setName(name)
@@ -7738,34 +7764,36 @@ public class PublishSeriesSampleRequestPiVersion {
       .setSeriesUuid(seriesUuid)
       .build();
     PublishSeriesResponse response = libraryClient.publishSeries(request);
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesSampleRequestSecondEdition.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestSecondEdition" ]
-//// STUB standalone sample "PublishSeriesSampleRequestSecondEdition" /////
+// [END sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseries/PublishSeriesRequestSecondEdition.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestSecondEdition" ]
+//// STUB standalone sample "PublishSeriesRequestSecondEdition" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "Request"
-//     valueSet "second_edition" ("Second edition")
+//      calling form: "Request"
+//        region tag: "sample"
+//         className: "PublishSeriesRequestSecondEdition"
+//          valueSet: "second_edition" ("Second edition")
 //       description: "Testing calling forms"
-//       [edition=2]
-//     apiMethod "publishSeries" of type "RequestObjectMethod"
+//        [edition=2]
+//      apiMethod "publishSeries" of type "RequestObjectMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class PublishSeriesSampleRequestSecondEdition {
+public class PublishSeriesRequestSecondEdition {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
     SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
@@ -7777,34 +7805,36 @@ public class PublishSeriesSampleRequestSecondEdition {
       .setEdition(edition)
       .build();
     PublishSeriesResponse response = libraryClient.publishSeries(request);
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseriescallable/PublishSeriesCallableSampleCallablePiVersion.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesCallableSampleCallablePiVersion" ]
-//// STUB standalone sample "PublishSeriesCallableSampleCallablePiVersion" /////
+// [END sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseriescallable/PublishSeriesCallableCallablePiVersion.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesCallableCallablePiVersion" ]
+//// STUB standalone sample "PublishSeriesCallableCallablePiVersion" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "Callable"
-//     valueSet "pi_version" ("Pi version")
+//      calling form: "Callable"
+//        region tag: "sample"
+//         className: "PublishSeriesCallableCallablePiVersion"
+//          valueSet: "pi_version" ("Pi version")
 //       description: "Testing calling forms"
-//       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
-//     apiMethod "publishSeriesCallable" of type "CallableMethod"
+//        [shelf.name=Math, series_uuid.series_string=xyz3141592654]
+//      apiMethod "publishSeriesCallable" of type "CallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class PublishSeriesCallableSampleCallablePiVersion {
+public class PublishSeriesCallableCallablePiVersion {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     String name = "Math";
     Shelf shelf = Shelf.newBuilder()
       .setName(name)
@@ -7822,34 +7852,36 @@ public class PublishSeriesCallableSampleCallablePiVersion {
     ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
     // Do something
     PublishSeriesResponse response = future.get();
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseriescallable/PublishSeriesCallableSampleCallableSecondEdition.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesCallableSampleCallableSecondEdition" ]
-//// STUB standalone sample "PublishSeriesCallableSampleCallableSecondEdition" /////
+// [END sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/publishseriescallable/PublishSeriesCallableCallableSecondEdition.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesCallableCallableSecondEdition" ]
+//// STUB standalone sample "PublishSeriesCallableCallableSecondEdition" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "Callable"
-//     valueSet "second_edition" ("Second edition")
+//      calling form: "Callable"
+//        region tag: "sample"
+//         className: "PublishSeriesCallableCallableSecondEdition"
+//          valueSet: "second_edition" ("Second edition")
 //       description: "Testing calling forms"
-//       [edition=2]
-//     apiMethod "publishSeriesCallable" of type "CallableMethod"
+//        [edition=2]
+//      apiMethod "publishSeriesCallable" of type "CallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class PublishSeriesCallableSampleCallableSecondEdition {
+public class PublishSeriesCallableCallableSecondEdition {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
     SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
@@ -7863,34 +7895,36 @@ public class PublishSeriesCallableSampleCallableSecondEdition {
     ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
     // Do something
     PublishSeriesResponse response = future.get();
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/streambookscallable/StreamBooksCallableSampleCallableStreamingServerProg.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksCallableSampleCallableStreamingServerProg" ]
-//// STUB standalone sample "StreamBooksCallableSampleCallableStreamingServerProg" /////
+// [END sample]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/streambookscallable/StreamBooksCallableCallableStreamingServerProg.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksCallableCallableStreamingServerProg" ]
+//// STUB standalone sample "StreamBooksCallableCallableStreamingServerProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START babbage]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "CallableStreamingServer"
-//     valueSet "prog" ("Programming Books")
+//      calling form: "CallableStreamingServer"
+//        region tag: "babbage"
+//         className: "StreamBooksCallableCallableStreamingServerProg"
+//          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//       [name=BASIC]
-//     apiMethod "streamBooksCallable" of type "CallableMethod"
+//        [name=BASIC]
+//      apiMethod "streamBooksCallable" of type "CallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class StreamBooksCallableSampleCallableStreamingServerProg {
+public class StreamBooksCallableCallableStreamingServerProg {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START babbage_core]
     String name = "BASIC";
     StreamBooksRequest request = StreamBooksRequest.newBuilder()
       .setName(name)
@@ -7900,47 +7934,49 @@ public class StreamBooksCallableSampleCallableStreamingServerProg {
     for (Book response : stream) {
       // Do something when receive a response
     }
-    // [END core_sample]
+    // [END babbage_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/streamshelvescallable/StreamShelvesCallableSampleCallableStreamingServerEmpty.java ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesCallableSampleCallableStreamingServerEmpty" ]
-//// STUB standalone sample "StreamShelvesCallableSampleCallableStreamingServerEmpty" /////
+// [END babbage]
+============== file: src/main/java/samples/com/google/gcloud/pubsub/v1/streamshelvescallable/StreamShelvesCallableCallableStreamingServerEmpty.java ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesCallableCallableStreamingServerEmpty" ]
+//// STUB standalone sample "StreamShelvesCallableCallableStreamingServerEmpty" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form: "CallableStreamingServer"
-//     valueSet "empty" ("Server streaming")
+//      calling form: "CallableStreamingServer"
+//        region tag: "sample"
+//         className: "StreamShelvesCallableCallableStreamingServerEmpty"
+//          valueSet: "empty" ("Server streaming")
 //       description: "Testing calling forms"
-//       []
-//     apiMethod "streamShelvesCallable" of type "CallableMethod"
+//        []
+//      apiMethod "streamShelvesCallable" of type "CallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
-public class StreamShelvesCallableSampleCallableStreamingServerEmpty {
+public class StreamShelvesCallableCallableStreamingServerEmpty {
   public static void main(String[] args) {
-    // [START core_sample]
+    // [START sample_core]
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
 
     ServerStream<StreamShelvesResponse> stream = libraryClient.streamShelvesCallable().call(request);
     for (StreamShelvesResponse response : stream) {
       // Do something when receive a response
     }
-    // [END core_sample]
+    // [END sample_core]
   }
 }
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
+// [END sample]
 ============== file: src/test/java/com/google/gcloud/pubsub/v1/LibraryClientTest.java ==============
 /*
  * Copyright 2018 Google LLC

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -248,23 +248,25 @@ module.exports.v1 = gapic.v1;
 // Alias `module.exports` as `module.exports.default`, for future-proofing.
 module.exports.default = Object.assign({}, module.exports);
 
-============== file: src/samples/v1/discuss_book_sample_request_streaming_bidi_prog.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookSampleRequestStreamingBidiProg" ]
-//// STUB standalone sample "DiscussBookSampleRequestStreamingBidiProg" /////
+============== file: src/samples/v1/discuss_book_request_streaming_bidi_prog.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookRequestStreamingBidiProg" ]
+//// STUB standalone sample "DiscussBookRequestStreamingBidiProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START turing_prog_request_streaming_bidi]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestStreamingBidi"
-//     valueSet "prog" ("Programming Books")
+//      calling form: "RequestStreamingBidi"
+//        region tag: "turing_prog_request_streaming_bidi"
+//         className: "DiscussBookRequestStreamingBidiProg"
+//          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//       [name=BASIC]
-//     apiMethod "discussBook" of type "OptionalArrayMethod"
+//        [name=BASIC]
+//      apiMethod "discussBook" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START turing_prog_request_streaming_bidi_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -279,28 +281,30 @@ var request = {
 // Write request objects.
 stream.write(request);
 */
-// [END core_sample]
+// [END turing_prog_request_streaming_bidi_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/samples/v1/find_related_books_sample_request_async_paged_all_odyssey.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestAsyncPagedAllOdyssey" ]
-//// STUB standalone sample "FindRelatedBooksSampleRequestAsyncPagedAllOdyssey" /////
+// [END turing_prog_request_streaming_bidi]
+============== file: src/samples/v1/find_related_books_request_async_paged_all_odyssey.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestAsyncPagedAllOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksRequestAsyncPagedAllOdyssey" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestAsyncPagedAll"
-//     valueSet "odyssey" ("The Odyssey")
+//      calling form: "RequestAsyncPagedAll"
+//        region tag: "sample"
+//         className: "FindRelatedBooksRequestAsyncPagedAllOdyssey"
+//          valueSet: "odyssey" ("The Odyssey")
 //       description: "Testing calling forms"
-//       [names[0]=Odyssey, shelves[0]=Classics]
-//     apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
+//        [names[0]=Odyssey, shelves[0]=Classics]
+//      apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -326,28 +330,30 @@ client.findRelatedBooks(request)
     console.error(err);
   });
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/samples/v1/find_related_books_sample_request_async_paged_odyssey.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestAsyncPagedOdyssey" ]
-//// STUB standalone sample "FindRelatedBooksSampleRequestAsyncPagedOdyssey" /////
+// [END sample]
+============== file: src/samples/v1/find_related_books_request_async_paged_odyssey.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestAsyncPagedOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksRequestAsyncPagedOdyssey" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestAsyncPaged"
-//     valueSet "odyssey" ("The Odyssey")
+//      calling form: "RequestAsyncPaged"
+//        region tag: "sample"
+//         className: "FindRelatedBooksRequestAsyncPagedOdyssey"
+//          valueSet: "odyssey" ("The Odyssey")
 //       description: "Testing calling forms"
-//       [names[0]=Odyssey, shelves[0]=Classics]
-//     apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
+//        [names[0]=Odyssey, shelves[0]=Classics]
+//      apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -385,28 +391,30 @@ client.findRelatedBooks(request, options)
     console.error(err);
   });
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/samples/v1/get_big_book_sample_long_running_event_emitter_wap.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleLongRunningEventEmitterWap" ]
-//// STUB standalone sample "GetBigBookSampleLongRunningEventEmitterWap" /////
+// [END sample]
+============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningEventEmitterWap" ]
+//// STUB standalone sample "GetBigBookLongRunningEventEmitterWap" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START hopper]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "LongRunningEventEmitter"
-//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//      calling form: "LongRunningEventEmitter"
+//        region tag: "hopper"
+//         className: "GetBigBookLongRunningEventEmitterWap"
+//          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//       [name="War and Peace"]
-//     apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
+//        [name="War and Peace"]
+//      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
 
-// [START core_sample]
+// [START hopper_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -440,28 +448,30 @@ client.getBigBook({name: formattedName})
     console.error(err);
   });
 */
-// [END core_sample]
+// [END hopper_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/samples/v1/get_big_book_sample_long_running_promise_wap.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleLongRunningPromiseWap" ]
-//// STUB standalone sample "GetBigBookSampleLongRunningPromiseWap" /////
+// [END hopper]
+============== file: src/samples/v1/get_big_book_long_running_promise_wap.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningPromiseWap" ]
+//// STUB standalone sample "GetBigBookLongRunningPromiseWap" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START hopper]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "LongRunningPromise"
-//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//      calling form: "LongRunningPromise"
+//        region tag: "hopper"
+//         className: "GetBigBookLongRunningPromiseWap"
+//          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//       [name="War and Peace"]
-//     apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
+//        [name="War and Peace"]
+//      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
 
-// [START core_sample]
+// [START hopper_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -491,28 +501,30 @@ client.getBigBook({name: formattedName})
     console.error(err);
   });
 */
-// [END core_sample]
+// [END hopper_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/samples/v1/monolog_about_book_sample_request_streaming_client_prog.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookSampleRequestStreamingClientProg" ]
-//// STUB standalone sample "MonologAboutBookSampleRequestStreamingClientProg" /////
+// [END hopper]
+============== file: src/samples/v1/monolog_about_book_request_streaming_client_prog.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookRequestStreamingClientProg" ]
+//// STUB standalone sample "MonologAboutBookRequestStreamingClientProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestStreamingClient"
-//     valueSet "prog" ("Programming Books")
+//      calling form: "RequestStreamingClient"
+//        region tag: "sample"
+//         className: "MonologAboutBookRequestStreamingClientProg"
+//          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//       [name=BASIC]
-//     apiMethod "monologAboutBook" of type "OptionalArrayMethod"
+//        [name=BASIC]
+//      apiMethod "monologAboutBook" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -531,28 +543,30 @@ var request = {
 // Write request objects.
 stream.write(request);
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/samples/v1/publish_series_sample_request_pi_version.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestPiVersion" ]
-//// STUB standalone sample "PublishSeriesSampleRequestPiVersion" /////
+// [END sample]
+============== file: src/samples/v1/publish_series_request_pi_version.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestPiVersion" ]
+//// STUB standalone sample "PublishSeriesRequestPiVersion" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Request"
-//     valueSet "pi_version" ("Pi version")
+//      calling form: "Request"
+//        region tag: "sample"
+//         className: "PublishSeriesRequestPiVersion"
+//          valueSet: "pi_version" ("Pi version")
 //       description: "Testing calling forms"
-//       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
-//     apiMethod "publishSeries" of type "OptionalArrayMethod"
+//        [shelf.name=Math, series_uuid.series_string=xyz3141592654]
+//      apiMethod "publishSeries" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -580,28 +594,30 @@ client.publishSeries(request)
     console.error(err);
   });
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/samples/v1/publish_series_sample_request_second_edition.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestSecondEdition" ]
-//// STUB standalone sample "PublishSeriesSampleRequestSecondEdition" /////
+// [END sample]
+============== file: src/samples/v1/publish_series_request_second_edition.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestSecondEdition" ]
+//// STUB standalone sample "PublishSeriesRequestSecondEdition" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Request"
-//     valueSet "second_edition" ("Second edition")
+//      calling form: "Request"
+//        region tag: "sample"
+//         className: "PublishSeriesRequestSecondEdition"
+//          valueSet: "second_edition" ("Second edition")
 //       description: "Testing calling forms"
-//       [edition=2]
-//     apiMethod "publishSeries" of type "OptionalArrayMethod"
+//        [edition=2]
+//      apiMethod "publishSeries" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -625,28 +641,30 @@ client.publishSeries(request)
     console.error(err);
   });
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/samples/v1/stream_books_sample_request_streaming_server_prog.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksSampleRequestStreamingServerProg" ]
-//// STUB standalone sample "StreamBooksSampleRequestStreamingServerProg" /////
+// [END sample]
+============== file: src/samples/v1/stream_books_request_streaming_server_prog.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksRequestStreamingServerProg" ]
+//// STUB standalone sample "StreamBooksRequestStreamingServerProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START lovelace]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestStreamingServer"
-//     valueSet "prog" ("Programming Books")
+//      calling form: "RequestStreamingServer"
+//        region tag: "lovelace"
+//         className: "StreamBooksRequestStreamingServerProg"
+//          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//       [name=BASIC]
-//     apiMethod "streamBooks" of type "OptionalArrayMethod"
+//        [name=BASIC]
+//      apiMethod "streamBooks" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START lovelace_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -656,28 +674,30 @@ var name = 'BASIC';
       // doThingsWith(response)
   });
 */
-// [END core_sample]
+// [END lovelace_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/samples/v1/stream_shelves_sample_request_streaming_server_empty.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesSampleRequestStreamingServerEmpty" ]
-//// STUB standalone sample "StreamShelvesSampleRequestStreamingServerEmpty" /////
+// [END lovelace]
+============== file: src/samples/v1/stream_shelves_request_streaming_server_empty.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesRequestStreamingServerEmpty" ]
+//// STUB standalone sample "StreamShelvesRequestStreamingServerEmpty" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestStreamingServer"
-//     valueSet "empty" ("Server streaming")
+//      calling form: "RequestStreamingServer"
+//        region tag: "sample"
+//         className: "StreamShelvesRequestStreamingServerEmpty"
+//          valueSet: "empty" ("Server streaming")
 //       description: "Testing calling forms"
-//       []
-//     apiMethod "streamShelves" of type "OptionalArrayMethod"
+//        []
+//      apiMethod "streamShelves" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -687,11 +707,11 @@ var name = 'BASIC';
       // doThingsWith(response)
   });
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
+// [END sample]
 ============== file: src/v1/doc/google/example/library/v1/doc_book_from_anywhere.js ==============
 // Copyright 2018 Google LLC
 //

--- a/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
@@ -2721,23 +2721,25 @@ return [
     ]
 ];
 
-============== file: src/V1/samples/discussBook/DiscussBookSampleRequestStreamingBidiAsyncProg.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookSampleRequestStreamingBidiAsyncProg" ]
-//// STUB standalone sample "DiscussBookSampleRequestStreamingBidiAsyncProg" /////
+============== file: src/V1/samples/discussBook/DiscussBookRequestStreamingBidiAsyncProg.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookRequestStreamingBidiAsyncProg" ]
+//// STUB standalone sample "DiscussBookRequestStreamingBidiAsyncProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START turing_prog_request_streaming_bidi_async]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestStreamingBidiAsync"
-//     valueSet "prog" ("Programming Books")
+//      calling form: "RequestStreamingBidiAsync"
+//        region tag: "turing_prog_request_streaming_bidi_async"
+//         className: "DiscussBookRequestStreamingBidiAsyncProg"
+//          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//       [name=BASIC]
-//     apiMethod "discussBook" of type "OptionalArrayMethod"
+//        [name=BASIC]
+//      apiMethod "discussBook" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START turing_prog_request_streaming_bidi_async_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -2772,28 +2774,30 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END turing_prog_request_streaming_bidi_async_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/V1/samples/discussBook/DiscussBookSampleRequestStreamingBidiProg.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookSampleRequestStreamingBidiProg" ]
-//// STUB standalone sample "DiscussBookSampleRequestStreamingBidiProg" /////
+// [END turing_prog_request_streaming_bidi_async]
+============== file: src/V1/samples/discussBook/DiscussBookRequestStreamingBidiProg.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookRequestStreamingBidiProg" ]
+//// STUB standalone sample "DiscussBookRequestStreamingBidiProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START turing_prog_request_streaming_bidi]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestStreamingBidi"
-//     valueSet "prog" ("Programming Books")
+//      calling form: "RequestStreamingBidi"
+//        region tag: "turing_prog_request_streaming_bidi"
+//         className: "DiscussBookRequestStreamingBidiProg"
+//          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//       [name=BASIC]
-//     apiMethod "discussBook" of type "OptionalArrayMethod"
+//        [name=BASIC]
+//      apiMethod "discussBook" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START turing_prog_request_streaming_bidi_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -2819,28 +2823,30 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END turing_prog_request_streaming_bidi_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/V1/samples/findRelatedBooks/FindRelatedBooksSampleRequestPagedAllOdyssey.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestPagedAllOdyssey" ]
-//// STUB standalone sample "FindRelatedBooksSampleRequestPagedAllOdyssey" /////
+// [END turing_prog_request_streaming_bidi]
+============== file: src/V1/samples/findRelatedBooks/FindRelatedBooksRequestPagedAllOdyssey.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestPagedAllOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksRequestPagedAllOdyssey" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestPagedAll"
-//     valueSet "odyssey" ("The Odyssey")
+//      calling form: "RequestPagedAll"
+//        region tag: "sample"
+//         className: "FindRelatedBooksRequestPagedAllOdyssey"
+//          valueSet: "odyssey" ("The Odyssey")
 //       description: "Testing calling forms"
-//       [names[0]=Odyssey, shelves[0]=Classics]
-//     apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
+//        [names[0]=Odyssey, shelves[0]=Classics]
+//      apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -2862,28 +2868,30 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/V1/samples/findRelatedBooks/FindRelatedBooksSampleRequestPagedOdyssey.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestPagedOdyssey" ]
-//// STUB standalone sample "FindRelatedBooksSampleRequestPagedOdyssey" /////
+// [END sample]
+============== file: src/V1/samples/findRelatedBooks/FindRelatedBooksRequestPagedOdyssey.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestPagedOdyssey" ]
+//// STUB standalone sample "FindRelatedBooksRequestPagedOdyssey" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestPaged"
-//     valueSet "odyssey" ("The Odyssey")
+//      calling form: "RequestPaged"
+//        region tag: "sample"
+//         className: "FindRelatedBooksRequestPagedOdyssey"
+//          valueSet: "odyssey" ("The Odyssey")
 //       description: "Testing calling forms"
-//       [names[0]=Odyssey, shelves[0]=Classics]
-//     apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
+//        [names[0]=Odyssey, shelves[0]=Classics]
+//      apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -2907,28 +2915,30 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/V1/samples/getBigBook/GetBigBookSampleLongRunningRequestAsyncWap.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleLongRunningRequestAsyncWap" ]
-//// STUB standalone sample "GetBigBookSampleLongRunningRequestAsyncWap" /////
+// [END sample]
+============== file: src/V1/samples/getBigBook/GetBigBookLongRunningRequestAsyncWap.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningRequestAsyncWap" ]
+//// STUB standalone sample "GetBigBookLongRunningRequestAsyncWap" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START hopper]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "LongRunningRequestAsync"
-//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//      calling form: "LongRunningRequestAsync"
+//        region tag: "hopper"
+//         className: "GetBigBookLongRunningRequestAsyncWap"
+//          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//       [name="War and Peace"]
-//     apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
+//        [name="War and Peace"]
+//      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
 
-// [START core_sample]
+// [START hopper_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -2958,28 +2968,30 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END hopper_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/V1/samples/getBigBook/GetBigBookSampleLongRunningRequestWap.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleLongRunningRequestWap" ]
-//// STUB standalone sample "GetBigBookSampleLongRunningRequestWap" /////
+// [END hopper]
+============== file: src/V1/samples/getBigBook/GetBigBookLongRunningRequestWap.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningRequestWap" ]
+//// STUB standalone sample "GetBigBookLongRunningRequestWap" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START hopper]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "LongRunningRequest"
-//     valueSet "wap" ("GetBigBook: 'War and Peace'")
+//      calling form: "LongRunningRequest"
+//        region tag: "hopper"
+//         className: "GetBigBookLongRunningRequestWap"
+//          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//       [name="War and Peace"]
-//     apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
+//        [name="War and Peace"]
+//      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
 
-// [START core_sample]
+// [START hopper_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -3002,28 +3014,30 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END hopper_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/V1/samples/monologAboutBook/MonologAboutBookSampleRequestStreamingClientAsyncProg.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookSampleRequestStreamingClientAsyncProg" ]
-//// STUB standalone sample "MonologAboutBookSampleRequestStreamingClientAsyncProg" /////
+// [END hopper]
+============== file: src/V1/samples/monologAboutBook/MonologAboutBookRequestStreamingClientAsyncProg.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookRequestStreamingClientAsyncProg" ]
+//// STUB standalone sample "MonologAboutBookRequestStreamingClientAsyncProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestStreamingClientAsync"
-//     valueSet "prog" ("Programming Books")
+//      calling form: "RequestStreamingClientAsync"
+//        region tag: "sample"
+//         className: "MonologAboutBookRequestStreamingClientAsyncProg"
+//          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//       [name=BASIC]
-//     apiMethod "monologAboutBook" of type "OptionalArrayMethod"
+//        [name=BASIC]
+//      apiMethod "monologAboutBook" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -3049,28 +3063,30 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/V1/samples/monologAboutBook/MonologAboutBookSampleRequestStreamingClientProg.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookSampleRequestStreamingClientProg" ]
-//// STUB standalone sample "MonologAboutBookSampleRequestStreamingClientProg" /////
+// [END sample]
+============== file: src/V1/samples/monologAboutBook/MonologAboutBookRequestStreamingClientProg.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookRequestStreamingClientProg" ]
+//// STUB standalone sample "MonologAboutBookRequestStreamingClientProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestStreamingClient"
-//     valueSet "prog" ("Programming Books")
+//      calling form: "RequestStreamingClient"
+//        region tag: "sample"
+//         className: "MonologAboutBookRequestStreamingClientProg"
+//          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//       [name=BASIC]
-//     apiMethod "monologAboutBook" of type "OptionalArrayMethod"
+//        [name=BASIC]
+//      apiMethod "monologAboutBook" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -3093,28 +3109,30 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/V1/samples/publishSeries/PublishSeriesSampleRequestPiVersion.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestPiVersion" ]
-//// STUB standalone sample "PublishSeriesSampleRequestPiVersion" /////
+// [END sample]
+============== file: src/V1/samples/publishSeries/PublishSeriesRequestPiVersion.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestPiVersion" ]
+//// STUB standalone sample "PublishSeriesRequestPiVersion" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Request"
-//     valueSet "pi_version" ("Pi version")
+//      calling form: "Request"
+//        region tag: "sample"
+//         className: "PublishSeriesRequestPiVersion"
+//          valueSet: "pi_version" ("Pi version")
 //       description: "Testing calling forms"
-//       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
-//     apiMethod "publishSeries" of type "OptionalArrayMethod"
+//        [shelf.name=Math, series_uuid.series_string=xyz3141592654]
+//      apiMethod "publishSeries" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -3139,28 +3157,30 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/V1/samples/publishSeries/PublishSeriesSampleRequestSecondEdition.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestSecondEdition" ]
-//// STUB standalone sample "PublishSeriesSampleRequestSecondEdition" /////
+// [END sample]
+============== file: src/V1/samples/publishSeries/PublishSeriesRequestSecondEdition.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestSecondEdition" ]
+//// STUB standalone sample "PublishSeriesRequestSecondEdition" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "Request"
-//     valueSet "second_edition" ("Second edition")
+//      calling form: "Request"
+//        region tag: "sample"
+//         className: "PublishSeriesRequestSecondEdition"
+//          valueSet: "second_edition" ("Second edition")
 //       description: "Testing calling forms"
-//       [edition=2]
-//     apiMethod "publishSeries" of type "OptionalArrayMethod"
+//        [edition=2]
+//      apiMethod "publishSeries" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -3182,28 +3202,30 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/V1/samples/streamBooks/StreamBooksSampleRequestStreamingServerProg.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksSampleRequestStreamingServerProg" ]
-//// STUB standalone sample "StreamBooksSampleRequestStreamingServerProg" /////
+// [END sample]
+============== file: src/V1/samples/streamBooks/StreamBooksRequestStreamingServerProg.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksRequestStreamingServerProg" ]
+//// STUB standalone sample "StreamBooksRequestStreamingServerProg" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START lovelace]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestStreamingServer"
-//     valueSet "prog" ("Programming Books")
+//      calling form: "RequestStreamingServer"
+//        region tag: "lovelace"
+//         className: "StreamBooksRequestStreamingServerProg"
+//          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//       [name=BASIC]
-//     apiMethod "streamBooks" of type "OptionalArrayMethod"
+//        [name=BASIC]
+//      apiMethod "streamBooks" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START lovelace_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -3222,28 +3244,30 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END lovelace_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
-============== file: src/V1/samples/streamShelves/StreamShelvesSampleRequestStreamingServerEmpty.php ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesSampleRequestStreamingServerEmpty" ]
-//// STUB standalone sample "StreamShelvesSampleRequestStreamingServerEmpty" /////
+// [END lovelace]
+============== file: src/V1/samples/streamShelves/StreamShelvesRequestStreamingServerEmpty.php ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesRequestStreamingServerEmpty" ]
+//// STUB standalone sample "StreamShelvesRequestStreamingServerEmpty" /////
 
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
-// [START full_sample]
+// [START sample]
 
 // FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-//     calling form "RequestStreamingServer"
-//     valueSet "empty" ("Server streaming")
+//      calling form: "RequestStreamingServer"
+//        region tag: "sample"
+//         className: "StreamShelvesRequestStreamingServerEmpty"
+//          valueSet: "empty" ("Server streaming")
 //       description: "Testing calling forms"
-//       []
-//     apiMethod "streamShelves" of type "OptionalArrayMethod"
+//        []
+//      apiMethod "streamShelves" of type "OptionalArrayMethod"
 
-// [START core_sample]
+// [START sample_core]
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -3260,11 +3284,11 @@ try {
     $libraryServiceClient->close();
 }
 */
-// [END core_sample]
+// [END sample_core]
 
 // FIXME: Insert here clean-up code.
 
-// [END full_sample]
+// [END sample]
 ============== file: tests/System/V1/LibraryServiceSmokeTest.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -4058,26 +4058,28 @@ def lint_setup_py(session):
     session.install('docutils', 'pygments')
     session.run(
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')
-============== file: samples/google/cloud/example/library_v1/gapic/discuss_book/discuss_book_sample_request_streaming_bidi_prog.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookSampleRequestStreamingBidiProg" ]
-#### STUB standalone sample "DiscussBookSampleRequestStreamingBidiProg" #####
+============== file: samples/google/cloud/example/library_v1/gapic/discuss_book/discuss_book_request_streaming_bidi_prog.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookRequestStreamingBidiProg" ]
+#### STUB standalone sample "DiscussBookRequestStreamingBidiProg" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 # To run with the published packaged, execute the following before running this code:
 #   pip install google-cloud-library
 
-# [START full_sample]
+# [START turing_prog_request_streaming_bidi]
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "RequestStreamingBidi"
-##     valueSet "prog" ("Programming Books")
-##       description: "Testing calling forms"
+##     calling form: "RequestStreamingBidi"
+##       region tag: "turing_prog_request_streaming_bidi"
+##        className: "DiscussBookRequestStreamingBidiProg"
+##         valueSet: "prog" ("Programming Books")
+##      description: "Testing calling forms"
 ##       [name=BASIC]
 ##     apiMethod "discuss_book" of type "OptionalArrayMethod"
 
-# [START core_sample]
+# [END turing_prog_request_streaming_bidi_core]
 
 # FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -4094,31 +4096,33 @@ for element in client.discuss_book(requests):
     pass
 print(response)
 
-# [END core_sample]
+# [END turing_prog_request_streaming_bidi_core]
 
 # FIXME: Insert here clean-up code.
 
-# [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/find_related_books/find_related_books_sample_request_paged_all_odyssey.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestPagedAllOdyssey" ]
-#### STUB standalone sample "FindRelatedBooksSampleRequestPagedAllOdyssey" #####
+# [END turing_prog_request_streaming_bidi]
+============== file: samples/google/cloud/example/library_v1/gapic/find_related_books/find_related_books_request_paged_all_odyssey.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestPagedAllOdyssey" ]
+#### STUB standalone sample "FindRelatedBooksRequestPagedAllOdyssey" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 # To run with the published packaged, execute the following before running this code:
 #   pip install google-cloud-library
 
-# [START full_sample]
+# [START sample]
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "RequestPagedAll"
-##     valueSet "odyssey" ("The Odyssey")
-##       description: "Testing calling forms"
+##     calling form: "RequestPagedAll"
+##       region tag: "sample"
+##        className: "FindRelatedBooksRequestPagedAllOdyssey"
+##         valueSet: "odyssey" ("The Odyssey")
+##      description: "Testing calling forms"
 ##       [names[0]=Odyssey, shelves[0]=Classics]
 ##     apiMethod "find_related_books" of type "PagedOptionalArrayMethod"
 
-# [START core_sample]
+# [END sample_core]
 
 # FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -4136,31 +4140,33 @@ for element in client.find_related_books(names, shelves):
     book = element
     print('Here\'s a related book: {}'.format(book))
 
-# [END core_sample]
+# [END sample_core]
 
 # FIXME: Insert here clean-up code.
 
-# [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/find_related_books/find_related_books_sample_request_paged_odyssey.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksSampleRequestPagedOdyssey" ]
-#### STUB standalone sample "FindRelatedBooksSampleRequestPagedOdyssey" #####
+# [END sample]
+============== file: samples/google/cloud/example/library_v1/gapic/find_related_books/find_related_books_request_paged_odyssey.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestPagedOdyssey" ]
+#### STUB standalone sample "FindRelatedBooksRequestPagedOdyssey" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 # To run with the published packaged, execute the following before running this code:
 #   pip install google-cloud-library
 
-# [START full_sample]
+# [START sample]
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "RequestPaged"
-##     valueSet "odyssey" ("The Odyssey")
-##       description: "Testing calling forms"
+##     calling form: "RequestPaged"
+##       region tag: "sample"
+##        className: "FindRelatedBooksRequestPagedOdyssey"
+##         valueSet: "odyssey" ("The Odyssey")
+##      description: "Testing calling forms"
 ##       [names[0]=Odyssey, shelves[0]=Classics]
 ##     apiMethod "find_related_books" of type "PagedOptionalArrayMethod"
 
-# [START core_sample]
+# [END sample_core]
 
 # FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -4179,31 +4185,33 @@ for page in client.find_related_books(names, shelves, options=CallOptions(page_t
         book = element
         print('Here\'s a related book: {}'.format(book))
 
-# [END core_sample]
+# [END sample_core]
 
 # FIXME: Insert here clean-up code.
 
-# [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/get_big_book/get_big_book_sample_long_running_promise_wap.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookSampleLongRunningPromiseWap" ]
-#### STUB standalone sample "GetBigBookSampleLongRunningPromiseWap" #####
+# [END sample]
+============== file: samples/google/cloud/example/library_v1/gapic/get_big_book/get_big_book_long_running_promise_wap.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningPromiseWap" ]
+#### STUB standalone sample "GetBigBookLongRunningPromiseWap" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 # To run with the published packaged, execute the following before running this code:
 #   pip install google-cloud-library
 
-# [START full_sample]
+# [START hopper]
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "LongRunningPromise"
-##     valueSet "wap" ("GetBigBook: 'War and Peace'")
-##       description: "Testing calling forms"
+##     calling form: "LongRunningPromise"
+##       region tag: "hopper"
+##        className: "GetBigBookLongRunningPromiseWap"
+##         valueSet: "wap" ("GetBigBook: 'War and Peace'")
+##      description: "Testing calling forms"
 ##       [name="War and Peace"]
 ##     apiMethod "get_big_book" of type "LongRunningOptionalArrayMethod"
 
-# [START core_sample]
+# [END hopper_core]
 
 # FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -4225,31 +4233,33 @@ response.add_done_callback(callback)
 metadata = response.metadata()
 print(response)
 
-# [END core_sample]
+# [END hopper_core]
 
 # FIXME: Insert here clean-up code.
 
-# [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/monolog_about_book/monolog_about_book_sample_request_streaming_client_prog.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookSampleRequestStreamingClientProg" ]
-#### STUB standalone sample "MonologAboutBookSampleRequestStreamingClientProg" #####
+# [END hopper]
+============== file: samples/google/cloud/example/library_v1/gapic/monolog_about_book/monolog_about_book_request_streaming_client_prog.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookRequestStreamingClientProg" ]
+#### STUB standalone sample "MonologAboutBookRequestStreamingClientProg" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 # To run with the published packaged, execute the following before running this code:
 #   pip install google-cloud-library
 
-# [START full_sample]
+# [START sample]
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "RequestStreamingClient"
-##     valueSet "prog" ("Programming Books")
-##       description: "Testing calling forms"
+##     calling form: "RequestStreamingClient"
+##       region tag: "sample"
+##        className: "MonologAboutBookRequestStreamingClientProg"
+##         valueSet: "prog" ("Programming Books")
+##      description: "Testing calling forms"
 ##       [name=BASIC]
 ##     apiMethod "monolog_about_book" of type "OptionalArrayMethod"
 
-# [START core_sample]
+# [END sample_core]
 
 # FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -4264,31 +4274,33 @@ requests = [request]
 response = client.monolog_about_book(requests)
 print(response)
 
-# [END core_sample]
+# [END sample_core]
 
 # FIXME: Insert here clean-up code.
 
-# [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/publish_series/publish_series_sample_request_pi_version.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestPiVersion" ]
-#### STUB standalone sample "PublishSeriesSampleRequestPiVersion" #####
+# [END sample]
+============== file: samples/google/cloud/example/library_v1/gapic/publish_series/publish_series_request_pi_version.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestPiVersion" ]
+#### STUB standalone sample "PublishSeriesRequestPiVersion" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 # To run with the published packaged, execute the following before running this code:
 #   pip install google-cloud-library
 
-# [START full_sample]
+# [START sample]
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "Request"
-##     valueSet "pi_version" ("Pi version")
-##       description: "Testing calling forms"
+##     calling form: "Request"
+##       region tag: "sample"
+##        className: "PublishSeriesRequestPiVersion"
+##         valueSet: "pi_version" ("Pi version")
+##      description: "Testing calling forms"
 ##       [shelf.name=Math, series_uuid.series_string=xyz3141592654]
 ##     apiMethod "publish_series" of type "OptionalArrayMethod"
 
-# [START core_sample]
+# [END sample_core]
 
 # FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -4309,31 +4321,33 @@ for title in response.book_names:
   print('Title: {}'.format(title))
 print('That\'s all!')
 
-# [END core_sample]
+# [END sample_core]
 
 # FIXME: Insert here clean-up code.
 
-# [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/publish_series/publish_series_sample_request_second_edition.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesSampleRequestSecondEdition" ]
-#### STUB standalone sample "PublishSeriesSampleRequestSecondEdition" #####
+# [END sample]
+============== file: samples/google/cloud/example/library_v1/gapic/publish_series/publish_series_request_second_edition.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestSecondEdition" ]
+#### STUB standalone sample "PublishSeriesRequestSecondEdition" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 # To run with the published packaged, execute the following before running this code:
 #   pip install google-cloud-library
 
-# [START full_sample]
+# [START sample]
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "Request"
-##     valueSet "second_edition" ("Second edition")
-##       description: "Testing calling forms"
+##     calling form: "Request"
+##       region tag: "sample"
+##        className: "PublishSeriesRequestSecondEdition"
+##         valueSet: "second_edition" ("Second edition")
+##      description: "Testing calling forms"
 ##       [edition=2]
 ##     apiMethod "publish_series" of type "OptionalArrayMethod"
 
-# [START core_sample]
+# [END sample_core]
 
 # FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -4354,31 +4368,33 @@ edition = 2
 response = client.publish_series(shelf, books, series_uuid, edition=edition)
 print(response)
 
-# [END core_sample]
+# [END sample_core]
 
 # FIXME: Insert here clean-up code.
 
-# [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/stream_books/stream_books_sample_request_streaming_server_prog.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksSampleRequestStreamingServerProg" ]
-#### STUB standalone sample "StreamBooksSampleRequestStreamingServerProg" #####
+# [END sample]
+============== file: samples/google/cloud/example/library_v1/gapic/stream_books/stream_books_request_streaming_server_prog.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksRequestStreamingServerProg" ]
+#### STUB standalone sample "StreamBooksRequestStreamingServerProg" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 # To run with the published packaged, execute the following before running this code:
 #   pip install google-cloud-library
 
-# [START full_sample]
+# [START lovelace]
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "RequestStreamingServer"
-##     valueSet "prog" ("Programming Books")
-##       description: "Testing calling forms"
+##     calling form: "RequestStreamingServer"
+##       region tag: "lovelace"
+##        className: "StreamBooksRequestStreamingServerProg"
+##         valueSet: "prog" ("Programming Books")
+##      description: "Testing calling forms"
 ##       [name=BASIC]
 ##     apiMethod "stream_books" of type "OptionalArrayMethod"
 
-# [START core_sample]
+# [END lovelace_core]
 
 # FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -4393,31 +4409,33 @@ for element in client.stream_books(name):
     pass
 print(response)
 
-# [END core_sample]
+# [END lovelace_core]
 
 # FIXME: Insert here clean-up code.
 
-# [END full_sample]
-============== file: samples/google/cloud/example/library_v1/gapic/stream_shelves/stream_shelves_sample_request_streaming_server_empty.py ==============
-#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesSampleRequestStreamingServerEmpty" ]
-#### STUB standalone sample "StreamShelvesSampleRequestStreamingServerEmpty" #####
+# [END lovelace]
+============== file: samples/google/cloud/example/library_v1/gapic/stream_shelves/stream_shelves_request_streaming_server_empty.py ==============
+#### [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesRequestStreamingServerEmpty" ]
+#### STUB standalone sample "StreamShelvesRequestStreamingServerEmpty" #####
 
 # FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 # To run with the published packaged, execute the following before running this code:
 #   pip install google-cloud-library
 
-# [START full_sample]
+# [START sample]
 
 # FIXME: Insert here boilerplate code not directly related to the method call itself.
 
-##     calling form "RequestStreamingServer"
-##     valueSet "empty" ("Server streaming")
-##       description: "Testing calling forms"
+##     calling form: "RequestStreamingServer"
+##       region tag: "sample"
+##        className: "StreamShelvesRequestStreamingServerEmpty"
+##         valueSet: "empty" ("Server streaming")
+##      description: "Testing calling forms"
 ##       []
 ##     apiMethod "stream_shelves" of type "OptionalArrayMethod"
 
-# [START core_sample]
+# [END sample_core]
 
 # FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
@@ -4430,11 +4448,11 @@ for element in client.stream_shelves():
     pass
 print(response)
 
-# [END core_sample]
+# [END sample_core]
 
 # FIXME: Insert here clean-up code.
 
-# [END full_sample]
+# [END sample]
 ============== file: setup.cfg ==============
 [bdist_wheel]
 universal = 1

--- a/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
@@ -553,8 +553,14 @@ interfaces:
       - calling_forms: ".*"
         value_sets: ".*"
       standalone:
-      - calling_forms: ".*"
-        value_sets: ".*"
+      # Python only
+      - calling_forms: request_streaming_server
+        value_sets: prog
+        region_tag: lovelace
+      # Java only
+      - calling_forms: callable_streaming_server
+        value_sets: "prog"
+        region_tag: babbage
       api_explorer:
       - calling_forms: ".*"
         value_sets: ".*"
@@ -582,6 +588,7 @@ interfaces:
       standalone:
       - calling_forms: ".*"
         value_sets: ".*"
+        region_tag: "turing_%v_%c"
       api_explorer:
       - calling_forms: ".*"
         value_sets: ".*"
@@ -741,6 +748,7 @@ interfaces:
       standalone:
       - calling_forms: ".*"
         value_sets: ".*"
+        region_tag: hopper
   - name: GetBigNothing
     flattening:
       groups:


### PR DESCRIPTION
- The default region tag is "sample"
- Custom region tags can be specified in the GAPIC YAML. The region tag specification accepts (but does not require) `%m`, `%c`, and `%v` placeholders for method name, calling form name, and value set id.
- If the sample specification would result in differently configured samples being written to the same path, an exception is thrown. This can happen if the same value set and calling form combo is specified more than once (eg with wildcards) with different region names.