### PR TITLE
Add tests for printing nested messages

### DIFF
--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
@@ -554,6 +554,7 @@ message PublishSeriesResponse {
   repeated string book_names = 1 [
     (google.api.required) = true,
     (google.api.resource_type) = "google.example.library.v1.Book"];
+  SeriesUuid series_uuid = 2;
 }
 
 // Request message for LibraryService.GetBook.

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -7704,6 +7704,7 @@ public class PublishSeriesFlattenedPiVersion {
       System.out.printf("Title: %s\n", title);
     }
     System.out.println("That's all!");
+    System.out.printf("series_uuid: %s\n", response.getSeriesUuid());
     // [END canonical_core]
   }
 }
@@ -7791,6 +7792,7 @@ public class PublishSeriesRequestPiVersion {
       System.out.printf("Title: %s\n", title);
     }
     System.out.println("That's all!");
+    System.out.printf("series_uuid: %s\n", response.getSeriesUuid());
     // [END canonical_core]
   }
 }
@@ -7888,6 +7890,7 @@ public class PublishSeriesCallableCallablePiVersion {
       System.out.printf("Title: %s\n", title);
     }
     System.out.println("That's all!");
+    System.out.printf("series_uuid: %s\n", response.getSeriesUuid());
     // [END canonical_core]
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -7704,7 +7704,7 @@ public class PublishSeriesFlattenedPiVersion {
       System.out.printf("Title: %s\n", title);
     }
     System.out.println("That's all!");
-    System.out.printf("series_uuid: %s\n", response.getSeriesUuid());
+    System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     // [END canonical_core]
   }
 }
@@ -7792,7 +7792,7 @@ public class PublishSeriesRequestPiVersion {
       System.out.printf("Title: %s\n", title);
     }
     System.out.println("That's all!");
-    System.out.printf("series_uuid: %s\n", response.getSeriesUuid());
+    System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     // [END canonical_core]
   }
 }
@@ -7890,7 +7890,7 @@ public class PublishSeriesCallableCallablePiVersion {
       System.out.printf("Title: %s\n", title);
     }
     System.out.println("That's all!");
-    System.out.printf("series_uuid: %s\n", response.getSeriesUuid());
+    System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     // [END canonical_core]
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -1292,6 +1292,8 @@ const SeriesUuid = {
  *   The names of the books in the series that were published
  *
  * @property {Object} seriesUuid
+ *   Uniquely identifies the series published
+ *
  *   This object should have the same structure as [SeriesUuid]{@link google.example.library.v1.SeriesUuid}
  *
  * @typedef PublishSeriesResponse

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -1291,6 +1291,9 @@ const SeriesUuid = {
  * @property {string[]} bookNames
  *   The names of the books in the series that were published
  *
+ * @property {Object} seriesUuid
+ *   This object should have the same structure as [SeriesUuid]{@link google.example.library.v1.SeriesUuid}
+ *
  * @typedef PublishSeriesResponse
  * @memberof google.example.library.v1
  * @see [google.example.library.v1.PublishSeriesResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -4433,7 +4433,7 @@ def sample_publish_series(name, edition):
   for title in response.book_names:
     print('Title: {}'.format(title))
   print('That\'s all!')
-  print('series_uuid: {}'.format(response.series_uuid))
+  print('series_uuid: {}'.format(response.series_uuid.series_bytes))
 
   # [END canonical_core]
 # [END canonical]

--- a/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_library.baseline
@@ -4433,6 +4433,7 @@ def sample_publish_series(name, edition):
   for title in response.book_names:
     print('Title: {}'.format(title))
   print('That\'s all!')
+  print('series_uuid: {}'.format(response.series_uuid))
 
   # [END canonical_core]
 # [END canonical]

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -2257,6 +2257,7 @@ module Google
         #     The names of the books in the series that were published
         # @!attribute [rw] series_uuid
         #   @return [Google::Example::Library::V1::SeriesUuid]
+        #     Uniquely identifies the series published
         class PublishSeriesResponse; end
 
         # Request message for LibraryService.GetBook.

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -2255,6 +2255,8 @@ module Google
         # @!attribute [rw] book_names
         #   @return [Array<String>]
         #     The names of the books in the series that were published
+        # @!attribute [rw] series_uuid
+        #   @return [Google::Example::Library::V1::SeriesUuid]
         class PublishSeriesResponse; end
 
         # Request message for LibraryService.GetBook.

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
@@ -436,6 +436,8 @@ message SeriesUuid {
 message PublishSeriesResponse {
   // The names of the books in the series that were published
   repeated string book_names = 1;
+
+  SeriesUuid series_uuid = 2;
 }
 
 // Request message for LibraryService.GetBook.

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
@@ -437,6 +437,7 @@ message PublishSeriesResponse {
   // The names of the books in the series that were published
   repeated string book_names = 1;
 
+  // Uniquely identifies the series published
   SeriesUuid series_uuid = 2;
 }
 

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -262,7 +262,7 @@ interfaces:
         - "That's all!"
       - print:
         - "series_uuid: %s"
-        - $resp.series_uuid
+        - $resp.series_uuid.series_bytes
       # callingFormCheck: second_edition java: Flattened Request Callable
       # callingFormCheck: second_edition nodejs: Request
       # callingFormCheck: second_edition py: Request

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -260,6 +260,9 @@ interfaces:
               - title
       - print:
         - "That's all!"
+      - print:
+        - "series_uuid: %s"
+        - $resp.series_uuid
       # callingFormCheck: second_edition java: Flattened Request Callable
       # callingFormCheck: second_edition nodejs: Request
       # callingFormCheck: second_edition py: Request


### PR DESCRIPTION
Currently we don't have tests for printing nested messages in output handling. Adding these would give us more confidence in generating samples.