### PR TITLE
Deprecate request_object_method from config

### DIFF
--- a/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
@@ -138,8 +138,6 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
       error = true;
     }
 
-    boolean hasRequestObjectMethod = methodConfigProto.getRequestObjectMethod();
-
     ImmutableMap<String, String> fieldNamePatterns =
         ImmutableMap.copyOf(methodConfigProto.getFieldNamePatterns());
 
@@ -206,7 +204,6 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
           optionalFieldConfigs,
           defaultResourceNameTreatment,
           batching,
-          hasRequestObjectMethod,
           fieldNamePatterns,
           sampleCodeInitFields,
           sampleSpec,

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -135,16 +135,6 @@ public abstract class GapicMethodConfig extends MethodConfig {
       error = true;
     }
 
-    boolean hasRequestObjectMethod = methodConfigProto.getRequestObjectMethod();
-    if (hasRequestObjectMethod && method.getRequestStreaming()) {
-      diagCollector.addDiag(
-          Diag.error(
-              SimpleLocation.TOPLEVEL,
-              "request_object_method incompatible with streaming method %s",
-              method.getFullName()));
-      error = true;
-    }
-
     ImmutableMap<String, String> fieldNamePatterns =
         ImmutableMap.copyOf(methodConfigProto.getFieldNamePatterns());
 
@@ -226,7 +216,6 @@ public abstract class GapicMethodConfig extends MethodConfig {
           optionalFieldConfigs,
           defaultResourceNameTreatment,
           batching,
-          hasRequestObjectMethod,
           fieldNamePatterns,
           sampleCodeInitFields,
           sampleSpec,

--- a/src/main/java/com/google/api/codegen/config/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/MethodConfig.java
@@ -63,8 +63,6 @@ public abstract class MethodConfig {
   @Nullable
   public abstract BatchingConfig getBatching();
 
-  public abstract boolean hasRequestObjectMethod();
-
   public abstract ImmutableMap<String, String> getFieldNamePatterns();
 
   public abstract List<String> getSampleCodeInitFields();

--- a/src/main/java/com/google/api/codegen/configgen/mergers/MethodMerger.java
+++ b/src/main/java/com/google/api/codegen/configgen/mergers/MethodMerger.java
@@ -25,7 +25,6 @@ import com.google.api.codegen.configgen.nodes.FieldConfigNode;
 import com.google.api.codegen.configgen.nodes.ListItemConfigNode;
 import com.google.api.codegen.configgen.nodes.metadata.DefaultComment;
 import com.google.api.codegen.configgen.nodes.metadata.FixmeComment;
-import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,8 +34,6 @@ public class MethodMerger {
   // Do not apply flattening if the parameter count exceeds the threshold.
   // TODO(garrettjones): Investigate a more intelligent way to handle this.
   private static final int FLATTENING_THRESHOLD = 4;
-
-  private static final int REQUEST_OBJECT_METHOD_THRESHOLD = 1;
 
   // Default LRO values.
   private static final String LRO_TOTAL_POLL_TIMEOUT = "300000";
@@ -58,8 +55,6 @@ public class MethodMerger {
           + "  Consists of groups, which each represent a list of parameters to be "
           + "flattened. Each parameter listed must be a field of the request message.\n\n"
           + "  required_fields - Fields that are always required for a request to be valid.\n\n"
-          + "  request_object_method - Turns on or off the generation of a method whose sole "
-          + "parameter is a request object. Not all languages will generate this method.\n\n"
           + "  resource_name_treatment - An enum that specifies how to treat the resource name "
           + "formats defined in the field_name_patterns and response_field_name_patterns fields.\n"
           + "  UNSET: default value\n"
@@ -170,19 +165,7 @@ public class MethodMerger {
       prevNode = requiredFieldsNode;
     }
 
-    // use all fields for the following check; if there are ignored fields for flattening
-    // purposes, the caller still needs a way to set them (by using the request object method).
-    int fieldCount = Iterables.size(method.getInputFields());
-    boolean requestObjectMethod =
-        (fieldCount > REQUEST_OBJECT_METHOD_THRESHOLD || fieldCount != parameterList.size())
-            && !method.getRequestStreaming();
-    ConfigNode requestObjectMethodNode =
-        FieldConfigNode.createStringPair(
-            NodeFinder.getNextLine(prevNode),
-            "request_object_method",
-            String.valueOf(requestObjectMethod));
-    prevNode.insertNext(requestObjectMethodNode);
-    return requestObjectMethodNode;
+    return prevNode;
   }
 
   private ConfigNode generateLongRunningNode(ConfigNode prevNode, MethodModel methodModel) {

--- a/src/main/java/com/google/api/codegen/configgen/transformer/MethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/MethodTransformer.java
@@ -27,7 +27,6 @@ import com.google.api.codegen.configgen.viewmodel.PageStreamingRequestView;
 import com.google.api.codegen.configgen.viewmodel.PageStreamingResponseView;
 import com.google.api.codegen.configgen.viewmodel.PageStreamingView;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -87,11 +86,7 @@ public class MethodTransformer {
     }
 
     methodView.requiredFields(parameters);
-    // use all fields for the following check; if there are ignored fields for flattening
-    // purposes, the caller still needs a way to set them (by using the request object method).
-    methodView.requestObjectMethod(
-        (Iterators.size(inputFields.iterator()) != parameterList.size())
-            && !method.getRequestStreaming());
+
     methodView.resourceNameTreatment(helperTransformer.getResourceNameTreatment(method));
   }
 

--- a/src/main/java/com/google/api/codegen/configgen/transformer/MethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/MethodTransformer.java
@@ -47,8 +47,6 @@ public class MethodTransformer {
   // TODO(shinfan): Investigate a more intelligent way to handle this.
   private static final int FLATTENING_THRESHOLD = 4;
 
-  private static final int REQUEST_OBJECT_METHOD_THRESHOLD = 1;
-
   public List<MethodView> generateMethods(
       InterfaceModel apiInterface, Map<String, String> collectionNameMap) {
     ImmutableList.Builder<MethodView> methods = ImmutableList.builder();
@@ -92,8 +90,7 @@ public class MethodTransformer {
     // use all fields for the following check; if there are ignored fields for flattening
     // purposes, the caller still needs a way to set them (by using the request object method).
     methodView.requestObjectMethod(
-        (Iterators.size(inputFields.iterator()) > REQUEST_OBJECT_METHOD_THRESHOLD
-                || Iterators.size(inputFields.iterator()) != parameterList.size())
+        (Iterators.size(inputFields.iterator()) != parameterList.size())
             && !method.getRequestStreaming());
     methodView.resourceNameTreatment(helperTransformer.getResourceNameTreatment(method));
   }

--- a/src/main/java/com/google/api/codegen/configgen/viewmodel/MethodView.java
+++ b/src/main/java/com/google/api/codegen/configgen/viewmodel/MethodView.java
@@ -37,9 +37,6 @@ public abstract class MethodView implements Comparable<MethodView> {
   /** The fields that are always required for a request to be valid. */
   public abstract List<String> requiredFields();
 
-  /** Turns on or off generation of a method whose sole parameter is a request object. */
-  public abstract boolean requestObjectMethod();
-
   /** The resource name treatment. */
   @Nullable
   public abstract ResourceNameTreatment resourceNameTreatment();
@@ -84,8 +81,6 @@ public abstract class MethodView implements Comparable<MethodView> {
     public abstract Builder flattening(FlatteningView val);
 
     public abstract Builder requiredFields(List<String> val);
-
-    public abstract Builder requestObjectMethod(boolean val);
 
     public abstract Builder resourceNameTreatment(ResourceNameTreatment val);
 

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -765,12 +765,8 @@ public class StaticLangApiMethodTransformer {
 
     RequestObjectMethodDetailView.Builder detailBuilder =
         RequestObjectMethodDetailView.newBuilder();
-    if (context.getMethodConfig().hasRequestObjectMethod()) {
-      detailBuilder.accessModifier(
-          context.getNamer().getVisiblityKeyword(context.getMethodConfig().getVisibility()));
-    } else {
-      detailBuilder.accessModifier(context.getNamer().getPrivateAccessModifier());
-    }
+    detailBuilder.accessModifier(
+        context.getNamer().getVisiblityKeyword(context.getMethodConfig().getVisibility()));
     detailBuilder.callableMethodName(callableMethodName);
     methodViewBuilder.requestObjectMethod(detailBuilder.build());
   }

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -34,7 +34,6 @@ option java_package = "com.google.api.codegen";
 //         ...
 //       methods:
 //       - name: PublishBooks
-//         request_object_method: true
 //         flattening:
 //           groups:
 //           - parameters:
@@ -256,7 +255,7 @@ message MethodConfigProto {
 
   // Turns on or off the generation of a method whose sole parameter is
   // a request object. Not all languages will generate this method.
-  bool request_object_method = 7;
+  bool request_object_method = 7; // UNSUPPORTED.
 
   // Fields that are always required for a request to be valid.
   repeated string required_fields = 8;

--- a/src/main/resources/com/google/api/codegen/configgen/gapic_config.snip
+++ b/src/main/resources/com/google/api/codegen/configgen/gapic_config.snip
@@ -103,9 +103,6 @@
       @#       message.
       @#   required_fields - Fields that are always required for a request to be
       @#       valid.
-      @#   request_object_method - Turns on or off the generation of a method whose
-      @#       sole parameter is a request object. Not all languages will generate
-      @#       this method.
       @#   resource_name_treatment - An enum that specifies how to treat the
       @#       resource name formats defined in the field_name_patterns
       @#       and response_field_name_patterns fields.
@@ -151,7 +148,6 @@
             required_fields:
             {@renderStringList(method.requiredFields)}
           @end
-          request_object_method: {@method.requestObjectMethod}
           @if method.hasResourceNameTreatment
             resource_name_treatment: {@method.resourceNameTreatment}
           @end

--- a/src/test/java/com/google/api/codegen/config/testdata/missing_config_schema_version.yaml
+++ b/src/test/java/com/google/api/codegen/config/testdata/missing_config_schema_version.yaml
@@ -34,4 +34,3 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 1000
-    request_object_method: false

--- a/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
@@ -83,10 +83,6 @@ interfaces:
   #   required_fields - Fields that are always required for a request to be
   #   valid.
   #
-  #   request_object_method - Turns on or off the generation of a method whose
-  #   sole parameter is a request object. Not all languages will generate this
-  #   method.
-  #
   #   resource_name_treatment - An enum that specifies how to treat the resource
   #   name formats defined in the field_name_patterns and
   #   response_field_name_patterns fields.
@@ -136,7 +132,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - shelf
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -159,7 +154,6 @@ interfaces:
     - message
     - string_builder
     - options
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
@@ -169,7 +163,6 @@ interfaces:
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: ListShelves
-    request_object_method: true
     page_streaming:
       request:
         token_field: page_token
@@ -192,7 +185,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
@@ -213,7 +205,6 @@ interfaces:
     required_fields:
     - name
     - other_shelf_name
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -234,7 +225,6 @@ interfaces:
     required_fields:
     - name
     - book
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -257,7 +247,6 @@ interfaces:
     - shelf
     - books
     - series_uuid
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -274,7 +263,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
@@ -295,7 +283,6 @@ interfaces:
     required_fields:
     - name
     - filter
-    request_object_method: true
     page_streaming:
       request:
         page_size_field: page_size
@@ -321,7 +308,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
@@ -338,7 +324,6 @@ interfaces:
     - book
     - update_mask
     - physical_mask
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
@@ -359,7 +344,6 @@ interfaces:
     required_fields:
     - name
     - other_shelf_name
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -378,7 +362,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: true
     page_streaming:
       request:
         page_size_field: page_size
@@ -404,7 +387,6 @@ interfaces:
     required_fields:
     - name
     - comments
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -423,7 +405,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
@@ -444,7 +425,6 @@ interfaces:
     required_fields:
     - name
     - alt_book_name
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
@@ -463,7 +443,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -486,7 +465,6 @@ interfaces:
     - name
     - index_name
     - index_map
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -496,7 +474,6 @@ interfaces:
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: StreamShelves
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -513,7 +490,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -532,7 +508,6 @@ interfaces:
     required_fields:
     - name
     - comment
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -551,7 +526,6 @@ interfaces:
     required_fields:
     - name
     - comment
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -570,7 +544,6 @@ interfaces:
     required_fields:
     - names
     - shelves
-    request_object_method: true
     page_streaming:
       request:
         page_size_field: page_size
@@ -596,7 +569,6 @@ interfaces:
     required_fields:
     - resource
     - tag
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -615,7 +587,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
@@ -644,7 +615,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
@@ -724,7 +694,6 @@ interfaces:
     - optional_repeated_fixed32
     - optional_repeated_fixed64
     - optional_map
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -743,7 +712,6 @@ interfaces:
     required_fields:
     - resource
     - tag
-    request_object_method: true
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.

--- a/src/test/java/com/google/api/codegen/configgen/testdata/longrunning_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/longrunning_config.baseline
@@ -77,10 +77,6 @@ interfaces:
   #   required_fields - Fields that are always required for a request to be
   #   valid.
   #
-  #   request_object_method - Turns on or off the generation of a method whose
-  #   sole parameter is a request object. Not all languages will generate this
-  #   method.
-  #
   #   resource_name_treatment - An enum that specifies how to treat the resource
   #   name formats defined in the field_name_patterns and
   #   response_field_name_patterns fields.
@@ -132,7 +128,6 @@ interfaces:
     required_fields:
     - name
     - filter
-    request_object_method: true
     page_streaming:
       request:
         page_size_field: page_size
@@ -156,7 +151,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
@@ -185,7 +179,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
@@ -204,7 +197,6 @@ interfaces:
     # FIXME: Configure which fields are required.
     required_fields:
     - name
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.

--- a/src/test/java/com/google/api/codegen/configgen/testdata/multiple_services_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/multiple_services_config.baseline
@@ -75,10 +75,6 @@ interfaces:
   #   required_fields - Fields that are always required for a request to be
   #   valid.
   #
-  #   request_object_method - Turns on or off the generation of a method whose
-  #   sole parameter is a request object. Not all languages will generate this
-  #   method.
-  #
   #   resource_name_treatment - An enum that specifies how to treat the resource
   #   name formats defined in the field_name_patterns and
   #   response_field_name_patterns fields.
@@ -119,7 +115,6 @@ interfaces:
   #   the call is retrying, refer to retry_params_name instead.
   methods:
   - name: Increment
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -173,10 +168,6 @@ interfaces:
   #   required_fields - Fields that are always required for a request to be
   #   valid.
   #
-  #   request_object_method - Turns on or off the generation of a method whose
-  #   sole parameter is a request object. Not all languages will generate this
-  #   method.
-  #
   #   resource_name_treatment - An enum that specifies how to treat the resource
   #   name formats defined in the field_name_patterns and
   #   response_field_name_patterns fields.
@@ -217,7 +208,6 @@ interfaces:
   #   the call is retrying, refer to retry_params_name instead.
   methods:
   - name: Decrement
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.

--- a/src/test/java/com/google/api/codegen/configgen/testdata/no_path_templates_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/no_path_templates_config.baseline
@@ -75,10 +75,6 @@ interfaces:
   #   required_fields - Fields that are always required for a request to be
   #   valid.
   #
-  #   request_object_method - Turns on or off the generation of a method whose
-  #   sole parameter is a request object. Not all languages will generate this
-  #   method.
-  #
   #   resource_name_treatment - An enum that specifies how to treat the resource
   #   name formats defined in the field_name_patterns and
   #   response_field_name_patterns fields.
@@ -119,7 +115,6 @@ interfaces:
   #   the call is retrying, refer to retry_params_name instead.
   methods:
   - name: Increment
-    request_object_method: false
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
@@ -81,9 +81,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -129,7 +126,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -156,7 +152,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - address
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -176,7 +171,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - address
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -198,7 +192,6 @@ interfaces:
     required_fields:
     - region
     - addressResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -218,7 +211,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -249,7 +241,6 @@ interfaces:
     - address
     - region
     - addressResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -271,7 +262,6 @@ interfaces:
     required_fields:
     - address
     - addressResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -331,9 +321,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -379,7 +366,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -406,7 +392,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -426,7 +411,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - dummyObject
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -374,7 +374,7 @@ public class LibraryClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final Shelf createShelf(CreateShelfRequest request) {
+  public final Shelf createShelf(CreateShelfRequest request) {
     return createShelfCallable().call(request);
   }
 
@@ -592,7 +592,7 @@ public class LibraryClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final ListShelvesPagedResponse listShelves(ListShelvesRequest request) {
+  public final ListShelvesPagedResponse listShelves(ListShelvesRequest request) {
     return listShelvesPagedCallable()
         .call(request);
   }
@@ -710,7 +710,7 @@ public class LibraryClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final void deleteShelf(DeleteShelfRequest request) {
+  public final void deleteShelf(DeleteShelfRequest request) {
     deleteShelfCallable().call(request);
   }
 
@@ -1077,7 +1077,7 @@ public class LibraryClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final Book getBook(GetBookRequest request) {
+  public final Book getBook(GetBookRequest request) {
     return getBookCallable().call(request);
   }
 
@@ -1308,7 +1308,7 @@ public class LibraryClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final void deleteBook(DeleteBookRequest request) {
+  public final void deleteBook(DeleteBookRequest request) {
     deleteBookCallable().call(request);
   }
 
@@ -1697,7 +1697,7 @@ public class LibraryClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final ListStringsPagedResponse listStrings(ListStringsRequest request) {
+  public final ListStringsPagedResponse listStrings(ListStringsRequest request) {
     return listStringsPagedCallable()
         .call(request);
   }
@@ -1913,7 +1913,7 @@ public class LibraryClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final BookFromArchive getBookFromArchive(GetBookFromArchiveRequest request) {
+  public final BookFromArchive getBookFromArchive(GetBookFromArchiveRequest request) {
     return getBookFromArchiveCallable().call(request);
   }
 
@@ -2014,7 +2014,7 @@ public class LibraryClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final BookFromAnywhere getBookFromAnywhere(GetBookFromAnywhereRequest request) {
+  public final BookFromAnywhere getBookFromAnywhere(GetBookFromAnywhereRequest request) {
     return getBookFromAnywhereCallable().call(request);
   }
 
@@ -2107,7 +2107,7 @@ public class LibraryClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final BookFromAnywhere getBookFromAbsolutelyAnywhere(GetBookFromAbsolutelyAnywhereRequest request) {
+  public final BookFromAnywhere getBookFromAbsolutelyAnywhere(GetBookFromAbsolutelyAnywhereRequest request) {
     return getBookFromAbsolutelyAnywhereCallable().call(request);
   }
 
@@ -2414,7 +2414,7 @@ public class LibraryClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final FindRelatedBooksPagedResponse findRelatedBooks(FindRelatedBooksRequest request) {
+  public final FindRelatedBooksPagedResponse findRelatedBooks(FindRelatedBooksRequest request) {
     return findRelatedBooksPagedCallable()
         .call(request);
   }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -249,7 +249,7 @@ public class NoTemplatesApiServiceClient implements BackgroundResource {
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  private final void increment(IncrementRequest request) {
+  public final void increment(IncrementRequest request) {
     incrementCallable().call(request);
   }
 

--- a/src/test/java/com/google/api/codegen/testsrc/common/longrunning_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/longrunning_gapic.yaml
@@ -57,7 +57,6 @@ interfaces:
         - name
     required_fields:
     - name
-    request_object_method: false
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 60000
@@ -88,7 +87,6 @@ interfaces:
         - name
     required_fields:
     - name
-    request_object_method: false
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 60000

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -107,7 +107,6 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 1000
-    request_object_method: false
     resource_name_treatment: STATIC_TYPES
   - name: GetShelf
     flattening:
@@ -133,7 +132,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 2000
-    request_object_method: true
     field_name_patterns:
       name: shelf
   - name: ListShelves
@@ -149,7 +147,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 3000
-    request_object_method: false
   - name: DeleteShelf
     flattening:
       groups:
@@ -160,7 +157,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 4000
-    request_object_method: false
     resource_name_treatment: STATIC_TYPES
     field_name_patterns:
       name: shelf
@@ -176,7 +172,6 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 5000
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     field_name_patterns:
       name: shelf
@@ -193,7 +188,6 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 6000
-    request_object_method: true
     # Test resource_name_treatment set to NONE with field_name_patterns
     resource_name_treatment: NONE
     field_name_patterns:
@@ -229,7 +223,6 @@ interfaces:
           - edition
           - shelf.name
         subresponse_field: book_names
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     sample_code_init_fields:
     - series_uuid.series_string=foobar
@@ -298,7 +291,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 8000
-    request_object_method: false
     resource_name_treatment: STATIC_TYPES
     field_name_patterns:
       name: book
@@ -331,7 +323,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 10000
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     field_name_patterns:
       name: shelf
@@ -349,7 +340,6 @@ interfaces:
     retry_params_name: default
     timeout_millis: 10000
     # leaving commented out to test the default
-    #request_object_method: false
     resource_name_treatment: STATIC_TYPES
     field_name_patterns:
       name: book
@@ -373,7 +363,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 10000
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     field_name_patterns:
       name: book
@@ -389,7 +378,6 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 10000
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     field_name_patterns:
       name: book
@@ -410,7 +398,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 10000
-    request_object_method: false
     resource_name_treatment: STATIC_TYPES
     field_name_patterns:
       name: "*"
@@ -436,7 +423,6 @@ interfaces:
         batched_field: comments
         discriminator_fields:
           - name
-    request_object_method: true
     # Test resource_name_treatment unset, so using default
     # resource_name_treatment: VALIDATE
     field_name_patterns:
@@ -455,7 +441,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 10000
-    request_object_method: false
     resource_name_treatment: STATIC_TYPES
     field_name_patterns:
       name: archived_book
@@ -471,7 +456,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 10000
-    request_object_method: false
     resource_name_treatment: STATIC_TYPES
     field_name_patterns:
       name: book_oneof
@@ -486,7 +470,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 10000
-    request_object_method: false
     resource_name_treatment: STATIC_TYPES
     field_name_patterns:
       name: book_oneof
@@ -501,7 +484,6 @@ interfaces:
     - name
     - index_name
     - index_map
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     retry_codes_name: idempotent
     retry_params_name: default
@@ -512,7 +494,6 @@ interfaces:
       - index_name="default index"
       - index_map{"default_key"}
   - name: StreamShelves
-    request_object_method: false
     grpc_streaming:
       response:
         resources_field: shelves
@@ -537,7 +518,6 @@ interfaces:
       - calling_forms: ".*"
         value_sets: ".*"
   - name: StreamBooks
-    request_object_method: false
     resource_name_treatment: STATIC_TYPES
     flattening:
       groups:
@@ -578,7 +558,6 @@ interfaces:
     # required_fields makes a difference on sample code.
     required_fields:
     - name
-    request_object_method: false
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 30000
@@ -607,7 +586,6 @@ interfaces:
     # required_fields makes a difference on sample code.
     required_fields:
     - name
-    request_object_method: false
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 30000
@@ -650,7 +628,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 3000
-    request_object_method: false
     resource_name_treatment: STATIC_TYPES
     sample_code_init_fields:
     - names[0]
@@ -692,7 +669,6 @@ interfaces:
     required_fields:
     - resource
     - tag
-    request_object_method: true
     resource_name_treatment: VALIDATE
     retry_codes_name: non_idempotent
     retry_params_name: default
@@ -712,7 +688,6 @@ interfaces:
     required_fields:
     - resource
     - label
-    request_object_method: true
     resource_name_treatment: VALIDATE
     retry_codes_name: non_idempotent
     retry_params_name: default
@@ -733,7 +708,6 @@ interfaces:
         - name
     required_fields:
     - name
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     retry_codes_name: non_idempotent
     retry_params_name: default
@@ -770,7 +744,6 @@ interfaces:
         - name
     required_fields:
     - name
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     retry_codes_name: non_idempotent
     retry_params_name: default
@@ -878,7 +851,6 @@ interfaces:
     - required_repeated_fixed32
     - required_repeated_fixed64
     - required_map
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     retry_codes_name: non_idempotent
     retry_params_name: default

--- a/src/test/java/com/google/api/codegen/testsrc/showcase_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/showcase_gapic.yaml
@@ -74,10 +74,6 @@ interfaces:
   #   required_fields - Fields that are always required for a request to be
   #   valid.
   #
-  #   request_object_method - Turns on or off the generation of a method whose
-  #   sole parameter is a request object. Not all languages will generate this
-  #   method.
-  #
   #   resource_name_treatment - An enum that specifies how to treat the resource
   #   name formats defined in the field_name_patterns and
   #   response_field_name_patterns fields.
@@ -118,7 +114,6 @@ interfaces:
   #   the call is retrying, refer to retry_params_name instead.
   methods:
   - name: Echo
-    request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 60000
@@ -128,17 +123,14 @@ interfaces:
       - parameters:
         - content
         - error
-    request_object_method: false
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 60000
   - name: Collect
-    request_object_method: false
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 60000
   - name: Chat
-    request_object_method: false
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 60000
@@ -149,7 +141,6 @@ interfaces:
         - response_delay
     required_fields:
     - response_delay
-    request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 60000
@@ -161,7 +152,6 @@ interfaces:
         - page_size_override
     required_fields:
     - max_response
-    request_object_method: true
     page_streaming:
       request:
         page_size_field: page_size

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
@@ -36,12 +36,10 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 1000
-    request_object_method: false
   - name: LroMethod
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 1000
-    request_object_method: false
     long_running:
       return_type: google.example.myproto.v1.SimpleResponse
       metadata_type: google.example.myproto.v1.SimpleResponse
@@ -53,7 +51,6 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 1000
-    request_object_method: false
   - name: RetryMethod
     flattening:
       groups:
@@ -64,7 +61,6 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 1000
-    request_object_method: false
   - name: PageStreamMethod
     page_streaming:
       request:
@@ -75,22 +71,18 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 1000
-    request_object_method: false
   - name: ServerStreamMethod
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 1000
-    request_object_method: false
   - name: ClientStreamMethod
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 1000
-    request_object_method: false
   - name: BidiStreamMethod
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 1000
-    request_object_method: false
 - name: google.example.myproto.v1.Guru
   retry_codes_def:
   - name: idempotent


### PR DESCRIPTION
By default, we will generate a public request object method.