### PR TITLE
sample: comment out arg defaults

### DIFF
--- a/src/main/java/com/google/api/codegen/util/CommonRenderingUtil.java
+++ b/src/main/java/com/google/api/codegen/util/CommonRenderingUtil.java
@@ -14,10 +14,12 @@
  */
 package com.google.api.codegen.util;
 
+import com.google.api.tools.framework.snippet.Doc;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /** Utility class to process text in the templates. */
@@ -107,5 +109,11 @@ public class CommonRenderingUtil {
    */
   public static int toInt(String value) {
     return Integer.valueOf(value);
+  }
+
+  public static List<String> pretty(Doc doc) {
+    StringBuilder sb = new StringBuilder();
+    doc.prettyPrint(sb);
+    return Arrays.asList(sb.toString().split("\n"));
   }
 }

--- a/src/main/java/com/google/api/codegen/util/java/JavaRenderingUtil.java
+++ b/src/main/java/com/google/api/codegen/util/java/JavaRenderingUtil.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.util.java;
 
 import com.google.api.codegen.util.CommonRenderingUtil;
+import com.google.api.tools.framework.snippet.Doc;
 import java.util.Arrays;
 import java.util.List;
 
@@ -41,5 +42,9 @@ public class JavaRenderingUtil {
     Arrays.fill(array, '=');
     String eqsString = new String(array);
     return Arrays.asList(eqsString, heading, eqsString);
+  }
+
+  public static List<String> pretty(Doc doc) {
+    return CommonRenderingUtil.pretty(doc);
   }
 }

--- a/src/main/java/com/google/api/codegen/util/py/PythonRenderingUtil.java
+++ b/src/main/java/com/google/api/codegen/util/py/PythonRenderingUtil.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.util.py;
 
 import com.google.api.codegen.util.CommonRenderingUtil;
+import com.google.api.tools.framework.snippet.Doc;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -71,5 +72,9 @@ public class PythonRenderingUtil {
   /** @see CommonRenderingUtil#toInt(String) */
   public static int toInt(String value) {
     return CommonRenderingUtil.toInt(value);
+  }
+
+  public static List<String> pretty(Doc doc) {
+    return CommonRenderingUtil.pretty(doc);
   }
 }

--- a/src/main/resources/com/google/api/codegen/java/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/java/initcode.snip
@@ -2,9 +2,10 @@
 
 @snippet initCode(initCodeSpec)
   @if initCodeSpec.argDefaultLines
-    // FIXME(pongad): should be commented to not clobber args
-    {@initCodeLines(initCodeSpec.argDefaultLines)}
-    // FIXME(pongad): args end
+    @join line : util.pretty(initCodeLines(initCodeSpec.argDefaultLines))
+      // {@line}
+    @end
+
 
   @end
   {@initCodeLines(initCodeSpec.lines)}

--- a/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
@@ -345,9 +345,10 @@
 
 @snippet initCode(apiMethod, init)
   @if init.argDefaultLines
-    // FIXME(pongad): should be commented to not clobber args
-    {@initCodeLines(init.argDefaultLines)}
-    // FIXME(pongad): args end
+    @join line : util.pretty(initCodeLines(init.argDefaultLines))
+      // {@line}
+    @end
+
 
   @end
   {@initCodeLines(init.lines)}

--- a/src/main/resources/com/google/api/codegen/php/sample_common.snip
+++ b/src/main/resources/com/google/api/codegen/php/sample_common.snip
@@ -132,9 +132,10 @@
 
 @snippet initCode(initCode, apiVariableName)
     @if initCode.argDefaultLines
-        // FIXME(pongad): Should be commented out here to not clobber args
-        {@initCodeLines(initCode.argDefaultLines, apiVariableName)}
-        // FIXME(pongad): args end
+        @join line : util.pretty(initCodeLines(initCode.argDefaultLines, apiVariableName))
+          // {@line}
+        @end
+
 
     @end
     {@initCodeLines(initCode.lines, apiVariableName)}

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -75,9 +75,10 @@
   client = {@apiMethod.apiModuleName}.{@apiMethod.apiClassName}()
 
   @if sample.initCode.argDefaultLines
-    @# FIXME(pongad): These lines should be commented. The top-level vars are declared by function param.
-    {@initCode(sample.initCode.argDefaultLines)}
-    @# FIXME(pongad): ARGS ENDS
+    @join line : util.pretty(initCode(sample.initCode.argDefaultLines))
+      @# {@line}
+    @end
+
 
   @end
   @if sample.initCode.lines

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -7673,9 +7673,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
 public class PublishSeriesFlattenedPiVersion {
   public static void main(String[] args) {
     // [START sample_core]
-    // FIXME(pongad): should be commented to not clobber args
-    String name = "Math";
-    // FIXME(pongad): args end
+    // String name = "Math";
     Shelf shelf = Shelf.newBuilder()
       .setName(name)
       .build();
@@ -7751,9 +7749,7 @@ public class PublishSeriesFlattenedSecondEdition {
 public class PublishSeriesRequestPiVersion {
   public static void main(String[] args) {
     // [START sample_core]
-    // FIXME(pongad): should be commented to not clobber args
-    String name = "Math";
-    // FIXME(pongad): args end
+    // String name = "Math";
     Shelf shelf = Shelf.newBuilder()
       .setName(name)
       .build();
@@ -7839,9 +7835,7 @@ public class PublishSeriesRequestSecondEdition {
 public class PublishSeriesCallableCallablePiVersion {
   public static void main(String[] args) {
     // [START sample_core]
-    // FIXME(pongad): should be commented to not clobber args
-    String name = "Math";
-    // FIXME(pongad): args end
+    // String name = "Math";
     Shelf shelf = Shelf.newBuilder()
       .setName(name)
       .build();

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -571,9 +571,7 @@ stream.write(request);
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 /*
-// FIXME(pongad): should be commented to not clobber args
-var name = 'Math';
-// FIXME(pongad): args end
+// var name = 'Math';
 var shelf = {
   name: name,
 };

--- a/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
@@ -3143,9 +3143,7 @@ use \Google\Example\Library\V1\Shelf;
 
 $libraryServiceClient = new LibraryServiceClient();
 
-// FIXME(pongad): Should be commented out here to not clobber args
-$name = 'Math';
-// FIXME(pongad): args end
+// $name = 'Math';
 $shelf = new Shelf();
 $shelf->setName($name);
 $books = [];

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -4308,9 +4308,7 @@ from google.cloud.example import library_v1
 
 client = library_v1.LibraryServiceClient()
 
-# FIXME(pongad): These lines should be commented. The top-level vars are declared by function param.
-name = 'Math'
-# FIXME(pongad): ARGS ENDS
+# name = 'Math'
 
 shelf = {'name': name}
 


### PR DESCRIPTION
Since these values are passed by arguments,
we comment out the initializations so that they serve as
documentation but won't clobber the arguments.