### PR TITLE
Don't throw error on multiple version strings

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
@@ -331,9 +331,10 @@ public class RubyPackageMetadataTransformer implements ModelToViewTransformer<Pr
     for (InterfaceModel apiInterface : interfaces) {
       versionNamespaces.add(namer.getNamespace(apiInterface));
     }
-    if (versionNamespaces.size() > 1) {
-      throw new IllegalArgumentException("Multiple versionNamespaces found for the package.");
-    }
+    // TODO: log a warning instead?
+    // if (versionNamespaces.size() > 1) {
+    //  throw new IllegalArgumentException("Multiple versionNamespaces found for the package.");
+    // }
     return versionNamespaces.iterator().next();
   }
 


### PR DESCRIPTION
Resolves #2192 by removing the sanity check for multiple version like strings.

This should unblock: https://github.com/googleapis/artman/issues/483

I wanted to convert this to a warning but it appears that there is no logger used for this project?