### PR TITLE
Remove python comment reformatter logic

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/py/PythonApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonApiMethodParamTransformer.java
@@ -138,6 +138,8 @@ public class PythonApiMethodParamTransformer implements ApiMethodParamTransforme
             messageType = context.getTypeTable().getFullNameForElementType(field);
           }
           docLines.add(
+              // Add a blank line between previous doc lines and this one, to
+              // preserve valid restructuredtext.
               "",
               "If a dict is provided, it must be of the same form as the protobuf",
               String.format(

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonApiMethodParamTransformer.java
@@ -138,6 +138,7 @@ public class PythonApiMethodParamTransformer implements ApiMethodParamTransforme
             messageType = context.getTypeTable().getFullNameForElementType(field);
           }
           docLines.add(
+              "",
               "If a dict is provided, it must be of the same form as the protobuf",
               String.format(
                   "message :class:`%s`",

--- a/src/main/java/com/google/api/codegen/util/py/PythonCommentReformatter.java
+++ b/src/main/java/com/google/api/codegen/util/py/PythonCommentReformatter.java
@@ -14,54 +14,13 @@
  */
 package com.google.api.codegen.util.py;
 
-import com.google.api.codegen.util.CommentPatterns;
 import com.google.api.codegen.util.CommentReformatter;
-import com.google.api.codegen.util.CommentTransformer;
-import com.google.api.codegen.util.LinkPattern;
-import com.google.common.base.Splitter;
 
+// Python comment transformation occurs in the descriptor set, before calling
+// gapic-generator, so this class does not modify the comments at all.
 public class PythonCommentReformatter implements CommentReformatter {
-
-  private CommentTransformer transformer =
-      CommentTransformer.newBuilder()
-          .replace(CommentPatterns.BACK_QUOTE_PATTERN, "``")
-          .transform(LinkPattern.PROTO.toFormat("``$TITLE``"))
-          .transform(LinkPattern.ABSOLUTE.toFormat("`$TITLE <$URL>`_"))
-          .transform(
-              LinkPattern.RELATIVE
-                  .withUrlPrefix(CommentTransformer.CLOUD_URL_PREFIX)
-                  .toFormat("`$TITLE <$URL>`_"))
-          .build();
-
   @Override
   public String reformat(String comment) {
-    boolean inCodeBlock = false;
-    boolean first = true;
-    Iterable<String> lines = Splitter.on("\n").split(comment);
-    StringBuffer sb = new StringBuffer();
-    for (String line : lines) {
-      if (inCodeBlock) {
-        // Code blocks are either empty or indented
-        if (!(line.trim().isEmpty()
-            || CommentPatterns.CODE_BLOCK_PATTERN.matcher(line).matches())) {
-          inCodeBlock = false;
-          line = transformer.transform(line);
-        }
-
-      } else if (CommentPatterns.CODE_BLOCK_PATTERN.matcher(line).matches()) {
-        inCodeBlock = true;
-        line = "::\n\n" + line;
-
-      } else {
-        line = transformer.transform(line);
-      }
-
-      if (!first) {
-        sb.append("\n");
-      }
-      first = false;
-      sb.append(line.replace("\"", "\\\""));
-    }
-    return sb.toString().trim();
+    return comment;
   }
 }

--- a/src/main/java/com/google/api/codegen/util/py/PythonRenderingUtil.java
+++ b/src/main/java/com/google/api/codegen/util/py/PythonRenderingUtil.java
@@ -17,25 +17,9 @@ package com.google.api.codegen.util.py;
 import com.google.api.codegen.util.CommonRenderingUtil;
 import com.google.api.tools.framework.snippet.Doc;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 public class PythonRenderingUtil {
-  public List<String> trimDocs(List<String> docLines) {
-    // TODO (geigerj): "trimming" the docs means we don't support code blocks. Investigate
-    // supporting code blocks here.
-    ImmutableList.Builder<String> trimmedDocLines = ImmutableList.builder();
-    for (int i = 0; i < docLines.size(); ++i) {
-      String line = docLines.get(i).trim();
-      if (line.equals("::")) {
-        ++i;
-      } else {
-        trimmedDocLines.add(line);
-      }
-    }
-    return trimmedDocLines.build();
-  }
-
   public List<String> getDocLines(String text) {
     return CommonRenderingUtil.getDocLines(text);
   }

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -159,7 +159,7 @@
             def {@apiMethod.name}(
                     {@renderMethodParams(apiMethod.methodParams)}):
                 """
-                @join line : util.trimDocs(apiMethod.doc.mainDocLines)
+                @join line : apiMethod.doc.mainDocLines
                     {@line}
                 @end
 

--- a/src/main/resources/com/google/api/codegen/py/transport.snip
+++ b/src/main/resources/com/google/api/codegen/py/transport.snip
@@ -98,7 +98,7 @@
             def {@apiMethod.name}(self):
                 """Return the gRPC stub for {$apiMethod.name}.
 
-                @join line : util.trimDocs(apiMethod.doc.mainDocLines)
+                @join line : apiMethod.doc.mainDocLines
                     {@line}
                 @end
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -233,10 +233,10 @@ public class NoTemplatesApiServiceClient implements BackgroundResource {
   /**
    * Increments something.
    *   Sometimes the comments are indented, but Sphinx doesn't like that. So
-   *  in Python we trim all
-   *      leading
-   *         and trailing
-   *    whitespace.
+   *  in Python we apply a pandoc transformation before the comments
+   *      get
+   *         to gapic-generator, and we don't need
+   *    to do anything here.
    *
    * Sample code:
    * <pre><code>
@@ -257,10 +257,10 @@ public class NoTemplatesApiServiceClient implements BackgroundResource {
   /**
    * Increments something.
    *   Sometimes the comments are indented, but Sphinx doesn't like that. So
-   *  in Python we trim all
-   *      leading
-   *         and trailing
-   *    whitespace.
+   *  in Python we apply a pandoc transformation before the comments
+   *      get
+   *         to gapic-generator, and we don't need
+   *    to do anything here.
    *
    * Sample code:
    * <pre><code>

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -334,10 +334,10 @@ class NoTemplatesApiServiceClient {
   /**
    * Increments something.
    *   Sometimes the comments are indented, but Sphinx doesn't like that. So
-   *  in Python we trim all
-   *      leading
-   *         and trailing
-   *    whitespace.
+   *  in Python we apply a pandoc transformation before the comments
+   *      get
+   *         to gapic-generator, and we don't need
+   *    to do anything here.
    *
    * @param {Object} [request]
    *   The request object that will be sent.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
@@ -190,10 +190,10 @@ class NoTemplatesApiServiceGapicClient
     /**
      * Increments something.
      *   Sometimes the comments are indented, but Sphinx doesn't like that. So
-     *  in Python we trim all
-     *      leading
-     *         and trailing
-     *    whitespace.
+     *  in Python we apply a pandoc transformation before the comments
+     *      get
+     *         to gapic-generator, and we don't need
+     *    to do anything here.
      *
      * Sample code:
      * ```

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -286,7 +286,7 @@ LibraryServiceClient
 
     name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
 
-    # TODO: Initialize ``book``:
+    # TODO: Initialize `book`:
     book = {}
 
     response = client.update_book(name, book)
@@ -714,7 +714,7 @@ LibraryServiceClient
 
     name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
 
-    # TODO: Initialize ``book``:
+    # TODO: Initialize `book`:
     book = {}
 
     response = client.update_book(name, book)
@@ -882,10 +882,10 @@ import enum
 
 class NullValue(enum.IntEnum):
     """
-    ``NullValue`` is a singleton enumeration to represent the null value for the
-    ``Value`` type union.
+    `NullValue` is a singleton enumeration to represent the null value for the
+    `Value` type union.
 
-     The JSON representation for ``NullValue`` is JSON ``null``.
+     The JSON representation for `NullValue` is JSON `null`.
 
     Attributes:
       NULL_VALUE (int): Null value.
@@ -915,7 +915,7 @@ class Book(object):
         """
         Attributes:
           GOOD (int): GOOD enum description
-          BAD (int): Enum description with special characters: <>&\"``'@.
+          BAD (int): Enum description with special characters: <>&"`'@.
         """
         GOOD = 0
         BAD = 1
@@ -1057,16 +1057,16 @@ class LibraryServiceClient(object):
     resources and Book resources in the library. It defines the following
     resource model:
 
-    - The API has a collection of ``Shelf``
+    - The API has a collection of [Shelf][google.example.library.v1.Shelf]
       resources, named ``bookShelves/*``
 
-    - Each Shelf has a collection of ``Book``
-      resources, named ``bookShelves/*/books/*``
+    - Each Shelf has a collection of [Book][google.example.library.v1.Book]
+      resources, named `bookShelves/*/books/*`
 
-    Check out `cloud docs! <https://cloud.google.com/library/example/link>`_.
-    This is `not a cloud link <http://www.google.com>`_.
+    Check out [cloud docs!](/library/example/link).
+    This is [not a cloud link](http://www.google.com).
 
-    Service comment may include special characters: <>&\"``'@.
+    Service comment may include special characters: <>&"`'@.
     """
 
     SERVICE_ADDRESS = 'library-example.googleapis.com:1234'
@@ -1236,14 +1236,14 @@ class LibraryServiceClient(object):
             metadata=None):
         """
         Creates a shelf, and returns the new Shelf.
-        RPC method comment may include special characters: <>&\"``'@.
+        RPC method comment may include special characters: <>&"`'@.
 
         Example:
             >>> from google.cloud.example import library_v1
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> # TODO: Initialize ``shelf``:
+            >>> # TODO: Initialize `shelf`:
             >>> shelf = {}
             >>>
             >>> response = client.create_shelf(shelf)
@@ -1304,7 +1304,7 @@ class LibraryServiceClient(object):
             >>>
             >>> name = client.shelf_path('[SHELF_ID]')
             >>>
-            >>> # TODO: Initialize ``options_``:
+            >>> # TODO: Initialize `options_`:
             >>> options_ = ''
             >>>
             >>> response = client.get_shelf(name, options_)
@@ -1481,8 +1481,8 @@ class LibraryServiceClient(object):
             metadata=None):
         """
         Merges two shelves by adding all books from the shelf named
-        ``other_shelf_name`` to shelf ``name``, and deletes
-        ``other_shelf_name``. Returns the updated shelf.
+        `other_shelf_name` to shelf `name`, and deletes
+        `other_shelf_name`. Returns the updated shelf.
 
         Example:
             >>> from google.cloud.example import library_v1
@@ -1548,7 +1548,7 @@ class LibraryServiceClient(object):
             >>>
             >>> name = client.shelf_path('[SHELF_ID]')
             >>>
-            >>> # TODO: Initialize ``book``:
+            >>> # TODO: Initialize `book`:
             >>> book = {}
             >>>
             >>> response = client.create_book(name, book)
@@ -1621,10 +1621,10 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> # TODO: Initialize ``shelf``:
+            >>> # TODO: Initialize `shelf`:
             >>> shelf = {}
             >>>
-            >>> # TODO: Initialize ``books``:
+            >>> # TODO: Initialize `books`:
             >>> books = []
             >>> series_string = 'foobar'
             >>> series_uuid = {'series_string': series_string}
@@ -1897,7 +1897,7 @@ class LibraryServiceClient(object):
             >>>
             >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
             >>>
-            >>> # TODO: Initialize ``book``:
+            >>> # TODO: Initialize `book`:
             >>> book = {}
             >>>
             >>> response = client.update_book(name, book)
@@ -2332,7 +2332,7 @@ class LibraryServiceClient(object):
             >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
             >>> index_name = 'default index'
             >>>
-            >>> # TODO: Initialize ``index_map_item``:
+            >>> # TODO: Initialize `index_map_item`:
             >>> index_map_item = ''
             >>> index_map = {'default_key': index_map_item}
             >>>
@@ -2438,7 +2438,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> # TODO: Initialize ``name``:
+            >>> # TODO: Initialize `name`:
             >>> name = ''
             >>>
             >>> for element in client.stream_books(name):
@@ -2497,7 +2497,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> # TODO: Initialize ``name``:
+            >>> # TODO: Initialize `name`:
             >>> name = ''
             >>> request = {'name': name}
             >>>
@@ -2556,7 +2556,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> # TODO: Initialize ``name``:
+            >>> # TODO: Initialize `name`:
             >>> name = ''
             >>> request = {'name': name}
             >>>
@@ -2611,11 +2611,11 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> # TODO: Initialize ``names_element``:
+            >>> # TODO: Initialize `names_element`:
             >>> names_element = ''
             >>> names = [names_element]
             >>>
-            >>> # TODO: Initialize ``shelves``:
+            >>> # TODO: Initialize `shelves`:
             >>> shelves = []
             >>>
             >>> # Iterate over all results
@@ -2703,7 +2703,7 @@ class LibraryServiceClient(object):
             >>>
             >>> resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
             >>>
-            >>> # TODO: Initialize ``tag``:
+            >>> # TODO: Initialize `tag`:
             >>> tag = ''
             >>>
             >>> response = client.add_tag(resource, tag)
@@ -2764,7 +2764,7 @@ class LibraryServiceClient(object):
             >>>
             >>> resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
             >>>
-            >>> # TODO: Initialize ``label``:
+            >>> # TODO: Initialize `label`:
             >>> label = ''
             >>>
             >>> response = client.add_label(resource, label)
@@ -3016,91 +3016,91 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> # TODO: Initialize ``required_singular_int32``:
+            >>> # TODO: Initialize `required_singular_int32`:
             >>> required_singular_int32 = 0
             >>>
-            >>> # TODO: Initialize ``required_singular_int64``:
+            >>> # TODO: Initialize `required_singular_int64`:
             >>> required_singular_int64 = 0
             >>>
-            >>> # TODO: Initialize ``required_singular_float``:
+            >>> # TODO: Initialize `required_singular_float`:
             >>> required_singular_float = 0.0
             >>>
-            >>> # TODO: Initialize ``required_singular_double``:
+            >>> # TODO: Initialize `required_singular_double`:
             >>> required_singular_double = 0.0
             >>>
-            >>> # TODO: Initialize ``required_singular_bool``:
+            >>> # TODO: Initialize `required_singular_bool`:
             >>> required_singular_bool = False
             >>>
-            >>> # TODO: Initialize ``required_singular_enum``:
+            >>> # TODO: Initialize `required_singular_enum`:
             >>> required_singular_enum = enums.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO
             >>>
-            >>> # TODO: Initialize ``required_singular_string``:
+            >>> # TODO: Initialize `required_singular_string`:
             >>> required_singular_string = ''
             >>>
-            >>> # TODO: Initialize ``required_singular_bytes``:
+            >>> # TODO: Initialize `required_singular_bytes`:
             >>> required_singular_bytes = b''
             >>>
-            >>> # TODO: Initialize ``required_singular_message``:
+            >>> # TODO: Initialize `required_singular_message`:
             >>> required_singular_message = {}
             >>>
-            >>> # TODO: Initialize ``required_singular_resource_name``:
+            >>> # TODO: Initialize `required_singular_resource_name`:
             >>> required_singular_resource_name = ''
             >>>
-            >>> # TODO: Initialize ``required_singular_resource_name_oneof``:
+            >>> # TODO: Initialize `required_singular_resource_name_oneof`:
             >>> required_singular_resource_name_oneof = ''
             >>>
-            >>> # TODO: Initialize ``required_singular_resource_name_common``:
+            >>> # TODO: Initialize `required_singular_resource_name_common`:
             >>> required_singular_resource_name_common = ''
             >>>
-            >>> # TODO: Initialize ``required_singular_fixed32``:
+            >>> # TODO: Initialize `required_singular_fixed32`:
             >>> required_singular_fixed32 = 0
             >>>
-            >>> # TODO: Initialize ``required_singular_fixed64``:
+            >>> # TODO: Initialize `required_singular_fixed64`:
             >>> required_singular_fixed64 = 0
             >>>
-            >>> # TODO: Initialize ``required_repeated_int32``:
+            >>> # TODO: Initialize `required_repeated_int32`:
             >>> required_repeated_int32 = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_int64``:
+            >>> # TODO: Initialize `required_repeated_int64`:
             >>> required_repeated_int64 = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_float``:
+            >>> # TODO: Initialize `required_repeated_float`:
             >>> required_repeated_float = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_double``:
+            >>> # TODO: Initialize `required_repeated_double`:
             >>> required_repeated_double = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_bool``:
+            >>> # TODO: Initialize `required_repeated_bool`:
             >>> required_repeated_bool = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_enum``:
+            >>> # TODO: Initialize `required_repeated_enum`:
             >>> required_repeated_enum = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_string``:
+            >>> # TODO: Initialize `required_repeated_string`:
             >>> required_repeated_string = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_bytes``:
+            >>> # TODO: Initialize `required_repeated_bytes`:
             >>> required_repeated_bytes = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_message``:
+            >>> # TODO: Initialize `required_repeated_message`:
             >>> required_repeated_message = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_resource_name``:
+            >>> # TODO: Initialize `required_repeated_resource_name`:
             >>> required_repeated_resource_name = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_resource_name_oneof``:
+            >>> # TODO: Initialize `required_repeated_resource_name_oneof`:
             >>> required_repeated_resource_name_oneof = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_resource_name_common``:
+            >>> # TODO: Initialize `required_repeated_resource_name_common`:
             >>> required_repeated_resource_name_common = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_fixed32``:
+            >>> # TODO: Initialize `required_repeated_fixed32`:
             >>> required_repeated_fixed32 = []
             >>>
-            >>> # TODO: Initialize ``required_repeated_fixed64``:
+            >>> # TODO: Initialize `required_repeated_fixed64`:
             >>> required_repeated_fixed64 = []
             >>>
-            >>> # TODO: Initialize ``required_map``:
+            >>> # TODO: Initialize `required_map`:
             >>> required_map = {}
             >>>
             >>> response = client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
@@ -3551,7 +3551,7 @@ class LibraryServiceGrpcTransport(object):
         """Return the gRPC stub for {$apiMethod.name}.
 
         Creates a shelf, and returns the new Shelf.
-        RPC method comment may include special characters: <>&\"``'@.
+        RPC method comment may include special characters: <>&"`'@.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -3604,8 +3604,8 @@ class LibraryServiceGrpcTransport(object):
         """Return the gRPC stub for {$apiMethod.name}.
 
         Merges two shelves by adding all books from the shelf named
-        ``other_shelf_name`` to shelf ``name``, and deletes
-        ``other_shelf_name``. Returns the updated shelf.
+        `other_shelf_name` to shelf `name`, and deletes
+        `other_shelf_name`. Returns the updated shelf.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -4419,7 +4419,7 @@ def sample_publish_series(name, edition):
 
   shelf = {'name': name}
 
-  # TODO: Initialize ``books``:
+  # TODO: Initialize `books`:
   books = []
   series_string = 'xyz3141592654'
   series_uuid = {'series_string': series_string}
@@ -4481,13 +4481,13 @@ def sample_publish_series():
 
   client = library_v1.LibraryServiceClient()
 
-  # TODO: Initialize ``shelf``:
+  # TODO: Initialize `shelf`:
   shelf = {}
 
-  # TODO: Initialize ``books``:
+  # TODO: Initialize `books`:
   books = []
 
-  # TODO: Initialize ``series_uuid``:
+  # TODO: Initialize `series_uuid`:
   series_uuid = {}
   edition = 2
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -1250,6 +1250,7 @@ class LibraryServiceClient(object):
 
         Args:
             shelf (Union[dict, ~google.cloud.example.library_v1.types.Shelf]): The shelf to create.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.Shelf`
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
@@ -1313,9 +1314,11 @@ class LibraryServiceClient(object):
             name (str): The name of the shelf to retrieve.
             options_ (str): To test 'options' parameter name conflict.
             message (Union[dict, ~google.cloud.example.library_v1.types.SomeMessage]): Field to verify that message-type query parameter gets flattened.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.SomeMessage`
-            string_builder (Union[dict, ~google.cloud.example.library_v1.types.StringBuilder]): If a dict is provided, it must be of the same form as the protobuf
+            string_builder (Union[dict, ~google.cloud.example.library_v1.types.StringBuilder]):
+                If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.StringBuilder`
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will not
@@ -1556,6 +1559,7 @@ class LibraryServiceClient(object):
         Args:
             name (str): The name of the shelf in which the book is created.
             book (Union[dict, ~google.cloud.example.library_v1.types.Book]): The book to create.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.Book`
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
@@ -1633,12 +1637,15 @@ class LibraryServiceClient(object):
 
         Args:
             shelf (Union[dict, ~google.cloud.example.library_v1.types.Shelf]): The shelf in which the series is created.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.Shelf`
             books (list[Union[dict, ~google.cloud.example.library_v1.types.Book]]): The books to publish in the series.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.Book`
             series_uuid (Union[dict, ~google.cloud.example.library_v1.types.SeriesUuid]): Uniquely identifies the series to the publishing house.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.SeriesUuid`
             edition (int): The edition of the series
@@ -1905,13 +1912,16 @@ class LibraryServiceClient(object):
         Args:
             name (str): The name of the book to update.
             book (Union[dict, ~google.cloud.example.library_v1.types.Book]): The book to update with.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.Book`
             optional_foo (str): An optional foo.
             update_mask (Union[dict, ~google.cloud.example.library_v1.types.FieldMask]): A field mask to apply, rendered as an HTTP parameter.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.FieldMask`
             physical_mask (Union[dict, ~google.cloud.example.library_v1.types.FieldMask]): To test Python import clash resolution.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.FieldMask`
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
@@ -2116,7 +2126,8 @@ class LibraryServiceClient(object):
 
         Args:
             name (str)
-            comments (list[Union[dict, ~google.cloud.example.library_v1.types.Comment]]): If a dict is provided, it must be of the same form as the protobuf
+            comments (list[Union[dict, ~google.cloud.example.library_v1.types.Comment]]):
+                If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.Comment`
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will not
@@ -3114,7 +3125,8 @@ class LibraryServiceClient(object):
             required_singular_enum (~google.cloud.example.library_v1.types.InnerEnum)
             required_singular_string (str)
             required_singular_bytes (bytes)
-            required_singular_message (Union[dict, ~google.cloud.example.library_v1.types.InnerMessage]): If a dict is provided, it must be of the same form as the protobuf
+            required_singular_message (Union[dict, ~google.cloud.example.library_v1.types.InnerMessage]):
+                If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.InnerMessage`
             required_singular_resource_name (str)
             required_singular_resource_name_oneof (str)
@@ -3129,7 +3141,8 @@ class LibraryServiceClient(object):
             required_repeated_enum (list[~google.cloud.example.library_v1.types.InnerEnum])
             required_repeated_string (list[str])
             required_repeated_bytes (list[bytes])
-            required_repeated_message (list[Union[dict, ~google.cloud.example.library_v1.types.InnerMessage]]): If a dict is provided, it must be of the same form as the protobuf
+            required_repeated_message (list[Union[dict, ~google.cloud.example.library_v1.types.InnerMessage]]):
+                If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.InnerMessage`
             required_repeated_resource_name (list[str])
             required_repeated_resource_name_oneof (list[str])
@@ -3145,7 +3158,8 @@ class LibraryServiceClient(object):
             optional_singular_enum (~google.cloud.example.library_v1.types.InnerEnum)
             optional_singular_string (str)
             optional_singular_bytes (bytes)
-            optional_singular_message (Union[dict, ~google.cloud.example.library_v1.types.InnerMessage]): If a dict is provided, it must be of the same form as the protobuf
+            optional_singular_message (Union[dict, ~google.cloud.example.library_v1.types.InnerMessage]):
+                If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.InnerMessage`
             optional_singular_resource_name (str)
             optional_singular_resource_name_oneof (str)
@@ -3160,7 +3174,8 @@ class LibraryServiceClient(object):
             optional_repeated_enum (list[~google.cloud.example.library_v1.types.InnerEnum])
             optional_repeated_string (list[str])
             optional_repeated_bytes (list[bytes])
-            optional_repeated_message (list[Union[dict, ~google.cloud.example.library_v1.types.InnerMessage]]): If a dict is provided, it must be of the same form as the protobuf
+            optional_repeated_message (list[Union[dict, ~google.cloud.example.library_v1.types.InnerMessage]]):
+                If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.InnerMessage`
             optional_repeated_resource_name (list[str])
             optional_repeated_resource_name_oneof (list[str])

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -930,10 +930,10 @@ class NoTemplatesAPIServiceClient(object):
         """
         Increments something.
           Sometimes the comments are indented, but Sphinx doesn't like that. So
-         in Python we trim all
-             leading
-                and trailing
-           whitespace.
+         in Python we apply a pandoc transformation before the comments
+             get
+                to gapic-generator, and we don't need
+           to do anything here.
 
         Example:
             >>> import example
@@ -1104,10 +1104,10 @@ class NoTemplatesApiServiceGrpcTransport(object):
 
         Increments something.
           Sometimes the comments are indented, but Sphinx doesn't like that. So
-         in Python we trim all
-             leading
-                and trailing
-           whitespace.
+         in Python we apply a pandoc transformation before the comments
+             get
+                to gapic-generator, and we don't need
+           to do anything here.
 
         Returns:
             Callable: A callable which accepts the appropriate

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -929,11 +929,11 @@ class NoTemplatesAPIServiceClient(object):
             metadata=None):
         """
         Increments something.
-        Sometimes the comments are indented, but Sphinx doesn't like that. So
-        in Python we trim all
-        leading
-        and trailing
-        whitespace.
+          Sometimes the comments are indented, but Sphinx doesn't like that. So
+         in Python we trim all
+             leading
+                and trailing
+           whitespace.
 
         Example:
             >>> import example
@@ -1103,11 +1103,11 @@ class NoTemplatesApiServiceGrpcTransport(object):
         """Return the gRPC stub for {$apiMethod.name}.
 
         Increments something.
-        Sometimes the comments are indented, but Sphinx doesn't like that. So
-        in Python we trim all
-        leading
-        and trailing
-        whitespace.
+          Sometimes the comments are indented, but Sphinx doesn't like that. So
+         in Python we trim all
+             leading
+                and trailing
+           whitespace.
 
         Returns:
             Callable: A callable which accepts the appropriate

--- a/src/test/java/com/google/api/codegen/testsrc/common/no_path_templates.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/no_path_templates.proto
@@ -16,10 +16,10 @@ service NoTemplatesAPIService {
 
   // Increments something.
   //   Sometimes the comments are indented, but Sphinx doesn't like that. So
-  //  in Python we trim all
-  //      leading
-  //         and trailing
-  //    whitespace.
+  //  in Python we apply a pandoc transformation before the comments
+  //      get
+  //         to gapic-generator, and we don't need
+  //    to do anything here.
   rpc Increment(IncrementRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = { post: "/v1/me:increment" body: "*" };
   }

--- a/src/test/java/com/google/api/codegen/util/ProtoDocumentLinkTest.java
+++ b/src/test/java/com/google/api/codegen/util/ProtoDocumentLinkTest.java
@@ -15,7 +15,6 @@
 package com.google.api.codegen.util;
 
 import com.google.api.codegen.util.js.JSCommentReformatter;
-import com.google.api.codegen.util.py.PythonCommentReformatter;
 import com.google.api.codegen.util.ruby.RubyCommentReformatter;
 import com.google.common.truth.Truth;
 import java.util.regex.Matcher;
@@ -70,27 +69,6 @@ public class ProtoDocumentLinkTest {
         .isEqualTo("[not a cloud link](http://www.google.com)");
     Truth.assertThat(commentReformatter.reformat("[not a cloud link](http://www.google.com$)"))
         .isEqualTo("[not a cloud link](http://www.google.com$)");
-  }
-
-  @Test
-  public void testPythonCommentReformater() {
-    PythonCommentReformatter commentReformatter = new PythonCommentReformatter();
-    Truth.assertThat(commentReformatter.reformat("[Shelf][google.example.library.v1.Shelf]"))
-        .isEqualTo("``Shelf``");
-    Truth.assertThat(commentReformatter.reformat("[$Shelf][google.example.library.v1.Shelf]"))
-        .isEqualTo("``$Shelf``");
-
-    // Cloud link may contain special character '$'
-    Truth.assertThat(commentReformatter.reformat("[cloud docs!](/library/example/link)"))
-        .isEqualTo("`cloud docs! <https://cloud.google.com/library/example/link>`_");
-    Truth.assertThat(commentReformatter.reformat("[cloud docs!](/library/example/link$)"))
-        .isEqualTo("`cloud docs! <https://cloud.google.com/library/example/link$>`_");
-
-    // Absolute link may contain special character '$'
-    Truth.assertThat(commentReformatter.reformat("[not a cloud link](http://www.google.com)"))
-        .isEqualTo("`not a cloud link <http://www.google.com>`_");
-    Truth.assertThat(commentReformatter.reformat("[not a cloud link](http://www.google.com$)"))
-        .isEqualTo("`not a cloud link <http://www.google.com$>`_");
   }
 
   @Test


### PR DESCRIPTION
Python will rely on comment transformation being done in artman, as per this PR: https://github.com/googleapis/artman/pull/499

These two PRs should be merged/released together.