### PR TITLE
Leave backticks alone

### DIFF
--- a/src/main/java/com/google/api/codegen/util/ruby/RubyCommentReformatter.java
+++ b/src/main/java/com/google/api/codegen/util/ruby/RubyCommentReformatter.java
@@ -49,7 +49,6 @@ public class RubyCommentReformatter implements CommentReformatter {
 
   private CommentTransformer transformer =
       CommentTransformer.newBuilder()
-          .replace(CommentPatterns.BACK_QUOTE_PATTERN, "+")
           .transform(PROTO_TO_RUBY_DOC_TRANSFORMATION)
           .transform(
               LinkPattern.RELATIVE

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -687,15 +687,15 @@ module Library
   # resource model:
   #
   # * The API has a collection of {Google::Example::Library::V1::Shelf Shelf}
-  #   resources, named +bookShelves/*+
+  #   resources, named ``bookShelves/*``
   #
   # * Each Shelf has a collection of {Google::Example::Library::V1::Book Book}
-  #   resources, named +bookShelves/*/books/*+
+  #   resources, named `bookShelves/*/books/*`
   #
   # Check out [cloud docs!](https://cloud.google.com/library/example/link).
   # This is [not a cloud link](http://www.google.com).
   #
-  # Service comment may include special characters: <>&"+'@.
+  # Service comment may include special characters: <>&"`'@.
   #
   # @param version [Symbol, String]
   #   The major version of the service to be used. By default :v1
@@ -845,15 +845,15 @@ module Library
     # resource model:
     #
     # * The API has a collection of {Google::Example::Library::V1::Shelf Shelf}
-    #   resources, named +bookShelves/*+
+    #   resources, named ``bookShelves/*``
     #
     # * Each Shelf has a collection of {Google::Example::Library::V1::Book Book}
-    #   resources, named +bookShelves/*/books/*+
+    #   resources, named `bookShelves/*/books/*`
     #
     # Check out [cloud docs!](https://cloud.google.com/library/example/link).
     # This is [not a cloud link](http://www.google.com).
     #
-    # Service comment may include special characters: <>&"+'@.
+    # Service comment may include special characters: <>&"`'@.
     #
     # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
     #   Provides the means for authenticating requests made by the client. This parameter can
@@ -970,8 +970,8 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name of the book.
-        #     Book names have the form +bookShelves/{shelf_id}/books/{book_id}+ or
-        #     +archives/{archive_id}/books/{book_id}+.
+        #     Book names have the form `bookShelves/{shelf_id}/books/{book_id}` or
+        #     `archives/{archive_id}/books/{book_id}`.
         # @!attribute [rw] author
         #   @return [String]
         #     The name of the book author.
@@ -1047,7 +1047,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -1056,8 +1056,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -1065,13 +1065,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.
@@ -1148,7 +1148,7 @@ end
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -1202,9 +1202,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -1220,7 +1220,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -1232,15 +1232,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -1253,7 +1253,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]
@@ -1345,9 +1345,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end
@@ -1377,7 +1377,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end
@@ -1398,14 +1398,14 @@ end
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -1468,7 +1468,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -1560,7 +1560,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -1604,7 +1604,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.
@@ -1628,25 +1628,25 @@ end
 
 module Google
   module Protobuf
-    # +Struct+ represents a structured data value, consisting of fields
-    # which map to dynamically typed values. In some languages, +Struct+
+    # `Struct` represents a structured data value, consisting of fields
+    # which map to dynamically typed values. In some languages, `Struct`
     # might be supported by a native representation. For example, in
     # scripting languages like JS a struct is represented as an
     # object. The details of that representation are described together
     # with the proto support for the language.
     #
-    # The JSON representation for +Struct+ is JSON object.
+    # The JSON representation for `Struct` is JSON object.
     # @!attribute [rw] fields
     #   @return [Hash{String => Google::Protobuf::Value}]
     #     Unordered map of dynamically typed values.
     class Struct; end
 
-    # +Value+ represents a dynamically typed value which can be either
+    # `Value` represents a dynamically typed value which can be either
     # null, a number, a string, a boolean, a recursive struct value, or a
     # list of values. A producer of value is expected to set one of that
     # variants, absence of any variant indicates an error.
     #
-    # The JSON representation for +Value+ is JSON value.
+    # The JSON representation for `Value` is JSON value.
     # @!attribute [rw] null_value
     #   @return [Google::Protobuf::NullValue]
     #     Represents a null value.
@@ -1664,21 +1664,21 @@ module Google
     #     Represents a structured value.
     # @!attribute [rw] list_value
     #   @return [Google::Protobuf::ListValue]
-    #     Represents a repeated +Value+.
+    #     Represents a repeated `Value`.
     class Value; end
 
-    # +ListValue+ is a wrapper around a repeated field of values.
+    # `ListValue` is a wrapper around a repeated field of values.
     #
-    # The JSON representation for +ListValue+ is JSON array.
+    # The JSON representation for `ListValue` is JSON array.
     # @!attribute [rw] values
     #   @return [Array<Google::Protobuf::Value>]
     #     Repeated field of dynamically typed values.
     class ListValue; end
 
-    # +NullValue+ is a singleton enumeration to represent the null value for the
-    # +Value+ type union.
+    # `NullValue` is a singleton enumeration to represent the null value for the
+    # `Value` type union.
     #
-    #  The JSON representation for +NullValue+ is JSON +null+.
+    #  The JSON representation for `NullValue` is JSON `null`.
     module NullValue
       # Null value.
       NULL_VALUE = 0
@@ -1716,13 +1716,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -1731,7 +1731,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -1743,7 +1743,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -1774,10 +1774,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds
@@ -1811,73 +1811,73 @@ end
 
 module Google
   module Protobuf
-    # Wrapper message for +double+.
+    # Wrapper message for `double`.
     #
-    # The JSON representation for +DoubleValue+ is JSON number.
+    # The JSON representation for `DoubleValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The double value.
     class DoubleValue; end
 
-    # Wrapper message for +float+.
+    # Wrapper message for `float`.
     #
-    # The JSON representation for +FloatValue+ is JSON number.
+    # The JSON representation for `FloatValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The float value.
     class FloatValue; end
 
-    # Wrapper message for +int64+.
+    # Wrapper message for `int64`.
     #
-    # The JSON representation for +Int64Value+ is JSON string.
+    # The JSON representation for `Int64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int64 value.
     class Int64Value; end
 
-    # Wrapper message for +uint64+.
+    # Wrapper message for `uint64`.
     #
-    # The JSON representation for +UInt64Value+ is JSON string.
+    # The JSON representation for `UInt64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint64 value.
     class UInt64Value; end
 
-    # Wrapper message for +int32+.
+    # Wrapper message for `int32`.
     #
-    # The JSON representation for +Int32Value+ is JSON number.
+    # The JSON representation for `Int32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int32 value.
     class Int32Value; end
 
-    # Wrapper message for +uint32+.
+    # Wrapper message for `uint32`.
     #
-    # The JSON representation for +UInt32Value+ is JSON number.
+    # The JSON representation for `UInt32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint32 value.
     class UInt32Value; end
 
-    # Wrapper message for +bool+.
+    # Wrapper message for `bool`.
     #
-    # The JSON representation for +BoolValue+ is JSON +true+ and +false+.
+    # The JSON representation for `BoolValue` is JSON `true` and `false`.
     # @!attribute [rw] value
     #   @return [true, false]
     #     The bool value.
     class BoolValue; end
 
-    # Wrapper message for +string+.
+    # Wrapper message for `string`.
     #
-    # The JSON representation for +StringValue+ is JSON string.
+    # The JSON representation for `StringValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The string value.
     class StringValue; end
 
-    # Wrapper message for +bytes+.
+    # Wrapper message for `bytes`.
     #
-    # The JSON representation for +BytesValue+ is JSON string.
+    # The JSON representation for `BytesValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The bytes value.
@@ -1901,7 +1901,7 @@ end
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -1910,7 +1910,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -1918,40 +1918,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]
@@ -1988,12 +1988,12 @@ module Google
     module Library
       module V1
         # A single book in the library.
-        # Message comment may include special characters: <>&"+'@.
+        # Message comment may include special characters: <>&"`'@.
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name of the book.
-        #     Book names have the form +bookShelves/{shelf_id}/books/{book_id}+.
-        #     Message field comment may include special characters: <>&"+'@.
+        #     Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+        #     Message field comment may include special characters: <>&"`'@.
         # @!attribute [rw] author
         #   @return [String]
         #     The name of the book author.
@@ -2064,7 +2064,7 @@ module Google
             # GOOD enum description
             GOOD = 0
 
-            # Enum description with special characters: <>&"+'@.
+            # Enum description with special characters: <>&"`'@.
             BAD = 1
           end
         end
@@ -2073,7 +2073,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name of the book.
-        #     Book names have the form +archives/{archive_id}/books/{book_id}+.
+        #     Book names have the form `archives/{archive_id}/books/{book_id}`.
         # @!attribute [rw] author
         #   @return [String]
         #     The name of the book author.
@@ -2137,7 +2137,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name of the shelf.
-        #     Shelf names have the form +bookShelves/{shelf_id}+.
+        #     Shelf names have the form `bookShelves/{shelf_id}`.
         # @!attribute [rw] theme
         #   @return [String]
         #     The theme of the shelf
@@ -2177,7 +2177,7 @@ module Google
         #     A token identifying a page of results the server should return.
         #     Typically, this is the value of
         #     {Google::Example::Library::V1::ListShelvesResponse#next_page_token ListShelvesResponse#next_page_token}
-        #     returned from the previous call to +ListShelves+ method.
+        #     returned from the previous call to `ListShelves` method.
         class ListShelvesRequest; end
 
         # Response message for LibraryService.ListShelves.
@@ -2189,7 +2189,7 @@ module Google
         #     A token to retrieve next page of results.
         #     Pass this value in the
         #     {Google::Example::Library::V1::ListShelvesRequest#page_token ListShelvesRequest#page_token}
-        #     field in the subsequent call to +ListShelves+ method to retrieve the next
+        #     field in the subsequent call to `ListShelves` method to retrieve the next
         #     page of results.
         class ListShelvesResponse; end
 
@@ -2276,7 +2276,7 @@ module Google
         #     A token identifying a page of results the server should return.
         #     Typically, this is the value of
         #     {Google::Example::Library::V1::ListBooksResponse#next_page_token ListBooksResponse#next_page_token}.
-        #     returned from the previous call to +ListBooks+ method.
+        #     returned from the previous call to `ListBooks` method.
         # @!attribute [rw] filter
         #   @return [String]
         #     To test python built-in wrapping.
@@ -2291,7 +2291,7 @@ module Google
         #     A token to retrieve next page of results.
         #     Pass this value in the
         #     {Google::Example::Library::V1::ListBooksRequest#page_token ListBooksRequest#page_token}
-        #     field in the subsequent call to +ListBooks+ method to retrieve the next
+        #     field in the subsequent call to `ListBooks` method to retrieve the next
         #     page of results.
         class ListBooksResponse; end
 
@@ -2651,11 +2651,11 @@ module Google
       #     REQUIRED: The label to add.
       class AddLabelRequest; end
 
-      # Response message for the +AddTag+ method.
+      # Response message for the `AddTag` method.
       # empty for now
       class AddTagResponse; end
 
-      # Response message for the +AddLabel+ method.
+      # Response message for the `AddLabel` method.
       # empty for now
       class AddLabelResponse; end
     end
@@ -2701,15 +2701,15 @@ module Library
     # resource model:
     #
     # * The API has a collection of {Google::Example::Library::V1::Shelf Shelf}
-    #   resources, named +bookShelves/*+
+    #   resources, named ``bookShelves/*``
     #
     # * Each Shelf has a collection of {Google::Example::Library::V1::Book Book}
-    #   resources, named +bookShelves/*/books/*+
+    #   resources, named `bookShelves/*/books/*`
     #
     # Check out [cloud docs!](https://cloud.google.com/library/example/link).
     # This is [not a cloud link](http://www.google.com).
     #
-    # Service comment may include special characters: <>&"+'@.
+    # Service comment may include special characters: <>&"`'@.
     #
     # @!attribute [r] library_service_stub
     #   @return [Google::Example::Library::V1::LibraryService::Stub]
@@ -3134,7 +3134,7 @@ module Library
       # Service calls
 
       # Creates a shelf, and returns the new Shelf.
-      # RPC method comment may include special characters: <>&"+'@.
+      # RPC method comment may include special characters: <>&"`'@.
       #
       # @param shelf [Google::Example::Library::V1::Shelf | Hash]
       #   The shelf to create.
@@ -3153,7 +3153,7 @@ module Library
       #
       #   library_service_client = Library.new(version: :v1)
       #
-      #   # TODO: Initialize +shelf+:
+      #   # TODO: Initialize `shelf`:
       #   shelf = {}
       #   response = library_service_client.create_shelf(shelf)
 
@@ -3195,7 +3195,7 @@ module Library
       #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #
-      #   # TODO: Initialize +options_+:
+      #   # TODO: Initialize `options_`:
       #   options_ = ''
       #   response = library_service_client.get_shelf(formatted_name, options_)
 
@@ -3284,8 +3284,8 @@ module Library
       end
 
       # Merges two shelves by adding all books from the shelf named
-      # +other_shelf_name+ to shelf +name+, and deletes
-      # +other_shelf_name+. Returns the updated shelf.
+      # `other_shelf_name` to shelf `name`, and deletes
+      # `other_shelf_name`. Returns the updated shelf.
       #
       # @param name [String]
       #   The name of the shelf we're adding books to.
@@ -3342,7 +3342,7 @@ module Library
       #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #
-      #   # TODO: Initialize +book+:
+      #   # TODO: Initialize `book`:
       #   book = {}
       #   response = library_service_client.create_book(formatted_name, book)
 
@@ -3390,10 +3390,10 @@ module Library
       #
       #   library_service_client = Library.new(version: :v1)
       #
-      #   # TODO: Initialize +shelf+:
+      #   # TODO: Initialize `shelf`:
       #   shelf = {}
       #
-      #   # TODO: Initialize +books+:
+      #   # TODO: Initialize `books`:
       #   books = []
       #   series_string = "foobar"
       #   series_uuid = { series_string: series_string }
@@ -3569,7 +3569,7 @@ module Library
       #   library_service_client = Library.new(version: :v1)
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
-      #   # TODO: Initialize +book+:
+      #   # TODO: Initialize `book`:
       #   book = {}
       #   response = library_service_client.update_book(formatted_name, book)
 
@@ -3840,7 +3840,7 @@ module Library
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   index_name = "default index"
       #
-      #   # TODO: Initialize +index_map_item+:
+      #   # TODO: Initialize `index_map_item`:
       #   index_map_item = ''
       #   index_map = { "default_key" => index_map_item }
       #   library_service_client.update_book_index(formatted_name, index_name, index_map)
@@ -3901,7 +3901,7 @@ module Library
       #
       #   library_service_client = Library.new(version: :v1)
       #
-      #   # TODO: Initialize +name+:
+      #   # TODO: Initialize `name`:
       #   name = ''
       #   library_service_client.stream_books(name).each do |element|
       #     # Process element.
@@ -3940,7 +3940,7 @@ module Library
       #
       #   library_service_client = Library.new(version: :v1)
       #
-      #   # TODO: Initialize +name+:
+      #   # TODO: Initialize `name`:
       #   name = ''
       #   request = { name: name }
       #   requests = [request]
@@ -3976,7 +3976,7 @@ module Library
       #
       #   library_service_client = Library.new(version: :v1)
       #
-      #   # TODO: Initialize +name+:
+      #   # TODO: Initialize `name`:
       #   name = ''
       #   request = { name: name }
       #   requests = [request]
@@ -4014,11 +4014,11 @@ module Library
       #
       #   library_service_client = Library.new(version: :v1)
       #
-      #   # TODO: Initialize +names_element+:
+      #   # TODO: Initialize `names_element`:
       #   names_element = ''
       #   names = [names_element]
       #
-      #   # TODO: Initialize +shelves+:
+      #   # TODO: Initialize `shelves`:
       #   shelves = []
       #
       #   # Iterate over all results.
@@ -4071,7 +4071,7 @@ module Library
       #   library_service_client = Library.new(version: :v1)
       #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
-      #   # TODO: Initialize +tag+:
+      #   # TODO: Initialize `tag`:
       #   tag = ''
       #   response = library_service_client.add_tag(formatted_resource, tag)
 
@@ -4110,7 +4110,7 @@ module Library
       #   library_service_client = Library.new(version: :v1)
       #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
-      #   # TODO: Initialize +label+:
+      #   # TODO: Initialize `label`:
       #   label = ''
       #   response = library_service_client.add_label(formatted_resource, label)
 
@@ -4328,91 +4328,91 @@ module Library
       #
       #   library_service_client = Library.new(version: :v1)
       #
-      #   # TODO: Initialize +required_singular_int32+:
+      #   # TODO: Initialize `required_singular_int32`:
       #   required_singular_int32 = 0
       #
-      #   # TODO: Initialize +required_singular_int64+:
+      #   # TODO: Initialize `required_singular_int64`:
       #   required_singular_int64 = 0
       #
-      #   # TODO: Initialize +required_singular_float+:
+      #   # TODO: Initialize `required_singular_float`:
       #   required_singular_float = 0.0
       #
-      #   # TODO: Initialize +required_singular_double+:
+      #   # TODO: Initialize `required_singular_double`:
       #   required_singular_double = 0.0
       #
-      #   # TODO: Initialize +required_singular_bool+:
+      #   # TODO: Initialize `required_singular_bool`:
       #   required_singular_bool = false
       #
-      #   # TODO: Initialize +required_singular_enum+:
+      #   # TODO: Initialize `required_singular_enum`:
       #   required_singular_enum = :ZERO
       #
-      #   # TODO: Initialize +required_singular_string+:
+      #   # TODO: Initialize `required_singular_string`:
       #   required_singular_string = ''
       #
-      #   # TODO: Initialize +required_singular_bytes+:
+      #   # TODO: Initialize `required_singular_bytes`:
       #   required_singular_bytes = ''
       #
-      #   # TODO: Initialize +required_singular_message+:
+      #   # TODO: Initialize `required_singular_message`:
       #   required_singular_message = {}
       #
-      #   # TODO: Initialize +required_singular_resource_name+:
+      #   # TODO: Initialize `required_singular_resource_name`:
       #   required_singular_resource_name = ''
       #
-      #   # TODO: Initialize +required_singular_resource_name_oneof+:
+      #   # TODO: Initialize `required_singular_resource_name_oneof`:
       #   required_singular_resource_name_oneof = ''
       #
-      #   # TODO: Initialize +required_singular_resource_name_common+:
+      #   # TODO: Initialize `required_singular_resource_name_common`:
       #   required_singular_resource_name_common = ''
       #
-      #   # TODO: Initialize +required_singular_fixed32+:
+      #   # TODO: Initialize `required_singular_fixed32`:
       #   required_singular_fixed32 = 0
       #
-      #   # TODO: Initialize +required_singular_fixed64+:
+      #   # TODO: Initialize `required_singular_fixed64`:
       #   required_singular_fixed64 = 0
       #
-      #   # TODO: Initialize +required_repeated_int32+:
+      #   # TODO: Initialize `required_repeated_int32`:
       #   required_repeated_int32 = []
       #
-      #   # TODO: Initialize +required_repeated_int64+:
+      #   # TODO: Initialize `required_repeated_int64`:
       #   required_repeated_int64 = []
       #
-      #   # TODO: Initialize +required_repeated_float+:
+      #   # TODO: Initialize `required_repeated_float`:
       #   required_repeated_float = []
       #
-      #   # TODO: Initialize +required_repeated_double+:
+      #   # TODO: Initialize `required_repeated_double`:
       #   required_repeated_double = []
       #
-      #   # TODO: Initialize +required_repeated_bool+:
+      #   # TODO: Initialize `required_repeated_bool`:
       #   required_repeated_bool = []
       #
-      #   # TODO: Initialize +required_repeated_enum+:
+      #   # TODO: Initialize `required_repeated_enum`:
       #   required_repeated_enum = []
       #
-      #   # TODO: Initialize +required_repeated_string+:
+      #   # TODO: Initialize `required_repeated_string`:
       #   required_repeated_string = []
       #
-      #   # TODO: Initialize +required_repeated_bytes+:
+      #   # TODO: Initialize `required_repeated_bytes`:
       #   required_repeated_bytes = []
       #
-      #   # TODO: Initialize +required_repeated_message+:
+      #   # TODO: Initialize `required_repeated_message`:
       #   required_repeated_message = []
       #
-      #   # TODO: Initialize +formatted_required_repeated_resource_name+:
+      #   # TODO: Initialize `formatted_required_repeated_resource_name`:
       #   formatted_required_repeated_resource_name = []
       #
-      #   # TODO: Initialize +formatted_required_repeated_resource_name_oneof+:
+      #   # TODO: Initialize `formatted_required_repeated_resource_name_oneof`:
       #   formatted_required_repeated_resource_name_oneof = []
       #
-      #   # TODO: Initialize +required_repeated_resource_name_common+:
+      #   # TODO: Initialize `required_repeated_resource_name_common`:
       #   required_repeated_resource_name_common = []
       #
-      #   # TODO: Initialize +required_repeated_fixed32+:
+      #   # TODO: Initialize `required_repeated_fixed32`:
       #   required_repeated_fixed32 = []
       #
-      #   # TODO: Initialize +required_repeated_fixed64+:
+      #   # TODO: Initialize `required_repeated_fixed64`:
       #   required_repeated_fixed64 = []
       #
-      #   # TODO: Initialize +required_map+:
+      #   # TODO: Initialize `required_map`:
       #   required_map = {}
       #   response = library_service_client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, formatted_required_repeated_resource_name, formatted_required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -779,7 +779,7 @@ module Google
     # interface to receive the real response asynchronously by polling the
     # operation resource, or pass the operation resource to another API (such as
     # Google Cloud Pub/Sub API) to receive the response.  Any API service that
-    # returns long-running operations should implement the +Operations+ interface
+    # returns long-running operations should implement the `Operations` interface
     # so developers can have a consistent client experience.
     #
     # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
@@ -866,7 +866,7 @@ end
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -920,9 +920,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -938,7 +938,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -950,15 +950,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -971,7 +971,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]
@@ -1018,7 +1018,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end
@@ -1053,7 +1053,7 @@ end
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -1062,7 +1062,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -1070,40 +1070,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]
@@ -1157,7 +1157,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -1166,8 +1166,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -1175,13 +1175,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.
@@ -1280,7 +1280,7 @@ module Google
     # interface to receive the real response asynchronously by polling the
     # operation resource, or pass the operation resource to another API (such as
     # Google Cloud Pub/Sub API) to receive the response.  Any API service that
-    # returns long-running operations should implement the +Operations+ interface
+    # returns long-running operations should implement the `Operations` interface
     # so developers can have a consistent client experience.
     #
     # @!attribute [r] operations_stub
@@ -1460,7 +1460,7 @@ module Google
       #
       #   operations_client = Google::Longrunning.new
       #
-      #   # TODO: Initialize +name+:
+      #   # TODO: Initialize `name`:
       #   name = ''
       #   response = operations_client.get_operation(name)
 
@@ -1476,10 +1476,10 @@ module Google
       end
 
       # Lists operations that match the specified filter in the request. If the
-      # server doesn't support this method, it returns +UNIMPLEMENTED+.
+      # server doesn't support this method, it returns `UNIMPLEMENTED`.
       #
-      # NOTE: the +name+ binding below allows API services to override the binding
-      # to use different resource name schemes, such as +users/*/operations+.
+      # NOTE: the `name` binding below allows API services to override the binding
+      # to use different resource name schemes, such as `users/*/operations`.
       #
       # @param name [String]
       #   The name of the operation collection.
@@ -1508,10 +1508,10 @@ module Google
       #
       #   operations_client = Google::Longrunning.new
       #
-      #   # TODO: Initialize +name+:
+      #   # TODO: Initialize `name`:
       #   name = ''
       #
-      #   # TODO: Initialize +filter+:
+      #   # TODO: Initialize `filter`:
       #   filter = ''
       #
       #   # Iterate over all results.
@@ -1545,13 +1545,13 @@ module Google
       # Starts asynchronous cancellation on a long-running operation.  The server
       # makes a best effort to cancel the operation, but success is not
       # guaranteed.  If the server doesn't support this method, it returns
-      # +google.rpc.Code.UNIMPLEMENTED+.  Clients can use
+      # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
       # {Google::Longrunning::Operations::GetOperation Operations::GetOperation} or
       # other methods to check whether the cancellation succeeded or whether the
       # operation completed despite cancellation. On successful cancellation,
       # the operation is not deleted; instead, it becomes an operation with
       # an {Google::Longrunning::Operation#error Operation#error} value with a {Google::Rpc::Status#code} of 1,
-      # corresponding to +Code.CANCELLED+.
+      # corresponding to `Code.CANCELLED`.
       #
       # @param name [String]
       #   The name of the operation resource to be cancelled.
@@ -1567,7 +1567,7 @@ module Google
       #
       #   operations_client = Google::Longrunning.new
       #
-      #   # TODO: Initialize +name+:
+      #   # TODO: Initialize `name`:
       #   name = ''
       #   operations_client.cancel_operation(name)
 
@@ -1586,7 +1586,7 @@ module Google
       # Deletes a long-running operation. This method indicates that the client is
       # no longer interested in the operation result. It does not cancel the
       # operation. If the server doesn't support this method, it returns
-      # +google.rpc.Code.UNIMPLEMENTED+.
+      # `google.rpc.Code.UNIMPLEMENTED`.
       #
       # @param name [String]
       #   The name of the operation resource to be deleted.
@@ -1602,7 +1602,7 @@ module Google
       #
       #   operations_client = Google::Longrunning.new
       #
-      #   # TODO: Initialize +name+:
+      #   # TODO: Initialize `name`:
       #   name = ''
       #   operations_client.delete_operation(name)
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -1170,7 +1170,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end


### PR DESCRIPTION
This change removes the replacement of backticks from proto comments.

fixes #2303