### PR TITLE
Run gapic-generator unit tests in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,9 +283,9 @@ jobs:
   test-gapic-generator:
     docker:
       - image: circleci/openjdk:8-jdk
-    working_directory: /tmp/
+    working_directory: /gapic-generator
     environment:
-      TEST_REPORTS_DIR: /tmp/workspace/reports/gapic-generator
+      TEST_REPORTS_DIR: /gapic-generator/reports/gapic-generator
     steps:
       - checkout
       - run:
@@ -304,7 +304,7 @@ jobs:
           path: ${TEST_REPORTS_DIR}
       - persist_to_workspace:
           # Save all generated directories in workspace for later CircleCI jobs.
-          root: /tmp/workspace
+          root: /gapic-generator
           paths:
             - reports/gapic-generator
   generate-clients:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,7 @@ jobs:
       - run:
           name: Make reports directory
           command: |
-            mkdir -p ${TEST_REPORTS_DIR}
+            mkdir -p reports/gapic-generator
       - run:
           name: Run unit tests for gapic-generator
           command: |
@@ -301,14 +301,14 @@ jobs:
             find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ${TEST_REPORTS_DIR} \;
           when: always
       - store_test_results:
-          path: ${TEST_REPORTS_DIR}
+          path: reports/gapic-generator
       - store_artifacts:
-          path: ${TEST_REPORTS_DIR}
+          path: reports/gapic-generator
       - persist_to_workspace:
           # Save all generated directories in workspace for later CircleCI jobs.
           root: /tmp/workspace
           paths:
-            - ${TEST_REPORTS_DIR}
+            - reports/gapic-generator
   generate-clients:
     docker:
       - image: googleapis/artman:0.15.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,36 @@ jobs:
             - gapic-generator
             - googleapis
             - showcase-protos
+  test-gapic-generator:
+    docker:
+      - image: circleci/openjdk:8-jdk
+    working_directory: /tmp/
+    environment:
+      TEST_REPORTS_DIR: /tmp/workspace/reports/gapic-generator
+    steps:
+      - attach_workspace:
+          at: workspace
+      - run:
+          name: Make reports directory
+          command: |
+            mkdir -p ${TEST_REPORTS_DIR}
+      - run:
+          name: Run unit tests for gapic-generator
+          command: |
+            cd workspace/gapic-generator
+            ./gradlew test
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ${TEST_REPORTS_DIR} \;
+          when: always
+      - store_test_results:
+          path: ${TEST_REPORTS_DIR}
+      - store_artifacts:
+          path: ${TEST_REPORTS_DIR}
+      - persist_to_workspace:
+          # Save all generated directories in workspace for later CircleCI jobs.
+          root: /tmp/workspace
+          paths:
+            - gapic-generator/artman-genfiles
+            - reports
   generate-clients:
     docker:
       - image: googleapis/artman:0.15.2
@@ -429,6 +459,9 @@ workflows:
   run_generated_tests:
     jobs:
       - install-gapic-generator
+      - test-gapic-generator:
+          requires:
+            - install-gapic-generator
       - generate-clients:
           requires:
             - install-gapic-generator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ jobs:
       - image: circleci/openjdk:8-jdk
     working_directory: /tmp/workspace
     environment:
-      TEST_REPORTS_DIR: /tmp/workspace/reports/gapic-generator
+      TEST_REPORTS_DIR: reports/gapic-generator
     steps:
       - checkout:
           path: gapic-generator
@@ -308,7 +308,7 @@ jobs:
           # Save all generated directories in workspace for later CircleCI jobs.
           root: /tmp/workspace
           paths:
-            - reports/gapic-generator
+            - ${TEST_REPORTS_DIR}
   generate-clients:
     docker:
       - image: googleapis/artman:0.15.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,8 +287,7 @@ jobs:
     environment:
       TEST_REPORTS_DIR: /tmp/workspace/reports/gapic-generator
     steps:
-      - attach_workspace:
-          at: workspace
+      - checkout
       - run:
           name: Make reports directory
           command: |
@@ -296,8 +295,7 @@ jobs:
       - run:
           name: Run unit tests for gapic-generator
           command: |
-            cd workspace/gapic-generator
-            ./gradlew test
+            ./gradlew clean test
             find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ${TEST_REPORTS_DIR} \;
           when: always
       - store_test_results:
@@ -308,8 +306,7 @@ jobs:
           # Save all generated directories in workspace for later CircleCI jobs.
           root: /tmp/workspace
           paths:
-            - gapic-generator/artman-genfiles
-            - reports
+            - reports/gapic-generator
   generate-clients:
     docker:
       - image: googleapis/artman:0.15.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,6 +296,7 @@ jobs:
       - run:
           name: Run unit tests for gapic-generator
           command: |
+            cd gapic-generator
             ./gradlew clean test
             find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ${TEST_REPORTS_DIR} \;
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,8 +284,6 @@ jobs:
     docker:
       - image: circleci/openjdk:8-jdk
     working_directory: /tmp/workspace
-    environment:
-      TEST_REPORTS_DIR: reports/gapic-generator
     steps:
       - checkout:
           path: gapic-generator
@@ -298,6 +296,7 @@ jobs:
           command: |
             cd gapic-generator
             ./gradlew clean test
+            export TEST_REPORTS_DIR=/tmp/workspace/reports/gapic-generator
             find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ${TEST_REPORTS_DIR} \;
           when: always
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,11 +283,12 @@ jobs:
   test-gapic-generator:
     docker:
       - image: circleci/openjdk:8-jdk
-    working_directory: /gapic-generator
+    working_directory: /tmp/workspace
     environment:
-      TEST_REPORTS_DIR: /gapic-generator/reports/gapic-generator
+      TEST_REPORTS_DIR: /tmp/workspace/reports/gapic-generator
     steps:
-      - checkout
+      - checkout:
+          path: gapic-generator
       - run:
           name: Make reports directory
           command: |
@@ -304,7 +305,7 @@ jobs:
           path: ${TEST_REPORTS_DIR}
       - persist_to_workspace:
           # Save all generated directories in workspace for later CircleCI jobs.
-          root: /gapic-generator
+          root: /tmp/workspace
           paths:
             - reports/gapic-generator
   generate-clients:


### PR DESCRIPTION
Our TravisCI is [failing](https://travis-ci.org/googleapis/gapic-generator/builds/422278897) because of https://github.com/travis-ci/travis-ci/issues/10053, so we should maintain gapic-generator unit test coverage with CircleCI. This can be a temporary patch while we or TravisCI figures out what the deal is.