### PR TITLE
[Proto annotations]: Retry Settings Defaults (WIP)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ ext {
     autovalue: 'com.google.auto.value:auto-value:1.6',
     autovalueAnnotation: 'com.google.auto.value:auto-value-annotations:1.6',
     commonmark: 'com.atlassian.commonmark:commonmark:0.9.0',
-    commonProtos: 'com.google.api.grpc:grpc-google-common-protos:1.13.0-pre1',
+    commonProtos: 'com.google.api.grpc:proto-google-common-protos:1.13.0-pre1',
     commonsLang: 'org.apache.commons:commons-lang3:3.6',
     commonsCli: 'commons-cli:commons-cli:1.4',
     gson: 'com.google.code.gson:gson:2.3',
@@ -114,6 +114,7 @@ dependencies {
     libraries.protobuf,
     libraries.snakeyaml,
     libraries.threetenbp,
+    libraries.commonProtos,
     libraries.toolsFxTesting
 
   testCompile libraries.junit,
@@ -121,7 +122,6 @@ dependencies {
     libraries.truth8,
     libraries.toolsFxTesting,
     libraries.mockito,
-    libraries.commonProtos,
     libraries.junitParams
 
   annotationProcessor libraries.autovalue

--- a/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
@@ -70,9 +70,9 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
       ResourceNameMessageConfigs messageConfigs,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs) {
 
-    ImmutableMap<String, ImmutableSet<String>> retryCodesDefinition =
+    ImmutableMap<String, List<String>> retryCodesDefinition =
         RetryDefinitionsTransformer.createRetryCodesDefinition(
-            model.getDiagCollector(), interfaceConfigProto);
+            model.getDiagCollector(), interfaceConfigProto, null, ImmutableMap.builder());
     ImmutableMap<String, RetryParamsDefinitionProto> retrySettingsDefinition =
         RetryDefinitionsTransformer.createRetrySettingsDefinition(interfaceConfigProto);
 
@@ -86,8 +86,8 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
               interfaceConfigProto,
               messageConfigs,
               resourceNameConfigs,
-              retryCodesDefinition.keySet(),
-              retrySettingsDefinition.keySet());
+              ImmutableList.copyOf(retryCodesDefinition.keySet()),
+              ImmutableList.copyOf(retrySettingsDefinition.keySet()));
       methodConfigs =
           GapicInterfaceConfig.createMethodConfigs(methodConfigMap, interfaceConfigProto);
     }
@@ -184,8 +184,8 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
       InterfaceConfigProto interfaceConfigProto,
       ResourceNameMessageConfigs messageConfigs,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs,
-      ImmutableSet<String> retryCodesConfigNames,
-      ImmutableSet<String> retryParamsConfigNames) {
+      List<String> retryCodesConfigNames,
+      List<String> retryParamsConfigNames) {
     ImmutableMap.Builder<String, DiscoGapicMethodConfig> methodConfigMapBuilder =
         ImmutableMap.builder();
 

--- a/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -86,8 +87,8 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
               interfaceConfigProto,
               messageConfigs,
               resourceNameConfigs,
-              ImmutableList.copyOf(retryCodesDefinition.keySet()),
-              ImmutableList.copyOf(retrySettingsDefinition.keySet()));
+              retryCodesDefinition.keySet(),
+              retrySettingsDefinition.keySet());
       methodConfigs =
           GapicInterfaceConfig.createMethodConfigs(methodConfigMap, interfaceConfigProto);
     }
@@ -184,8 +185,8 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
       InterfaceConfigProto interfaceConfigProto,
       ResourceNameMessageConfigs messageConfigs,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs,
-      List<String> retryCodesConfigNames,
-      List<String> retryParamsConfigNames) {
+      Set<String> retryCodesConfigNames,
+      Set<String> retryParamsConfigNames) {
     ImmutableMap.Builder<String, DiscoGapicMethodConfig> methodConfigMapBuilder =
         ImmutableMap.builder();
 

--- a/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
@@ -26,6 +26,7 @@ import com.google.api.codegen.common.TargetLanguage;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.configgen.transformer.DiscoveryMethodTransformer;
 import com.google.api.codegen.discovery.Method;
+import com.google.api.codegen.transformer.RetryDefinitionsTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
@@ -36,6 +37,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -81,8 +83,8 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
       Method method,
       ResourceNameMessageConfigs messageConfigs,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs,
-      List<String> retryCodesConfigNames,
-      List<String> retryParamsConfigNames) {
+      Set<String> retryCodesConfigNames,
+      Set<String> retryParamsConfigNames) {
 
     boolean error = false;
     DiscoveryMethodModel methodModel = new DiscoveryMethodModel(method, apiModel);
@@ -130,16 +132,10 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
       error = true;
     }
 
-    String retryParamsName = methodConfigProto.getRetryParamsName();
-    if (!retryParamsConfigNames.isEmpty() && !retryParamsConfigNames.contains(retryParamsName)) {
-      diagCollector.addDiag(
-          Diag.error(
-              SimpleLocation.TOPLEVEL,
-              "Retry parameters config used but not defined: %s (in method %s)",
-              retryParamsName,
-              methodModel.getFullName()));
-      error = true;
-    }
+    String retryParamsName =
+        RetryDefinitionsTransformer.getRetryParamsName(
+            methodConfigProto, diagCollector, retryParamsConfigNames);
+    error |= (retryParamsName == null);
 
     Duration timeout = Duration.ofMillis(methodConfigProto.getTimeoutMillis());
     if (timeout.toMillis() <= 0) {

--- a/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
@@ -33,7 +33,6 @@ import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
@@ -82,8 +81,8 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
       Method method,
       ResourceNameMessageConfigs messageConfigs,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs,
-      ImmutableSet<String> retryCodesConfigNames,
-      ImmutableSet<String> retryParamsConfigNames) {
+      List<String> retryCodesConfigNames,
+      List<String> retryParamsConfigNames) {
 
     boolean error = false;
     DiscoveryMethodModel methodModel = new DiscoveryMethodModel(method, apiModel);

--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -135,18 +135,13 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
     SmokeTestConfig smokeTestConfig =
         createSmokeTestConfig(diagCollector, apiInterface, interfaceConfigProto);
 
-    ImmutableList<String> requiredConstructorParams;
-    if (interfaceConfigProto != null) {
-      requiredConstructorParams =
-          ImmutableList.copyOf(interfaceConfigProto.getRequiredConstructorParamsList());
-      for (String param : interfaceConfigProto.getRequiredConstructorParamsList()) {
-        if (!CONSTRUCTOR_PARAMS.contains(param)) {
-          diagCollector.addDiag(
-              Diag.error(SimpleLocation.TOPLEVEL, "Unsupported constructor param: %s", param));
-        }
+    ImmutableList<String> requiredConstructorParams =
+        ImmutableList.<String>copyOf(interfaceConfigProto.getRequiredConstructorParamsList());
+    for (String param : interfaceConfigProto.getRequiredConstructorParamsList()) {
+      if (!CONSTRUCTOR_PARAMS.contains(param)) {
+        diagCollector.addDiag(
+            Diag.error(SimpleLocation.TOPLEVEL, "Unsupported constructor param: %s", param));
       }
-    } else {
-      requiredConstructorParams = ImmutableList.of();
     }
 
     ImmutableList.Builder<SingleResourceNameConfig> resourcesBuilder = ImmutableList.builder();

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -14,8 +14,6 @@
  */
 package com.google.api.codegen.config;
 
-import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_PARAMS_DEFAULT_NAME;
-
 import com.google.api.codegen.BatchingConfigProto;
 import com.google.api.codegen.FlatteningConfigProto;
 import com.google.api.codegen.LongRunningConfigProto;
@@ -26,6 +24,7 @@ import com.google.api.codegen.ResourceNameTreatment;
 import com.google.api.codegen.SurfaceTreatmentProto;
 import com.google.api.codegen.VisibilityProto;
 import com.google.api.codegen.common.TargetLanguage;
+import com.google.api.codegen.transformer.RetryDefinitionsTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
@@ -121,23 +120,9 @@ public abstract class GapicMethodConfig extends MethodConfig {
 
     String retryCodesName = methodNamesToRetryCodeDefNames.get(method.getSimpleName());
 
-    String retryParamsName = null;
-    if (methodConfigProto != null) {
-      retryParamsName = methodConfigProto.getRetryParamsName();
-      if (!retryParamsConfigNames.isEmpty() && !retryParamsConfigNames.contains(retryParamsName)) {
-        diagCollector.addDiag(
-            Diag.error(
-                SimpleLocation.TOPLEVEL,
-                "Retry parameters config used but not defined: %s (in method %s)",
-                retryParamsName,
-                methodModel.getFullName()));
-        error = true;
-      }
-    }
-    // TODO(andrealin): handle default retry params
-    if (Strings.isNullOrEmpty(retryParamsName)) {
-      retryParamsName = RETRY_PARAMS_DEFAULT_NAME;
-    }
+    String retryParamsName =
+        RetryDefinitionsTransformer.getRetryParamsName(
+            methodConfigProto, diagCollector, retryParamsConfigNames);
 
     Duration timeout = Duration.ofMillis(methodConfigProto.getTimeoutMillis());
     if (timeout.toMillis() <= 0) {

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -120,9 +120,6 @@ public abstract class GapicMethodConfig extends MethodConfig {
     }
 
     String retryCodesName = methodNamesToRetryCodeDefNames.get(method.getSimpleName());
-    if (Strings.isNullOrEmpty(retryCodesName)) {
-      retryCodesName = "";
-    }
 
     String retryParamsName = null;
     if (methodConfigProto != null) {

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -123,6 +123,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
     String retryParamsName =
         RetryDefinitionsTransformer.getRetryParamsName(
             methodConfigProto, diagCollector, retryParamsConfigNames);
+    error |= (retryParamsName == null);
 
     Duration timeout = Duration.ofMillis(methodConfigProto.getTimeoutMillis());
     if (timeout.toMillis() <= 0) {

--- a/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
@@ -17,7 +17,6 @@ package com.google.api.codegen.config;
 import com.google.api.codegen.RetryParamsDefinitionProto;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -35,7 +34,7 @@ public interface InterfaceConfig {
 
   List<? extends MethodConfig> getMethodConfigs();
 
-  ImmutableMap<String, ImmutableSet<String>> getRetryCodesDefinition();
+  ImmutableMap<String, List<String>> getRetryCodesDefinition();
 
   ImmutableMap<String, RetryParamsDefinitionProto> getRetrySettingsDefinition();
 

--- a/src/main/java/com/google/api/codegen/config/MethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/MethodModel.java
@@ -91,13 +91,13 @@ public interface MethodModel {
 
   boolean isOutputTypeEmpty();
 
-  Iterable<? extends FieldModel> getInputFields();
+  List<? extends FieldModel> getInputFields();
 
   List<? extends FieldModel> getInputFieldsForResourceNameMethod();
 
-  Iterable<? extends FieldModel> getOutputFields();
+  List<? extends FieldModel> getOutputFields();
 
-  Iterable<? extends FieldModel> getResourceNameInputFields();
+  List<? extends FieldModel> getResourceNameInputFields();
 
   boolean isIdempotent();
 

--- a/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
@@ -40,7 +40,7 @@ import java.util.Map;
 public final class ProtoMethodModel implements MethodModel {
   private final Method method;
   private List<ProtoField> inputFields;
-  private Iterable<ProtoField> outputFields;
+  private List<ProtoField> outputFields;
   private final TypeModel inputType;
   private final TypeModel outputType;
 
@@ -195,7 +195,7 @@ public final class ProtoMethodModel implements MethodModel {
   }
 
   @Override
-  public Iterable<ProtoField> getOutputFields() {
+  public List<ProtoField> getOutputFields() {
     if (outputFields != null) {
       return outputFields;
     }
@@ -209,7 +209,7 @@ public final class ProtoMethodModel implements MethodModel {
   }
 
   @Override
-  public Iterable<ProtoField> getResourceNameInputFields() {
+  public List<ProtoField> getResourceNameInputFields() {
     return new ArrayList<>();
   }
 

--- a/src/main/java/com/google/api/codegen/configgen/ProtoMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/ProtoMethodTransformer.java
@@ -14,6 +14,8 @@
  */
 package com.google.api.codegen.configgen;
 
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFAULT_MAX_RETRY_DELAY;
+
 import com.google.api.BackendRule;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProtoMethodModel;
@@ -31,12 +33,16 @@ public class ProtoMethodTransformer implements MethodTransformer {
 
   @Override
   public String getTimeoutMillis(MethodModel method) {
-    Model model = ((ProtoMethodModel) method).getProtoMethod().getModel();
+    return String.valueOf(getTimeoutMillis((ProtoMethodModel) method));
+  }
+
+  public static long getTimeoutMillis(ProtoMethodModel method) {
+    Model model = method.getProtoMethod().getModel();
     for (BackendRule backendRule : model.getServiceConfig().getBackend().getRulesList()) {
       if (backendRule.getSelector().equals(method.getFullName())) {
-        return String.valueOf((int) Math.ceil(backendRule.getDeadline() * MILLIS_PER_SECOND));
+        return (long) Math.ceil(backendRule.getDeadline() * MILLIS_PER_SECOND);
       }
     }
-    return "60000";
+    return DEFAULT_MAX_RETRY_DELAY;
   }
 }

--- a/src/main/java/com/google/api/codegen/configgen/mergers/RetryMerger.java
+++ b/src/main/java/com/google/api/codegen/configgen/mergers/RetryMerger.java
@@ -21,16 +21,9 @@ import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFA
 import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFAULT_RETRY_DELAY_MULTIPLIER;
 import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFAULT_RPC_TIMEOUT_MULTIPLIER;
 import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFAULT_TOTAL_TIMEOUT_MILLIS;
-import static com.google.api.codegen.configgen.transformer.RetryTransformer.INITIAL_RETRY_DELAY_NAME;
-import static com.google.api.codegen.configgen.transformer.RetryTransformer.INITIAL_RPC_TIMEOUT_NAME;
-import static com.google.api.codegen.configgen.transformer.RetryTransformer.MAX_RETRY_DELAY_NAME;
-import static com.google.api.codegen.configgen.transformer.RetryTransformer.MAX_RPC_TIMEOUT_NAME;
 import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_CODES_IDEMPOTENT_NAME;
 import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_CODES_NON_IDEMPOTENT_NAME;
-import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_DELAY_MULTIPLIER_NAME;
 import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_PARAMS_DEFAULT_NAME;
-import static com.google.api.codegen.configgen.transformer.RetryTransformer.RPC_TIMEOUT_MULTIPLIER_NAME;
-import static com.google.api.codegen.configgen.transformer.RetryTransformer.TOTAL_TIMEOUT_NAME;
 
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.configgen.ListTransformer;
@@ -48,6 +41,14 @@ import java.util.Map;
 
 /** Merges retry properties from an API interface into a ConfigNode. */
 public class RetryMerger {
+
+  private static final String INITIAL_RETRY_DELAY_NAME = "initial_retry_delay_millis";
+  private static final String RETRY_DELAY_MULTIPLIER_NAME = "retry_delay_multiplier";
+  private static final String MAX_RETRY_DELAY_NAME = "max_retry_delay_millis";
+  private static final String INITIAL_RPC_TIMEOUT_NAME = "initial_rpc_timeout_millis";
+  private static final String RPC_TIMEOUT_MULTIPLIER_NAME = "rpc_timeout_multiplier";
+  private static final String MAX_RPC_TIMEOUT_NAME = "max_rpc_timeout_millis";
+  private static final String TOTAL_TIMEOUT_NAME = "total_timeout_millis";
 
   public static final Map<String, List<String>> DEFAULT_RETRY_CODES =
       ImmutableSortedMap.of(

--- a/src/main/java/com/google/api/codegen/configgen/transformer/MethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/MethodTransformer.java
@@ -14,6 +14,8 @@
  */
 package com.google.api.codegen.configgen.transformer;
 
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFAULT_MAX_RETRY_DELAY;
+
 import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodModel;
@@ -57,7 +59,7 @@ public class MethodTransformer {
       generatePageStreaming(method, methodView);
       generateRetry(method, methodView);
       generateFieldNamePatterns(method, methodView, collectionNameMap);
-      methodView.timeoutMillis("60000");
+      methodView.timeoutMillis(String.valueOf(DEFAULT_MAX_RETRY_DELAY));
       methods.add(methodView.build());
     }
     return methods.build();

--- a/src/main/java/com/google/api/codegen/configgen/transformer/RetryTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/RetryTransformer.java
@@ -26,6 +26,22 @@ public class RetryTransformer {
   public static final String RETRY_CODES_NON_IDEMPOTENT_NAME = "non_idempotent";
   public static final String RETRY_PARAMS_DEFAULT_NAME = "default";
 
+  public static final int DEFAULT_INITIAL_RETRY_DELAY = 100;
+  public static final double DEFAULT_RETRY_DELAY_MULTIPLIER = 1.3;
+  public static final int DEFAULT_MAX_RETRY_DELAY = 60000;
+  public static final int DEFAULT_INITIAL_RPC_TIMEOUT_MULTIPLIER = 20000;
+  public static final int DEFAULT_RPC_TIMEOUT_MULTIPLIER = 1;
+  public static final int DEFAULT_MAX_RPC_TIMEOUT_MILLIS = 20000;
+  public static final int DEFAULT_TOTAL_TIMEOUT_MILLIS = 600000;
+
+  public static final String INITIAL_RETRY_DELAY_NAME = "initial_retry_delay_millis";
+  public static final String RETRY_DELAY_MULTIPLIER_NAME = "retry_delay_multiplier";
+  public static final String MAX_RETRY_DELAY_NAME = "max_retry_delay_millis";
+  public static final String INITIAL_RPC_TIMEOUT_NAME = "initial_rpc_timeout_millis";
+  public static final String RPC_TIMEOUT_MULTIPLIER_NAME = "rpc_timeout_multiplier";
+  public static final String MAX_RPC_TIMEOUT_NAME = "max_rpc_timeout_millis";
+  public static final String TOTAL_TIMEOUT_NAME = "total_timeout_millis";
+
   public void generateRetryDefinitions(
       InterfaceView.Builder interfaceView,
       List<String> idempotentRetryCodes,
@@ -54,13 +70,13 @@ public class RetryTransformer {
     return ImmutableList.of(
         RetryParamView.newBuilder()
             .name(RETRY_PARAMS_DEFAULT_NAME)
-            .initialRetryDelayMillis("100")
-            .retryDelayMultiplier("1.3")
-            .maxRetryDelayMillis("60000")
-            .initialRpcTimeoutMillis("20000")
-            .rpcTimeoutMultiplier("1")
-            .maxRpcTimeoutMillis("20000")
-            .totalTimeoutMillis("600000")
+            .initialRetryDelayMillis(String.valueOf(DEFAULT_INITIAL_RETRY_DELAY))
+            .retryDelayMultiplier(String.valueOf(DEFAULT_RETRY_DELAY_MULTIPLIER))
+            .maxRetryDelayMillis(String.valueOf(DEFAULT_MAX_RETRY_DELAY))
+            .initialRpcTimeoutMillis(String.valueOf(DEFAULT_INITIAL_RPC_TIMEOUT_MULTIPLIER))
+            .rpcTimeoutMultiplier(String.valueOf(DEFAULT_RPC_TIMEOUT_MULTIPLIER))
+            .maxRpcTimeoutMillis(String.valueOf(DEFAULT_MAX_RPC_TIMEOUT_MILLIS))
+            .totalTimeoutMillis(String.valueOf(DEFAULT_TOTAL_TIMEOUT_MILLIS))
             .build());
   }
 }

--- a/src/main/java/com/google/api/codegen/configgen/transformer/RetryTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/RetryTransformer.java
@@ -34,14 +34,6 @@ public class RetryTransformer {
   public static final int DEFAULT_MAX_RPC_TIMEOUT_MILLIS = 20000;
   public static final int DEFAULT_TOTAL_TIMEOUT_MILLIS = 600000;
 
-  public static final String INITIAL_RETRY_DELAY_NAME = "initial_retry_delay_millis";
-  public static final String RETRY_DELAY_MULTIPLIER_NAME = "retry_delay_multiplier";
-  public static final String MAX_RETRY_DELAY_NAME = "max_retry_delay_millis";
-  public static final String INITIAL_RPC_TIMEOUT_NAME = "initial_rpc_timeout_millis";
-  public static final String RPC_TIMEOUT_MULTIPLIER_NAME = "rpc_timeout_multiplier";
-  public static final String MAX_RPC_TIMEOUT_NAME = "max_rpc_timeout_millis";
-  public static final String TOTAL_TIMEOUT_NAME = "total_timeout_millis";
-
   public void generateRetryDefinitions(
       InterfaceView.Builder interfaceView,
       List<String> idempotentRetryCodes,

--- a/src/main/java/com/google/api/codegen/transformer/RetryDefinitionsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/RetryDefinitionsTransformer.java
@@ -125,13 +125,6 @@ public class RetryDefinitionsTransformer {
           .filter(m -> !Strings.isNullOrEmpty(m.getRetryCodesName()))
           .forEach(m -> methodNamesToRetryNamesFromConfig.put(m.getName(), m.getRetryCodesName()));
     }
-    //    else {
-    //      // Use default values for retry settings.
-    //      builder.putAll(DEFAULT_RETRY_CODES);
-    //      for (Entry<String, List<String>> entry : DEFAULT_RETRY_CODES.entrySet()) {
-    //        retryCodeNameSymbolTable.getNewSymbol(entry.getKey());
-    //      }
-    //    }
 
     // Check proto annotations for retry settings.
     if (apiInterface != null) {

--- a/src/main/java/com/google/api/codegen/transformer/RetryDefinitionsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/RetryDefinitionsTransformer.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -224,6 +225,27 @@ public class RetryDefinitionsTransformer {
       builder.put(RETRY_PARAMS_DEFAULT_NAME, defaultRetryParams);
     }
     return builder.build();
+  }
+
+  public static String getRetryParamsName(
+      @Nullable MethodConfigProto methodConfigProto,
+      DiagCollector diagCollector,
+      Set<String> retryParamsConfigNames) {
+    if (methodConfigProto != null) {
+      String retryParamsName = methodConfigProto.getRetryParamsName();
+      if (!retryParamsConfigNames.isEmpty() && !retryParamsConfigNames.contains(retryParamsName)) {
+        diagCollector.addDiag(
+            Diag.error(
+                SimpleLocation.TOPLEVEL,
+                "Retry parameters config used but not defined: %s (in method %s)",
+                retryParamsName,
+                methodConfigProto.getName()));
+      } else {
+        return retryParamsName;
+      }
+    }
+    // TODO(andrealin): handle default retry params
+    return RETRY_PARAMS_DEFAULT_NAME;
   }
 
   public List<RetryParamsDefinitionView> generateRetryParamsDefinitions(InterfaceContext context) {

--- a/src/main/java/com/google/api/codegen/transformer/RetryDefinitionsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/RetryDefinitionsTransformer.java
@@ -14,23 +14,46 @@
  */
 package com.google.api.codegen.transformer;
 
+import static com.google.api.codegen.configgen.mergers.RetryMerger.DEFAULT_RETRY_CODES;
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFAULT_INITIAL_RETRY_DELAY;
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFAULT_MAX_RETRY_DELAY;
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFAULT_MAX_RPC_TIMEOUT_MILLIS;
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFAULT_RETRY_DELAY_MULTIPLIER;
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFAULT_RPC_TIMEOUT_MULTIPLIER;
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.DEFAULT_TOTAL_TIMEOUT_MILLIS;
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_CODES_IDEMPOTENT_NAME;
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_PARAMS_DEFAULT_NAME;
+
+import com.google.api.AnnotationsProto;
+import com.google.api.HttpRule;
+import com.google.api.Retry;
 import com.google.api.codegen.InterfaceConfigProto;
+import com.google.api.codegen.MethodConfigProto;
 import com.google.api.codegen.RetryCodesDefinitionProto;
 import com.google.api.codegen.RetryParamsDefinitionProto;
 import com.google.api.codegen.util.Name;
+import com.google.api.codegen.util.SymbolTable;
 import com.google.api.codegen.viewmodel.RetryCodesDefinitionView;
 import com.google.api.codegen.viewmodel.RetryParamsDefinitionView;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
+import com.google.api.tools.framework.model.Interface;
+import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.SimpleLocation;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import com.google.rpc.Code;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
+import java.util.Optional;
+import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /** RetryDefinitionsTransformer generates retry definitions from a service model. */
 public class RetryDefinitionsTransformer {
@@ -39,7 +62,7 @@ public class RetryDefinitionsTransformer {
     List<RetryCodesDefinitionView> definitions = new ArrayList<>();
 
     final SurfaceNamer namer = context.getNamer();
-    for (Entry<String, ImmutableSet<String>> retryCodesDef :
+    for (Entry<String, List<String>> retryCodesDef :
         context.getInterfaceConfig().getRetryCodesDefinition().entrySet()) {
       List<String> codeNames = new ArrayList<>();
       for (String code : retryCodesDef.getValue()) {
@@ -59,37 +82,157 @@ public class RetryDefinitionsTransformer {
     return definitions;
   }
 
-  public static ImmutableMap<String, ImmutableSet<String>> createRetryCodesDefinition(
-      DiagCollector diagCollector, InterfaceConfigProto interfaceConfigProto) {
-    ImmutableMap.Builder<String, ImmutableSet<String>> builder = ImmutableMap.builder();
-    for (RetryCodesDefinitionProto retryDef : interfaceConfigProto.getRetryCodesDefList()) {
-      // Enforce ordering on set for baseline test consistency.
-      Set<String> codes = new TreeSet<>();
-      for (String codeText : retryDef.getRetryCodesList()) {
-        try {
-          codes.add(String.valueOf(codeText));
-        } catch (IllegalArgumentException e) {
-          diagCollector.addDiag(
-              Diag.error(
-                  SimpleLocation.TOPLEVEL,
-                  "status code not found: '%s' (in interface %s)",
-                  codeText,
-                  interfaceConfigProto.getName()));
+  /**
+   * Returns a mapping of a retryCodeDef name to the list of retry codes it contains. Also populates
+   * the @param methodNameToRetryCodeNames with a mapping of
+   */
+  public static ImmutableMap<String, List<String>> createRetryCodesDefinition(
+      DiagCollector diagCollector,
+      @Nullable InterfaceConfigProto interfaceConfigProto,
+      Interface apiInterface,
+      ImmutableMap.Builder<String, String> methodNameToRetryCodeNames) {
+    // Use a symbol table to get unique names for retry codes.
+    SymbolTable retryCodeNameSymbolTable = new SymbolTable();
+    Map<String, String> methodNamesToRetryNamesFromConfig = new TreeMap<>();
+
+    ImmutableMap.Builder<String, List<String>> builder = ImmutableMap.builder();
+    if (interfaceConfigProto != null) {
+      for (RetryCodesDefinitionProto retryDef : interfaceConfigProto.getRetryCodesDefList()) {
+        // Enforce ordering on set for baseline test consistency.
+        List<String> codes = new ArrayList<>();
+        for (String codeText : retryDef.getRetryCodesList()) {
+          try {
+            codes.add(String.valueOf(codeText));
+          } catch (IllegalArgumentException e) {
+            diagCollector.addDiag(
+                Diag.error(
+                    SimpleLocation.TOPLEVEL,
+                    "status code not found: '%s' (in interface %s)",
+                    codeText,
+                    interfaceConfigProto.getName()));
+          }
         }
+        Collections.sort(codes);
+        builder.put(
+            retryDef.getName(), (new ImmutableList.Builder<String>()).addAll(codes).build());
+        retryCodeNameSymbolTable.getNewSymbol(retryDef.getName());
       }
-      builder.put(retryDef.getName(), (new ImmutableSet.Builder<String>()).addAll(codes).build());
+
+      // Map each methodConfig name to its retry codes name.
+      interfaceConfigProto
+          .getMethodsList()
+          .stream()
+          .filter(m -> !Strings.isNullOrEmpty(m.getRetryCodesName()))
+          .forEach(m -> methodNamesToRetryNamesFromConfig.put(m.getName(), m.getRetryCodesName()));
     }
+    //    else {
+    //      // Use default values for retry settings.
+    //      builder.putAll(DEFAULT_RETRY_CODES);
+    //      for (Entry<String, List<String>> entry : DEFAULT_RETRY_CODES.entrySet()) {
+    //        retryCodeNameSymbolTable.getNewSymbol(entry.getKey());
+    //      }
+    //    }
+
+    // Check proto annotations for retry settings.
+    if (apiInterface != null) {
+      for (Method method : apiInterface.getMethods()) {
+
+        TreeSet<String> retryCodes = null;
+        Retry retry = method.getDescriptor().getMethodAnnotation(AnnotationsProto.retry);
+        HttpRule httpRule = method.getDescriptor().getMethodAnnotation(AnnotationsProto.http);
+        String retryCodesName = null;
+
+        // Use GAPIC config if defines retry codes, and Retry proto annotation does not exist
+        if (methodNamesToRetryNamesFromConfig.containsKey(method.getSimpleName())
+            && retry.getCodesCount() == 0) {
+          String configRetryCodesName =
+              interfaceConfigProto
+                  .getMethodsList()
+                  .stream()
+                  .filter(mcp -> mcp.getName().equals(method.getSimpleName()))
+                  .map(MethodConfigProto::getRetryCodesName)
+                  .findFirst()
+                  .orElse(null);
+          if (!Strings.isNullOrEmpty(configRetryCodesName)) {
+            Optional<RetryCodesDefinitionProto> maybeRetryCodes =
+                interfaceConfigProto
+                    .getRetryCodesDefList()
+                    .stream()
+                    .filter(retryCodeDef -> configRetryCodesName.equals(retryCodeDef.getName()))
+                    .findFirst();
+            if (!maybeRetryCodes.isPresent()) {
+              diagCollector.addDiag(
+                  Diag.error(
+                      SimpleLocation.TOPLEVEL,
+                      "Retry codes config used but not defined: '%s' (in method %s)",
+                      configRetryCodesName,
+                      method.getFullName()));
+              return null;
+            }
+            retryCodes = new TreeSet<>(maybeRetryCodes.get().getRetryCodesList());
+            retryCodesName = maybeRetryCodes.get().getName();
+          }
+        }
+
+        if (retryCodes == null) {
+          retryCodes = new TreeSet<>();
+          if (!Strings.isNullOrEmpty(httpRule.getGet())) {
+            // If this is analogous to HTTP GET, then automatically retry on `INTERNAL` and
+            // `UNAVAILABLE`.
+            retryCodes.addAll(DEFAULT_RETRY_CODES.get(RETRY_CODES_IDEMPOTENT_NAME));
+          }
+          // Add all retry codes defined in the Retry proto annotation.
+          retryCodes.addAll(
+              retry.getCodesList().stream().map(Code::name).collect(Collectors.toList()));
+
+          if (retryCodes.isEmpty()) {
+            retryCodesName = "";
+          } else {
+            // Create a retryCode config internally.
+            retryCodesName = retryCodeNameSymbolTable.getNewSymbol(getRetryCodesName(method));
+            methodNamesToRetryNamesFromConfig.put(method.getSimpleName(), retryCodesName);
+            builder.put(
+                retryCodesName, (new ImmutableList.Builder<String>()).addAll(retryCodes).build());
+          }
+        }
+
+        methodNamesToRetryNamesFromConfig.put(method.getSimpleName(), retryCodesName);
+      }
+    }
+
+    methodNameToRetryCodeNames.putAll(methodNamesToRetryNamesFromConfig);
+
     if (diagCollector.getErrorCount() > 0) {
       return null;
     }
     return builder.build();
   }
 
+  private static String getRetryCodesName(Method method) {
+    return String.format("%s_retry_code", method.getSimpleName().toLowerCase());
+  }
+
   public static ImmutableMap<String, RetryParamsDefinitionProto> createRetrySettingsDefinition(
       InterfaceConfigProto interfaceConfigProto) {
     ImmutableMap.Builder<String, RetryParamsDefinitionProto> builder = ImmutableMap.builder();
-    for (RetryParamsDefinitionProto retryDef : interfaceConfigProto.getRetryParamsDefList()) {
-      builder.put(retryDef.getName(), retryDef);
+    if (interfaceConfigProto != null) {
+      for (RetryParamsDefinitionProto retryDef : interfaceConfigProto.getRetryParamsDefList()) {
+        builder.put(retryDef.getName(), retryDef);
+      }
+    } else {
+      // Use default values.
+      RetryParamsDefinitionProto defaultRetryParams =
+          RetryParamsDefinitionProto.getDefaultInstance()
+              .toBuilder()
+              .setInitialRetryDelayMillis(DEFAULT_INITIAL_RETRY_DELAY)
+              .setRetryDelayMultiplier(DEFAULT_RETRY_DELAY_MULTIPLIER)
+              .setMaxRetryDelayMillis(DEFAULT_MAX_RETRY_DELAY)
+              .setInitialRpcTimeoutMillis(DEFAULT_MAX_RPC_TIMEOUT_MILLIS)
+              .setRpcTimeoutMultiplier(DEFAULT_RPC_TIMEOUT_MULTIPLIER)
+              .setMaxRpcTimeoutMillis(DEFAULT_MAX_RPC_TIMEOUT_MILLIS)
+              .setTotalTimeoutMillis(DEFAULT_TOTAL_TIMEOUT_MILLIS)
+              .build();
+      builder.put(RETRY_PARAMS_DEFAULT_NAME, defaultRetryParams);
     }
     return builder.build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/RetryDefinitionsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/RetryDefinitionsTransformer.java
@@ -185,15 +185,11 @@ public class RetryDefinitionsTransformer {
           retryCodes.addAll(
               retry.getCodesList().stream().map(Code::name).collect(Collectors.toList()));
 
-          if (retryCodes.isEmpty()) {
-            retryCodesName = "";
-          } else {
-            // Create a retryCode config internally.
-            retryCodesName = retryCodeNameSymbolTable.getNewSymbol(getRetryCodesName(method));
-            methodNamesToRetryNamesFromConfig.put(method.getSimpleName(), retryCodesName);
-            builder.put(
-                retryCodesName, (new ImmutableList.Builder<String>()).addAll(retryCodes).build());
-          }
+          // Create a retryCode config internally.
+          retryCodesName = retryCodeNameSymbolTable.getNewSymbol(getRetryCodesName(method));
+          methodNamesToRetryNamesFromConfig.put(method.getSimpleName(), retryCodesName);
+          builder.put(
+              retryCodesName, (new ImmutableList.Builder<String>()).addAll(retryCodes).build());
         }
 
         methodNamesToRetryNamesFromConfig.put(method.getSimpleName(), retryCodesName);

--- a/src/main/java/com/google/api/codegen/transformer/RetryDefinitionsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/RetryDefinitionsTransformer.java
@@ -240,6 +240,7 @@ public class RetryDefinitionsTransformer {
                 "Retry parameters config used but not defined: %s (in method %s)",
                 retryParamsName,
                 methodConfigProto.getName()));
+        return null;
       } else {
         return retryParamsName;
       }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -57,7 +57,6 @@ import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
 import java.io.File;
 import java.util.ArrayList;
@@ -283,12 +282,12 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer<ProtoAp
     }
 
     TreeMap<RetryConfigDefinitionView.Name, RetryConfigDefinitionView> retryDef = new TreeMap<>();
-    Map<String, ImmutableSet<String>> retryCodesDef =
+    Map<String, List<String>> retryCodesDef =
         context.getInterfaceConfig().getRetryCodesDefinition();
     ImmutableMap<String, RetryParamsDefinitionProto> retryParamsDef =
         context.getInterfaceConfig().getRetrySettingsDefinition();
     for (RetryConfigDefinitionView.Name name : retryNames) {
-      ImmutableSet<String> codes = retryCodesDef.get(name.retryCodesConfigName());
+      List<String> codes = retryCodesDef.get(name.retryCodesConfigName());
       if (codes.isEmpty()) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/util/ProtoParser.java
+++ b/src/main/java/com/google/api/codegen/util/ProtoParser.java
@@ -14,9 +14,13 @@
  */
 package com.google.api.codegen.util;
 
+import com.google.api.AnnotationsProto;
+import com.google.api.Retry;
 import com.google.api.codegen.configgen.transformer.LanguageTransformer;
 import com.google.api.tools.framework.model.Interface;
+import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
+import com.google.common.base.Strings;
 import com.google.protobuf.Api;
 import javax.annotation.Nullable;
 
@@ -41,5 +45,16 @@ public class ProtoParser {
     LanguageTransformer.LanguageFormatter formatter =
         LanguageTransformer.LANGUAGE_FORMATTERS.get(language.toLowerCase());
     return formatter.getFormattedPackageName(basePackageName);
+  }
+
+  /** Return the extra retry codes for the given method. */
+  public Retry getRetry(Method method) {
+    return method.getDescriptor().getMethodAnnotation(AnnotationsProto.retry);
+  }
+
+  /** Return whether the method has the HttpRule for GET. */
+  public boolean isHttpGetMethod(Method method) {
+    return !Strings.isNullOrEmpty(
+        method.getDescriptor().getMethodAnnotation(AnnotationsProto.http).getGet());
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/RetryCodesDefinitionView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/RetryCodesDefinitionView.java
@@ -16,7 +16,6 @@ package com.google.api.codegen.viewmodel;
 
 import com.google.api.codegen.viewmodel.RetryParamsDefinitionView.Builder;
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -29,7 +28,7 @@ public abstract class RetryCodesDefinitionView {
 
   public abstract String retryFilterMethodName();
 
-  public abstract ImmutableSet<String> codes();
+  public abstract List<String> codes();
 
   @Nullable // Used in C#
   public abstract List<String> codeNames();
@@ -46,7 +45,7 @@ public abstract class RetryCodesDefinitionView {
 
     public abstract Builder retryFilterMethodName(String val);
 
-    public abstract Builder codes(ImmutableSet<String> val);
+    public abstract Builder codes(List<String> val);
 
     public abstract Builder codeNames(List<String> val);
 

--- a/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
@@ -958,6 +958,9 @@ public class NoTemplatesApiServiceStubSettings extends StubSettings<NoTemplatesA
 
     static {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
+      definitions.put(
+          "increment_retry_code",
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
       RETRYABLE_CODE_DEFINITIONS = definitions.build();
     }
 
@@ -993,7 +996,7 @@ public class NoTemplatesApiServiceStubSettings extends StubSettings<NoTemplatesA
     private static Builder initDefaults(Builder builder) {
 
       builder.incrementSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get(""))
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("increment_retry_code"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
       return builder;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -387,11 +387,15 @@ module.exports = DecrementerServiceClient;
 {
   "interfaces": {
     "google.cloud.example.v1.foo.DecrementerService": {
-      "retry_codes": {},
+      "retry_codes": {
+        "decrement_retry_code": []
+      },
       "retry_params": {},
       "methods": {
         "Decrement": {
-          "timeout_millis": 10000
+          "timeout_millis": 10000,
+          "retry_codes_name": "decrement_retry_code",
+          "retry_params_name": "default"
         }
       }
     }
@@ -687,11 +691,15 @@ module.exports = IncrementerServiceClient;
 {
   "interfaces": {
     "google.cloud.example.v1.foo.IncrementerService": {
-      "retry_codes": {},
+      "retry_codes": {
+        "increment_retry_code": []
+      },
       "retry_params": {},
       "methods": {
         "Increment": {
-          "timeout_millis": 10000
+          "timeout_millis": 10000,
+          "retry_codes_name": "increment_retry_code",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -382,11 +382,15 @@ module.exports = NoTemplatesApiServiceClient;
 {
   "interfaces": {
     "google.cloud.example.v1.NoTemplatesAPIService": {
-      "retry_codes": {},
+      "retry_codes": {
+        "increment_retry_code": []
+      },
       "retry_params": {},
       "methods": {
         "Increment": {
-          "timeout_millis": 10000
+          "timeout_millis": 10000,
+          "retry_codes_name": "increment_retry_code",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_no_path_templates.baseline
@@ -281,11 +281,15 @@ class NoTemplatesApiServiceClient extends NoTemplatesApiServiceGapicClient
 {
   "interfaces": {
     "google.cloud.example.v1.NoTemplatesAPIService": {
-      "retry_codes": {},
+      "retry_codes": {
+        "increment_retry_code": []
+      },
       "retry_params": {},
       "methods": {
         "Increment": {
-          "timeout_millis": 10000
+          "timeout_millis": 10000,
+          "retry_codes_name": "increment_retry_code",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_multiple_services.baseline
@@ -1026,11 +1026,15 @@ class DecrementerServiceClient(object):
 config = {
   "interfaces": {
     "google.cloud.example.v1.foo.DecrementerService": {
-      "retry_codes": {},
+      "retry_codes": {
+        "decrement_retry_code": []
+      },
       "retry_params": {},
       "methods": {
         "Decrement": {
-          "timeout_millis": 10000
+          "timeout_millis": 10000,
+          "retry_codes_name": "decrement_retry_code",
+          "retry_params_name": "default"
         }
       }
     }
@@ -1241,11 +1245,15 @@ class IncrementerServiceClient(object):
 config = {
   "interfaces": {
     "google.cloud.example.v1.foo.IncrementerService": {
-      "retry_codes": {},
+      "retry_codes": {
+        "increment_retry_code": []
+      },
       "retry_params": {},
       "methods": {
         "Increment": {
-          "timeout_millis": 10000
+          "timeout_millis": 10000,
+          "retry_codes_name": "increment_retry_code",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_no_path_templates.baseline
@@ -974,11 +974,15 @@ class NoTemplatesAPIServiceClient(object):
 config = {
   "interfaces": {
     "google.cloud.example.v1.NoTemplatesAPIService": {
-      "retry_codes": {},
+      "retry_codes": {
+        "increment_retry_code": []
+      },
       "retry_params": {},
       "methods": {
         "Increment": {
-          "timeout_millis": 10000
+          "timeout_millis": 10000,
+          "retry_codes_name": "increment_retry_code",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -1134,11 +1134,15 @@ end
 {
   "interfaces": {
     "google.cloud.example.v1.foo.DecrementerService": {
-      "retry_codes": {},
+      "retry_codes": {
+        "decrement_retry_code": []
+      },
       "retry_params": {},
       "methods": {
         "Decrement": {
-          "timeout_millis": 10000
+          "timeout_millis": 10000,
+          "retry_codes_name": "decrement_retry_code",
+          "retry_params_name": "default"
         }
       }
     }
@@ -1399,11 +1403,15 @@ end
 {
   "interfaces": {
     "google.cloud.example.v1.foo.IncrementerService": {
-      "retry_codes": {},
+      "retry_codes": {
+        "increment_retry_code": []
+      },
       "retry_params": {},
       "methods": {
         "Increment": {
-          "timeout_millis": 10000
+          "timeout_millis": 10000,
+          "retry_codes_name": "increment_retry_code",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/transformer/RetryDefinitionsTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/RetryDefinitionsTransformerTest.java
@@ -1,0 +1,140 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer;
+
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_CODES_IDEMPOTENT_NAME;
+import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_CODES_NON_IDEMPOTENT_NAME;
+import static com.google.rpc.Code.INVALID_ARGUMENT;
+import static com.google.rpc.Code.PERMISSION_DENIED;
+
+import com.google.api.Retry;
+import com.google.api.codegen.InterfaceConfigProto;
+import com.google.api.codegen.MethodConfigProto;
+import com.google.api.codegen.RetryCodesDefinitionProto;
+import com.google.api.codegen.util.ProtoParser;
+import com.google.api.tools.framework.model.BoundedDiagCollector;
+import com.google.api.tools.framework.model.DiagCollector;
+import com.google.api.tools.framework.model.Interface;
+import com.google.api.tools.framework.model.Method;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.Status;
+import java.util.List;
+import java.util.Map;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class RetryDefinitionsTransformerTest {
+
+  private static final ProtoParser protoParser = Mockito.mock(ProtoParser.class);
+  private static final Method noRetryCodesMethod = Mockito.mock(Method.class);
+  private static final Method idempotentMethod = Mockito.mock(Method.class);
+  private static final Method nonIdempotentMethod = Mockito.mock(Method.class);
+  private static final Method permissionDeniedMethod = Mockito.mock(Method.class);
+  private static final Interface apiInterface = Mockito.mock(Interface.class);
+
+  private static final String noRetryCodesMethodName = "NoRetryMethod";
+  private static final String idempotentMethodName = "NonIdempotentMethod";
+  private static final String nonIdempotentMethodName = "IdempotentMethod";
+  private static final String permissionDeniedMethodName = "PermissionDeniedMethod";
+
+  private static final String permissionDeniedRetryName = "permission_denied";
+
+  private static InterfaceConfigProto interfaceConfigProto;
+
+  @BeforeClass
+  public static void startUp() {
+    Mockito.when(noRetryCodesMethod.getSimpleName()).thenReturn("NoRetryMethod");
+    Mockito.when(nonIdempotentMethod.getSimpleName()).thenReturn("NonIdempotentMethod");
+    Mockito.when(idempotentMethod.getSimpleName()).thenReturn("IdempotentMethod");
+    Mockito.when(permissionDeniedMethod.getSimpleName()).thenReturn("PermissionDeniedMethod");
+
+    Mockito.when(permissionDeniedMethod.getSimpleName()).thenReturn("permissionDeniedMethod");
+    Mockito.when(apiInterface.getMethods())
+        .thenReturn(
+            ImmutableList.of(
+                noRetryCodesMethod, idempotentMethod, nonIdempotentMethod, permissionDeniedMethod));
+
+    InterfaceConfigProto interfaceConfigCustomRetry =
+        InterfaceConfigProto.newBuilder()
+            .addRetryCodesDef(
+                RetryCodesDefinitionProto.newBuilder()
+                    .setName(RETRY_CODES_IDEMPOTENT_NAME)
+                    // This is not the default list for idempotent retry codes.
+                    .addRetryCodes(Status.Code.RESOURCE_EXHAUSTED.name()))
+            .addRetryCodesDef(
+                RetryCodesDefinitionProto.newBuilder()
+                    .setName(RETRY_CODES_NON_IDEMPOTENT_NAME)
+                    // This is not the default list for non-idempotent retry codes.
+                    .addRetryCodes(Status.Code.FAILED_PRECONDITION.name()))
+            .addMethods(MethodConfigProto.newBuilder().setName(noRetryCodesMethodName))
+            .addMethods(
+                MethodConfigProto.newBuilder()
+                    .setName(nonIdempotentMethodName)
+                    .setRetryCodesName(RETRY_CODES_NON_IDEMPOTENT_NAME))
+            .addMethods(
+                MethodConfigProto.newBuilder()
+                    .setName(idempotentMethodName)
+                    .setRetryCodesName(RETRY_CODES_IDEMPOTENT_NAME))
+            .addMethods(
+                MethodConfigProto.newBuilder()
+                    .setName(permissionDeniedMethodName)
+                    .setRetryCodesName(permissionDeniedRetryName))
+            .build();
+
+    Mockito.when(protoParser.isHttpGetMethod(noRetryCodesMethod)).thenReturn(true);
+
+    Mockito.when(protoParser.getRetry(noRetryCodesMethod)).thenReturn(Retry.getDefaultInstance());
+    Mockito.when(protoParser.getRetry(idempotentMethod))
+        .thenReturn(Retry.newBuilder().addCodes(INVALID_ARGUMENT).build());
+    Mockito.when(protoParser.getRetry(nonIdempotentMethod)).thenReturn(Retry.getDefaultInstance());
+    Mockito.when(protoParser.getRetry(permissionDeniedMethod))
+        .thenReturn(Retry.newBuilder().addCodes(PERMISSION_DENIED).build());
+  }
+
+  @Test
+  public void testNoConfigProto() {
+
+    DiagCollector diagCollector = new BoundedDiagCollector();
+    ImmutableMap.Builder<String, String> methodNameToRetryCodeNames = ImmutableMap.builder();
+    Map<String, List<String>> retryCodesDef =
+        RetryDefinitionsTransformer.createRetryCodesDefinition(
+            diagCollector, null, apiInterface, methodNameToRetryCodeNames);
+
+    Map<String, String> retryCodesMap = methodNameToRetryCodeNames.build();
+  }
+
+  //  @Test
+  //  public void testWithConfigAndInterface() {
+  //
+  //    DiagCollector diagCollector = new BoundedDiagCollector();
+  //    Map<String, List<String>> retryCodesDef =
+  // RetryDefinitionsTransformer.createRetryCodesDefinition(diagCollector,
+  //        null, apiInterface, )
+  //  }
+  //
+  //  @Test
+  //  public void testWithInterfaceAndConfigDifferentFromDefaults() {
+  //
+  //    DiagCollector diagCollector = new BoundedDiagCollector();
+  //    Map<String, List<String>> retryCodesDef =
+  // RetryDefinitionsTransformer.createRetryCodesDefinition(diagCollector,
+  //        null, apiInterface, )
+  //  }
+
+  @Test
+  public void testConfigNoProto() {}
+}


### PR DESCRIPTION
Set up default retry settings.
If HTTP method is GET, then add retry codes `UNAVAILABLE` and `DEADLINE_EXCEEDED`.
Then, add extra retry codes specified in the proto annotations additional retry codes.
Then, add retry codes defined in GAPIC config.