### PR TITLE
Revert "set up for sample resource name testing (#2361)"

### DIFF
--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -682,12 +682,12 @@ namespace Google.Example.Library.V1.Snippets
         /// <summary>Snippet for PublishSeriesAsync</summary>
         public async Task PublishSeriesAsync()
         {
-            // Snippet: PublishSeriesAsync(ShelfName,IEnumerable<Book>,uint?,SeriesUuid,CallSettings)
-            // Additional: PublishSeriesAsync(ShelfName,IEnumerable<Book>,uint?,SeriesUuid,CancellationToken)
+            // Snippet: PublishSeriesAsync(Shelf,IEnumerable<Book>,uint?,SeriesUuid,CallSettings)
+            // Additional: PublishSeriesAsync(Shelf,IEnumerable<Book>,uint?,SeriesUuid,CancellationToken)
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName shelf = new ShelfName("[SHELF_ID]");
+            Shelf shelf = new Shelf();
             IEnumerable<Book> books = new List<Book>();
             uint edition = 0;
             SeriesUuid seriesUuid = new SeriesUuid
@@ -702,11 +702,11 @@ namespace Google.Example.Library.V1.Snippets
         /// <summary>Snippet for PublishSeries</summary>
         public void PublishSeries()
         {
-            // Snippet: PublishSeries(ShelfName,IEnumerable<Book>,uint?,SeriesUuid,CallSettings)
+            // Snippet: PublishSeries(Shelf,IEnumerable<Book>,uint?,SeriesUuid,CallSettings)
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName shelf = new ShelfName("[SHELF_ID]");
+            Shelf shelf = new Shelf();
             IEnumerable<Book> books = new List<Book>();
             uint edition = 0;
             SeriesUuid seriesUuid = new SeriesUuid
@@ -728,7 +728,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             PublishSeriesRequest request = new PublishSeriesRequest
             {
-                ShelfAsShelfName = new ShelfName("[SHELF_ID]"),
+                Shelf = new Shelf(),
                 Books = { },
                 SeriesUuid = new SeriesUuid
                              {
@@ -749,7 +749,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             PublishSeriesRequest request = new PublishSeriesRequest
             {
-                ShelfAsShelfName = new ShelfName("[SHELF_ID]"),
+                Shelf = new Shelf(),
                 Books = { },
                 SeriesUuid = new SeriesUuid
                              {
@@ -3497,7 +3497,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             PublishSeriesRequest expectedRequest = new PublishSeriesRequest
             {
-                ShelfAsShelfName = new ShelfName("[SHELF_ID]"),
+                Shelf = new Shelf(),
                 Books = { },
                 Edition = 1887963714,
                 SeriesUuid = new SeriesUuid
@@ -3514,7 +3514,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.PublishSeries(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName shelf = new ShelfName("[SHELF_ID]");
+            Shelf shelf = new Shelf();
             IEnumerable<Book> books = new List<Book>();
             uint edition = 1887963714;
             SeriesUuid seriesUuid = new SeriesUuid
@@ -3536,7 +3536,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             PublishSeriesRequest expectedRequest = new PublishSeriesRequest
             {
-                ShelfAsShelfName = new ShelfName("[SHELF_ID]"),
+                Shelf = new Shelf(),
                 Books = { },
                 Edition = 1887963714,
                 SeriesUuid = new SeriesUuid
@@ -3553,7 +3553,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.PublishSeriesAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<PublishSeriesResponse>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName shelf = new ShelfName("[SHELF_ID]");
+            Shelf shelf = new Shelf();
             IEnumerable<Book> books = new List<Book>();
             uint edition = 1887963714;
             SeriesUuid seriesUuid = new SeriesUuid
@@ -3575,7 +3575,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             PublishSeriesRequest request = new PublishSeriesRequest
             {
-                ShelfAsShelfName = new ShelfName("[SHELF_ID]"),
+                Shelf = new Shelf(),
                 Books = { },
                 SeriesUuid = new SeriesUuid
                              {
@@ -3606,7 +3606,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             PublishSeriesRequest request = new PublishSeriesRequest
             {
-                ShelfAsShelfName = new ShelfName("[SHELF_ID]"),
+                Shelf = new Shelf(),
                 Books = { },
                 SeriesUuid = new SeriesUuid
                              {
@@ -7262,14 +7262,14 @@ namespace Google.Example.Library.V1
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<PublishSeriesResponse> PublishSeriesAsync(
-            ShelfName shelf,
+            Shelf shelf,
             scg::IEnumerable<Book> books,
             uint? edition,
             SeriesUuid seriesUuid,
             gaxgrpc::CallSettings callSettings = null) => PublishSeriesAsync(
                 new PublishSeriesRequest
                 {
-                    ShelfAsShelfName = gax::GaxPreconditions.CheckNotNull(shelf, nameof(shelf)),
+                    Shelf = gax::GaxPreconditions.CheckNotNull(shelf, nameof(shelf)),
                     Books = { gax::GaxPreconditions.CheckNotNull(books, nameof(books)) },
                     Edition = edition ?? 0, // Optional
                     SeriesUuid = gax::GaxPreconditions.CheckNotNull(seriesUuid, nameof(seriesUuid)),
@@ -7298,7 +7298,7 @@ namespace Google.Example.Library.V1
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<PublishSeriesResponse> PublishSeriesAsync(
-            ShelfName shelf,
+            Shelf shelf,
             scg::IEnumerable<Book> books,
             uint? edition,
             SeriesUuid seriesUuid,
@@ -7331,14 +7331,14 @@ namespace Google.Example.Library.V1
         /// The RPC response.
         /// </returns>
         public virtual PublishSeriesResponse PublishSeries(
-            ShelfName shelf,
+            Shelf shelf,
             scg::IEnumerable<Book> books,
             uint? edition,
             SeriesUuid seriesUuid,
             gaxgrpc::CallSettings callSettings = null) => PublishSeries(
                 new PublishSeriesRequest
                 {
-                    ShelfAsShelfName = gax::GaxPreconditions.CheckNotNull(shelf, nameof(shelf)),
+                    Shelf = gax::GaxPreconditions.CheckNotNull(shelf, nameof(shelf)),
                     Books = { gax::GaxPreconditions.CheckNotNull(books, nameof(books)) },
                     Edition = edition ?? 0, // Optional
                     SeriesUuid = gax::GaxPreconditions.CheckNotNull(seriesUuid, nameof(seriesUuid)),
@@ -13102,19 +13102,6 @@ namespace Google.Example.Library.V1
         {
             get { return string.IsNullOrEmpty(OtherShelfName) ? null : Google.Example.Library.V1.ShelfName.Parse(OtherShelfName); }
             set { OtherShelfName = value != null ? value.ToString() : ""; }
-        }
-
-    }
-
-    public partial class PublishSeriesRequest
-    {
-        /// <summary>
-        /// <see cref="Google.Example.Library.V1.ShelfName"/>-typed view over the <see cref="Shelf"/> resource name property.
-        /// </summary>
-        public Google.Example.Library.V1.ShelfName ShelfAsShelfName
-        {
-            get { return string.IsNullOrEmpty(Shelf) ? null : Google.Example.Library.V1.ShelfName.Parse(Shelf); }
-            set { Shelf = value != null ? value.ToString() : ""; }
         }
 
     }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -2561,7 +2561,7 @@ func TestLibraryServicePublishSeries(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedShelf string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var shelf *librarypb.Shelf = &librarypb.Shelf{}
     var books []*librarypb.Book = nil
     var seriesString string = "foobar"
     var seriesUuid = &librarypb.SeriesUuid{
@@ -2570,7 +2570,7 @@ func TestLibraryServicePublishSeries(t *testing.T) {
         },
     }
     var request = &librarypb.PublishSeriesRequest{
-        Shelf: formattedShelf,
+        Shelf: shelf,
         Books: books,
         SeriesUuid: seriesUuid,
     }
@@ -2599,7 +2599,7 @@ func TestLibraryServicePublishSeriesError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedShelf string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var shelf *librarypb.Shelf = &librarypb.Shelf{}
     var books []*librarypb.Book = nil
     var seriesString string = "foobar"
     var seriesUuid = &librarypb.SeriesUuid{
@@ -2608,7 +2608,7 @@ func TestLibraryServicePublishSeriesError(t *testing.T) {
         },
     }
     var request = &librarypb.PublishSeriesRequest{
-        Shelf: formattedShelf,
+        Shelf: shelf,
         Books: books,
         SeriesUuid: seriesUuid,
     }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -925,7 +925,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName shelf = ShelfName.of("[SHELF_ID]");
+   *   Shelf shelf = Shelf.newBuilder().build();
    *   List&lt;Book&gt; books = new ArrayList&lt;&gt;();
    *   int edition = 0;
    *   String seriesString = "foobar";
@@ -942,43 +942,7 @@ public class LibraryClient implements BackgroundResource {
    * @param seriesUuid Uniquely identifies the series to the publishing house.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  public final PublishSeriesResponse publishSeries(ShelfName shelf, List<Book> books, int edition, SeriesUuid seriesUuid) {
-
-    PublishSeriesRequest request =
-        PublishSeriesRequest.newBuilder()
-        .setShelf(shelf == null ? null : shelf.toString())
-        .addAllBooks(books)
-        .setEdition(edition)
-        .setSeriesUuid(seriesUuid)
-        .build();
-    return publishSeries(request);
-  }
-
-  // AUTO-GENERATED DOCUMENTATION AND METHOD
-  /**
-   * Creates a series of books.
-   *
-   * Sample code:
-   * <pre><code>
-   * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName shelf = ShelfName.of("[SHELF_ID]");
-   *   List&lt;Book&gt; books = new ArrayList&lt;&gt;();
-   *   int edition = 0;
-   *   String seriesString = "foobar";
-   *   SeriesUuid seriesUuid = SeriesUuid.newBuilder()
-   *     .setSeriesString(seriesString)
-   *     .build();
-   *   PublishSeriesResponse response = libraryClient.publishSeries(shelf.toString(), books, edition, seriesUuid);
-   * }
-   * </code></pre>
-   *
-   * @param shelf The shelf in which the series is created.
-   * @param books The books to publish in the series.
-   * @param edition The edition of the series
-   * @param seriesUuid Uniquely identifies the series to the publishing house.
-   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
-   */
-  public final PublishSeriesResponse publishSeries(String shelf, List<Book> books, int edition, SeriesUuid seriesUuid) {
+  public final PublishSeriesResponse publishSeries(Shelf shelf, List<Book> books, int edition, SeriesUuid seriesUuid) {
 
     PublishSeriesRequest request =
         PublishSeriesRequest.newBuilder()
@@ -997,14 +961,14 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName shelf = ShelfName.of("[SHELF_ID]");
+   *   Shelf shelf = Shelf.newBuilder().build();
    *   List&lt;Book&gt; books = new ArrayList&lt;&gt;();
    *   String seriesString = "foobar";
    *   SeriesUuid seriesUuid = SeriesUuid.newBuilder()
    *     .setSeriesString(seriesString)
    *     .build();
    *   PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-   *     .setShelf(shelf.toString())
+   *     .setShelf(shelf)
    *     .addAllBooks(books)
    *     .setSeriesUuid(seriesUuid)
    *     .build();
@@ -1026,14 +990,14 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName shelf = ShelfName.of("[SHELF_ID]");
+   *   Shelf shelf = Shelf.newBuilder().build();
    *   List&lt;Book&gt; books = new ArrayList&lt;&gt;();
    *   String seriesString = "foobar";
    *   SeriesUuid seriesUuid = SeriesUuid.newBuilder()
    *     .setSeriesString(seriesString)
    *     .build();
    *   PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-   *     .setShelf(shelf.toString())
+   *     .setShelf(shelf)
    *     .addAllBooks(books)
    *     .setSeriesUuid(seriesUuid)
    *     .build();
@@ -6512,7 +6476,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       new BatchingDescriptor<PublishSeriesRequest, PublishSeriesResponse>() {
         @Override
         public PartitionKey getBatchPartitionKey(PublishSeriesRequest request) {
-          return new PartitionKey(request.getEdition(), request.getShelf());
+          return new PartitionKey(request.getEdition(), request.getName());
         }
 
         @Override
@@ -7717,7 +7681,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
 //         className: "PublishSeriesFlattenedPiVersion"
 //          valueSet: "pi_version" ("Pi version")
 //       description: "Testing calling forms"
-//        [shelf=Math, series_uuid.series_string=xyz3141592654, edition=123]
+//        [shelf.name=Math, series_uuid.series_string=xyz3141592654, edition=123]
 //      apiMethod "publishSeries" of type "FlattenedMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
@@ -7725,14 +7689,17 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
 public class PublishSeriesFlattenedPiVersion {
   public static void main(String[] args) {
     // [START canonical_core]
-    // ShelfName shelf = ShelfName.of("[SHELF_ID]");
+    // String name = "Math";
     // int edition = 123;
+    Shelf shelf = Shelf.newBuilder()
+      .setName(name)
+      .build();
     List<Book> books = new ArrayList<>();
     String seriesString = "xyz3141592654";
     SeriesUuid seriesUuid = SeriesUuid.newBuilder()
       .setSeriesString(seriesString)
       .build();
-    PublishSeriesResponse response = libraryClient.publishSeries(shelf.toString(), books, edition, seriesUuid);
+    PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
     for (String title : response.getBookNamesList()) {
       System.out.printf("Title: %s\n", title);
     }
@@ -7769,11 +7736,11 @@ public class PublishSeriesFlattenedPiVersion {
 public class PublishSeriesFlattenedSecondEdition {
   public static void main(String[] args) {
     // [START canonical_core]
-    ShelfName shelf = ShelfName.of("[SHELF_ID]");
+    Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
     int edition = 2;
     SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
-    PublishSeriesResponse response = libraryClient.publishSeries(shelf.toString(), books, edition, seriesUuid);
+    PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
     System.out.println(response);
     // [END canonical_core]
   }
@@ -7797,7 +7764,7 @@ public class PublishSeriesFlattenedSecondEdition {
 //         className: "PublishSeriesRequestPiVersion"
 //          valueSet: "pi_version" ("Pi version")
 //       description: "Testing calling forms"
-//        [shelf=Math, series_uuid.series_string=xyz3141592654, edition=123]
+//        [shelf.name=Math, series_uuid.series_string=xyz3141592654, edition=123]
 //      apiMethod "publishSeries" of type "RequestObjectMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
@@ -7805,15 +7772,18 @@ public class PublishSeriesFlattenedSecondEdition {
 public class PublishSeriesRequestPiVersion {
   public static void main(String[] args) {
     // [START canonical_core]
-    // ShelfName shelf = ShelfName.of("[SHELF_ID]");
+    // String name = "Math";
     // int edition = 123;
+    Shelf shelf = Shelf.newBuilder()
+      .setName(name)
+      .build();
     List<Book> books = new ArrayList<>();
     String seriesString = "xyz3141592654";
     SeriesUuid seriesUuid = SeriesUuid.newBuilder()
       .setSeriesString(seriesString)
       .build();
     PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-      .setShelf(shelf.toString())
+      .setShelf(shelf)
       .addAllBooks(books)
       .setSeriesUuid(seriesUuid)
       .setEdition(edition)
@@ -7855,12 +7825,12 @@ public class PublishSeriesRequestPiVersion {
 public class PublishSeriesRequestSecondEdition {
   public static void main(String[] args) {
     // [START canonical_core]
-    ShelfName shelf = ShelfName.of("[SHELF_ID]");
+    Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
     SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
     int edition = 2;
     PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-      .setShelf(shelf.toString())
+      .setShelf(shelf)
       .addAllBooks(books)
       .setSeriesUuid(seriesUuid)
       .setEdition(edition)
@@ -7889,7 +7859,7 @@ public class PublishSeriesRequestSecondEdition {
 //         className: "PublishSeriesCallableCallablePiVersion"
 //          valueSet: "pi_version" ("Pi version")
 //       description: "Testing calling forms"
-//        [shelf=Math, series_uuid.series_string=xyz3141592654, edition=123]
+//        [shelf.name=Math, series_uuid.series_string=xyz3141592654, edition=123]
 //      apiMethod "publishSeriesCallable" of type "CallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
@@ -7897,15 +7867,18 @@ public class PublishSeriesRequestSecondEdition {
 public class PublishSeriesCallableCallablePiVersion {
   public static void main(String[] args) {
     // [START canonical_core]
-    // ShelfName shelf = ShelfName.of("[SHELF_ID]");
+    // String name = "Math";
     // int edition = 123;
+    Shelf shelf = Shelf.newBuilder()
+      .setName(name)
+      .build();
     List<Book> books = new ArrayList<>();
     String seriesString = "xyz3141592654";
     SeriesUuid seriesUuid = SeriesUuid.newBuilder()
       .setSeriesString(seriesString)
       .build();
     PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-      .setShelf(shelf.toString())
+      .setShelf(shelf)
       .addAllBooks(books)
       .setSeriesUuid(seriesUuid)
       .setEdition(edition)
@@ -7951,12 +7924,12 @@ public class PublishSeriesCallableCallablePiVersion {
 public class PublishSeriesCallableCallableSecondEdition {
   public static void main(String[] args) {
     // [START canonical_core]
-    ShelfName shelf = ShelfName.of("[SHELF_ID]");
+    Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
     SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
     int edition = 2;
     PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-      .setShelf(shelf.toString())
+      .setShelf(shelf)
       .addAllBooks(books)
       .setSeriesUuid(seriesUuid)
       .setEdition(edition)
@@ -8583,7 +8556,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName shelf = ShelfName.of("[SHELF_ID]");
+    Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
     int edition = 1887963714;
     String seriesString = "foobar";
@@ -8599,7 +8572,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     PublishSeriesRequest actualRequest = (PublishSeriesRequest)actualRequests.get(0);
 
-    Assert.assertEquals(shelf, ShelfName.parse(actualRequest.getShelf()));
+    Assert.assertEquals(shelf, actualRequest.getShelf());
     Assert.assertEquals(books, actualRequest.getBooksList());
     Assert.assertEquals(edition, actualRequest.getEdition());
     Assert.assertEquals(seriesUuid, actualRequest.getSeriesUuid());
@@ -8616,7 +8589,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName shelf = ShelfName.of("[SHELF_ID]");
+      Shelf shelf = Shelf.newBuilder().build();
       List<Book> books = new ArrayList<>();
       int edition = 1887963714;
       String seriesString = "foobar";

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -563,7 +563,7 @@ stream.write(request);
 //         className: "PublishSeriesRequestPiVersion"
 //          valueSet: "pi_version" ("Pi version")
 //       description: "Testing calling forms"
-//        [shelf=Math, series_uuid.series_string=xyz3141592654, edition=123]
+//        [shelf.name=Math, series_uuid.series_string=xyz3141592654, edition=123]
 //      apiMethod "publishSeries" of type "OptionalArrayMethod"
 
 // [START canonical_core]
@@ -571,15 +571,18 @@ stream.write(request);
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 /*
-// const formattedShelf = client.shelfPath('[SHELF_ID]');
+// const name = 'Math';
 // const edition = 123;
+const shelf = {
+  name: name,
+};
 const books = [];
 const seriesString = 'xyz3141592654';
 const seriesUuid = {
   seriesString: seriesString,
 };
 const request = {
-  shelf: formattedShelf,
+  shelf: shelf,
   books: books,
   seriesUuid: seriesUuid,
   edition: edition,
@@ -621,12 +624,12 @@ client.publishSeries(request)
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 /*
-const formattedShelf = client.shelfPath('[SHELF_ID]');
+const shelf = {};
 const books = [];
 const seriesUuid = {};
 const edition = 2;
 const request = {
-  shelf: formattedShelf,
+  shelf: shelf,
   books: books,
   seriesUuid: seriesUuid,
   edition: edition,
@@ -1240,8 +1243,10 @@ const CreateBookRequest = {
 /**
  * Request message for LibraryService.PublishSeries.
  *
- * @property {string} shelf
+ * @property {Object} shelf
  *   The shelf in which the series is created.
+ *
+ *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
  *
  * @property {Object[]} books
  *   The books to publish in the series.
@@ -3303,7 +3308,7 @@ class LibraryServiceClient {
         'books',
         [
           'edition',
-          'shelf',
+          'shelf.name',
         ],
         'bookNames',
         gax.createByteLengthFunction(protoFilesRoot.lookup('google.example.library.v1.Book'))
@@ -3882,8 +3887,10 @@ class LibraryServiceClient {
    *
    * @param {Object} request
    *   The request object that will be sent.
-   * @param {string} request.shelf
+   * @param {Object} request.shelf
    *   The shelf in which the series is created.
+   *
+   *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
    * @param {Object[]} request.books
    *   The books to publish in the series.
    *
@@ -3915,14 +3922,14 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedShelf = client.shelfPath('[SHELF_ID]');
+   * const shelf = {};
    * const books = [];
    * const seriesString = 'foobar';
    * const seriesUuid = {
    *   seriesString: seriesString,
    * };
    * const request = {
-   *   shelf: formattedShelf,
+   *   shelf: shelf,
    *   books: books,
    *   seriesUuid: seriesUuid,
    * };
@@ -6262,14 +6269,14 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedShelf = client.shelfPath('[SHELF_ID]');
+      const shelf = {};
       const books = [];
       const seriesString = 'foobar';
       const seriesUuid = {
         seriesString: seriesString,
       };
       const request = {
-        shelf: formattedShelf,
+        shelf: shelf,
         books: books,
         seriesUuid: seriesUuid,
       };
@@ -6301,14 +6308,14 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedShelf = client.shelfPath('[SHELF_ID]');
+      const shelf = {};
       const books = [];
       const seriesString = 'foobar';
       const seriesUuid = {
         seriesString: seriesString,
       };
       const request = {
-        shelf: formattedShelf,
+        shelf: shelf,
         books: books,
         seriesUuid: seriesUuid,
       };

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -789,18 +789,18 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedShelf = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $shelf = new Shelf();
      *     $books = [];
      *     $seriesString = 'foobar';
      *     $seriesUuid = new SeriesUuid();
      *     $seriesUuid->setSeriesString($seriesString);
-     *     $response = $libraryServiceClient->publishSeries($formattedShelf, $books, $seriesUuid);
+     *     $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid);
      * } finally {
      *     $libraryServiceClient->close();
      * }
      * ```
      *
-     * @param string $shelf The shelf in which the series is created.
+     * @param Shelf $shelf The shelf in which the series is created.
      * @param Book[] $books The books to publish in the series.
      * @param SeriesUuid $seriesUuid Uniquely identifies the series to the publishing house.
      * @param array $optionalArgs {
@@ -3192,22 +3192,25 @@ namespace Google\Cloud\Example\Library\V1;
 
 use \Google\Example\Library\V1\Book;
 use \Google\Example\Library\V1\SeriesUuid;
+use \Google\Example\Library\V1\Shelf;
 
-function samplePublishSeries($formattedShelf, $edition)
+function samplePublishSeries($name, $edition)
 {
     // [START canonical_core]
 
     $libraryServiceClient = new LibraryServiceClient();
 
-    // $formattedShelf = $libraryServiceClient->shelfName('[SHELF_ID]');
+    // $name = 'Math';
     // $edition = 123;
+    $shelf = new Shelf();
+    $shelf->setName($name);
     $books = [];
     $seriesString = 'xyz3141592654';
     $seriesUuid = new SeriesUuid();
     $seriesUuid->setSeriesString($seriesString);
 
     try {
-        $response = $libraryServiceClient->publishSeries($formattedShelf, $books, $seriesUuid, ['edition' => $edition]);
+        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
         foreach ($response->getBookNames() as $title) {
             printf("Title: %s" . PHP_EOL, $title);
         }
@@ -3223,22 +3226,22 @@ function samplePublishSeries($formattedShelf, $edition)
 // [END canonical]
 
 $opts = [
-    'formattedShelf::',
+    'name::',
     'edition::',
 ];
 
 $defaultOptions = [
-    'formattedShelf' => $formattedShelf->shelfName('[SHELF_ID]'),
+    'name' => 'Math',
     'edition' => 123,
 ];
 
 $options = getopt('', $opts);
 $options += $defaultOptions;
 
-$formattedShelf = $options['formattedShelf'];
+$name = $options['name'];
 $edition = $options['edition'];
 
-samplePublishSeries($formattedShelf, $edition);
+samplePublishSeries($name, $edition);
 ============== file: src/V1/samples/publishSeries/PublishSeriesRequestSecondEdition.php ==============
 <?php
 /*
@@ -3266,6 +3269,7 @@ namespace Google\Cloud\Example\Library\V1;
 
 use \Google\Example\Library\V1\Book;
 use \Google\Example\Library\V1\SeriesUuid;
+use \Google\Example\Library\V1\Shelf;
 
 function samplePublishSeries()
 {
@@ -3273,13 +3277,13 @@ function samplePublishSeries()
 
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedShelf = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $shelf = new Shelf();
     $books = [];
     $seriesUuid = new SeriesUuid();
     $edition = 2;
 
     try {
-        $response = $libraryServiceClient->publishSeries($formattedShelf, $books, $seriesUuid, ['edition' => $edition]);
+        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
         printf("%s" . PHP_EOL, print_r($response, true));
     } finally {
         $libraryServiceClient->close();
@@ -4039,13 +4043,13 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedShelf = $client->shelfName('[SHELF_ID]');
+        $shelf = new Shelf();
         $books = [];
         $seriesString = 'foobar';
         $seriesUuid = new SeriesUuid();
         $seriesUuid->setSeriesString($seriesString);
 
-        $response = $client->publishSeries($formattedShelf, $books, $seriesUuid);
+        $response = $client->publishSeries($shelf, $books, $seriesUuid);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -4055,7 +4059,7 @@ class LibraryServiceClientTest extends GeneratedTest
 
         $actualValue = $actualRequestObject->getShelf();
 
-        $this->assertProtobufEquals($formattedShelf, $actualValue);
+        $this->assertProtobufEquals($shelf, $actualValue);
         $actualValue = $actualRequestObject->getBooks();
 
         $this->assertProtobufEquals($books, $actualValue);
@@ -4089,14 +4093,14 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedShelf = $client->shelfName('[SHELF_ID]');
+        $shelf = new Shelf();
         $books = [];
         $seriesString = 'foobar';
         $seriesUuid = new SeriesUuid();
         $seriesUuid->setSeriesString($seriesString);
 
         try {
-            $client->publishSeries($formattedShelf, $books, $seriesUuid);
+            $client->publishSeries($shelf, $books, $seriesUuid);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -1625,7 +1625,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> shelf = client.shelf_path('[SHELF_ID]')
+            >>> # TODO: Initialize `shelf`:
+            >>> shelf = {}
             >>>
             >>> # TODO: Initialize `books`:
             >>> books = []
@@ -1635,7 +1636,10 @@ class LibraryServiceClient(object):
             >>> response = client.publish_series(shelf, books, series_uuid)
 
         Args:
-            shelf (str): The shelf in which the series is created.
+            shelf (Union[dict, ~google.cloud.example.library_v1.types.Shelf]): The shelf in which the series is created.
+
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Shelf`
             books (list[Union[dict, ~google.cloud.example.library_v1.types.Book]]): The books to publish in the series.
 
                 If a dict is provided, it must be of the same form as the protobuf
@@ -4416,18 +4420,20 @@ import sys
 from google.cloud.example import library_v1
 import six
 
-def sample_publish_series(shelf, edition):
+def sample_publish_series(name, edition):
   """Testing calling forms"""
 
   # [START canonical_core]
 
   client = library_v1.LibraryServiceClient()
 
-  # shelf = client.shelf_path('[SHELF_ID]')
+  # name = 'Math'
   # edition = 123
 
-  if isinstance(shelf, six.binary_type):
-    shelf = shelf.decode('utf-8')
+  if isinstance(name, six.binary_type):
+    name = name.decode('utf-8')
+
+  shelf = {'name': name}
 
   # TODO: Initialize `books`:
   books = []
@@ -4448,11 +4454,11 @@ def main():
   import argparse
 
   parser = argparse.ArgumentParser()
-  parser.add_argument('--shelf', type=str, default=client.shelf_path('[SHELF_ID]'))
+  parser.add_argument('--name', type=str, default='Math')
   parser.add_argument('--edition', type=int, default=123)
   args = parser.parse_args()
 
-  sample_publish_series(args.shelf, args.edition)
+  sample_publish_series(args.name, args.edition)
 
 if __name__ == '__main__':
   main()
@@ -4491,7 +4497,8 @@ def sample_publish_series():
 
   client = library_v1.LibraryServiceClient()
 
-  shelf = client.shelf_path('[SHELF_ID]')
+  # TODO: Initialize `shelf`:
+  shelf = {}
 
   # TODO: Initialize `books`:
   books = []
@@ -5052,7 +5059,7 @@ class TestLibraryServiceClient(object):
             channel=channel)
 
         # Setup Request
-        shelf = client.shelf_path('[SHELF_ID]')
+        shelf = {}
         books = []
         series_string = 'foobar'
         series_uuid = {'series_string': series_string}
@@ -5072,7 +5079,7 @@ class TestLibraryServiceClient(object):
              channel=channel)
 
         # Setup request
-        shelf = client.shelf_path('[SHELF_ID]')
+        shelf = {}
         books = []
         series_string = 'foobar'
         series_uuid = {'series_string': series_string}

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -2229,7 +2229,7 @@ module Google
 
         # Request message for LibraryService.PublishSeries.
         # @!attribute [rw] shelf
-        #   @return [String]
+        #   @return [Google::Example::Library::V1::Shelf]
         #     The shelf in which the series is created.
         # @!attribute [rw] books
         #   @return [Array<Google::Example::Library::V1::Book>]
@@ -2758,7 +2758,7 @@ module Library
           "books",
           [
             "edition",
-            "shelf"
+            "shelf.name"
           ],
           subresponse_field: "book_names"),
         "add_comments" => Google::Gax::BundleDescriptor.new(
@@ -3364,8 +3364,10 @@ module Library
 
       # Creates a series of books.
       #
-      # @param shelf [String]
+      # @param shelf [Google::Example::Library::V1::Shelf | Hash]
       #   The shelf in which the series is created.
+      #   A hash of the same form as `Google::Example::Library::V1::Shelf`
+      #   can also be provided.
       # @param books [Array<Google::Example::Library::V1::Book | Hash>]
       #   The books to publish in the series.
       #   A hash of the same form as `Google::Example::Library::V1::Book`
@@ -3390,13 +3392,15 @@ module Library
       #   require "library"
       #
       #   library_service_client = Library.new(version: :v1)
-      #   formatted_shelf = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #
+      #   # TODO: Initialize `shelf`:
+      #   shelf = {}
       #
       #   # TODO: Initialize `books`:
       #   books = []
       #   series_string = "foobar"
       #   series_uuid = { series_string: series_string }
-      #   response = library_service_client.publish_series(formatted_shelf, books, series_uuid)
+      #   response = library_service_client.publish_series(shelf, books, series_uuid)
 
       def publish_series \
           shelf,
@@ -5298,7 +5302,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes publish_series without error' do
       # Create request parameters
-      formatted_shelf = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      shelf = {}
       books = []
       series_string = "foobar"
       series_uuid = { series_string: series_string }
@@ -5312,7 +5316,7 @@ describe Library::V1::LibraryServiceClient do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Example::Library::V1::PublishSeriesRequest, request)
-        assert_equal(formatted_shelf, request.shelf)
+        assert_equal(Google::Gax::to_proto(shelf, Google::Example::Library::V1::Shelf), request.shelf)
         books = books.map do |req|
           Google::Gax::to_proto(req, Google::Example::Library::V1::Book)
         end
@@ -5331,7 +5335,7 @@ describe Library::V1::LibraryServiceClient do
 
           # Call method
           response = client.publish_series(
-            formatted_shelf,
+            shelf,
             books,
             series_uuid
           )
@@ -5341,7 +5345,7 @@ describe Library::V1::LibraryServiceClient do
 
           # Call method with block
           client.publish_series(
-            formatted_shelf,
+            shelf,
             books,
             series_uuid
           ) do |response, operation|
@@ -5355,7 +5359,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes publish_series with error' do
       # Create request parameters
-      formatted_shelf = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      shelf = {}
       books = []
       series_string = "foobar"
       series_uuid = { series_string: series_string }
@@ -5363,7 +5367,7 @@ describe Library::V1::LibraryServiceClient do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Example::Library::V1::PublishSeriesRequest, request)
-        assert_equal(formatted_shelf, request.shelf)
+        assert_equal(Google::Gax::to_proto(shelf, Google::Example::Library::V1::Shelf), request.shelf)
         books = books.map do |req|
           Google::Gax::to_proto(req, Google::Example::Library::V1::Book)
         end
@@ -5383,7 +5387,7 @@ describe Library::V1::LibraryServiceClient do
           # Call method
           err = assert_raises Google::Gax::GaxError do
             client.publish_series(
-              formatted_shelf,
+              shelf,
               books,
               series_uuid
             )

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
@@ -414,7 +414,7 @@ message CreateBookRequest {
 // Request message for LibraryService.PublishSeries.
 message PublishSeriesRequest {
   // The shelf in which the series is created.
-  string shelf = 1;
+  Shelf shelf = 1;
 
   // The books to publish in the series.
   repeated Book books = 2;

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -203,8 +203,6 @@ interfaces:
         - books
         - edition
         - series_uuid
-        parameter_resource_name_treatment:
-          name: STATIC_TYPES
     required_fields:
       - shelf
       - books
@@ -223,11 +221,9 @@ interfaces:
         batched_field: books
         discriminator_fields:
           - edition
-          - shelf
+          - shelf.name
         subresponse_field: book_names
     resource_name_treatment: STATIC_TYPES
-    field_name_patterns:
-      shelf: shelf
     sample_code_init_fields:
     - series_uuid.series_string=foobar
     sample_value_sets:
@@ -239,11 +235,11 @@ interfaces:
       description: "Testing calling forms"
       parameters:
         defaults:
-        - shelf=Math
+        - shelf.name=Math
         - series_uuid.series_string=xyz3141592654
         - edition=123
         attributes:
-        - parameter: shelf
+        - parameter: shelf.name
           sample_argument_name: name
         - parameter: edition
           sample_argument_name: edition
@@ -941,9 +937,6 @@ resource_name_generation:
 - message_name: FindRelatedBooksResponse
   field_entity_map:
     names: book
-- message_name: PublishSeriesRequest
-  field_entity_map:
-    shelf: shelf
 - message_name: TestOptionalRequiredFlatteningParamsRequest
   field_entity_map:
     required_singular_resource_name: book


### PR DESCRIPTION
This reverts commit 17a31d653f20912c702f3f2e372dcc9e07a911ff.

The above commit broke Java's CLI parsing. Let's make Java work first
then we can figure out how to redo this change.