### PR TITLE
Normalize line endings when splitting for docs

### DIFF
--- a/src/main/java/com/google/api/codegen/util/CommonRenderingUtil.java
+++ b/src/main/java/com/google/api/codegen/util/CommonRenderingUtil.java
@@ -41,7 +41,8 @@ public class CommonRenderingUtil {
   public static List<String> getDocLines(String text) {
     // TODO: Convert markdown to language-specific doc format.
     // https://github.com/googleapis/toolkit/issues/331
-    List<String> result = Splitter.on(String.format("%n")).splitToList(text);
+    text = text.replace("\r\n", "\n").replace("\r", "\n");
+    List<String> result = Splitter.on('\n').splitToList(text);
     return result.size() == 1 && result.get(0).isEmpty() ? ImmutableList.<String>of() : result;
   }
 
@@ -51,6 +52,7 @@ public class CommonRenderingUtil {
    * <p>maxWidth includes the ending newline.
    */
   public static List<String> getDocLines(String text, int maxWidth) {
+    text = text.replace("\r\n", "\n").replace("\r", "\n");
     maxWidth = maxWidth - 1;
     List<String> lines = new ArrayList<>();
     for (String line : text.trim().split("\n")) {

--- a/src/test/java/com/google/api/codegen/util/CommonRenderingUtilTest.java
+++ b/src/test/java/com/google/api/codegen/util/CommonRenderingUtilTest.java
@@ -36,4 +36,15 @@ public class CommonRenderingUtilTest {
     assertThat(CommonRenderingUtil.stripQuotes("'a'bc'")).isEqualTo("'a'bc'");
     assertThat(CommonRenderingUtil.stripQuotes("\"a\"bc\"")).isEqualTo("\"a\"bc\"");
   }
+
+  @Test
+  public void testGetDocLines() {
+    // Check that we don't care which form of line break is used.
+    assertThat(CommonRenderingUtil.getDocLines("a\nb\nc")).containsExactly("a", "b", "c").inOrder();
+    assertThat(CommonRenderingUtil.getDocLines("a\rb\rc")).containsExactly("a", "b", "c").inOrder();
+    assertThat(CommonRenderingUtil.getDocLines("a\r\nb\r\nc"))
+        .containsExactly("a", "b", "c")
+        .inOrder();
+    assertThat(CommonRenderingUtil.getDocLines("")).isEmpty();
+  }
 }


### PR DESCRIPTION
The tests only cover one overload, but it basically works the same
in both cases.

Fixes #2268.