### PR TITLE
Don't generate methods that aren't present in GAPIC config

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -223,15 +223,15 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
       ProtoParser protoParser) {
     Map<String, GapicMethodConfig> methodConfigMapBuilder = new TreeMap<>();
 
-    // The order in which to create GapicMethodConfigs; first in the order of methods listed in
-    // the protofile, and then any remaining methods in the Gapic config.
+    // The order in which to create GapicMethodConfigs; only use .
     LinkedHashSet<String> methodNames = new LinkedHashSet<>();
+    // TODO(andrealin): After migration off GAPIC config is complete; generate all methods
+    // from protofile even if they aren't included in the GAPIC config.
 
     Map<String, Method> protoMethodsMap = new HashMap<>();
 
     for (Method method : apiInterface.getMethods()) {
       protoMethodsMap.put(method.getSimpleName(), method);
-      methodNames.add(method.getSimpleName());
     }
 
     Map<String, MethodConfigProto> methodConfigProtoMap = new HashMap<>();
@@ -292,10 +292,9 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
       methodConfigs.put(
           methodConfigProto.getName(), methodConfigMap.get(methodConfigProto.getName()));
     }
-    // Add in methods that aren't defined in the GAPIC config but are defined in the source protos.
-    for (Method method : apiInterface.getMethods()) {
-      methodConfigs.put(method.getSimpleName(), methodConfigMap.get(method.getSimpleName()));
-    }
+    // TODO(andrealin): After migration from GAPIC config, add in methods that aren't defined
+    // in the GAPIC config but are defined in the source protos.
+
     return new LinkedList<>(methodConfigs.values());
   }
 

--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -223,7 +223,7 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
       ProtoParser protoParser) {
     Map<String, GapicMethodConfig> methodConfigMapBuilder = new TreeMap<>();
 
-    // The order in which to create GapicMethodConfigs; only use .
+    // The order in which to create GapicMethodConfigs; only use methods defined in GAPIC config.
     LinkedHashSet<String> methodNames = new LinkedHashSet<>();
     // TODO(andrealin): After migration off GAPIC config is complete; generate all methods
     // from protofile even if they aren't included in the GAPIC config.

--- a/src/main/java/com/google/api/codegen/config/RetryCodesConfig.java
+++ b/src/main/java/com/google/api/codegen/config/RetryCodesConfig.java
@@ -33,7 +33,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.rpc.Code;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -157,7 +159,7 @@ public class RetryCodesConfig {
       return;
     }
 
-    populateRetryCodesDefinitionWithProtoFile(apiInterface, protoParser);
+    populateRetryCodesDefinitionWithProtoFile(apiInterface, interfaceConfigProto, protoParser);
   }
 
   /**
@@ -189,7 +191,7 @@ public class RetryCodesConfig {
    * settings name.
    */
   private void populateRetryCodesDefinitionWithProtoFile(
-      Interface apiInterface, ProtoParser protoParser) {
+      Interface apiInterface, InterfaceConfigProto interfaceConfigProto, ProtoParser protoParser) {
 
     SymbolTable symbolTable = new SymbolTable();
 
@@ -197,6 +199,17 @@ public class RetryCodesConfig {
       // Record all the preexisting retryCodeNames from configProto.
       symbolTable.getNewSymbol(retryCodesName);
     }
+
+    // For now, only create retryCodeDef for methods that are also defined in the GAPIC config.
+    Map<String, Method> methodsFromProtoFile =
+        apiInterface.getMethods().stream().collect(Collectors.toMap(Method::getSimpleName, m -> m));
+    List<Method> methodsFromGapicConfig =
+        interfaceConfigProto
+            .getMethodsList()
+            .stream()
+            .map(m -> methodsFromProtoFile.get(m.getName()))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
 
     // Unite all HTTP GET methods that have no additional retry codes under one retry code name to
     // reduce duplication.
@@ -206,7 +219,7 @@ public class RetryCodesConfig {
     String noRetryName = symbolTable.getNewSymbol(NO_RETRY_CODE_DEF_NAME);
 
     // Check proto annotations for retry settings.
-    for (Method method : apiInterface.getMethods()) {
+    for (Method method : methodsFromGapicConfig) {
       if (methodRetryNames.containsKey(method.getSimpleName())) {
         // https://github.com/googleapis/gapic-generator/issues/2311.
         // For now, let GAPIC config take precedent over proto annotations, for retry code

--- a/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
@@ -700,6 +700,24 @@ interfaces:
     retry_params_name: default
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  - name: PrivateGetBook
+    # FIXME: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - name
+    # FIXME: Configure which fields are required.
+    required_fields:
+    - name
+    # FIXME: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # FIXME: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      name: book_2
+    # FIXME: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: AddTag
     # FIXME: Configure which groups of fields should be flattened into method
     # params.

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
@@ -186,6 +186,12 @@ service LibraryService {
   rpc TestOptionalRequiredFlatteningParams(TestOptionalRequiredFlatteningParamsRequest) returns (TestOptionalRequiredFlatteningParamsResponse) {
     option (google.api.http) = { post: "/v1/testofp" body: "*" };
   }
+
+  // This method is not exposed in the GAPIC config.
+  rpc PrivateGetBook(GetBookRequest) returns (Book)  {
+    // http_get retry codes should not be generated from this private method.
+    option (google.api.http) = { get: "/v1/{name=bookShelves/*/books/*}" };
+  }
 }
 
 // A single book in the library.

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -867,6 +867,7 @@ interfaces:
       optional_repeated_resource_name: book
       optional_repeated_resource_name_oneof: book_oneof
     timeout_millis: 60000
+  # Intentionally leave out PrivateGetBook method from GAPIC config.
 resource_name_generation:
 - message_name: Book
   field_entity_map:


### PR DESCRIPTION
Also don't generate retry codes for methods that aren't defined in the GAPIC config.

Add a method to the test library.proto but not to its test GAPIC config to test that it won't be present in the generated surface.