### PR TITLE
Update enable API link

### DIFF
--- a/src/main/resources/com/google/api/codegen/readme.snip
+++ b/src/main/resources/com/google/api/codegen/readme.snip
@@ -27,7 +27,7 @@
 
   1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  3. [Enable the {@metadata.fullName}.](https://console.cloud.google.com/apis/api/{@metadata.shortName})
+  3. [Enable the {@metadata.fullName}.](https://console.cloud.google.com/apis/library/api/{@metadata.shortName}.googleapis.com)
   4. [Setup Authentication.]({@metadata.authDocumentationLink})
 
   @if installationLines

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -12,7 +12,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/api/library)
+3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -13,7 +13,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Example API.](https://console.cloud.google.com/apis/api/multiple_services)
+3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/api/multiple_services.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -12,7 +12,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Fake API.](https://console.cloud.google.com/apis/api/library)
+3. [Enable the Google Fake API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -274,7 +274,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/api/library)
+3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation
@@ -612,7 +612,7 @@ require "pathname"
 #
 # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-# 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/api/library)
+# 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
 # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 #
 # ### Preview
@@ -773,7 +773,7 @@ module Library
   #
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  # 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/api/library)
+  # 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
   # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
   #
   # ### Preview
@@ -2582,7 +2582,7 @@ end
 #
 # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-# 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/api/library)
+# 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
 # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 #
 # ### Installation

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -274,7 +274,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/api/longrunning)
+3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/library/api/longrunning.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation
@@ -700,7 +700,7 @@ module Google
   #
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  # 3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/api/longrunning)
+  # 3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/library/api/longrunning.googleapis.com)
   # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
   #
   # ### Preview
@@ -1270,7 +1270,7 @@ module Google
   #
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  # 3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/api/longrunning)
+  # 3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/library/api/longrunning.googleapis.com)
   # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
   #
   # ### Installation

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -275,7 +275,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Example API.](https://console.cloud.google.com/apis/api/multiple_services)
+3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/api/multiple_services.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation
@@ -544,7 +544,7 @@ module Google
   #
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/api/multiple_services)
+  # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/api/multiple_services.googleapis.com)
   # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
   #
   # ### Next Steps
@@ -730,7 +730,7 @@ module Google
     #
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-    # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/api/multiple_services)
+    # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/api/multiple_services.googleapis.com)
     # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
     #
     # ### Next Steps
@@ -1234,7 +1234,7 @@ module Google
   #
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/api/multiple_services)
+  # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/api/multiple_services.googleapis.com)
   # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
   #
   # ### Installation


### PR DESCRIPTION
Fixes #2195 by changing how the enable API link is generated.

It seems Ruby and Node share the implementation for this, but the other languages don't. I didn't check to see if they are using correct links but it may be worth updating as a separate change on an as needed basis.