### PR TITLE
Remove old doc for versioned modules in Ruby

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/message.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/message.snip
@@ -25,19 +25,6 @@
 @end
 
 @private tocModule(module, iterator, content)
-  @##
-  @# # {@module.fullName} Contents
-  @#
-  @# | Class | Description |
-  @# | ----- | ----------- |
-  @join class : module.contents
-    @# | [{@class.name}][] | {@class.description} |
-  @end
-  @#
-  @join class : module.contents
-    @# [{@class.name}]: {@class.link}
-  @end
-  @#
   {@simpleModule(module, iterator, content)}
 @end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -1948,17 +1948,6 @@ end
 module Google
   module Example
     module Library
-      ##
-      # # Google Example Library API Contents
-      #
-      # | Class | Description |
-      # | ----- | ----------- |
-      # | [LibraryServiceClient][] | This API represents a simple digital library. |
-      # | [Data Types][] | Data types for Library::V1 |
-      #
-      # [LibraryServiceClient]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/library/latest/google/example/library/v1/libraryserviceclient
-      # [Data Types]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/library/latest/google/example/library/v1/datatypes
-      #
       module V1
         # A single book in the library.
         # Message comment may include special characters: <>&"+'@.

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -1137,17 +1137,6 @@ end
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module Google
-  ##
-  # # Google Long Running Operations API Contents
-  #
-  # | Class | Description |
-  # | ----- | ----------- |
-  # | [OperationsClient][] | Manages long-running operations with an API service. |
-  # | [Data Types][] | Data types for Google::Longrunning |
-  #
-  # [OperationsClient]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google/latest/google/longrunning/operationsclient
-  # [Data Types]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google/latest/google/longrunning/datatypes
-  #
   module Longrunning
     # This resource represents a long-running operation that is the result of a
     # network API call.

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -1179,19 +1179,6 @@ end
 module Google
   module Cloud
     module Example
-      ##
-      # # Google Example API Contents
-      #
-      # | Class | Description |
-      # | ----- | ----------- |
-      # | [IncrementerServiceClient][] |  |
-      # | [DecrementerServiceClient][] |  |
-      # | [Data Types][] | Data types for Google::Example::V1::Foo |
-      #
-      # [IncrementerServiceClient]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-example/latest/google/cloud/example/v1/foo/incrementerserviceclient
-      # [DecrementerServiceClient]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-example/latest/google/cloud/example/v1/foo/decrementerserviceclient
-      # [Data Types]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-example/latest/google/cloud/example/v1/foo/datatypes
-      #
       module V1
         module Foo
           class IncrementRequest; end


### PR DESCRIPTION
Ruby clients are moving to a more standardized YARD based format for documentation. This change removes some outdated documentation (more to come). 

Details: https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/2231