### PR TITLE
rules_gapic: (Bazel) Refactor default dependencies

### DIFF
--- a/rules_gapic/gapic.bzl
+++ b/rules_gapic/gapic.bzl
@@ -117,6 +117,12 @@ def _proto_custom_library_impl(ctx):
             arguments = [intermediate_output.path, output.path],
         )
 
+    # This makes `proto_custom_library` pretend that it returns same provider as the native
+    # `proto_library rule`. This allows using proto_custom_library output as its own input (deps).
+    # Copy other properites of ProtoSourcesProvider if ever needed (currently only
+    # 'check_deps_sources' and 'transitive_imports' fields of ProtoSourcesProvider are supported)
+    return struct(proto = struct(check_deps_sources = srcs, transitive_imports = imports))
+
 proto_custom_library = rule(
     attrs = {
         "deps": attr.label_list(mandatory = True, allow_empty = False, providers = ["proto"]),

--- a/rules_gapic/gapic.bzl
+++ b/rules_gapic/gapic.bzl
@@ -119,7 +119,7 @@ def _proto_custom_library_impl(ctx):
 
     # This makes `proto_custom_library` pretend that it returns same provider as the native
     # `proto_library rule`. This allows using proto_custom_library output as its own input (deps).
-    # Copy other properites of ProtoSourcesProvider if ever needed (currently only
+    # Copy other properties of ProtoSourcesProvider if ever needed (currently only
     # 'check_deps_sources' and 'transitive_imports' fields of ProtoSourcesProvider are supported)
     return struct(proto = struct(check_deps_sources = srcs, transitive_imports = imports))
 

--- a/rules_gapic/java/java_gapic.bzl
+++ b/rules_gapic/java/java_gapic.bzl
@@ -146,7 +146,6 @@ def java_gapic_library(
             "@com_google_auth_google_auth_library_credentials//jar",
             "@com_google_auth_google_auth_library_oauth2_http//jar",
             "@com_google_http_client_google_http_client//jar",
-            "@com_google_api_grpc_proto_google_common_protos//jar",
         ],
         test_deps = test_deps + [
             "@com_google_api_gax_grpc_testlib//jar",
@@ -156,7 +155,6 @@ def java_gapic_library(
             "@io_grpc_grpc_netty_shaded//jar",
             "@io_grpc_grpc_stub//jar",
             "@io_opencensus_opencensus_contrib_grpc_metrics//jar",
-            "@com_google_api_grpc_grpc_google_common_protos//jar",
             "@junit_junit//jar",
         ],
         gapic_yaml = gapic_yaml,

--- a/rules_gapic/java/java_gapic_pkg.bzl
+++ b/rules_gapic/java/java_gapic_pkg.bzl
@@ -159,7 +159,6 @@ def java_gapic_proto_gradle_pkg(
         pkg_type = "proto",
         deps = deps + [
             "@com_google_protobuf_protobuf_java//jar",
-            "@com_google_api_grpc_proto_google_common_protos//jar",
         ],
         test_deps = test_deps,
         visibility = visibility,


### PR DESCRIPTION
This refactoring is to make client's `BUILD.bazel` files more homogeneous and make writing them easier. In most cases a new clients BUILD.bazel file can be created by copying existing one and changing the name of the client in each rule (which is a prefix of rules names).