### PR TITLE
Remove extra parentheses in ruby snip

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -107,7 +107,7 @@
       @if index.postVersionDirPath
         .select { |dir| File.exist?(File.join(dir, "{@index.postVersionDirPath}.rb")) }
       @else
-        .select { |dir| File.exist?(dir + ".rb")) }
+        .select { |dir| File.exist?(dir + ".rb") }
       @end
       .map { |dir| File.basename(dir) }
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -673,7 +673,7 @@ module Library
   AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
     .select { |file| File.directory?(file) }
     .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
-    .select { |dir| File.exist?(dir + ".rb")) }
+    .select { |dir| File.exist?(dir + ".rb") }
     .map { |dir| File.basename(dir) }
 
   ##


### PR DESCRIPTION
This error was caught in https://circleci.com/gh/googleapis/gapic-generator/424.