### PR TITLE
Minimize semantic differences between library.proto and library_gapic.yaml

### DIFF
--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
@@ -47,7 +47,7 @@ option (google.api.metadata) = {
 // Service comment may include special characters: <>&"`'@.
 //
 service LibraryService {
-  option (google.api.default_host) = "library-example.googleapis.com";
+  option (google.api.default_host) = "library-example.googleapis.com:1234";
   option (google.api.oauth) = {
     scopes: ["https://www.googleapis.com/auth/library",
       "https://www.googleapis.com/auth/cloud-platform"]
@@ -67,15 +67,19 @@ service LibraryService {
     option (google.api.http) = { get: "/v1/{name=bookShelves/*}" };
     option (google.api.method_signature) = {
       fields: ["name"]
-      additional_signatures: [{
-        fields: ["name", "message"]
-      }]
+      additional_signatures: [
+        {fields: ["name", "message"]},
+        {fields: ["name", "message", "string_builder"]}
+      ]
     };
   }
 
   // Lists shelves.
   rpc ListShelves(ListShelvesRequest) returns (ListShelvesResponse) {
     option (google.api.http) = { get: "/v1/bookShelves" };
+    option (google.api.method_signature) = {
+      fields: []
+    };
   }
 
   // Deletes a shelf.
@@ -111,7 +115,7 @@ service LibraryService {
   rpc PublishSeries(PublishSeriesRequest) returns (PublishSeriesResponse) {
     option (google.api.http) = { post: "/v1:publish" body: "*" };
     option (google.api.method_signature) = {
-      fields: ["shelf", "books"]
+      fields: ["shelf", "books", "edition", "series_uuid"]
     };
   }
 
@@ -127,7 +131,7 @@ service LibraryService {
   rpc ListBooks(ListBooksRequest) returns (ListBooksResponse) {
     option (google.api.http) = { get: "/v1/{name=bookShelves/*}/books" };
     option (google.api.method_signature) = {
-      fields: ["name"]
+      fields: ["name", "filter"]
     };
   }
 
@@ -143,7 +147,15 @@ service LibraryService {
   rpc UpdateBook(UpdateBookRequest) returns (Book) {
     option (google.api.http) = { put: "/v1/{name=bookShelves/*/books/*}" body: "book" };
     option (google.api.method_signature) = {
-      fields: ["name", "book", "update_mask"]
+      fields: ["name", "book"]
+      function_name: "update_book_1"
+      additional_signatures: [{
+        fields: ["name", "optional_foo", "book", "update_mask", "physical_mask"]
+        function_name: "update_book_2"}
+      ]
+    };
+    option (google.api.retry) = {
+      codes: [UNAVAILABLE, DEADLINE_EXCEEDED]
     };
   }
 
@@ -159,7 +171,10 @@ service LibraryService {
   rpc ListStrings(ListStringsRequest) returns (ListStringsResponse) {
     option (google.api.http) = { get: "/v1/strings" };
     option (google.api.method_signature) = {
-      fields: ["name"]
+      fields: []
+      additional_signatures: [
+        {fields: ["name"]}
+      ]
     };
   }
 
@@ -185,7 +200,7 @@ service LibraryService {
   rpc GetBookFromAnywhere(GetBookFromAnywhereRequest) returns (BookFromAnywhere) {
     option (google.api.http) = { get: "/v1/{name=archives/*/books/**}"};
     option (google.api.method_signature) = {
-      fields: ["name"]
+      fields: ["name", "alt_book_name"]
     };
   }
 
@@ -242,7 +257,7 @@ service LibraryService {
   rpc FindRelatedBooks(FindRelatedBooksRequest) returns (FindRelatedBooksResponse) {
     option (google.api.http) = { get: "/v1/bookShelves" };
     option (google.api.method_signature) = {
-      fields: ["names"]
+      fields: ["names", "shelves"]
     };
   }
 
@@ -280,6 +295,74 @@ service LibraryService {
   // Test optional flattening parameters of all types
   rpc TestOptionalRequiredFlatteningParams(TestOptionalRequiredFlatteningParamsRequest) returns (TestOptionalRequiredFlatteningParamsResponse) {
     option (google.api.http) = { post: "/v1/testofp" body: "*" };
+    option (google.api.method_signature) = {
+      fields: []
+      additional_signatures: {
+        fields: [
+          "required_singular_int32",
+          "required_singular_int64",
+          "required_singular_float",
+          "required_singular_double",
+          "required_singular_bool",
+          "required_singular_enum",
+          "required_singular_string",
+          "required_singular_bytes",
+          "required_singular_message",
+          "required_singular_resource_name",
+          "required_singular_resource_name_oneof",
+          "required_singular_resource_name_common",
+          "required_singular_fixed32",
+          "required_singular_fixed64",
+          "required_repeated_int32",
+          "required_repeated_int64",
+          "required_repeated_float",
+          "required_repeated_double",
+          "required_repeated_bool",
+          "required_repeated_enum",
+          "required_repeated_string",
+          "required_repeated_bytes",
+          "required_repeated_message",
+          "required_repeated_resource_name",
+          "required_repeated_resource_name_oneof",
+          "required_repeated_resource_name_common",
+          "required_repeated_fixed32",
+          "required_repeated_fixed64",
+          "required_map",
+          "optional_singular_int32",
+          "optional_singular_int64",
+          "optional_singular_float",
+          "optional_singular_double",
+          "optional_singular_bool",
+          "optional_singular_enum",
+          "optional_singular_string",
+          "optional_singular_bytes",
+          "optional_singular_message",
+          "optional_singular_resource_name",
+          "optional_singular_resource_name_oneof",
+          "optional_singular_resource_name_common",
+          "optional_singular_fixed32",
+          "optional_singular_fixed64",
+          "optional_repeated_int32",
+          "optional_repeated_int64",
+          "optional_repeated_float",
+          "optional_repeated_double",
+          "optional_repeated_bool",
+          "optional_repeated_enum",
+          "optional_repeated_string",
+          "optional_repeated_bytes",
+          "optional_repeated_message",
+          "optional_repeated_resource_name",
+          "optional_repeated_resource_name_oneof",
+          "optional_repeated_resource_name_common",
+          "optional_repeated_fixed32",
+          "optional_repeated_fixed64",
+          "optional_map"]
+      }
+    };
+    option (google.longrunning.operation_types) = {
+      response: "google.example.library.v1.Book"
+      metadata: "google.example.library.v1.GetBigBookMetadata"
+    };
   }
 }
 
@@ -291,7 +374,15 @@ message Book {
   // Message field comment may include special characters: <>&"`'@.
   string name = 1 [
     (google.api.required) = true,
-    (google.api.resource).path = "shelves/*/books/*"];
+    (google.api.resource_set) = {
+      base_name: "book_oneof"
+      resources: [
+        {base_name: "book"             path : "shelves/*/books/*"},
+        {base_name: "archived_book"    path : "archives/*/books/*"},
+        {base_name: "deleted_book"     path : "_deleted-book_"}
+      ]
+    }
+  ];
 
   // The name of the book author.
   string author = 2;
@@ -354,6 +445,7 @@ message BookFromArchive {
   // Book names have the form `archives/{archive_id}/books/{book_id}`.
   string name = 1 [
     (google.api.required) = true,
+    // TODO(andrealin): Make this refer only to the archived_book path.
     (google.api.resource_type) = "google.example.library.v1.Book"];
 
   // The name of the book author.
@@ -411,10 +503,10 @@ message SomeMessage2 {
 // A Shelf contains a collection of books with a theme.
 message Shelf {
   // The resource name of the shelf.
-  // Shelf names have the form `bookShelves/{shelf_id}`.
+  // Shelf names have the form `shelves/{shelf_id}`.
   string name = 1 [
     (google.api.required) = true,
-    (google.api.resource).path = "bookShelves/*"];
+    (google.api.resource).path = "shelves/*"];
 
   // The theme of the shelf
   string theme = 2;
@@ -427,8 +519,7 @@ message Shelf {
 message CreateShelfRequest {
   // The shelf to create.
   Shelf shelf = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.required) = true];
 }
 
 // Request message for LibraryService.GetShelf.
@@ -444,7 +535,8 @@ message GetShelfRequest {
   StringBuilder string_builder = 3;
 
   // To test 'options' parameter name conflict.
-  string options = 4;
+  string options = 4 [
+    (google.api.required) = true];
 }
 
 
@@ -465,8 +557,7 @@ message ListShelvesRequest {
 // Response message for LibraryService.ListShelves.
 message ListShelvesResponse {
   // The list of shelves.
-  repeated Shelf shelves = 1 [
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+  repeated Shelf shelves = 1;
 
   // A token to retrieve next page of results.
   // Pass this value in the
@@ -529,8 +620,7 @@ message PublishSeriesRequest {
 
   // The books to publish in the series.
   repeated Book books = 2 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.required) = true];
 
   oneof versioning {
     // The edition of the series
@@ -541,7 +631,8 @@ message PublishSeriesRequest {
   }
 
   // Uniquely identifies the series to the publishing house.
-  SeriesUuid series_uuid = 5;
+  SeriesUuid series_uuid = 5 [
+    (google.api.required) = true];
 }
 
 message SeriesUuid {
@@ -555,8 +646,7 @@ message SeriesUuid {
 message PublishSeriesResponse {
   // The names of the books in the series that were published
   repeated string book_names = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.required) = true];
   SeriesUuid series_uuid = 2;
 }
 
@@ -565,6 +655,7 @@ message GetBookRequest {
   // The name of the book to retrieve.
   string name = 1 [
     (google.api.required) = true,
+    // TODO(andrealin): Make this refer only to the book resource.
     (google.api.resource_type) = "google.example.library.v1.Book"];
 }
 
@@ -592,8 +683,7 @@ message ListBooksRequest {
 // Response message for LibraryService.ListBooks.
 message ListBooksResponse {
   // The list of books.
-  repeated Book books = 1 [
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+  repeated Book books = 1;
 
   // A token to retrieve next page of results.
   // Pass this value in the
@@ -607,8 +697,7 @@ message ListBooksResponse {
 message StreamBooksRequest {
   // The name of the shelf whose books we'd like to list.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.required) = true];
 }
 
 // Request message for LibraryService.UpdateBook.
@@ -616,6 +705,7 @@ message UpdateBookRequest {
   // The name of the book to update.
   string name = 1 [
     (google.api.required) = true,
+    // TODO(andrealin): Make this refer only to the book path.
     (google.api.resource_type) = "google.example.library.v1.Book"];
 
   // An optional foo.
@@ -627,9 +717,7 @@ message UpdateBookRequest {
   ];
 
   // A field mask to apply, rendered as an HTTP parameter.
-  google.protobuf.FieldMask update_mask = 4 [
-    (google.api.required) = true
-  ];
+  google.protobuf.FieldMask update_mask = 4;
 
   // To test Python import clash resolution.
   google.example.library.v1.FieldMask physical_mask = 5;
@@ -640,6 +728,7 @@ message DeleteBookRequest {
   // The name of the book to delete.
   string name = 1 [
     (google.api.required) = true,
+    // TODO(andrealin): Make this refer only to the book path.
     (google.api.resource_type) = "google.example.library.v1.Book"];
 }
 
@@ -671,11 +760,11 @@ message ListStringsResponse {
 message AddCommentsRequest {
   string name = 1 [
     (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Comment"];
+    // TODO(andrealin): Make this refer only to the archived_book path.
+    (google.api.resource_type) = "google.example.library.v1.Book"];
 
   repeated Comment comments = 2 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Comment"];
+    (google.api.required) = true];
 }
 
 message Comment {
@@ -704,6 +793,7 @@ message GetBookFromArchiveRequest {
   // The name of the book to retrieve.
   string name = 1 [
     (google.api.required) = true,
+    // TODO(andrealin): Make this refer only to the archived_book path.
     (google.api.resource_type) = "google.example.library.v1.Book"];
 }
 
@@ -717,6 +807,7 @@ message GetBookFromAnywhereRequest {
   // An alternate book name, used to test restricting flattened field to a
   // single resource name type in a oneof.
   string alt_book_name = 2 [
+    // TODO(andrealin): Make this refer only to the book path.
     (google.api.resource_type) = "google.example.library.v1.Book"];
 }
 
@@ -733,6 +824,7 @@ message UpdateBookIndexRequest {
   // The name of the book to update.
   string name = 1 [
     (google.api.required) = true,
+    // TODO(andrealin): Make this refer only to the book path.
     (google.api.resource_type) = "google.example.library.v1.Book"];
 
   // The name of the index for the book
@@ -749,8 +841,7 @@ message DiscussBookRequest {
   // of the stream and this is not specified, the name in the previous
   // message will be reused.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.required) = true];
 
   // The new comment.
   Comment comment = 2;
@@ -760,8 +851,11 @@ message DiscussBookRequest {
 message FindRelatedBooksRequest {
   repeated string names = 1 [
     (google.api.required) = true,
+    // TODO(andrealin): Make this refer only to the book path.
     (google.api.resource_type) = "google.example.library.v1.Book"];
-  repeated string shelves = 2;
+  repeated string shelves = 2 [
+    (google.api.required) = true,
+    (google.api.resource_type) = "google.example.library.v1.Shelf"];
   int32 page_size = 4;
   string page_token = 5;
 }
@@ -769,6 +863,7 @@ message FindRelatedBooksRequest {
 // Test repeated field with resource name format in page streaming response
 message FindRelatedBooksResponse {
   repeated string names = 1 [
+    // TODO(andrealin): Make this refer only to the book path.
     (google.api.resource_type) = "google.example.library.v1.Book"];
   string next_page_token = 2;
 }
@@ -803,9 +898,16 @@ message TestOptionalRequiredFlatteningParamsRequest {
   string required_singular_string = 7 [(google.api.required) = true];
   bytes required_singular_bytes = 8 [(google.api.required) = true];
   InnerMessage required_singular_message = 9 [(google.api.required) = true];
-  string required_singular_resource_name = 10 [(google.api.required) = true];
-  string required_singular_resource_name_oneof = 11 [(google.api.required) = true];
-  string required_singular_resource_name_common = 14 [(google.api.required) = true];
+  string required_singular_resource_name = 10 [(google.api.required) = true,
+    // TODO(andrealin): Make this refer only to the book path.
+    (google.api.resource_type) = "google.example.library.v1.Book"
+  ];
+  string required_singular_resource_name_oneof = 11 [(google.api.required) = true,
+    (google.api.resource_type) = "google.example.library.v1.Book"
+  ];
+  string required_singular_resource_name_common = 14 [(google.api.required) = true,
+    (google.api.resource_type) = "google.api.Project"
+  ];
   fixed32 required_singular_fixed32 = 12 [(google.api.required) = true];
   fixed64 required_singular_fixed64 = 13 [(google.api.required) = true];
 
@@ -818,9 +920,13 @@ message TestOptionalRequiredFlatteningParamsRequest {
   repeated string required_repeated_string = 27 [(google.api.required) = true];
   repeated bytes required_repeated_bytes = 28 [(google.api.required) = true];
   repeated InnerMessage required_repeated_message = 29 [(google.api.required) = true];
-  repeated string required_repeated_resource_name = 30 [(google.api.required) = true];
-  repeated string required_repeated_resource_name_oneof = 31 [(google.api.required) = true];
-  repeated string required_repeated_resource_name_common = 34 [(google.api.required) = true];
+  repeated string required_repeated_resource_name = 30 [(google.api.required) = true,
+    (google.api.resource_type) = "google.example.library.v1.Book"];
+  repeated string required_repeated_resource_name_oneof = 31 [(google.api.required) = true,
+    (google.api.resource_type) = "google.example.library.v1.Book"];
+  repeated string required_repeated_resource_name_common = 34 [(google.api.required) = true,
+    (google.api.resource_type) = "google.api.Project"
+  ];
   repeated fixed32 required_repeated_fixed32 = 32 [(google.api.required) = true];
   repeated fixed64 required_repeated_fixed64 = 33 [(google.api.required) = true];
 
@@ -835,9 +941,15 @@ message TestOptionalRequiredFlatteningParamsRequest {
   string optional_singular_string = 57;
   bytes optional_singular_bytes = 58;
   InnerMessage optional_singular_message = 59;
-  string optional_singular_resource_name = 60;
-  string optional_singular_resource_name_oneof = 61;
-  string optional_singular_resource_name_common = 64;
+  string optional_singular_resource_name = 60 [
+    (google.api.resource_type) = "google.example.library.v1.Book"
+  ];
+  string optional_singular_resource_name_oneof = 61 [
+    (google.api.resource_type) = "google.example.library.v1.Book"
+  ];
+  string optional_singular_resource_name_common = 64 [
+    (google.api.resource_type) = "google.api.Project"
+  ];
   fixed32 optional_singular_fixed32 = 62;
   fixed64 optional_singular_fixed64 = 63;
 
@@ -850,9 +962,15 @@ message TestOptionalRequiredFlatteningParamsRequest {
   repeated string optional_repeated_string = 77;
   repeated bytes optional_repeated_bytes = 78;
   repeated InnerMessage optional_repeated_message = 79;
-  repeated string optional_repeated_resource_name = 80;
-  repeated string optional_repeated_resource_name_oneof = 81;
-  repeated string optional_repeated_resource_name_common = 84;
+  repeated string optional_repeated_resource_name = 80 [
+    (google.api.resource_type) = "google.example.library.v1.Book"
+  ];
+  repeated string optional_repeated_resource_name_oneof = 81 [
+    (google.api.resource_type) = "google.example.library.v1.Book"
+  ];
+  repeated string optional_repeated_resource_name_common = 84 [
+    (google.api.resource_type) = "google.api.Project"
+  ];
   repeated fixed32 optional_repeated_fixed32 = 82;
   repeated fixed64 optional_repeated_fixed64 = 83;
 

--- a/src/test/java/com/google/api/codegen/util/ProtoParserTest.java
+++ b/src/test/java/com/google/api/codegen/util/ProtoParserTest.java
@@ -29,7 +29,6 @@ import com.google.api.tools.framework.model.ProtoFile;
 import com.google.api.tools.framework.model.testing.TestDataLocator;
 import com.google.longrunning.OperationTypes;
 import com.google.rpc.Code;
-import java.util.Collections;
 import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -151,11 +150,7 @@ public class ProtoParserTest {
   public void testGetRequiredFields() {
     Method publishSeriesMethod = libraryService.lookupMethod("PublishSeries");
     List<String> requiredFields = protoParser.getRequiredFields(publishSeriesMethod);
-    Collections.sort(requiredFields);
-    assertThat(requiredFields.size()).isEqualTo(3);
-    assertThat(requiredFields.get(0)).isEqualTo("books");
-    assertThat(requiredFields.get(1)).isEqualTo("series_uuid");
-    assertThat(requiredFields.get(2)).isEqualTo("shelf");
+    assertThat(requiredFields).containsExactly("books", "series_uuid", "shelf");
   }
 
   @Test
@@ -202,17 +197,17 @@ public class ProtoParserTest {
 
     MethodSignature additionalSignature2 = getShelfFlattenings.get(2);
     assertThat(additionalSignature2.getFieldsList().size()).isEqualTo(3);
-    assertThat(additionalSignature2.getFieldsList().get(0)).isEqualTo("name");
-    assertThat(additionalSignature2.getFieldsList().get(1)).isEqualTo("message");
-    assertThat(additionalSignature2.getFieldsList().get(2)).isEqualTo("string_builder");
+    assertThat(additionalSignature2.getFieldsList())
+        .containsExactly("name", "message", "string_builder");
   }
 
   /** The OAuth scopes for this service (e.g. "https://cloud.google.com/auth/cloud-platform"). */
   @Test
   public void testGetAuthScopes() {
     List<String> scopes = protoParser.getAuthScopes(libraryService);
-    assertThat(scopes.size()).isEqualTo(2);
-    assertThat(scopes.get(0)).isEqualTo("https://www.googleapis.com/auth/library");
-    assertThat(scopes.get(1)).isEqualTo("https://www.googleapis.com/auth/cloud-platform");
+    assertThat(scopes)
+        .containsExactly(
+            "https://www.googleapis.com/auth/library",
+            "https://www.googleapis.com/auth/cloud-platform");
   }
 }

--- a/src/test/java/com/google/api/codegen/util/ProtoParserTest.java
+++ b/src/test/java/com/google/api/codegen/util/ProtoParserTest.java
@@ -43,11 +43,11 @@ public class ProtoParserTest {
   private static Model model;
   private static TestDataLocator testDataLocator;
   private static ProtoFile libraryProtoFile;
-  private static Field bookNameField;
+  private static Field shelfNameField;
   private static Interface libraryService;
   private static Method deleteShelfMethod;
   private static Method getBigBookMethod;
-  private static MessageType book;
+  private static MessageType shelf;
 
   // Object under test.
   private static ProtoParser protoParser = new ProtoParser();
@@ -70,15 +70,18 @@ public class ProtoParserTest {
             .get();
 
     model.addRoot(libraryProtoFile);
-    book =
+
+    libraryService = libraryProtoFile.getInterfaces().get(0);
+
+    shelf =
         libraryProtoFile
             .getMessages()
             .stream()
-            .filter(m -> m.getSimpleName().equals("Book"))
+            .filter(m -> m.getSimpleName().equals("Shelf"))
             .findFirst()
             .get();
-    bookNameField =
-        book.getFields().stream().filter(f -> f.getSimpleName().equals("name")).findFirst().get();
+    shelfNameField =
+        shelf.getFields().stream().filter(f -> f.getSimpleName().equals("name")).findFirst().get();
 
     libraryService = libraryProtoFile.getInterfaces().get(0);
     deleteShelfMethod = libraryService.lookupMethod("DeleteShelf");
@@ -87,11 +90,20 @@ public class ProtoParserTest {
 
   @Test
   public void testGetResourcePath() {
-    assertThat(protoParser.getResourcePath(bookNameField)).isEqualTo("shelves/*/books/*");
+    Field shelfNameField =
+        shelf.getFields().stream().filter(f -> f.getSimpleName().equals("name")).findFirst().get();
+    assertThat(protoParser.getResourcePath(shelfNameField)).isEqualTo("shelves/*");
   }
 
   @Test
   public void testGetEmptyResourcePath() {
+    MessageType book =
+        libraryProtoFile
+            .getMessages()
+            .stream()
+            .filter(m -> m.getSimpleName().equals("Book"))
+            .findFirst()
+            .get();
     Field authorBookField =
         book.getFields().stream().filter(f -> f.getSimpleName().equals("author")).findFirst().get();
     assertThat(protoParser.getResourcePath(authorBookField)).isNull();
@@ -100,7 +112,7 @@ public class ProtoParserTest {
   /** Return the entity name, e.g. "shelf" for a resource field. */
   @Test
   public void getResourceEntityName() {
-    assertThat(protoParser.getResourceEntityName(bookNameField)).isEqualTo("book");
+    assertThat(protoParser.getResourceEntityName(shelfNameField)).isEqualTo("shelf");
   }
 
   @Test
@@ -132,7 +144,7 @@ public class ProtoParserTest {
   @Test
   public void testGetServiceAddress() {
     String defaultHost = protoParser.getServiceAddress(libraryService);
-    assertThat(defaultHost).isEqualTo("library-example.googleapis.com");
+    assertThat(defaultHost).isEqualTo("library-example.googleapis.com:1234");
   }
 
   @Test
@@ -140,25 +152,26 @@ public class ProtoParserTest {
     Method publishSeriesMethod = libraryService.lookupMethod("PublishSeries");
     List<String> requiredFields = protoParser.getRequiredFields(publishSeriesMethod);
     Collections.sort(requiredFields);
-    assertThat(requiredFields.size()).isEqualTo(2);
+    assertThat(requiredFields.size()).isEqualTo(3);
     assertThat(requiredFields.get(0)).isEqualTo("books");
-    assertThat(requiredFields.get(1)).isEqualTo("shelf");
+    assertThat(requiredFields.get(1)).isEqualTo("series_uuid");
+    assertThat(requiredFields.get(2)).isEqualTo("shelf");
   }
 
   @Test
   public void testGetResourceType() {
-    MessageType listShelvesResponse =
+    MessageType getShelfRequest =
         libraryProtoFile
             .getMessages()
             .stream()
-            .filter(m -> m.getSimpleName().equals("ListShelvesResponse"))
+            .filter(m -> m.getSimpleName().equals("GetShelfRequest"))
             .findFirst()
             .get();
     Field shelves =
-        listShelvesResponse
+        getShelfRequest
             .getFields()
             .stream()
-            .filter(f -> f.getSimpleName().equals("shelves"))
+            .filter(f -> f.getSimpleName().equals("name"))
             .findFirst()
             .get();
     String shelfType = protoParser.getResourceType(shelves);
@@ -176,7 +189,7 @@ public class ProtoParserTest {
             .get()
             .lookupMethod("GetShelf");
     List<MethodSignature> getShelfFlattenings = protoParser.getMethodSignatures(getShelfMethod);
-    assertThat(getShelfFlattenings.size()).isEqualTo(2);
+    assertThat(getShelfFlattenings.size()).isEqualTo(3);
 
     MethodSignature firstSignature = getShelfFlattenings.get(0);
     assertThat(firstSignature.getFieldsList().size()).isEqualTo(1);
@@ -186,6 +199,12 @@ public class ProtoParserTest {
     assertThat(additionalSignature.getFieldsList().size()).isEqualTo(2);
     assertThat(additionalSignature.getFieldsList().get(0)).isEqualTo("name");
     assertThat(additionalSignature.getFieldsList().get(1)).isEqualTo("message");
+
+    MethodSignature additionalSignature2 = getShelfFlattenings.get(2);
+    assertThat(additionalSignature2.getFieldsList().size()).isEqualTo(3);
+    assertThat(additionalSignature2.getFieldsList().get(0)).isEqualTo("name");
+    assertThat(additionalSignature2.getFieldsList().get(1)).isEqualTo("message");
+    assertThat(additionalSignature2.getFieldsList().get(2)).isEqualTo("string_builder");
   }
 
   /** The OAuth scopes for this service (e.g. "https://cloud.google.com/auth/cloud-platform"). */


### PR DESCRIPTION
This is so we can later test using only the library.proto (annotated) to generate a client, and it should have a similar surface to the client generated using the library_gapic.yaml.