### PR TITLE
[Proto Annotations] Enable passing in --package flag

### DIFF
--- a/src/main/java/com/google/api/codegen/GeneratorMain.java
+++ b/src/main/java/com/google/api/codegen/GeneratorMain.java
@@ -106,7 +106,7 @@ public class GeneratorMain {
           .argName("GAPIC-YAML")
           .required(true)
           .build();
-  private static final Option GAPIC_YAML_NON_REQUIRED_OPTION =
+  private static final Option GAPIC_YAML_NONREQUIRED_OPTION =
       Option.builder()
           .longOpt("gapic_yaml")
           .desc(
@@ -223,7 +223,7 @@ public class GeneratorMain {
     options.addOption(SERVICE_YAML_NONREQUIRED_OPTION);
     // TODO make required after artman passes this in
     options.addOption(LANGUAGE_NONREQUIRED_OPTION);
-    options.addOption(GAPIC_YAML_NON_REQUIRED_OPTION);
+    options.addOption(GAPIC_YAML_NONREQUIRED_OPTION);
     options.addOption(PACKAGE_YAML2_OPTION);
     options.addOption(TARGET_API_PROTO_PACKAGE);
     options.addOption(OUTPUT_OPTION);
@@ -251,7 +251,7 @@ public class GeneratorMain {
 
     // TODO(andrealin): Write system tests to ensure at least one option given.
     checkAtLeastOneOption(cl, SERVICE_YAML_NONREQUIRED_OPTION, TARGET_API_PROTO_PACKAGE);
-    checkAtLeastOneOption(cl, GAPIC_YAML_NON_REQUIRED_OPTION, TARGET_API_PROTO_PACKAGE);
+    checkAtLeastOneOption(cl, GAPIC_YAML_NONREQUIRED_OPTION, TARGET_API_PROTO_PACKAGE);
     checkAtLeastOneOption(cl, PACKAGE_YAML2_OPTION, TARGET_API_PROTO_PACKAGE);
 
     toolOptions.set(
@@ -272,10 +272,10 @@ public class GeneratorMain {
           Lists.newArrayList(cl.getOptionValues(SERVICE_YAML_NONREQUIRED_OPTION.getLongOpt())));
       checkFiles(toolOptions.get(ToolOptions.CONFIG_FILES));
     }
-    if (cl.getOptionValues(GAPIC_YAML_NON_REQUIRED_OPTION.getLongOpt()) != null) {
+    if (cl.getOptionValues(GAPIC_YAML_NONREQUIRED_OPTION.getLongOpt()) != null) {
       toolOptions.set(
           GapicGeneratorApp.GENERATOR_CONFIG_FILES,
-          Lists.newArrayList(cl.getOptionValues(GAPIC_YAML_NON_REQUIRED_OPTION.getLongOpt())));
+          Lists.newArrayList(cl.getOptionValues(GAPIC_YAML_NONREQUIRED_OPTION.getLongOpt())));
       checkFiles(toolOptions.get(GapicGeneratorApp.GENERATOR_CONFIG_FILES));
     }
     if (!Strings.isNullOrEmpty(toolOptions.get(GapicGeneratorApp.PACKAGE_CONFIG2_FILE))) {
@@ -448,7 +448,7 @@ public class GeneratorMain {
     }
   }
 
-  // Throws an exception if neither options were given.
+  // Throws an exception if neither option was given.
   private static void checkAtLeastOneOption(CommandLine cl, Option option1, Option option2) {
     if (cl.getOptionValues(option1.getLongOpt()) == null
         && cl.getOptionValues(option2.getLongOpt()) == null) {

--- a/src/main/java/com/google/api/codegen/GeneratorMain.java
+++ b/src/main/java/com/google/api/codegen/GeneratorMain.java
@@ -48,6 +48,16 @@ public class GeneratorMain {
           .argName("DESCRIPTOR-SET")
           .required(true)
           .build();
+  private static final Option TARGET_API_PROTO_PACKAGE =
+      Option.builder()
+          .longOpt("package")
+          .desc(
+              "The proto package designating the files actually intended for output. "
+                  + "This option is required if a GAPIC config is not given.")
+          .hasArg()
+          .argName("PACKAGE")
+          .required(false)
+          .build();
   private static final Option SERVICE_YAML_OPTION =
       Option.builder()
           .longOpt("service_yaml")
@@ -95,6 +105,16 @@ public class GeneratorMain {
           .hasArg()
           .argName("GAPIC-YAML")
           .required(true)
+          .build();
+  private static final Option GAPIC_YAML_NON_REQUIRED_OPTION =
+      Option.builder()
+          .longOpt("gapic_yaml")
+          .desc(
+              "The GAPIC YAML configuration file or files. This is required only if "
+                  + "the --package option is not specified.")
+          .hasArg()
+          .argName("GAPIC-YAML")
+          .required(false)
           .build();
   private static final Option PACKAGE_YAML2_OPTION =
       Option.builder("c2")
@@ -200,11 +220,12 @@ public class GeneratorMain {
     Options options = new Options();
     options.addOption("h", "help", false, "show usage");
     options.addOption(DESCRIPTOR_SET_OPTION);
-    options.addOption(SERVICE_YAML_OPTION);
+    options.addOption(SERVICE_YAML_NONREQUIRED_OPTION);
     // TODO make required after artman passes this in
     options.addOption(LANGUAGE_NONREQUIRED_OPTION);
-    options.addOption(GAPIC_YAML_OPTION);
+    options.addOption(GAPIC_YAML_NON_REQUIRED_OPTION);
     options.addOption(PACKAGE_YAML2_OPTION);
+    options.addOption(TARGET_API_PROTO_PACKAGE);
     options.addOption(OUTPUT_OPTION);
     Option enabledArtifactsOption =
         Option.builder()
@@ -227,23 +248,36 @@ public class GeneratorMain {
     ToolOptions toolOptions = ToolOptions.create();
     toolOptions.set(
         ToolOptions.DESCRIPTOR_SET, cl.getOptionValue(DESCRIPTOR_SET_OPTION.getLongOpt()));
+
+    // TODO(andrealin): Write system tests to ensure at least one option given.
+    checkAtLeastOneOption(cl, SERVICE_YAML_NONREQUIRED_OPTION, TARGET_API_PROTO_PACKAGE);
+    checkAtLeastOneOption(cl, GAPIC_YAML_NON_REQUIRED_OPTION, TARGET_API_PROTO_PACKAGE);
+    checkAtLeastOneOption(cl, PACKAGE_YAML2_OPTION, TARGET_API_PROTO_PACKAGE);
+
     toolOptions.set(
-        ToolOptions.CONFIG_FILES,
-        Lists.newArrayList(cl.getOptionValues(SERVICE_YAML_OPTION.getLongOpt())));
+        GapicGeneratorApp.PROTO_PACKAGE, cl.getOptionValue(TARGET_API_PROTO_PACKAGE.getLongOpt()));
     toolOptions.set(
         GapicGeneratorApp.LANGUAGE, cl.getOptionValue(LANGUAGE_NONREQUIRED_OPTION.getLongOpt()));
     toolOptions.set(
         GapicGeneratorApp.OUTPUT_FILE, cl.getOptionValue(OUTPUT_OPTION.getLongOpt(), ""));
     toolOptions.set(
-        GapicGeneratorApp.GENERATOR_CONFIG_FILES,
-        Lists.newArrayList(cl.getOptionValues(GAPIC_YAML_OPTION.getLongOpt())));
-    toolOptions.set(
         GapicGeneratorApp.PACKAGE_CONFIG2_FILE,
         cl.getOptionValue(PACKAGE_YAML2_OPTION.getLongOpt()));
 
     checkFile(toolOptions.get(ToolOptions.DESCRIPTOR_SET));
-    checkFiles(toolOptions.get(ToolOptions.CONFIG_FILES));
-    checkFiles(toolOptions.get(GapicGeneratorApp.GENERATOR_CONFIG_FILES));
+
+    if (cl.getOptionValues(SERVICE_YAML_NONREQUIRED_OPTION.getLongOpt()) != null) {
+      toolOptions.set(
+          ToolOptions.CONFIG_FILES,
+          Lists.newArrayList(cl.getOptionValues(SERVICE_YAML_NONREQUIRED_OPTION.getLongOpt())));
+      checkFiles(toolOptions.get(ToolOptions.CONFIG_FILES));
+    }
+    if (cl.getOptionValues(GAPIC_YAML_NON_REQUIRED_OPTION.getLongOpt()) != null) {
+      toolOptions.set(
+          GapicGeneratorApp.GENERATOR_CONFIG_FILES,
+          Lists.newArrayList(cl.getOptionValues(GAPIC_YAML_NON_REQUIRED_OPTION.getLongOpt())));
+      checkFiles(toolOptions.get(GapicGeneratorApp.GENERATOR_CONFIG_FILES));
+    }
     if (!Strings.isNullOrEmpty(toolOptions.get(GapicGeneratorApp.PACKAGE_CONFIG2_FILE))) {
       checkFile(toolOptions.get(GapicGeneratorApp.PACKAGE_CONFIG2_FILE));
     }
@@ -262,6 +296,7 @@ public class GeneratorMain {
     Options options = new Options();
     options.addOption("h", "help", false, "show usage");
     options.addOption(DESCRIPTOR_SET_OPTION);
+    options.addOption(TARGET_API_PROTO_PACKAGE);
     options.addOption(SERVICE_YAML_NONREQUIRED_OPTION);
     options.addOption(LANGUAGE_OPTION);
     Option inputOption =
@@ -294,11 +329,16 @@ public class GeneratorMain {
     }
 
     ToolOptions toolOptions = ToolOptions.create();
+
+    checkAtLeastOneOption(cl, TARGET_API_PROTO_PACKAGE, PACKAGE_YAML2_OPTION);
     toolOptions.set(PackageGeneratorApp.LANGUAGE, cl.getOptionValue(LANGUAGE_OPTION.getLongOpt()));
     toolOptions.set(PackageGeneratorApp.INPUT_DIR, cl.getOptionValue(inputOption.getLongOpt()));
     toolOptions.set(PackageGeneratorApp.OUTPUT_DIR, cl.getOptionValue(OUTPUT_OPTION.getLongOpt()));
     toolOptions.set(
         ToolOptions.DESCRIPTOR_SET, cl.getOptionValue(DESCRIPTOR_SET_OPTION.getLongOpt()));
+    toolOptions.set(
+        PackageGeneratorApp.PROTO_PACKAGE,
+        cl.getOptionValue(TARGET_API_PROTO_PACKAGE.getLongOpt()));
     if (cl.getOptionValues(SERVICE_YAML_NONREQUIRED_OPTION.getLongOpt()) != null) {
       toolOptions.set(
           ToolOptions.CONFIG_FILES,
@@ -349,8 +389,7 @@ public class GeneratorMain {
     // TODO make required after artman passes this in
     options.addOption(LANGUAGE_NONREQUIRED_OPTION);
     options.addOption(DISCOVERY_DOC_OPTION);
-    // TODO add this option back
-    // options.addOption(SERVICE_YAML_OPTION);
+    // TODO (andrealin): Make Gapic YAML optional
     options.addOption(GAPIC_YAML_OPTION);
     options.addOption(PACKAGE_YAML2_OPTION);
     options.addOption(OUTPUT_OPTION);
@@ -406,6 +445,17 @@ public class GeneratorMain {
   private static void checkFile(String filePath) {
     if (!new File(filePath).exists()) {
       throw new IllegalArgumentException("File not found: " + filePath);
+    }
+  }
+
+  // Throws an exception if neither options were given.
+  private static void checkAtLeastOneOption(CommandLine cl, Option option1, Option option2) {
+    if (cl.getOptionValues(option1.getLongOpt()) == null
+        && cl.getOptionValues(option2.getLongOpt()) == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "At least one of --%s and/or --%s must be given.",
+              option1.getLongOpt(), option2.getLongOpt()));
     }
   }
 }

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -47,12 +47,16 @@ public abstract class ResourceNameMessageConfigs {
   public static ResourceNameMessageConfigs createMessageResourceTypesConfig(
       Model model, ConfigProto configProto, String defaultPackage) {
     ImmutableMap.Builder<String, ResourceNameMessageConfig> builder = ImmutableMap.builder();
-    for (ResourceNameMessageConfigProto messageResourceTypesProto :
-        configProto.getResourceNameGenerationList()) {
-      ResourceNameMessageConfig messageResourceTypeConfig =
-          ResourceNameMessageConfig.createResourceNameMessageConfig(
-              model.getDiagCollector(), messageResourceTypesProto, defaultPackage);
-      builder.put(messageResourceTypeConfig.messageName(), messageResourceTypeConfig);
+    if (configProto != null) {
+      // Get ResourceNameMessageConfigs from configProto.
+      for (ResourceNameMessageConfigProto messageResourceTypesProto :
+          configProto.getResourceNameGenerationList()) {
+        ResourceNameMessageConfig messageResourceTypeConfig =
+            ResourceNameMessageConfig.createResourceNameMessageConfig(
+                model.getDiagCollector(), messageResourceTypesProto, defaultPackage);
+        builder.put(messageResourceTypeConfig.messageName(), messageResourceTypeConfig);
+      }
+      // TODO(andrealin): Get ResourceNameMessageConfigs from proto annotations.
     }
     ImmutableMap<String, ResourceNameMessageConfig> messageResourceTypeConfigMap = builder.build();
 

--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
@@ -59,6 +59,13 @@ public class GapicGeneratorApp extends ToolDriverBase {
           "output_file",
           "The name of the output file or folder to put generated code.",
           "");
+  public static final Option<String> PROTO_PACKAGE =
+      ToolOptions.createOption(
+          String.class,
+          "proto_package",
+          "The proto package designating the files actually intended for output.\n"
+              + "This option is required if the GAPIC generator config files are not given.",
+          "");
 
   public static final Option<List<String>> GENERATOR_CONFIG_FILES =
       ToolOptions.createOption(

--- a/src/main/java/com/google/api/codegen/packagegen/PackageGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/packagegen/PackageGeneratorApp.java
@@ -49,7 +49,19 @@ public class PackageGeneratorApp extends ToolDriverBase {
           "The name of the folder containing the gRPC package to generate metadata for.",
           "");
   public static final Option<String> PACKAGE_CONFIG2_FILE =
-      ToolOptions.createOption(String.class, "package_config2", "The packaging configuration.", "");
+      ToolOptions.createOption(
+          String.class,
+          "package_config2",
+          "The packaging configuration. This is required if --proto_package "
+              + "option is not given.",
+          "");
+  public static final Option<String> PROTO_PACKAGE =
+      ToolOptions.createOption(
+          String.class,
+          "proto_package",
+          "The proto package designating the files actually intended for output.\n"
+              + "This option is required if the package_yaml2 file is not given.",
+          "");
   public static final Option<PackagingArtifactType> ARTIFACT_TYPE =
       ToolOptions.createOption(
           PackagingArtifactType.class,
@@ -98,6 +110,8 @@ public class PackageGeneratorApp extends ToolDriverBase {
       config =
           PackageMetadataConfig.createFromPackaging(
               apiDefaultsConfig, dependenciesConfig, packagingConfig);
+    } else {
+      // TODO(andrealin): Get PackageMetadataConfig from proto annotations.
     }
     Preconditions.checkNotNull(config);
 


### PR DESCRIPTION
The `--package` flag is necessary when only a descriptor set is given (no service yaml, no gapic config, no package2.yaml). It specifies the proto package e.g. `google.pubsub.v1` for the source protos that we actually want to make a library for, as opposed to imported packages like `google.api.http`.