### PR TITLE
Use api-compiler-0.0.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ ext {
   libraries = [
     // General
     apiCommon: 'com.google.api:api-common:1.1.0',
-    apiCompiler: 'com.google.api:api-compiler:0.0.7',
+    apiCompiler: 'com.google.api:api-compiler:0.0.8',
     autovalue: 'com.google.auto.value:auto-value:1.6',
     autovalueAnnotation: 'com.google.auto.value:auto-value-annotations:1.6',
     commonmark: 'com.atlassian.commonmark:commonmark:0.9.0',

--- a/src/main/java/com/google/api/codegen/advising/Adviser.java
+++ b/src/main/java/com/google/api/codegen/advising/Adviser.java
@@ -50,7 +50,8 @@ public class Adviser {
 
       for (String message : rule.collectAdvice(model, configProto)) {
         model
-            .getDiagReporter().getDiagCollector()
+            .getDiagReporter()
+            .getDiagCollector()
             .addDiag(Diag.warning(GAPIC_CONFIG_LOCATION, "(%s) %s", rule.getName(), message));
       }
     }

--- a/src/main/java/com/google/api/codegen/advising/Adviser.java
+++ b/src/main/java/com/google/api/codegen/advising/Adviser.java
@@ -50,7 +50,7 @@ public class Adviser {
 
       for (String message : rule.collectAdvice(model, configProto)) {
         model
-            .getDiagCollector()
+            .getDiagReporter().getDiagCollector()
             .addDiag(Diag.warning(GAPIC_CONFIG_LOCATION, "(%s) %s", rule.getName(), message));
       }
     }

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -132,7 +132,7 @@ public abstract class GapicProductConfig implements ProductConfig {
             model, configProto, defaultPackage);
 
     ImmutableMap<String, ResourceNameConfig> resourceNameConfigs =
-        createResourceNameConfigs(model.getDiagCollector(), configProto, file, language);
+        createResourceNameConfigs(model.getDiagReporter().getDiagCollector(), configProto, file, language);
 
     TransportProtocol transportProtocol = TransportProtocol.GRPC;
 
@@ -144,7 +144,7 @@ public abstract class GapicProductConfig implements ProductConfig {
 
     ImmutableMap<String, InterfaceConfig> interfaceConfigMap =
         createInterfaceConfigMap(
-            model.getDiagCollector(),
+            model.getDiagReporter().getDiagCollector(),
             configProto,
             settings,
             messageConfigs,
@@ -161,11 +161,11 @@ public abstract class GapicProductConfig implements ProductConfig {
               .toBuilder()
               .mergeFrom(settings.getLicenseHeaderOverride())
               .build();
-      copyrightLines = loadCopyrightLines(model.getDiagCollector(), licenseHeader);
-      licenseLines = loadLicenseLines(model.getDiagCollector(), licenseHeader);
+      copyrightLines = loadCopyrightLines(model.getDiagReporter().getDiagCollector(), licenseHeader);
+      licenseLines = loadLicenseLines(model.getDiagReporter().getDiagCollector(), licenseHeader);
     } catch (Exception e) {
       model
-          .getDiagCollector()
+          .getDiagReporter().getDiagCollector()
           .addDiag(Diag.error(SimpleLocation.TOPLEVEL, "Exception: %s", e.getMessage()));
       e.printStackTrace(System.err);
       throw new RuntimeException(e);
@@ -175,7 +175,7 @@ public abstract class GapicProductConfig implements ProductConfig {
     // TODO(eoogbe): Move the validation logic to GAPIC config advisor.
     if (Strings.isNullOrEmpty(configSchemaVersion)) {
       model
-          .getDiagCollector()
+          .getDiagReporter().getDiagCollector()
           .addDiag(
               Diag.error(
                   SimpleLocation.TOPLEVEL,
@@ -238,8 +238,7 @@ public abstract class GapicProductConfig implements ProductConfig {
       copyrightLines = getResourceLines(licenseHeader.getCopyrightFile());
       licenseLines = getResourceLines(licenseHeader.getLicenseFile());
     } catch (Exception e) {
-      model
-          .getDiagCollector()
+      model.getDiagCollector()
           .addDiag(Diag.error(SimpleLocation.TOPLEVEL, "Exception: %s", e.getMessage()));
       e.printStackTrace(System.err);
       throw new RuntimeException(e);
@@ -248,8 +247,7 @@ public abstract class GapicProductConfig implements ProductConfig {
     String configSchemaVersion = configProto.getConfigSchemaVersion();
     // TODO(eoogbe): Move the validation logic to GAPIC config advisor.
     if (Strings.isNullOrEmpty(configSchemaVersion)) {
-      model
-          .getDiagCollector()
+      model.getDiagCollector()
           .addDiag(
               Diag.error(
                   SimpleLocation.TOPLEVEL,

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -132,7 +132,8 @@ public abstract class GapicProductConfig implements ProductConfig {
             model, configProto, defaultPackage);
 
     ImmutableMap<String, ResourceNameConfig> resourceNameConfigs =
-        createResourceNameConfigs(model.getDiagReporter().getDiagCollector(), configProto, file, language);
+        createResourceNameConfigs(
+            model.getDiagReporter().getDiagCollector(), configProto, file, language);
 
     TransportProtocol transportProtocol = TransportProtocol.GRPC;
 
@@ -161,11 +162,13 @@ public abstract class GapicProductConfig implements ProductConfig {
               .toBuilder()
               .mergeFrom(settings.getLicenseHeaderOverride())
               .build();
-      copyrightLines = loadCopyrightLines(model.getDiagReporter().getDiagCollector(), licenseHeader);
+      copyrightLines =
+          loadCopyrightLines(model.getDiagReporter().getDiagCollector(), licenseHeader);
       licenseLines = loadLicenseLines(model.getDiagReporter().getDiagCollector(), licenseHeader);
     } catch (Exception e) {
       model
-          .getDiagReporter().getDiagCollector()
+          .getDiagReporter()
+          .getDiagCollector()
           .addDiag(Diag.error(SimpleLocation.TOPLEVEL, "Exception: %s", e.getMessage()));
       e.printStackTrace(System.err);
       throw new RuntimeException(e);
@@ -175,7 +178,8 @@ public abstract class GapicProductConfig implements ProductConfig {
     // TODO(eoogbe): Move the validation logic to GAPIC config advisor.
     if (Strings.isNullOrEmpty(configSchemaVersion)) {
       model
-          .getDiagReporter().getDiagCollector()
+          .getDiagReporter()
+          .getDiagCollector()
           .addDiag(
               Diag.error(
                   SimpleLocation.TOPLEVEL,
@@ -238,7 +242,8 @@ public abstract class GapicProductConfig implements ProductConfig {
       copyrightLines = getResourceLines(licenseHeader.getCopyrightFile());
       licenseLines = getResourceLines(licenseHeader.getLicenseFile());
     } catch (Exception e) {
-      model.getDiagCollector()
+      model
+          .getDiagCollector()
           .addDiag(Diag.error(SimpleLocation.TOPLEVEL, "Exception: %s", e.getMessage()));
       e.printStackTrace(System.err);
       throw new RuntimeException(e);
@@ -247,7 +252,8 @@ public abstract class GapicProductConfig implements ProductConfig {
     String configSchemaVersion = configProto.getConfigSchemaVersion();
     // TODO(eoogbe): Move the validation logic to GAPIC config advisor.
     if (Strings.isNullOrEmpty(configSchemaVersion)) {
-      model.getDiagCollector()
+      model
+          .getDiagCollector()
           .addDiag(
               Diag.error(
                   SimpleLocation.TOPLEVEL,

--- a/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
@@ -121,7 +121,7 @@ public class ProtoApiModel implements ApiModel {
 
   @Override
   public DiagCollector getDiagCollector() {
-    return protoModel.getDiagCollector();
+    return protoModel.getDiagReporter().getDiagCollector();
   }
 
   /** Helper to extract the types from the underlying model. */

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -89,7 +89,7 @@ public abstract class ResourceNameMessageConfigs {
         configProto.getResourceNameGenerationList()) {
       ResourceNameMessageConfig messageResourceTypeConfig =
           ResourceNameMessageConfig.createResourceNameMessageConfig(
-              model.getDiagCollector(), messageResourceTypesProto, defaultPackage);
+              model.getDiagReporter().getDiagCollector(), messageResourceTypesProto, defaultPackage);
       builder.put(messageResourceTypeConfig.messageName(), messageResourceTypeConfig);
     }
     ImmutableMap<String, ResourceNameMessageConfig> messageResourceTypeConfigMap = builder.build();

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -53,7 +53,7 @@ public abstract class ResourceNameMessageConfigs {
           configProto.getResourceNameGenerationList()) {
         ResourceNameMessageConfig messageResourceTypeConfig =
             ResourceNameMessageConfig.createResourceNameMessageConfig(
-                model.getDiagCollector(), messageResourceTypesProto, defaultPackage);
+                model.getDiagReporter().getDiagCollector(), messageResourceTypesProto, defaultPackage);
         builder.put(messageResourceTypeConfig.messageName(), messageResourceTypeConfig);
       }
       // TODO(andrealin): Get ResourceNameMessageConfigs from proto annotations.
@@ -89,7 +89,7 @@ public abstract class ResourceNameMessageConfigs {
         configProto.getResourceNameGenerationList()) {
       ResourceNameMessageConfig messageResourceTypeConfig =
           ResourceNameMessageConfig.createResourceNameMessageConfig(
-              model.getDiagReporter().getDiagCollector(),
+              model.getDiagCollector(),
               messageResourceTypesProto,
               defaultPackage);
       builder.put(messageResourceTypeConfig.messageName(), messageResourceTypeConfig);

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -89,7 +89,9 @@ public abstract class ResourceNameMessageConfigs {
         configProto.getResourceNameGenerationList()) {
       ResourceNameMessageConfig messageResourceTypeConfig =
           ResourceNameMessageConfig.createResourceNameMessageConfig(
-              model.getDiagReporter().getDiagCollector(), messageResourceTypesProto, defaultPackage);
+              model.getDiagReporter().getDiagCollector(),
+              messageResourceTypesProto,
+              defaultPackage);
       builder.put(messageResourceTypeConfig.messageName(), messageResourceTypeConfig);
     }
     ImmutableMap<String, ResourceNameMessageConfig> messageResourceTypeConfigMap = builder.build();

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -53,7 +53,9 @@ public abstract class ResourceNameMessageConfigs {
           configProto.getResourceNameGenerationList()) {
         ResourceNameMessageConfig messageResourceTypeConfig =
             ResourceNameMessageConfig.createResourceNameMessageConfig(
-                model.getDiagReporter().getDiagCollector(), messageResourceTypesProto, defaultPackage);
+                model.getDiagReporter().getDiagCollector(),
+                messageResourceTypesProto,
+                defaultPackage);
         builder.put(messageResourceTypeConfig.messageName(), messageResourceTypeConfig);
       }
       // TODO(andrealin): Get ResourceNameMessageConfigs from proto annotations.
@@ -89,9 +91,7 @@ public abstract class ResourceNameMessageConfigs {
         configProto.getResourceNameGenerationList()) {
       ResourceNameMessageConfig messageResourceTypeConfig =
           ResourceNameMessageConfig.createResourceNameMessageConfig(
-              model.getDiagCollector(),
-              messageResourceTypesProto,
-              defaultPackage);
+              model.getDiagCollector(), messageResourceTypesProto, defaultPackage);
       builder.put(messageResourceTypeConfig.messageName(), messageResourceTypeConfig);
     }
     ImmutableMap<String, ResourceNameMessageConfig> messageResourceTypeConfigMap = builder.build();

--- a/src/main/java/com/google/api/codegen/configgen/GapicConfigGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/configgen/GapicConfigGeneratorApp.java
@@ -40,8 +40,8 @@ public class GapicConfigGeneratorApp extends ToolDriverBase {
   @Override
   protected void process() throws Exception {
     model.establishStage(Merged.KEY);
-    if (model.getDiagCollector().getErrorCount() > 0) {
-      for (Diag diag : model.getDiagCollector().getDiags()) {
+    if (model.getDiagReporter().getDiagCollector().getErrorCount() > 0) {
+      for (Diag diag : model.getDiagReporter().getDiagCollector().getDiags()) {
         System.err.println(diag.toString());
       }
       return;

--- a/src/main/java/com/google/api/codegen/configgen/mergers/ProtoConfigMerger.java
+++ b/src/main/java/com/google/api/codegen/configgen/mergers/ProtoConfigMerger.java
@@ -37,7 +37,7 @@ public class ProtoConfigMerger {
   }
 
   private ConfigMerger createMerger(Model model, String fileName) {
-    ConfigHelper helper = new ConfigHelper(model.getDiagCollector(), fileName);
+    ConfigHelper helper = new ConfigHelper(model.getDiagReporter().getDiagCollector(), fileName);
     String packageName = getPackageName(model, helper);
     if (packageName == null) {
       return null;

--- a/src/main/java/com/google/api/codegen/gapic/GapicGenerator.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGenerator.java
@@ -56,13 +56,13 @@ public class GapicGenerator implements CodeGenerator<Doc> {
   public Map<String, GeneratedResult<Doc>> generate() {
     // Establish required stage for generation.
     model.establishStage(Merged.KEY);
-    if (model.getDiagCollector().getErrorCount() > 0) {
+    if (model.getDiagReporter().getDiagCollector().getErrorCount() > 0) {
       return null;
     }
 
     List<ViewModel> surfaceDocs =
         modelToViewTransformer.transform(new ProtoApiModel(model), productConfig);
-    if (model.getDiagCollector().getErrorCount() > 0) {
+    if (model.getDiagReporter().getDiagCollector().getErrorCount() > 0) {
       return null;
     }
 

--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
@@ -131,8 +131,8 @@ public class GapicGeneratorApp extends ToolDriverBase {
     Adviser adviser = new Adviser(adviceSuppressors);
     adviser.advise(model, configProto);
 
-    if (model.getDiagCollector().getErrorCount() > 0) {
-      for (Diag diag : model.getDiagCollector().getDiags()) {
+    if (model.getDiagReporter().getDiagCollector().getErrorCount() > 0) {
+      for (Diag diag : model.getDiagReporter().getDiagCollector().getDiags()) {
         System.err.println(diag.toString());
       }
       return;
@@ -212,13 +212,13 @@ public class GapicGeneratorApp extends ToolDriverBase {
 
   private ConfigSource loadConfigFromFiles(List<String> configFileNames) {
     List<File> configFiles = pathsToFiles(configFileNames);
-    if (model.getDiagCollector().getErrorCount() > 0) {
+    if (model.getDiagReporter().getDiagCollector().getErrorCount() > 0) {
       return null;
     }
     ImmutableMap<String, Message> supportedConfigTypes =
         ImmutableMap.of(
             ConfigProto.getDescriptor().getFullName(), ConfigProto.getDefaultInstance());
-    return MultiYamlReader.read(model.getDiagCollector(), configFiles, supportedConfigTypes);
+    return MultiYamlReader.read(model.getDiagReporter().getDiagCollector(), configFiles, supportedConfigTypes);
   }
 
   private List<File> pathsToFiles(List<String> configFileNames) {
@@ -237,10 +237,10 @@ public class GapicGeneratorApp extends ToolDriverBase {
   }
 
   private void error(String message, Object... args) {
-    model.getDiagCollector().addDiag(Diag.error(SimpleLocation.TOPLEVEL, message, args));
+    model.getDiagReporter().getDiagCollector().addDiag(Diag.error(SimpleLocation.TOPLEVEL, message, args));
   }
 
   private void warning(String message, Object... args) {
-    model.getDiagCollector().addDiag(Diag.warning(SimpleLocation.TOPLEVEL, message, args));
+    model.getDiagReporter().getDiagCollector().addDiag(Diag.warning(SimpleLocation.TOPLEVEL, message, args));
   }
 }

--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
@@ -218,7 +218,8 @@ public class GapicGeneratorApp extends ToolDriverBase {
     ImmutableMap<String, Message> supportedConfigTypes =
         ImmutableMap.of(
             ConfigProto.getDescriptor().getFullName(), ConfigProto.getDefaultInstance());
-    return MultiYamlReader.read(model.getDiagReporter().getDiagCollector(), configFiles, supportedConfigTypes);
+    return MultiYamlReader.read(
+        model.getDiagReporter().getDiagCollector(), configFiles, supportedConfigTypes);
   }
 
   private List<File> pathsToFiles(List<String> configFileNames) {
@@ -237,10 +238,16 @@ public class GapicGeneratorApp extends ToolDriverBase {
   }
 
   private void error(String message, Object... args) {
-    model.getDiagReporter().getDiagCollector().addDiag(Diag.error(SimpleLocation.TOPLEVEL, message, args));
+    model
+        .getDiagReporter()
+        .getDiagCollector()
+        .addDiag(Diag.error(SimpleLocation.TOPLEVEL, message, args));
   }
 
   private void warning(String message, Object... args) {
-    model.getDiagReporter().getDiagCollector().addDiag(Diag.warning(SimpleLocation.TOPLEVEL, message, args));
+    model
+        .getDiagReporter()
+        .getDiagCollector()
+        .addDiag(Diag.warning(SimpleLocation.TOPLEVEL, message, args));
   }
 }

--- a/src/main/java/com/google/api/codegen/gapic/LegacyGapicGenerator.java
+++ b/src/main/java/com/google/api/codegen/gapic/LegacyGapicGenerator.java
@@ -68,7 +68,7 @@ public class LegacyGapicGenerator implements CodeGenerator<Doc> {
   private Map<String, GeneratedResult<Doc>> generate(String snippetFileName) {
     // Establish required stage for generation.
     model.establishStage(Merged.KEY);
-    if (model.getDiagCollector().getErrorCount() > 0) {
+    if (model.getDiagReporter().getDiagCollector().getErrorCount() > 0) {
       return ImmutableMap.of();
     }
 
@@ -94,7 +94,7 @@ public class LegacyGapicGenerator implements CodeGenerator<Doc> {
     }
 
     // Return result.
-    if (model.getDiagCollector().getErrorCount() > 0) {
+    if (model.getDiagReporter().getDiagCollector().getErrorCount() > 0) {
       return ImmutableMap.of();
     }
 

--- a/src/main/java/com/google/api/codegen/packagegen/PackageGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/packagegen/PackageGeneratorApp.java
@@ -84,8 +84,8 @@ public class PackageGeneratorApp extends ToolDriverBase {
   protected void process() throws Exception {
     model.establishStage(Merged.KEY);
 
-    if (model.getDiagCollector().getErrorCount() > 0) {
-      for (Diag diag : model.getDiagCollector().getDiags()) {
+    if (model.getDiagReporter().getDiagCollector().getErrorCount() > 0) {
+      for (Diag diag : model.getDiagReporter().getDiagCollector().getDiags()) {
         System.err.println(diag.toString());
       }
       return;

--- a/src/test/java/com/google/api/codegen/GapicTestBase2.java
+++ b/src/test/java/com/google/api/codegen/GapicTestBase2.java
@@ -78,7 +78,7 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
     super.setupModel();
     gapicConfig =
         CodegenTestUtil.readConfig(
-            model.getDiagCollector(), getTestDataLocator(), gapicConfigFileNames);
+            model.getDiagReporter().getDiagCollector(), getTestDataLocator(), gapicConfigFileNames);
     if (!Strings.isNullOrEmpty(packageConfigFileName)) {
       try {
         ApiDefaultsConfig apiDefaultsConfig = ApiDefaultsConfig.load();
@@ -95,8 +95,8 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
       }
     }
     // TODO (garrettjones) depend on the framework to take care of this.
-    if (model.getDiagCollector().getErrorCount() > 0) {
-      for (Diag diag : model.getDiagCollector().getDiags()) {
+    if (model.getDiagReporter().getDiagCollector().getErrorCount() > 0) {
+      for (Diag diag : model.getDiagReporter().getDiagCollector().getDiags()) {
         System.err.println(diag.toString());
       }
       throw new IllegalArgumentException("Problem creating Generator");
@@ -151,8 +151,8 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
   @Override
   public Map<String, ?> run() throws IOException {
     model.establishStage(Merged.KEY);
-    if (model.getDiagCollector().getErrorCount() > 0) {
-      for (Diag diag : model.getDiagCollector().getDiags()) {
+    if (model.getDiagReporter().getDiagCollector().getErrorCount() > 0) {
+      for (Diag diag : model.getDiagReporter().getDiagCollector().getDiags()) {
         System.err.println(diag.toString());
       }
       return null;
@@ -160,7 +160,7 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
 
     GapicProductConfig productConfig = GapicProductConfig.create(model, gapicConfig, language);
     if (productConfig == null) {
-      for (Diag diag : model.getDiagCollector().getDiags()) {
+      for (Diag diag : model.getDiagReporter().getDiagCollector().getDiags()) {
         System.err.println(diag.toString());
       }
       return null;

--- a/src/test/java/com/google/api/codegen/GapicTestModelGenerator.java
+++ b/src/test/java/com/google/api/codegen/GapicTestModelGenerator.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen;
 
+import com.google.api.tools.framework.model.Experiments;
 import com.google.api.tools.framework.model.testing.TestConfig;
 import com.google.api.tools.framework.model.testing.TestDataLocator;
 import com.google.api.tools.framework.model.testing.TestModelGenerator;
@@ -27,7 +28,8 @@ public class GapicTestModelGenerator extends TestModelGenerator {
   }
 
   @Override
-  public TestConfig createTestConfig(String tempDir, List<String> protoFiles) {
+  public TestConfig createTestConfig(
+      String tempDir, List<String> protoFiles, Experiments experiments) {
     return new GapicTestConfig(getTestDataLocator(), tempDir, protoFiles);
   }
 }

--- a/src/test/java/com/google/api/codegen/advising/AdviserTest.java
+++ b/src/test/java/com/google/api/codegen/advising/AdviserTest.java
@@ -14,24 +14,16 @@
  */
 package com.google.api.codegen.advising;
 
-import com.google.api.Service;
 import com.google.api.codegen.CodegenTestUtil;
 import com.google.api.codegen.ConfigProto;
 import com.google.api.codegen.LanguageSettingsProto;
-import com.google.api.tools.framework.model.ConfigAspect;
-import com.google.api.tools.framework.model.ProtoElement;
+import com.google.api.tools.framework.aspects.control.ControlConfigAspect;
 import com.google.api.tools.framework.model.stages.Merged;
 import com.google.api.tools.framework.model.testing.ConfigBaselineTestCase;
 import com.google.common.collect.ImmutableList;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-
 import org.junit.Before;
 import org.junit.Test;
-
-import javax.annotation.Nullable;
 
 public class AdviserTest extends ConfigBaselineTestCase {
   private ConfigProto configProto;
@@ -42,7 +34,8 @@ public class AdviserTest extends ConfigBaselineTestCase {
     model
         .getDiagReporter()
         .getDiagSuppressor()
-        .addSuppressionDirective(model, "<aspect>-*", Arrays.asList());
+        .addSuppressionDirective(
+            model, "control-*", Arrays.asList(ControlConfigAspect.create(model)));
     model.getDiagReporter().getDiagSuppressor().addPattern(model, "http:.*");
     model.establishStage(Merged.KEY);
     adviser.advise(model, configProto);

--- a/src/test/java/com/google/api/codegen/advising/AdviserTest.java
+++ b/src/test/java/com/google/api/codegen/advising/AdviserTest.java
@@ -14,14 +14,24 @@
  */
 package com.google.api.codegen.advising;
 
+import com.google.api.Service;
 import com.google.api.codegen.CodegenTestUtil;
 import com.google.api.codegen.ConfigProto;
 import com.google.api.codegen.LanguageSettingsProto;
+import com.google.api.tools.framework.model.ConfigAspect;
+import com.google.api.tools.framework.model.ProtoElement;
 import com.google.api.tools.framework.model.stages.Merged;
 import com.google.api.tools.framework.model.testing.ConfigBaselineTestCase;
 import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.annotation.Nullable;
 
 public class AdviserTest extends ConfigBaselineTestCase {
   private ConfigProto configProto;
@@ -29,8 +39,11 @@ public class AdviserTest extends ConfigBaselineTestCase {
 
   @Override
   public Object run() throws Exception {
-    model.addSupressionDirective(model, "control-*");
-    model.getDiagSuppressor().addPattern(model, "http:.*");
+    model
+        .getDiagReporter()
+        .getDiagSuppressor()
+        .addSuppressionDirective(model, "<aspect>-*", Arrays.asList());
+    model.getDiagReporter().getDiagSuppressor().addPattern(model, "http:.*");
     model.establishStage(Merged.KEY);
     adviser.advise(model, configProto);
     return "";

--- a/src/test/java/com/google/api/codegen/config/GapicConfigProducerTest.java
+++ b/src/test/java/com/google/api/codegen/config/GapicConfigProducerTest.java
@@ -43,12 +43,14 @@ public class GapicConfigProducerTest {
 
     ConfigProto configProto =
         CodegenTestUtil.readConfig(
-            model.getDiagCollector(), locator, new String[] {"missing_config_schema_version.yaml"});
+            model.getDiagReporter().getDiagCollector(),
+            locator,
+            new String[] {"missing_config_schema_version.yaml"});
     productConfig = GapicProductConfig.create(model, configProto, TargetLanguage.JAVA);
     Diag expectedError =
         Diag.error(
             SimpleLocation.TOPLEVEL, "config_schema_version field is required in GAPIC yaml.");
-    Truth.assertThat(model.getDiagCollector().hasErrors()).isTrue();
-    Truth.assertThat(model.getDiagCollector().getDiags()).contains(expectedError);
+    Truth.assertThat(model.getDiagReporter().getDiagCollector().hasErrors()).isTrue();
+    Truth.assertThat(model.getDiagReporter().getDiagCollector().getDiags()).contains(expectedError);
   }
 }

--- a/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
@@ -62,12 +62,15 @@ public class GoGapicSurfaceTransformerTest {
 
     ConfigProto configProto =
         CodegenTestUtil.readConfig(
-            model.getDiagCollector(), locator, new String[] {"myproto_gapic.yaml"});
+            model.getDiagReporter().getDiagCollector(),
+            locator,
+            new String[] {"myproto_gapic.yaml"});
 
     productConfig = GapicProductConfig.create(model, configProto, TargetLanguage.GO);
 
-    if (model.getDiagCollector().hasErrors()) {
-      throw new IllegalStateException(model.getDiagCollector().getDiags().toString());
+    if (model.getDiagReporter().getDiagCollector().hasErrors()) {
+      throw new IllegalStateException(
+          model.getDiagReporter().getDiagCollector().getDiags().toString());
     }
   }
 


### PR DESCRIPTION
api-compiler is needed to support the [api-common-protos](https://github.com/googleapis/api-common-protos/tree/input-contract) (from branch input-contract) that are needed to be installed in gapic-generator in order to parse annotated protos, using [annotations.proto](https://github.com/googleapis/api-common-protos/blob/master/google/api/annotations.proto)

Edit: all other changes in src/ are due to surface changes from the new api-compiler dependency.