### PR TITLE
Tweak output handling in baseline

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
@@ -121,12 +121,8 @@ class OutputTransformer {
 
     ScopeTable scope = localVars.newChild();
     String loopVariable = loop.getVariable();
-    Preconditions.checkArgument(
-        !RESERVED_KEYWORDS.contains(loopVariable),
-        "%s:%s cannot define loop variable %s: it is a reserved keyword",
-        context.getMethodModel().getSimpleName(),
-        valueSet.getId(),
-        loopVariable);
+    assertIdentifierNotReserved(
+        loopVariable, context.getMethodModel().getSimpleName(), valueSet.getId());
     OutputView.VariableView accessor =
         accessorNewVariable(
             new Scanner(loop.getCollection()), context, valueSet, scope, loopVariable, true);
@@ -153,12 +149,8 @@ class OutputTransformer {
         valueSet.getId(),
         definition.input());
     String identifier = definition.tokenStr();
-    Preconditions.checkArgument(
-        !RESERVED_KEYWORDS.contains(identifier),
-        "%s:%s cannot define variable %s: it is a reserved keyword",
-        context.getMethodModel().getSimpleName(),
-        valueSet.getId(),
-        identifier);
+    assertIdentifierNotReserved(
+        identifier, context.getMethodModel().getSimpleName(), valueSet.getId());
     Preconditions.checkArgument(
         definition.scan() == '=',
         "%s:%s invalid definition, expecting '=': %s",
@@ -321,12 +313,8 @@ class OutputTransformer {
     }
 
     if (newVar != null) {
-      Preconditions.checkArgument(
-          !RESERVED_KEYWORDS.contains(newVar),
-          "%s:%s \"%s\" is a reserved keyword",
-          context.getMethodModel().getSimpleName(),
-          valueSet.getId(),
-          newVar);
+      assertIdentifierNotReserved(
+          newVar, context.getMethodModel().getSimpleName(), valueSet.getId());
       if (scalarTypeForCollection) {
         Preconditions.checkArgument(
             type != null,
@@ -361,6 +349,16 @@ class OutputTransformer {
     }
 
     return view.accessors(accessors.build()).build();
+  }
+
+  private static void assertIdentifierNotReserved(
+      String identifier, String methodName, String valueSetId) {
+    Preconditions.checkArgument(
+        !RESERVED_KEYWORDS.contains(identifier),
+        "%s:%s cannot define variable %s: it is a reserved keyword",
+        methodName,
+        valueSetId,
+        identifier);
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
@@ -123,7 +123,7 @@ class OutputTransformer {
     String loopVariable = loop.getVariable();
     Preconditions.checkArgument(
         !RESERVED_KEYWORDS.contains(loopVariable),
-        "%s:%s cannot define variable %s: it is a reserved keyword",
+        "%s:%s cannot define loop variable %s: it is a reserved keyword",
         context.getMethodModel().getSimpleName(),
         valueSet.getId(),
         loopVariable);
@@ -323,7 +323,7 @@ class OutputTransformer {
     if (newVar != null) {
       Preconditions.checkArgument(
           !RESERVED_KEYWORDS.contains(newVar),
-          "%s:%s cannot define variable %s: it is a reserved keyword",
+          "%s:%s \"%s\" is a reserved keyword",
           context.getMethodModel().getSimpleName(),
           valueSet.getId(),
           newVar);

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -1543,13 +1543,13 @@ public class SurfaceNamer extends NameFormatterDelegator {
   public String getSampleResponseVarName(MethodContext context) {
     MethodConfig config = context.getMethodConfig();
     if (config.getPageStreaming() != null) {
-      return "element";
+      return "responseItem";
     }
     if (config.getGrpcStreaming() != null) {
       GrpcStreamingConfig.GrpcStreamingType type = config.getGrpcStreaming().getType();
       if (type == GrpcStreamingConfig.GrpcStreamingType.ServerStreaming
           || type == GrpcStreamingConfig.GrpcStreamingType.BidiStreaming) {
-        return "element";
+        return "responseItem";
       }
     }
     return "response";

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -1541,7 +1541,18 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   public String getSampleResponseVarName(MethodContext context) {
-    return context.getMethodConfig().getPageStreaming() == null ? "response" : "element";
+    MethodConfig config = context.getMethodConfig();
+    if (config.getPageStreaming() != null) {
+      return "element";
+    }
+    if (config.getGrpcStreaming() != null) {
+      GrpcStreamingConfig.GrpcStreamingType type = config.getGrpcStreaming().getType();
+      if (type == GrpcStreamingConfig.GrpcStreamingType.ServerStreaming
+          || type == GrpcStreamingConfig.GrpcStreamingType.BidiStreaming) {
+        return "element";
+      }
+    }
+    return "response";
   }
 
   /////////////////////////////////// Transport Protocol /////////////////////////////////////////

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -470,4 +470,9 @@ public class PythonSurfaceNamer extends SurfaceNamer {
       cursor = p + 2;
     }
   }
+
+  @Override
+  public String getSampleResponseVarName(MethodContext context) {
+    return Name.anyCamel(super.getSampleResponseVarName(context)).toLowerUnderscore().toString();
+  }
 }

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -1,6 +1,8 @@
 @extends "java/common.snip"
 @extends "java/initcode.snip"
 
+#FIXME: currently the variable of output of an api call is hardcoded to "response"
+# and "response_item". We should fix it by saving the variable name in the view model  
 @snippet generate(sampleFile)
   //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "{@sampleFile.classView.name}" ]
   //// STUB standalone sample "{@sampleFile.classView.name}" /////

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -83,7 +83,7 @@
 # since standalone samples can perform more sophisticated response handling
 @private pagedIterableMethodSampleCode(apiMethod, sample)
   {@initCode(sample.initCode)}
-  for ({@apiMethod.listMethod.resourceTypeName} element : {@sampleSyncMethodCall(apiMethod)}.{@apiMethod.listMethod.iterateMethodName}()) {
+  for ({@apiMethod.listMethod.resourceTypeName} responseItem : {@sampleSyncMethodCall(apiMethod)}.{@apiMethod.listMethod.iterateMethodName}()) {
     {@processResponse(sample)}
   }
 @end
@@ -94,7 +94,7 @@
 
   // Do something
 
-  for ({@apiMethod.listMethod.resourceTypeName} element : future.get().{@apiMethod.listMethod.iterateMethodName}()) {
+  for ({@apiMethod.listMethod.resourceTypeName} responseItem : future.get().{@apiMethod.listMethod.iterateMethodName}()) {
     {@processResponse(sample)}
   }
 @end
@@ -105,7 +105,7 @@
     {@apiMethod.responseTypeName} response = \
         {@apiMethod.apiVariableName}.{@apiMethod.name}().call(\
         {@sampleMethodCallArgList(sample.initCode.fieldSettings)});
-    for ({@apiMethod.listMethod.resourceTypeName} element : \
+    for ({@apiMethod.listMethod.resourceTypeName} responseItem : \
         {@resourceListGetCall(apiMethod)}) {
       {@processResponse(sample)}
     }
@@ -183,7 +183,7 @@
 
   {@initCode(sample.initCode)}
   bidiStream.send(request);
-  for ({@apiMethod.callableMethod.genericAwareResponseType} element : bidiStream) {
+  for ({@apiMethod.callableMethod.genericAwareResponseType} responseItem : bidiStream) {
     {@processResponse(sample)}
   }
 @end
@@ -193,7 +193,7 @@
 
   ServerStream<{@apiMethod.callableMethod.genericAwareResponseType}> stream = {@apiMethod.apiVariableName}.{@apiMethod.name}().call(\
       {@sampleMethodCallArgList(sample.initCode.fieldSettings)});
-  for ({@apiMethod.callableMethod.genericAwareResponseType} element : stream) {
+  for ({@apiMethod.callableMethod.genericAwareResponseType} responseItem : stream) {
     {@processResponse(sample)}
   }
 @end

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -183,7 +183,7 @@
 
   {@initCode(sample.initCode)}
   bidiStream.send(request);
-  for ({@apiMethod.callableMethod.genericAwareResponseType} response : bidiStream) {
+  for ({@apiMethod.callableMethod.genericAwareResponseType} element : bidiStream) {
     {@processResponse(sample)}
   }
 @end
@@ -193,7 +193,7 @@
 
   ServerStream<{@apiMethod.callableMethod.genericAwareResponseType}> stream = {@apiMethod.apiVariableName}.{@apiMethod.name}().call(\
       {@sampleMethodCallArgList(sample.initCode.fieldSettings)});
-  for ({@apiMethod.callableMethod.genericAwareResponseType} response : stream) {
+  for ({@apiMethod.callableMethod.genericAwareResponseType} element : stream) {
     {@processResponse(sample)}
   }
 @end

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -60,14 +60,12 @@
       @case "RequestPagedAll"
         {@pagedOptionalArrayMethodSampleCodeAll(apiMethod, sample)}
       @case "RequestStreamingBidi"
-        {@optionalArrayMethodSampleCodeBidiStreaming(apiMethod, sample.initCode)}
-        {@processResponse(sample)}
+        {@optionalArrayMethodSampleCodeBidiStreaming(apiMethod, sample)}
       @case "RequestStreamingClient"
         {@optionalArrayMethodSampleCodeClientStreaming(apiMethod, sample.initCode)}
         {@processResponse(sample)}
       @case "RequestStreamingServer"
-        {@optionalArrayMethodSampleCodeServerStreaming(apiMethod, sample.initCode)}
-        {@processResponse(sample)}
+        {@optionalArrayMethodSampleCodeServerStreaming(apiMethod, sample)}
       @case "LongRunningPromise"
         {@lroSampleCode(apiMethod, sample.initCode)}
         {@processResponse(sample)}
@@ -122,9 +120,9 @@
       {@processResponse(sample)}
 @end
 
-@private optionalArrayMethodSampleCodeBidiStreaming(apiMethod, initCode)
+@private optionalArrayMethodSampleCodeBidiStreaming(apiMethod, sample)
   requests = [request]
-  {@responseStreamingSampleCode(apiMethod, initCode)}
+  {@responseStreamingSampleCode(apiMethod, sample)}
 @end
 
 @private optionalArrayMethodSampleCodeClientStreaming(apiMethod, initCode)
@@ -132,8 +130,8 @@
   {@singularResponseSampleCode(apiMethod, initCode)}
 @end
 
-@private optionalArrayMethodSampleCodeServerStreaming(apiMethod, initCode)
-  {@responseStreamingSampleCode(apiMethod, initCode)}
+@private optionalArrayMethodSampleCodeServerStreaming(apiMethod, sample)
+  {@responseStreamingSampleCode(apiMethod, sample)}
 @end
 
 @private lroSampleCode(apiMethod, initCode)
@@ -168,10 +166,9 @@
   @end
 @end
 
-@private responseStreamingSampleCode(apiMethod, initCode)
-  for element in {@methodCallSampleCode(apiMethod, initCode)}:
-      @# process element
-      pass
+@private responseStreamingSampleCode(apiMethod, sample)
+  for element in {@methodCallSampleCode(apiMethod, sample.initCode)}:
+      {@processResponse(sample)}
 @end
 
 # Render the API method call for page streaming

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -110,13 +110,13 @@
 @private pagedOptionalArrayMethodSampleCodePaged(apiMethod, sample)
   @# Iterate over results one page at a time
   for page in {@pagedMethodCallSampleCode(apiMethod, sample.initCode)}:
-      for element in page:
+      for response_item in page:
           {@processResponse(sample)}
 @end
 
 @private pagedOptionalArrayMethodSampleCodeAll(apiMethod, sample)
   @# Iterate over all results
-  for element in {@methodCallSampleCode(apiMethod, sample.initCode)}:
+  for response_item in {@methodCallSampleCode(apiMethod, sample.initCode)}:
       {@processResponse(sample)}
 @end
 
@@ -167,7 +167,7 @@
 @end
 
 @private responseStreamingSampleCode(apiMethod, sample)
-  for element in {@methodCallSampleCode(apiMethod, sample.initCode)}:
+  for response_item in {@methodCallSampleCode(apiMethod, sample.initCode)}:
       {@processResponse(sample)}
 @end
 

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -53,8 +53,7 @@
       @end
       @switch sample.callingForm
       @case "Request"
-        {@optionalArrayMethodSampleCodeNonStreaming(apiMethod, sample.initCode)}
-        {@processResponse(sample)}
+        {@optionalArrayMethodSampleCodeNonStreaming(apiMethod, sample)}
       @case "RequestPaged"
         {@pagedOptionalArrayMethodSampleCodePaged(apiMethod, sample)}
       @case "RequestPagedAll"
@@ -62,13 +61,11 @@
       @case "RequestStreamingBidi"
         {@optionalArrayMethodSampleCodeBidiStreaming(apiMethod, sample)}
       @case "RequestStreamingClient"
-        {@optionalArrayMethodSampleCodeClientStreaming(apiMethod, sample.initCode)}
-        {@processResponse(sample)}
+        {@optionalArrayMethodSampleCodeClientStreaming(apiMethod, sample)}
       @case "RequestStreamingServer"
         {@optionalArrayMethodSampleCodeServerStreaming(apiMethod, sample)}
       @case "LongRunningPromise"
-        {@lroSampleCode(apiMethod, sample.initCode)}
-        {@processResponse(sample)}
+        {@lroSampleCode(apiMethod, sample)}
       @default
         $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
       @end
@@ -103,8 +100,9 @@
   @end
 @end
 
-@private optionalArrayMethodSampleCodeNonStreaming(apiMethod, initCode)
-  {@singularResponseSampleCode(apiMethod, initCode)}
+@private optionalArrayMethodSampleCodeNonStreaming(apiMethod, sample)
+  {@singularResponseSampleCode(apiMethod, sample.initCode)}
+  {@processResponse(sample)}
 @end
 
 @private pagedOptionalArrayMethodSampleCodePaged(apiMethod, sample)
@@ -125,17 +123,18 @@
   {@responseStreamingSampleCode(apiMethod, sample)}
 @end
 
-@private optionalArrayMethodSampleCodeClientStreaming(apiMethod, initCode)
+@private optionalArrayMethodSampleCodeClientStreaming(apiMethod, sample)
   requests = [request]
-  {@singularResponseSampleCode(apiMethod, initCode)}
+  {@singularResponseSampleCode(apiMethod, sample.initCode)}
+  {@processResponse(sample)}
 @end
 
 @private optionalArrayMethodSampleCodeServerStreaming(apiMethod, sample)
   {@responseStreamingSampleCode(apiMethod, sample)}
 @end
 
-@private lroSampleCode(apiMethod, initCode)
-  response = {@methodCallSampleCode(apiMethod, initCode)}
+@private lroSampleCode(apiMethod, sample)
+  response = {@methodCallSampleCode(apiMethod, sample.initCode)}
 
   def callback(operation_future):
       @# Handle result.
@@ -145,6 +144,7 @@
 
   @# Handle metadata.
   metadata = response.metadata()
+  {@processResponse(sample)}
 @end
 
 @private singularResponseSampleCode(apiMethod, initCode)

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -7271,8 +7271,8 @@ public class DiscussBookCallableCallableStreamingBidiProg {
       .setName(name)
       .build();
     bidiStream.send(request);
-    for (Comment response : bidiStream) {
-      System.out.println(response);
+    for (Comment element : bidiStream) {
+      System.out.println(element);
     }
     // [END turing_prog_callable_streaming_bidi_core]
   }
@@ -7966,8 +7966,8 @@ public class StreamBooksCallableCallableStreamingServerProg {
       .build();
 
     ServerStream<Book> stream = libraryClient.streamBooksCallable().call(request);
-    for (Book response : stream) {
-      System.out.println(response);
+    for (Book element : stream) {
+      System.out.println(element);
     }
     // [END babbage_core]
   }
@@ -8002,8 +8002,8 @@ public class StreamShelvesCallableCallableStreamingServerEmpty {
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
 
     ServerStream<StreamShelvesResponse> stream = libraryClient.streamShelvesCallable().call(request);
-    for (StreamShelvesResponse response : stream) {
-      System.out.println(response);
+    for (StreamShelvesResponse element : stream) {
+      System.out.println(element);
     }
     // [END sample_core]
   }

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -7271,8 +7271,8 @@ public class DiscussBookCallableCallableStreamingBidiProg {
       .setName(name)
       .build();
     bidiStream.send(request);
-    for (Comment element : bidiStream) {
-      System.out.println(element);
+    for (Comment responseItem : bidiStream) {
+      System.out.println(responseItem);
     }
     // [END turing_prog_callable_streaming_bidi_core]
   }
@@ -7312,8 +7312,8 @@ public class FindRelatedBooksFlattenedPagedOdyssey {
 
     // Do something
 
-    for (ShelfBookName element : future.get().iterateAllAsShelfBookName()) {
-      ShelfBookName book = element;
+    for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
+      ShelfBookName book = responseItem;
       System.out.printf("Here's a related book: %s\n", book);
     }
     // [END sample_core]
@@ -7354,8 +7354,8 @@ public class FindRelatedBooksRequestPagedOdyssey {
       .addAllNames(ShelfBookName.toStringList(names))
       .addAllShelves(ShelfName.toStringList(shelves))
       .build();
-    for (ShelfBookName element : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
-      ShelfBookName book = element;
+    for (ShelfBookName responseItem : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
+      ShelfBookName book = responseItem;
       System.out.printf("Here's a related book: %s\n", book);
     }
     // [END sample_core]
@@ -7398,8 +7398,8 @@ public class FindRelatedBooksCallableCallableListOdyssey {
       .build();
     while (true) {
       FindRelatedBooksResponse response = libraryClient.findRelatedBooksCallable().call(request);
-      for (ShelfBookName element : ShelfBookName.parseList(response.getNamesList())) {
-        ShelfBookName book = element;
+      for (ShelfBookName responseItem : ShelfBookName.parseList(response.getNamesList())) {
+        ShelfBookName book = responseItem;
         System.out.printf("Here's a related book: %s\n", book);
       }
       String nextPageToken = response.getNextPageToken();
@@ -7451,8 +7451,8 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
 
     // Do something
 
-    for (ShelfBookName element : future.get().iterateAllAsShelfBookName()) {
-      ShelfBookName book = element;
+    for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
+      ShelfBookName book = responseItem;
       System.out.printf("Here's a related book: %s\n", book);
     }
     // [END sample_core]
@@ -7966,8 +7966,8 @@ public class StreamBooksCallableCallableStreamingServerProg {
       .build();
 
     ServerStream<Book> stream = libraryClient.streamBooksCallable().call(request);
-    for (Book element : stream) {
-      System.out.println(element);
+    for (Book responseItem : stream) {
+      System.out.println(responseItem);
     }
     // [END babbage_core]
   }
@@ -8002,8 +8002,8 @@ public class StreamShelvesCallableCallableStreamingServerEmpty {
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
 
     ServerStream<StreamShelvesResponse> stream = libraryClient.streamShelvesCallable().call(request);
-    for (StreamShelvesResponse element : stream) {
-      System.out.println(element);
+    for (StreamShelvesResponse responseItem : stream) {
+      System.out.println(responseItem);
     }
     // [END sample_core]
   }

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -4131,9 +4131,7 @@ def sample_discuss_book():
 
   requests = [request]
   for element in client.discuss_book(requests):
-      # process element
-      pass
-  print(response)
+      print(element)
 
   # [END turing_prog_request_streaming_bidi_core]
 # [END turing_prog_request_streaming_bidi]
@@ -4519,9 +4517,7 @@ def sample_stream_books():
   name = 'BASIC'
 
   for element in client.stream_books(name):
-      # process element
-      pass
-  print(response)
+      print(element)
 
   # [END lovelace_core]
 # [END lovelace]
@@ -4568,9 +4564,7 @@ def sample_stream_shelves():
   client = library_v1.LibraryServiceClient()
 
   for element in client.stream_shelves():
-      # process element
-      pass
-  print(response)
+      print(element)
 
   # [END sample_core]
 # [END sample]

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -4130,8 +4130,8 @@ def sample_discuss_book():
   request = {'name': name}
 
   requests = [request]
-  for element in client.discuss_book(requests):
-      print(element)
+  for response_item in client.discuss_book(requests):
+      print(response_item)
 
   # [END turing_prog_request_streaming_bidi_core]
 # [END turing_prog_request_streaming_bidi]
@@ -4183,8 +4183,8 @@ def sample_find_related_books():
   shelves = [shelves_element]
 
   # Iterate over all results
-  for element in client.find_related_books(names, shelves):
-      book = element
+  for response_item in client.find_related_books(names, shelves):
+      book = response_item
       print('Here\'s a related book: {}'.format(book))
 
   # [END sample_core]
@@ -4238,8 +4238,8 @@ def sample_find_related_books():
 
   # Iterate over results one page at a time
   for page in client.find_related_books(names, shelves, options=CallOptions(page_token=INITIAL_PAGE)):
-      for element in page:
-          book = element
+      for response_item in page:
+          book = response_item
           print('Here\'s a related book: {}'.format(book))
 
   # [END sample_core]
@@ -4516,8 +4516,8 @@ def sample_stream_books():
 
   name = 'BASIC'
 
-  for element in client.stream_books(name):
-      print(element)
+  for response_item in client.stream_books(name):
+      print(response_item)
 
   # [END lovelace_core]
 # [END lovelace]
@@ -4563,8 +4563,8 @@ def sample_stream_shelves():
 
   client = library_v1.LibraryServiceClient()
 
-  for element in client.stream_shelves():
-      print(element)
+  for response_item in client.stream_shelves():
+      print(response_item)
 
   # [END sample_core]
 # [END sample]

--- a/src/test/java/com/google/api/codegen/transformer/OutputTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/OutputTransformerTest.java
@@ -69,6 +69,23 @@ public class OutputTransformerTest {
   }
 
   @Test
+  public void testAccessorNewVariableFailWithReservedKeyword() {
+    Scanner scanner = new Scanner("$resp");
+    when(config.getPageStreaming()).thenReturn(pageStreamingConfig);
+    when(pageStreamingConfig.getResourcesFieldConfig()).thenReturn(resourceFieldConfig);
+    when(namer.getAndSaveElementResourceTypeName(typeTable, resourceFieldConfig))
+        .thenReturn("ShelfBookName");
+    when(featureConfig.useResourceNameFormatOption(resourceFieldConfig)).thenReturn(true);
+    try {
+      OutputView.VariableView variableView =
+          accessorNewVariable(scanner, context, valueSet, parent, "response", false);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage().contains("\"response\" is a reserved keyword."));
+    }
+  }
+
+  @Test
   public void testAccessorNewVariablePageStreamingResourceNameResponse() {
     Scanner scanner = new Scanner("$resp");
 

--- a/src/test/java/com/google/api/codegen/transformer/OutputTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/OutputTransformerTest.java
@@ -81,7 +81,17 @@ public class OutputTransformerTest {
           accessorNewVariable(scanner, context, valueSet, parent, "response", false);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage().contains("\"response\" is a reserved keyword."));
+      assertThat(
+          e.getMessage().contains("cannot define variable response: it is a reserved keyword"));
+    }
+    try {
+      OutputView.VariableView variableView =
+          accessorNewVariable(scanner, context, valueSet, parent, "response_item", false);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(
+          e.getMessage()
+              .contains("cannot define variable response_item: it is a reserved keyword"));
     }
   }
 


### PR DESCRIPTION
- Renaming all loop variables in response streaming (server, bidi) and paged streaming to `responseItem` (or `response_item`) and the collection variable to `response` so that response handling is consistent for `$resp`.
- Restrict user from defining a variable `response` or `responseItem`.
- This PR touches standalone samples only.
- This PR touches Java and Python only. Nodejs is more complicated since node uses indices to access element rather than a foreach kind of loop. I'll have a separate PR for PHP.

