### PR TITLE
Order default retry codes alphabetically

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/mergers/RetryMerger.java
+++ b/src/main/java/com/google/api/codegen/configgen/mergers/RetryMerger.java
@@ -51,7 +51,7 @@ public class RetryMerger {
         generateRetryCodeDefNode(
             NodeFinder.getNextLine(parentNode),
             RETRY_CODES_IDEMPOTENT_NAME,
-            ImmutableList.of(Status.Code.UNAVAILABLE.name(), Status.Code.DEADLINE_EXCEEDED.name()));
+            ImmutableList.of(Status.Code.DEADLINE_EXCEEDED.name(), Status.Code.UNAVAILABLE.name()));
     parentNode.setChild(idempotentNode);
     ConfigNode nonIdempotentNode =
         generateRetryCodeDefNode(

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -53,8 +53,8 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
     - DEADLINE_EXCEEDED
+    - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.

--- a/src/test/java/com/google/api/codegen/testdata/longrunning_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/longrunning_config.baseline
@@ -47,8 +47,8 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
     - DEADLINE_EXCEEDED
+    - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.

--- a/src/test/java/com/google/api/codegen/testdata/multiple_services_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/multiple_services_config.baseline
@@ -45,8 +45,8 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
     - DEADLINE_EXCEEDED
+    - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -143,8 +143,8 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
     - DEADLINE_EXCEEDED
+    - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates_config.baseline
@@ -45,8 +45,8 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
     - DEADLINE_EXCEEDED
+    - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.


### PR DESCRIPTION
There's a lot of refactoring to be done for proto annotations support in the near future, and having an ordered list of values in the baseline tests will make for a cleaner baseline diff in future PRs.