### PR TITLE
Samplegen: PHP Output Handling

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -273,4 +273,9 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   public String getApiSampleFileName(String className) {
     return className + ".php";
   }
+
+  @Override
+  public String getPrintSpec(String spec) {
+    return spec;
+  }
 }

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -218,7 +218,6 @@
 @end
 
 @private processResponse(sample)
-  {@sample.outputs}
   @if sample.outputs.size == 0
     System.out.println(response);
   @else

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -218,6 +218,7 @@
 @end
 
 @private processResponse(sample)
+  {@sample.outputs}
   @if sample.outputs.size == 0
     System.out.println(response);
   @else

--- a/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
@@ -331,7 +331,7 @@
 
 @private processResponse(sample)
     @if sample.outputs.size == 0
-        printf($response . PHP_EOL);
+        print_r($response);
     @else
         {@processOutputViews(sample.outputs)}
     @end

--- a/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
@@ -330,9 +330,8 @@
 @end
 
 @private processResponse(sample)
-    #{@sample.outputs}
     @if sample.outputs.size == 0
-        print($response);
+        printf($response . PHP_EOL);
     @else
         {@processOutputViews(sample.outputs)}
     @end
@@ -356,15 +355,10 @@
 @end
 
 @private processPrintView(view)
-    # Since numeric comparison seems to not work, we use explicit zero tests
     @if not(view.args.size)
-        print("{@view.format}");
+        printf("{@view.format}" . PHP_EOL);
     @else
-        @if view.format == "%s"
-            print({@variableField(view.args.get(0))});
-        @else
-            printf("{@view.format}", {@concatenatedArgs(view.args)});
-        @end
+        printf("{@view.format}" . PHP_EOL, {@concatenatedArgs(view.args)});
     @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
@@ -75,7 +75,6 @@
             {@longRunningAsyncSampleCode(sample, apiMethod)}
         @case "Request"
             {@requestSampleCode(sample, apiMethod)}
-            {@processResponse(sample)}
         @case "RequestPaged"
             {@pagedSampleCode(sample, apiMethod)}
         @case "RequestPagedAll"
@@ -86,10 +85,8 @@
             {@bidiStreamingAsyncSampleCode(sample, apiMethod)}
         @case "RequestStreamingClient"
             {@clientStreamingSampleCode(sample, apiMethod)}
-            {@processResponse(sample)}
         @case "RequestStreamingClientAsync"
             {@clientStreamingAsyncSampleCode(sample, apiMethod)}
-            {@processResponse(sample)}
         @case "RequestStreamingServer"
             {@serverStreamingSampleCode(sample, apiMethod)}
         @default
@@ -122,7 +119,7 @@
         @if apiMethod.longRunningView.isEmptyOperation
             // operation succeeded and returns no value
         @else
-            $result = $operationResponse->getResult();
+            $response = $operationResponse->getResult();
             {@processResponse(sample)}
         @end
     } else {
@@ -145,7 +142,7 @@
       @if apiMethod.longRunningView.isEmptyOperation
           // operation succeeded and returns no value
       @else
-          $result = $newOperationResponse->getResult();
+          $response = $newOperationResponse->getResult();
           {@processResponse(sample)}
       @end
     } else {
@@ -157,17 +154,19 @@
 @private requestSampleCode(sample, apiMethod)
     @if apiMethod.hasReturnValue
         $response = {@methodCallSampleCode(apiMethod)};
+
     @else
         {@methodCallSampleCode(apiMethod)};
     @end
+    {@processResponse(sample)}
 @end
 
 @private pagedSampleCode(sample, apiMethod)
     // Iterate over pages of elements
     $pagedResponse = {@methodCallSampleCode(apiMethod)};
     foreach ($pagedResponse->iteratePages() as $page) {
-        foreach ($page as $element) {
-            {@processResponse(sample)};
+        foreach ($page as $responseItem) {
+            {@processResponse(sample)}
         }
     }
 @end
@@ -175,7 +174,7 @@
 @private pagedAllSampleCode(sample, apiMethod)
     // Iterate through all elements
     $pagedResponse = {@methodCallSampleCode(apiMethod)};
-    foreach ($pagedResponse->iterateAllElements() as $element) {
+    foreach ($pagedResponse->iterateAllElements() as $responseItem) {
         {@processResponse(sample)}
     }
 @end
@@ -184,7 +183,8 @@
     // Write data to server and wait for a response
     $requests = [$request];
     $stream = {@methodCallSampleCode(apiMethod)};
-    $result = $stream->writeAllAndReadResponse($requests);
+    $response = $stream->writeAllAndReadResponse($requests);
+    {@processResponse(sample)}
 @end
 
 @private clientStreamingAsyncSampleCode(sample, apiMethod)
@@ -194,14 +194,15 @@
     foreach ($requests as $request) {
         $stream->write($request);
     }
-    $result = $stream->readResponse();
+    $response = $stream->readResponse();
+    {@processResponse(sample)}
 @end
 
 @private serverStreamingSampleCode(sample, apiMethod)
     // Read all responses until the stream is complete
     $stream = {@methodCallSampleCode(apiMethod)};
-    foreach ($stream->readAll() as $element) {
-        {@processResponse(sample)};
+    foreach ($stream->readAll() as $responseItem) {
+        {@processResponse(sample)}
     }
 @end
 
@@ -211,8 +212,8 @@
     $requests = [$request];
     $stream = {@methodCallSampleCode(apiMethod)};
     $stream->writeAll($requests);
-    foreach ($stream->closeWriteAndReadAll() as $element) {
-        {@processResponse(sample)};
+    foreach ($stream->closeWriteAndReadAll() as $responseItem) {
+        {@processResponse(sample)}
     }
 @end
 
@@ -225,14 +226,14 @@
     foreach ($requests as $request) {
         $stream->write($request);
         // if required, read a single response from the stream
-        $element = $stream->read();
+        $responseItem = $stream->read();
         {@processResponse(sample)}
     }
     $stream->closeWrite();
-    $element = $stream->read();
-    while (!is_null($element)) {
-        // doSomethingWith($element)
-        $element = $stream->read();
+    $responseItem = $stream->read();
+    while (!is_null($responseItem)) {
+        {@processResponse(sample)}
+        $responseItem = $stream->read();
     }
 @end
 
@@ -329,9 +330,9 @@
 @end
 
 @private processResponse(sample)
-    {@sample.outputs}
+    #{@sample.outputs}
     @if sample.outputs.size == 0
-        print(response)
+        print($response);
     @else
         {@processOutputViews(sample.outputs)}
     @end
@@ -357,9 +358,9 @@
 @private processPrintView(view)
     # Since numeric comparison seems to not work, we use explicit zero tests
     @if not(view.args.size)
-        print('{@view.format}');
+        print("{@view.format}");
     @else
-        @if view.format == "{}"
+        @if view.format == "%s"
             print({@variableField(view.args.get(0))});
         @else
             printf("{@view.format}", {@concatenatedArgs(view.args)});
@@ -372,13 +373,13 @@
 @end
 
 @private processLoopView(view)
-    foreach ({@variableField(view.collection)} as {@view.variableName}) {
+    foreach ({@variableField(view.collection)} as {@variable(view.variableName)}) {
         {@processOutputViews(view.body)}
     }
 @end
 
 @private processDefineView(view)
-    ${@view.variableName} = {@variableField(view.reference)};
+    {@variable(view.variableName)} = {@variableField(view.reference)};
 @end
 
 
@@ -389,11 +390,15 @@
 @end
 
 @private variableField(arg)
-    {@arg.variable}{@accessor(arg.accessors)}
+    {@variable(arg.variable)}{@accessor(arg.accessors)}
+@end
+
+@private variable(var)
+    ${@var}
 @end
 
 @private accessor(accessors)
     @join field : accessors on ""
-        ->{@field}
+        ->{@field}()
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
@@ -70,25 +70,28 @@
     try {
         @switch sample.callingForm
         @case "LongRunningRequest"
-            {@longRunningSampleCode(apiMethod)}
+            {@longRunningSampleCode(sample, apiMethod)}
         @case "LongRunningRequestAsync"
-            {@longRunningAsyncSampleCode(apiMethod)}
+            {@longRunningAsyncSampleCode(sample, apiMethod)}
         @case "Request"
-            {@requestSampleCode(apiMethod)}
+            {@requestSampleCode(sample, apiMethod)}
+            {@processResponse(sample)}
         @case "RequestPaged"
-            {@pagedSampleCode(apiMethod)}
+            {@pagedSampleCode(sample, apiMethod)}
         @case "RequestPagedAll"
-            {@pagedAllSampleCode(apiMethod)}
+            {@pagedAllSampleCode(sample, apiMethod)}
         @case "RequestStreamingBidi"
-            {@bidiStreamingSampleCode(apiMethod)}
+            {@bidiStreamingSampleCode(sample, apiMethod)}
         @case "RequestStreamingBidiAsync"
-            {@bidiStreamingAsyncSampleCode(apiMethod)}
+            {@bidiStreamingAsyncSampleCode(sample, apiMethod)}
         @case "RequestStreamingClient"
-            {@clientStreamingSampleCode(apiMethod)}
+            {@clientStreamingSampleCode(sample, apiMethod)}
+            {@processResponse(sample)}
         @case "RequestStreamingClientAsync"
-            {@clientStreamingAsyncSampleCode(apiMethod)}
+            {@clientStreamingAsyncSampleCode(sample, apiMethod)}
+            {@processResponse(sample)}
         @case "RequestStreamingServer"
-            {@serverStreamingSampleCode(apiMethod)}
+            {@serverStreamingSampleCode(sample, apiMethod)}
         @default
             $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
         @end
@@ -112,7 +115,7 @@
     @end
 @end
 
-@private longRunningSampleCode(apiMethod)
+@private longRunningSampleCode(sample, apiMethod)
     $operationResponse = {@methodCallSampleCode(apiMethod)};
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
@@ -120,7 +123,7 @@
             // operation succeeded and returns no value
         @else
             $result = $operationResponse->getResult();
-            // doSomethingWith($result)
+            {@processResponse(sample)}
         @end
     } else {
         $error = $operationResponse->getError();
@@ -128,7 +131,7 @@
     }
 @end
 
-@private longRunningAsyncSampleCode(apiMethod)
+@private longRunningAsyncSampleCode(sample, apiMethod)
     // start the operation, keep the operation name, and resume later
     $operationResponse = {@methodCallSampleCode(apiMethod)};
     $operationName = $operationResponse->getName();
@@ -143,7 +146,7 @@
           // operation succeeded and returns no value
       @else
           $result = $newOperationResponse->getResult();
-          // doSomethingWith($result)
+          {@processResponse(sample)}
       @end
     } else {
       $error = $newOperationResponse->getError();
@@ -151,7 +154,7 @@
     }
 @end
 
-@private requestSampleCode(apiMethod)
+@private requestSampleCode(sample, apiMethod)
     @if apiMethod.hasReturnValue
         $response = {@methodCallSampleCode(apiMethod)};
     @else
@@ -159,33 +162,32 @@
     @end
 @end
 
-@private pagedSampleCode(apiMethod)
+@private pagedSampleCode(sample, apiMethod)
     // Iterate over pages of elements
     $pagedResponse = {@methodCallSampleCode(apiMethod)};
     foreach ($pagedResponse->iteratePages() as $page) {
         foreach ($page as $element) {
-            // doSomethingWith($element);
+            {@processResponse(sample)};
         }
     }
 @end
 
-@private pagedAllSampleCode(apiMethod)
+@private pagedAllSampleCode(sample, apiMethod)
     // Iterate through all elements
     $pagedResponse = {@methodCallSampleCode(apiMethod)};
     foreach ($pagedResponse->iterateAllElements() as $element) {
-        // doSomethingWith($element);
+        {@processResponse(sample)}
     }
 @end
 
-@private clientStreamingSampleCode(apiMethod)
+@private clientStreamingSampleCode(sample, apiMethod)
     // Write data to server and wait for a response
     $requests = [$request];
     $stream = {@methodCallSampleCode(apiMethod)};
     $result = $stream->writeAllAndReadResponse($requests);
-    // doSomethingWith($result)
 @end
 
-@private clientStreamingAsyncSampleCode(apiMethod)
+@private clientStreamingAsyncSampleCode(sample, apiMethod)
     // Write data as it becomes available, then wait for a response
     $requests = [$request];
     $stream = {@methodCallSampleCode(apiMethod)};
@@ -193,29 +195,28 @@
         $stream->write($request);
     }
     $result = $stream->readResponse();
-    // doSomethingWith($result)
 @end
 
-@private serverStreamingSampleCode(apiMethod)
+@private serverStreamingSampleCode(sample, apiMethod)
     // Read all responses until the stream is complete
     $stream = {@methodCallSampleCode(apiMethod)};
     foreach ($stream->readAll() as $element) {
-        // doSomethingWith($element);
+        {@processResponse(sample)};
     }
 @end
 
-@private bidiStreamingSampleCode(apiMethod)
+@private bidiStreamingSampleCode(sample, apiMethod)
     // Write all requests to the server, then read all responses until the
     // stream is complete
     $requests = [$request];
     $stream = {@methodCallSampleCode(apiMethod)};
     $stream->writeAll($requests);
     foreach ($stream->closeWriteAndReadAll() as $element) {
-        // doSomethingWith($element);
+        {@processResponse(sample)};
     }
 @end
 
-@private bidiStreamingAsyncSampleCode(apiMethod)
+@private bidiStreamingAsyncSampleCode(sample, apiMethod)
     // Write requests individually, making read() calls if
     // required. Call closeWrite() once writes are complete, and read the
     // remaining responses from the server.
@@ -225,7 +226,7 @@
         $stream->write($request);
         // if required, read a single response from the stream
         $element = $stream->read();
-        // doSomethingWith($element)
+        {@processResponse(sample)}
     }
     $stream->closeWrite();
     $element = $stream->read();
@@ -275,11 +276,11 @@
     @end
 @end
 
-@snippet optionalField(fieldSettings)
+@private optionalField(fieldSettings)
     [{@optionalFieldEntries(fieldSettings)}]
 @end
 
-@snippet optionalFieldEntries(fieldSettings)
+@private optionalFieldEntries(fieldSettings)
     @join fieldSetting : fieldSettings on ", "
         '{@fieldSetting.fieldName}' => ${@fieldSetting.identifier}
     @end
@@ -296,7 +297,7 @@
     ${@line.identifier} = [{@varList(line.elementIdentifiers)}];
 @end
 
-@snippet varList(args)
+@private varList(args)
     @join arg : args on ", "
         ${@arg}
     @end
@@ -324,5 +325,75 @@
         ${@apiVariableName}->{@initValue.formatFunctionName}({@argList(initValue.formatArgs)})
     @default
         $unhandledCase: {@initValue.type}$
+    @end
+@end
+
+@private processResponse(sample)
+    {@sample.outputs}
+    @if sample.outputs.size == 0
+        print(response)
+    @else
+        {@processOutputViews(sample.outputs)}
+    @end
+@end
+
+@private processOutputViews(outputViews)
+    @join view : outputViews on BREAK
+        @switch view.kind
+        @case "COMMENT"
+            {@processCommentView(view)}
+        @case "DEFINE"
+            {@processDefineView(view)}
+        @case "LOOP"
+            {@processLoopView(view)}
+        @case "PRINT"
+            {@processPrintView(view)}
+        @default
+            $unhandledResponseForm: {@view}
+        @end
+    @end
+@end
+
+@private processPrintView(view)
+    # Since numeric comparison seems to not work, we use explicit zero tests
+    @if not(view.args.size)
+        print('{@view.format}');
+    @else
+        @if view.format == "{}"
+            print({@variableField(view.args.get(0))});
+        @else
+            printf("{@view.format}", {@concatenatedArgs(view.args)});
+        @end
+    @end
+@end
+
+@private processCommentView(view)
+    {@toComments(view.lines)}
+@end
+
+@private processLoopView(view)
+    foreach ({@variableField(view.collection)} as {@view.variableName}) {
+        {@processOutputViews(view.body)}
+    }
+@end
+
+@private processDefineView(view)
+    ${@view.variableName} = {@variableField(view.reference)};
+@end
+
+
+@private concatenatedArgs(args)
+    @join arg : args on ", "
+        {@variableField(arg)}
+    @end
+@end
+
+@private variableField(arg)
+    {@arg.variable}{@accessor(arg.accessors)}
+@end
+
+@private accessor(accessors)
+    @join field : accessors on ""
+        ->{@field}
     @end
 @end

--- a/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
@@ -2763,12 +2763,12 @@ try {
         $stream->write($request);
         // if required, read a single response from the stream
         $responseItem = $stream->read();
-        print($responseItem);
+        printf("%s" . PHP_EOL, $responseItem);
     }
     $stream->closeWrite();
     $responseItem = $stream->read();
     while (!is_null($responseItem)) {
-        print($responseItem);
+        printf("%s" . PHP_EOL, $responseItem);
         $responseItem = $stream->read();
     }
 } finally {
@@ -2818,7 +2818,7 @@ try {
     $stream = $libraryServiceClient->discussBook();
     $stream->writeAll($requests);
     foreach ($stream->closeWriteAndReadAll() as $responseItem) {
-        print($responseItem);
+        printf("%s" . PHP_EOL, $responseItem);
     }
 } finally {
     $libraryServiceClient->close();
@@ -2864,7 +2864,7 @@ try {
     $pagedResponse = $libraryServiceClient->findRelatedBooks($names, $shelves);
     foreach ($pagedResponse->iterateAllElements() as $responseItem) {
         $book = $responseItem;
-        printf("Here's a related book: %s", $book);
+        printf("Here's a related book: %s" . PHP_EOL, $book);
     }
 } finally {
     $libraryServiceClient->close();
@@ -2911,7 +2911,7 @@ try {
     foreach ($pagedResponse->iteratePages() as $page) {
         foreach ($page as $responseItem) {
             $book = $responseItem;
-            printf("Here's a related book: %s", $book);
+            printf("Here's a related book: %s" . PHP_EOL, $book);
         }
     }
 } finally {
@@ -2962,7 +2962,7 @@ try {
     }
     if ($newOperationResponse->operationSucceeded()) {
       $response = $newOperationResponse->getResult();
-      print($response);
+      printf("%s" . PHP_EOL, $response);
     } else {
       $error = $newOperationResponse->getError();
       // handleError($error)
@@ -3008,7 +3008,7 @@ try {
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
         $response = $operationResponse->getResult();
-        print($response);
+        printf("%s" . PHP_EOL, $response);
     } else {
         $error = $operationResponse->getError();
         // handleError($error)
@@ -3061,7 +3061,7 @@ try {
         $stream->write($request);
     }
     $response = $stream->readResponse();
-    print($response);
+    printf("%s" . PHP_EOL, $response);
 } finally {
     $libraryServiceClient->close();
 }
@@ -3107,7 +3107,7 @@ try {
     $requests = [$request];
     $stream = $libraryServiceClient->monologAboutBook();
     $response = $stream->writeAllAndReadResponse($requests);
-    print($response);
+    printf("%s" . PHP_EOL, $response);
 } finally {
     $libraryServiceClient->close();
 }
@@ -3158,9 +3158,9 @@ $seriesUuid->setSeriesString($seriesString);
 try {
     $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
     foreach ($response->getBookNames() as $title) {
-        printf("Title: %s", $title);
+        printf("Title: %s" . PHP_EOL, $title);
     }
-    print("That's all!");
+    printf("That's all!" . PHP_EOL);
 } finally {
     $libraryServiceClient->close();
 }
@@ -3205,8 +3205,13 @@ $seriesUuid = new SeriesUuid();
 $edition = 2;
 
 try {
+<<<<<<< HEAD
     $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
     print($response);
+=======
+    $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid);
+    printf("%s" . PHP_EOL, $response);
+>>>>>>> wip
 } finally {
     $libraryServiceClient->close();
 }
@@ -3247,7 +3252,7 @@ try {
     // Read all responses until the stream is complete
     $stream = $libraryServiceClient->streamBooks($name);
     foreach ($stream->readAll() as $responseItem) {
-        print($responseItem);
+        printf("%s" . PHP_EOL, $responseItem);
     }
 } finally {
     $libraryServiceClient->close();
@@ -3287,7 +3292,7 @@ try {
     // Read all responses until the stream is complete
     $stream = $libraryServiceClient->streamShelves();
     foreach ($stream->readAll() as $responseItem) {
-        print($responseItem);
+        printf("%s" . PHP_EOL, $responseItem);
     }
 } finally {
     $libraryServiceClient->close();

--- a/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
@@ -3161,6 +3161,7 @@ try {
         printf("Title: %s" . PHP_EOL, $title);
     }
     printf("That's all!" . PHP_EOL);
+    printf("series_uuid: %s" . PHP_EOL, $response->getSeriesUuid()->getSeriesBytes());
 } finally {
     $libraryServiceClient->close();
 }
@@ -3205,13 +3206,8 @@ $seriesUuid = new SeriesUuid();
 $edition = 2;
 
 try {
-<<<<<<< HEAD
     $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
-    print($response);
-=======
-    $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid);
     printf("%s" . PHP_EOL, $response);
->>>>>>> wip
 } finally {
     $libraryServiceClient->close();
 }

--- a/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
@@ -2762,14 +2762,14 @@ try {
     foreach ($requests as $request) {
         $stream->write($request);
         // if required, read a single response from the stream
-        $element = $stream->read();
-        // doSomethingWith($element)
+        $responseItem = $stream->read();
+        print($responseItem);
     }
     $stream->closeWrite();
-    $element = $stream->read();
-    while (!is_null($element)) {
-        // doSomethingWith($element)
-        $element = $stream->read();
+    $responseItem = $stream->read();
+    while (!is_null($responseItem)) {
+        print($responseItem);
+        $responseItem = $stream->read();
     }
 } finally {
     $libraryServiceClient->close();
@@ -2817,8 +2817,8 @@ try {
     $requests = [$request];
     $stream = $libraryServiceClient->discussBook();
     $stream->writeAll($requests);
-    foreach ($stream->closeWriteAndReadAll() as $element) {
-        // doSomethingWith($element);
+    foreach ($stream->closeWriteAndReadAll() as $responseItem) {
+        print($responseItem);
     }
 } finally {
     $libraryServiceClient->close();
@@ -2862,8 +2862,9 @@ $shelves = [$shelvesElement];
 try {
     // Iterate through all elements
     $pagedResponse = $libraryServiceClient->findRelatedBooks($names, $shelves);
-    foreach ($pagedResponse->iterateAllElements() as $element) {
-        // doSomethingWith($element);
+    foreach ($pagedResponse->iterateAllElements() as $responseItem) {
+        $book = $responseItem;
+        printf("Here's a related book: %s", $book);
     }
 } finally {
     $libraryServiceClient->close();
@@ -2908,8 +2909,9 @@ try {
     // Iterate over pages of elements
     $pagedResponse = $libraryServiceClient->findRelatedBooks($names, $shelves);
     foreach ($pagedResponse->iteratePages() as $page) {
-        foreach ($page as $element) {
-            // doSomethingWith($element);
+        foreach ($page as $responseItem) {
+            $book = $responseItem;
+            printf("Here's a related book: %s", $book);
         }
     }
 } finally {
@@ -2959,8 +2961,8 @@ try {
         $newOperationResponse->reload();
     }
     if ($newOperationResponse->operationSucceeded()) {
-      $result = $newOperationResponse->getResult();
-      // doSomethingWith($result)
+      $response = $newOperationResponse->getResult();
+      print($response);
     } else {
       $error = $newOperationResponse->getError();
       // handleError($error)
@@ -3005,8 +3007,8 @@ try {
     $operationResponse = $libraryServiceClient->getBigBook($formattedName);
     $operationResponse->pollUntilComplete();
     if ($operationResponse->operationSucceeded()) {
-        $result = $operationResponse->getResult();
-        // doSomethingWith($result)
+        $response = $operationResponse->getResult();
+        print($response);
     } else {
         $error = $operationResponse->getError();
         // handleError($error)
@@ -3058,8 +3060,8 @@ try {
     foreach ($requests as $request) {
         $stream->write($request);
     }
-    $result = $stream->readResponse();
-    // doSomethingWith($result)
+    $response = $stream->readResponse();
+    print($response);
 } finally {
     $libraryServiceClient->close();
 }
@@ -3104,8 +3106,8 @@ try {
     // Write data to server and wait for a response
     $requests = [$request];
     $stream = $libraryServiceClient->monologAboutBook();
-    $result = $stream->writeAllAndReadResponse($requests);
-    // doSomethingWith($result)
+    $response = $stream->writeAllAndReadResponse($requests);
+    print($response);
 } finally {
     $libraryServiceClient->close();
 }
@@ -3155,6 +3157,10 @@ $seriesUuid->setSeriesString($seriesString);
 
 try {
     $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
+    foreach ($response->getBookNames() as $title) {
+        printf("Title: %s", $title);
+    }
+    print("That's all!");
 } finally {
     $libraryServiceClient->close();
 }
@@ -3200,6 +3206,7 @@ $edition = 2;
 
 try {
     $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
+    print($response);
 } finally {
     $libraryServiceClient->close();
 }
@@ -3239,8 +3246,8 @@ $name = 'BASIC';
 try {
     // Read all responses until the stream is complete
     $stream = $libraryServiceClient->streamBooks($name);
-    foreach ($stream->readAll() as $element) {
-        // doSomethingWith($element);
+    foreach ($stream->readAll() as $responseItem) {
+        print($responseItem);
     }
 } finally {
     $libraryServiceClient->close();
@@ -3279,8 +3286,8 @@ $libraryServiceClient = new LibraryServiceClient();
 try {
     // Read all responses until the stream is complete
     $stream = $libraryServiceClient->streamShelves();
-    foreach ($stream->readAll() as $element) {
-        // doSomethingWith($element);
+    foreach ($stream->readAll() as $responseItem) {
+        print($responseItem);
     }
 } finally {
     $libraryServiceClient->close();


### PR DESCRIPTION
- PHP output handling
- Also renaming `$result` and `$element` to `$response` and `$responseItem` to make return values consistent with Java and Python.