### PR TITLE
Remove api segment from enable api url

### DIFF
--- a/src/main/resources/com/google/api/codegen/readme.snip
+++ b/src/main/resources/com/google/api/codegen/readme.snip
@@ -27,7 +27,7 @@
 
   1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  3. [Enable the {@metadata.fullName}.](https://console.cloud.google.com/apis/library/api/{@metadata.shortName}.googleapis.com)
+  3. [Enable the {@metadata.fullName}.](https://console.cloud.google.com/apis/library/{@metadata.shortName}.googleapis.com)
   4. [Setup Authentication.]({@metadata.authDocumentationLink})
 
   @if installationLines

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -12,7 +12,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
+3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/library.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -13,7 +13,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/api/multiple_services.googleapis.com)
+3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/multiple_services.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -12,7 +12,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Fake API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
+3. [Enable the Google Fake API.](https://console.cloud.google.com/apis/library/library.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -275,7 +275,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
+3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/library.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation
@@ -613,7 +613,7 @@ require "pathname"
 #
 # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-# 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
+# 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/library.googleapis.com)
 # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 #
 # ### Preview
@@ -774,7 +774,7 @@ module Library
   #
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  # 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
+  # 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/library.googleapis.com)
   # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
   #
   # ### Preview
@@ -2572,7 +2572,7 @@ end
 #
 # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-# 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/api/library.googleapis.com)
+# 3. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/library/library.googleapis.com)
 # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 #
 # ### Installation

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -275,7 +275,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/library/api/longrunning.googleapis.com)
+3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/library/longrunning.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation
@@ -703,7 +703,7 @@ module Google
   #
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  # 3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/library/api/longrunning.googleapis.com)
+  # 3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/library/longrunning.googleapis.com)
   # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
   #
   # ### Preview
@@ -1262,7 +1262,7 @@ module Google
   #
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  # 3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/library/api/longrunning.googleapis.com)
+  # 3. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/library/longrunning.googleapis.com)
   # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
   #
   # ### Installation

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -276,7 +276,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/api/multiple_services.googleapis.com)
+3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/multiple_services.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation
@@ -547,7 +547,7 @@ module Google
   #
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/api/multiple_services.googleapis.com)
+  # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/multiple_services.googleapis.com)
   # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
   #
   # ### Next Steps
@@ -733,7 +733,7 @@ module Google
     #
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-    # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/api/multiple_services.googleapis.com)
+    # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/multiple_services.googleapis.com)
     # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
     #
     # ### Next Steps
@@ -1224,7 +1224,7 @@ module Google
   #
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-  # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/api/multiple_services.googleapis.com)
+  # 3. [Enable the Google Example API.](https://console.cloud.google.com/apis/library/multiple_services.googleapis.com)
   # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
   #
   # ### Installation


### PR DESCRIPTION
The change in #2198 left a trailing `/api/` segment in the enable API links (see #2195). This removes it.