### PR TITLE
Samplegen: CLI for Java standalone samples

### DIFF
--- a/src/main/resources/com/google/api/codegen/java/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/java/initcode.snip
@@ -52,7 +52,7 @@
   {@line.typeName} {@line.identifier} = {@renderInitValue(line.initValue)};
 @end
 
-@private renderInitValue(initValue)
+@snippet renderInitValue(initValue)
   @switch initValue.type
   @case "SimpleInitValueView"
     {@initValue.initialValue}

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -26,15 +26,21 @@
     // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
     public class {@sampleFile.classView.name} {
-      public static void main(String[] args) {
+      public static void {@sample.sampleFunctionName}({@commaSeparatedArgAndTypes(sample.initCode.argDefaultParams)}) {
         // [START {@sample.regionTag}_core]
         @let coreSampleCode = generateSample(apiMethod, sample)
           {@methodLines(coreSampleCode)}
         @end
         // [END {@sample.regionTag}_core]
       }
-    }
 
+      public static void main(String[] args) {
+        @if sample.initCode.argDefaultParams.size
+          {@processCliArguments(sample)}
+        @end
+        {@sample.sampleFunctionName}({@commaSeparatedArgs(sample.initCode.argDefaultParams)});
+      }
+    }
     // FIXME: Insert here clean-up code.
 
     // [END {@sample.regionTag}]
@@ -214,6 +220,54 @@
 @private methodLines(methodSampleCode)
   @join sampleLine : util.splitLines(methodSampleCode)
     {@sampleLine}
+  @end
+@end
+
+@private processCliArguments(sample)
+  Options options = new Options();
+  @join param : sample.initCode.argDefaultParams
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("{@param.identifier}")
+          .build());
+  @end
+  CommandLine cl = (new DefaultParser()).parse(options, args);
+  @join param : sample.initCode.argDefaultParams
+    @switch param.typeName
+    @case "String"
+      String {@param.identifier} = cl.getOptionValue("{@param.identifier}", {@renderInitValue(param.initValue)});
+    @case "int"
+      int {@param.identifier} = 
+          cl.getOptionValue("{@param.identifier}") != null
+              ? Integer.parseInt(cl.getOptionValue("{@param.identifier}"))
+              : {@renderInitValue(param.initValue)};
+    @case "double"
+      double {@param.identifier} = 
+          cl.getOptionValue("{@param.identifier}") != null
+              ? Double.parseDouble(cl.getOptionValue("{@param.identifier}"))
+              : {@renderInitValue(param.initValue)};
+    @case "boolean"
+      boolean {@param.identifier} =
+          cl.getOptionValue("{@param.identifier}") != null
+              ? Boolean.parseBoolean(cl.getOptionValue("{@param.identifier}"))
+              : {@renderInitValue(param.initValue)};
+    @default
+      $unhandledCase: {@param.typeName}$
+    @end
+  @end
+@end
+
+@private commaSeparatedArgs(args)
+  @join arg : args on ", "
+    {@arg.identifier}
+  @end
+@end
+
+@private commaSeparatedArgAndTypes(args)
+  @join arg : args on ", "
+    {@arg.typeName} {@arg.identifier}
   @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -25,7 +25,7 @@
 
     // FIXME: Insert here code to prepare the request fields, make the call, process the response.
     # FIXME: change the package name from pubsub to library
-    
+
     package {@sampleFile.fileHeader.packageName};
     
     @if sample.initCode.argDefaultParams.size
@@ -55,6 +55,7 @@
       public static void main(String[] args) {
         @if sample.initCode.argDefaultParams.size
           {@processCliArguments(sample)}
+
         @end
         {@sample.sampleFunctionName}({@commaSeparatedArgs(sample.initCode.argDefaultParams)});
       }
@@ -251,6 +252,7 @@
           .longOpt("{@param.identifier}")
           .build());
   @end
+
   CommandLine cl = (new DefaultParser()).parse(options, args);
   @join param : sample.initCode.argDefaultParams
     @switch param.typeName

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -25,12 +25,22 @@
 
     // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+    package {@sampleFile.fileHeader.packageName};
+    
+    @if sample.initCode.importSection.appImports.size
+      {@importList(sample.initCode.importSection.appImports)}
+    
+    @end
     public class {@sampleFile.classView.name} {
       public static void {@sample.sampleFunctionName}({@commaSeparatedArgAndTypes(sample.initCode.argDefaultParams)}) {
         // [START {@sample.regionTag}_core]
-        @let coreSampleCode = generateSample(apiMethod, sample)
-          {@methodLines(coreSampleCode)}
-        @end
+        try ({@apiMethod.apiClassName} {@apiMethod.apiVariableName} = {@apiMethod.apiClassName}.create()) {
+          @let coreSampleCode = generateSample(apiMethod, sample)
+            {@methodLines(coreSampleCode)}
+          @end
+        } catch (Exception exception) {
+          System.err.println("Failed to create the client due to: " + exception);          
+        }
         // [END {@sample.regionTag}_core]
       }
 

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -24,7 +24,8 @@
     //      apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
 
     // FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
+    # FIXME: change the package name from pubsub to library
+    
     package {@sampleFile.fileHeader.packageName};
     
     @if sample.initCode.argDefaultParams.size
@@ -33,6 +34,7 @@
       import org.apache.commons.cli.Option;
       import org.apache.commons.cli.Options;     
     @end
+    # FIXME: also import the client
     @if sample.initCode.importSection.appImports.size
       {@importList(sample.initCode.importSection.appImports)}
     

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -27,6 +27,12 @@
 
     package {@sampleFile.fileHeader.packageName};
     
+    @if sample.initCode.argDefaultParams.size
+      import org.apache.commons.cli.CommandLine;
+      import org.apache.commons.cli.DefaultParser;
+      import org.apache.commons.cli.Option;
+      import org.apache.commons.cli.Options;     
+    @end
     @if sample.initCode.importSection.appImports.size
       {@importList(sample.initCode.importSection.appImports)}
     

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -7805,6 +7805,10 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
 
 package com.google.gcloud.pubsub.v1;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.SeriesUuid;
 import com.google.example.library.v1.Shelf;
@@ -7937,6 +7941,10 @@ public class PublishSeriesFlattenedSecondEdition {
 
 package com.google.gcloud.pubsub.v1;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.SeriesUuid;
@@ -8083,6 +8091,10 @@ public class PublishSeriesRequestSecondEdition {
 
 package com.google.gcloud.pubsub.v1;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.SeriesUuid;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -7261,7 +7261,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class DiscussBookCallableCallableStreamingBidiProg {
-  public static void main(String[] args) {
+  public static void sampleDiscussBook() {
     // [START turing_prog_callable_streaming_bidi_core]
     BidiStream<DiscussBookRequest, Comment> bidiStream =
         libraryClient.discussBookCallable().call();
@@ -7276,8 +7276,11 @@ public class DiscussBookCallableCallableStreamingBidiProg {
     }
     // [END turing_prog_callable_streaming_bidi_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleDiscussBook();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END turing_prog_callable_streaming_bidi]
@@ -7302,7 +7305,7 @@ public class DiscussBookCallableCallableStreamingBidiProg {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class FindRelatedBooksFlattenedPagedOdyssey {
-  public static void main(String[] args) {
+  public static void sampleFindRelatedBooks() {
     // [START sample_core]
     String namesElement = "Odyssey";
     List<String> names = Arrays.asList(namesElement);
@@ -7318,8 +7321,11 @@ public class FindRelatedBooksFlattenedPagedOdyssey {
     }
     // [END sample_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END sample]
@@ -7344,7 +7350,7 @@ public class FindRelatedBooksFlattenedPagedOdyssey {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class FindRelatedBooksRequestPagedOdyssey {
-  public static void main(String[] args) {
+  public static void sampleFindRelatedBooks() {
     // [START sample_core]
     ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     List<ShelfBookName> names = Arrays.asList(namesElement);
@@ -7360,8 +7366,11 @@ public class FindRelatedBooksRequestPagedOdyssey {
     }
     // [END sample_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END sample]
@@ -7386,7 +7395,7 @@ public class FindRelatedBooksRequestPagedOdyssey {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class FindRelatedBooksCallableCallableListOdyssey {
-  public static void main(String[] args) {
+  public static void sampleFindRelatedBooks() {
     // [START sample_core]
     ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     List<ShelfBookName> names = Arrays.asList(namesElement);
@@ -7411,8 +7420,11 @@ public class FindRelatedBooksCallableCallableListOdyssey {
     }
     // [END sample_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END sample]
@@ -7437,7 +7449,7 @@ public class FindRelatedBooksCallableCallableListOdyssey {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
-  public static void main(String[] args) {
+  public static void sampleFindRelatedBooks() {
     // [START sample_core]
     ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     List<ShelfBookName> names = Arrays.asList(namesElement);
@@ -7457,8 +7469,11 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
     }
     // [END sample_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END sample]
@@ -7483,15 +7498,18 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
-  public static void main(String[] args) {
+  public static void sampleGetBigBook() {
     // [START hopper_core]
     ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     Book response = libraryClient.getBigBookAsync(name.toString()).get();
     System.out.println(response);
     // [END hopper_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleGetBigBook();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
@@ -7516,7 +7534,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class GetBigBookAsyncLongRunningRequestAsyncWap {
-  public static void main(String[] args) {
+  public static void sampleGetBigBook() {
     // [START hopper_core]
     ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     GetBookRequest request = GetBookRequest.newBuilder()
@@ -7526,8 +7544,11 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
     System.out.println(response);
     // [END hopper_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleGetBigBook();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
@@ -7552,7 +7573,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class GetBigBookCallableCallableWap {
-  public static void main(String[] args) {
+  public static void sampleGetBigBook() {
     // [START hopper_core]
     ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     GetBookRequest request = GetBookRequest.newBuilder()
@@ -7566,8 +7587,11 @@ public class GetBigBookCallableCallableWap {
     System.out.println(response);
     // [END hopper_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleGetBigBook();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
@@ -7592,7 +7616,7 @@ public class GetBigBookCallableCallableWap {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class GetBigBookOperationCallableLongRunningCallableWap {
-  public static void main(String[] args) {
+  public static void sampleGetBigBook() {
     // [START hopper_core]
     ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     GetBookRequest request = GetBookRequest.newBuilder()
@@ -7606,8 +7630,11 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
     System.out.println(response);
     // [END hopper_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleGetBigBook();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
@@ -7632,7 +7659,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class MonologAboutBookCallableCallableStreamingClientProg {
-  public static void main(String[] args) {
+  public static void sampleMonologAboutBook() {
     // [START sample_core]
     ApiStreamObserver<Comment> responseObserver =
         new ApiStreamObserver<Comment>() {
@@ -7661,8 +7688,11 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
     requestObserver.onNext(request);
     // [END sample_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleMonologAboutBook();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END sample]
@@ -7687,7 +7717,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class PublishSeriesFlattenedPiVersion {
-  public static void main(String[] args) {
+  public static void samplePublishSeries(String name, int edition) {
     // [START canonical_core]
     // String name = "Math";
     // int edition = 123;
@@ -7708,8 +7738,30 @@ public class PublishSeriesFlattenedPiVersion {
     System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     // [END canonical_core]
   }
-}
 
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("name")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("edition")
+          .build());
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String name = cl.getOptionValue("name", "Math");
+    int edition =
+        cl.getOptionValue("edition") != null
+            ? Integer.parseInt(cl.getOptionValue("edition"))
+            : 123;
+    samplePublishSeries(name, edition);
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
@@ -7734,7 +7786,7 @@ public class PublishSeriesFlattenedPiVersion {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class PublishSeriesFlattenedSecondEdition {
-  public static void main(String[] args) {
+  public static void samplePublishSeries() {
     // [START canonical_core]
     Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
@@ -7744,8 +7796,11 @@ public class PublishSeriesFlattenedSecondEdition {
     System.out.println(response);
     // [END canonical_core]
   }
-}
 
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
@@ -7770,7 +7825,7 @@ public class PublishSeriesFlattenedSecondEdition {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class PublishSeriesRequestPiVersion {
-  public static void main(String[] args) {
+  public static void samplePublishSeries(String name, int edition) {
     // [START canonical_core]
     // String name = "Math";
     // int edition = 123;
@@ -7797,8 +7852,30 @@ public class PublishSeriesRequestPiVersion {
     System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     // [END canonical_core]
   }
-}
 
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("name")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("edition")
+          .build());
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String name = cl.getOptionValue("name", "Math");
+    int edition =
+        cl.getOptionValue("edition") != null
+            ? Integer.parseInt(cl.getOptionValue("edition"))
+            : 123;
+    samplePublishSeries(name, edition);
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
@@ -7823,7 +7900,7 @@ public class PublishSeriesRequestPiVersion {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class PublishSeriesRequestSecondEdition {
-  public static void main(String[] args) {
+  public static void samplePublishSeries() {
     // [START canonical_core]
     Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
@@ -7839,8 +7916,11 @@ public class PublishSeriesRequestSecondEdition {
     System.out.println(response);
     // [END canonical_core]
   }
-}
 
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
@@ -7865,7 +7945,7 @@ public class PublishSeriesRequestSecondEdition {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class PublishSeriesCallableCallablePiVersion {
-  public static void main(String[] args) {
+  public static void samplePublishSeries(String name, int edition) {
     // [START canonical_core]
     // String name = "Math";
     // int edition = 123;
@@ -7896,8 +7976,30 @@ public class PublishSeriesCallableCallablePiVersion {
     System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     // [END canonical_core]
   }
-}
 
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("name")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("edition")
+          .build());
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String name = cl.getOptionValue("name", "Math");
+    int edition =
+        cl.getOptionValue("edition") != null
+            ? Integer.parseInt(cl.getOptionValue("edition"))
+            : 123;
+    samplePublishSeries(name, edition);
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
@@ -7922,7 +8024,7 @@ public class PublishSeriesCallableCallablePiVersion {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class PublishSeriesCallableCallableSecondEdition {
-  public static void main(String[] args) {
+  public static void samplePublishSeries() {
     // [START canonical_core]
     Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
@@ -7942,8 +8044,11 @@ public class PublishSeriesCallableCallableSecondEdition {
     System.out.println(response);
     // [END canonical_core]
   }
-}
 
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
@@ -7968,7 +8073,7 @@ public class PublishSeriesCallableCallableSecondEdition {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class StreamBooksCallableCallableStreamingServerProg {
-  public static void main(String[] args) {
+  public static void sampleStreamBooks() {
     // [START babbage_core]
     String name = "BASIC";
     StreamBooksRequest request = StreamBooksRequest.newBuilder()
@@ -7981,8 +8086,11 @@ public class StreamBooksCallableCallableStreamingServerProg {
     }
     // [END babbage_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleStreamBooks();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END babbage]
@@ -8007,7 +8115,7 @@ public class StreamBooksCallableCallableStreamingServerProg {
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 public class StreamShelvesCallableCallableStreamingServerEmpty {
-  public static void main(String[] args) {
+  public static void sampleStreamShelves() {
     // [START sample_core]
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
 
@@ -8017,8 +8125,11 @@ public class StreamShelvesCallableCallableStreamingServerEmpty {
     }
     // [END sample_core]
   }
-}
 
+  public static void main(String[] args) {
+    sampleStreamShelves();
+  }
+}
 // FIXME: Insert here clean-up code.
 
 // [END sample]

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -7856,12 +7856,14 @@ public class PublishSeriesFlattenedPiVersion {
           .hasArg(true)
           .longOpt("edition")
           .build());
+
     CommandLine cl = (new DefaultParser()).parse(options, args);
     String name = cl.getOptionValue("name", "Math");
     int edition =
         cl.getOptionValue("edition") != null
             ? Integer.parseInt(cl.getOptionValue("edition"))
             : 123;
+
     samplePublishSeries(name, edition);
   }
 }
@@ -7999,12 +8001,14 @@ public class PublishSeriesRequestPiVersion {
           .hasArg(true)
           .longOpt("edition")
           .build());
+
     CommandLine cl = (new DefaultParser()).parse(options, args);
     String name = cl.getOptionValue("name", "Math");
     int edition =
         cl.getOptionValue("edition") != null
             ? Integer.parseInt(cl.getOptionValue("edition"))
             : 123;
+
     samplePublishSeries(name, edition);
   }
 }
@@ -8153,12 +8157,14 @@ public class PublishSeriesCallableCallablePiVersion {
           .hasArg(true)
           .longOpt("edition")
           .build());
+
     CommandLine cl = (new DefaultParser()).parse(options, args);
     String name = cl.getOptionValue("name", "Math");
     int edition =
         cl.getOptionValue("edition") != null
             ? Integer.parseInt(cl.getOptionValue("edition"))
             : 123;
+
     samplePublishSeries(name, edition);
   }
 }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -7260,19 +7260,27 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.DiscussBookRequest;
+
 public class DiscussBookCallableCallableStreamingBidiProg {
   public static void sampleDiscussBook() {
     // [START turing_prog_callable_streaming_bidi_core]
-    BidiStream<DiscussBookRequest, Comment> bidiStream =
-        libraryClient.discussBookCallable().call();
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      BidiStream<DiscussBookRequest, Comment> bidiStream =
+          libraryClient.discussBookCallable().call();
 
-    String name = "BASIC";
-    DiscussBookRequest request = DiscussBookRequest.newBuilder()
-      .setName(name)
-      .build();
-    bidiStream.send(request);
-    for (Comment responseItem : bidiStream) {
-      System.out.println(responseItem);
+      String name = "BASIC";
+      DiscussBookRequest request = DiscussBookRequest.newBuilder()
+        .setName(name)
+        .build();
+      bidiStream.send(request);
+      for (Comment responseItem : bidiStream) {
+        System.out.println(responseItem);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
     }
     // [END turing_prog_callable_streaming_bidi_core]
   }
@@ -7304,20 +7312,26 @@ public class DiscussBookCallableCallableStreamingBidiProg {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
 public class FindRelatedBooksFlattenedPagedOdyssey {
   public static void sampleFindRelatedBooks() {
     // [START sample_core]
-    String namesElement = "Odyssey";
-    List<String> names = Arrays.asList(namesElement);
-    String shelvesElement = "Classics";
-    List<String> shelves = Arrays.asList(shelvesElement);
-    ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooks().futureCall(names, shelves);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      String namesElement = "Odyssey";
+      List<String> names = Arrays.asList(namesElement);
+      String shelvesElement = "Classics";
+      List<String> shelves = Arrays.asList(shelvesElement);
+      ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooks().futureCall(names, shelves);
 
-    // Do something
+      // Do something
 
-    for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
-      ShelfBookName book = responseItem;
-      System.out.printf("Here's a related book: %s\n", book);
+      for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
+        ShelfBookName book = responseItem;
+        System.out.printf("Here's a related book: %s\n", book);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
     }
     // [END sample_core]
   }
@@ -7349,20 +7363,30 @@ public class FindRelatedBooksFlattenedPagedOdyssey {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+
 public class FindRelatedBooksRequestPagedOdyssey {
   public static void sampleFindRelatedBooks() {
     // [START sample_core]
-    ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    List<ShelfBookName> names = Arrays.asList(namesElement);
-    ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
-    List<ShelfName> shelves = Arrays.asList(shelvesElement);
-    FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
-      .addAllNames(ShelfBookName.toStringList(names))
-      .addAllShelves(ShelfName.toStringList(shelves))
-      .build();
-    for (ShelfBookName responseItem : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
-      ShelfBookName book = responseItem;
-      System.out.printf("Here's a related book: %s\n", book);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      List<ShelfBookName> names = Arrays.asList(namesElement);
+      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      List<ShelfName> shelves = Arrays.asList(shelvesElement);
+      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+        .addAllNames(ShelfBookName.toStringList(names))
+        .addAllShelves(ShelfName.toStringList(shelves))
+        .build();
+      for (ShelfBookName responseItem : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
+        ShelfBookName book = responseItem;
+        System.out.printf("Here's a related book: %s\n", book);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
     }
     // [END sample_core]
   }
@@ -7394,29 +7418,39 @@ public class FindRelatedBooksRequestPagedOdyssey {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+
 public class FindRelatedBooksCallableCallableListOdyssey {
   public static void sampleFindRelatedBooks() {
     // [START sample_core]
-    ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    List<ShelfBookName> names = Arrays.asList(namesElement);
-    ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
-    List<ShelfName> shelves = Arrays.asList(shelvesElement);
-    FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
-      .addAllNames(ShelfBookName.toStringList(names))
-      .addAllShelves(ShelfName.toStringList(shelves))
-      .build();
-    while (true) {
-      FindRelatedBooksResponse response = libraryClient.findRelatedBooksCallable().call(request);
-      for (ShelfBookName responseItem : ShelfBookName.parseList(response.getNamesList())) {
-        ShelfBookName book = responseItem;
-        System.out.printf("Here's a related book: %s\n", book);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      List<ShelfBookName> names = Arrays.asList(namesElement);
+      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      List<ShelfName> shelves = Arrays.asList(shelvesElement);
+      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+        .addAllNames(ShelfBookName.toStringList(names))
+        .addAllShelves(ShelfName.toStringList(shelves))
+        .build();
+      while (true) {
+        FindRelatedBooksResponse response = libraryClient.findRelatedBooksCallable().call(request);
+        for (ShelfBookName responseItem : ShelfBookName.parseList(response.getNamesList())) {
+          ShelfBookName book = responseItem;
+          System.out.printf("Here's a related book: %s\n", book);
+        }
+        String nextPageToken = response.getNextPageToken();
+        if (!Strings.isNullOrEmpty(nextPageToken)) {
+          request = request.toBuilder().setPageToken(nextPageToken).build();
+        } else {
+          break;
+        }
       }
-      String nextPageToken = response.getNextPageToken();
-      if (!Strings.isNullOrEmpty(nextPageToken)) {
-        request = request.toBuilder().setPageToken(nextPageToken).build();
-      } else {
-        break;
-      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
     }
     // [END sample_core]
   }
@@ -7448,24 +7482,34 @@ public class FindRelatedBooksCallableCallableListOdyssey {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+
 public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   public static void sampleFindRelatedBooks() {
     // [START sample_core]
-    ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    List<ShelfBookName> names = Arrays.asList(namesElement);
-    ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
-    List<ShelfName> shelves = Arrays.asList(shelvesElement);
-    FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
-      .addAllNames(ShelfBookName.toStringList(names))
-      .addAllShelves(ShelfName.toStringList(shelves))
-      .build();
-    ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooksPagedCallable().futureCall(request);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      List<ShelfBookName> names = Arrays.asList(namesElement);
+      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      List<ShelfName> shelves = Arrays.asList(shelvesElement);
+      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+        .addAllNames(ShelfBookName.toStringList(names))
+        .addAllShelves(ShelfName.toStringList(shelves))
+        .build();
+      ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooksPagedCallable().futureCall(request);
 
-    // Do something
+      // Do something
 
-    for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
-      ShelfBookName book = responseItem;
-      System.out.printf("Here's a related book: %s\n", book);
+      for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
+        ShelfBookName book = responseItem;
+        System.out.printf("Here's a related book: %s\n", book);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
     }
     // [END sample_core]
   }
@@ -7497,12 +7541,20 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.ShelfBookName;
+
 public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
   public static void sampleGetBigBook() {
     // [START hopper_core]
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    Book response = libraryClient.getBigBookAsync(name.toString()).get();
-    System.out.println(response);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      Book response = libraryClient.getBigBookAsync(name.toString()).get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
     // [END hopper_core]
   }
 
@@ -7533,15 +7585,24 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.ShelfBookName;
+
 public class GetBigBookAsyncLongRunningRequestAsyncWap {
   public static void sampleGetBigBook() {
     // [START hopper_core]
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    GetBookRequest request = GetBookRequest.newBuilder()
-      .setName(name.toString())
-      .build();
-    Book response = libraryClient.getBigBookAsync(request).get();
-    System.out.println(response);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      Book response = libraryClient.getBigBookAsync(request).get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
     // [END hopper_core]
   }
 
@@ -7572,19 +7633,28 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.ShelfBookName;
+
 public class GetBigBookCallableCallableWap {
   public static void sampleGetBigBook() {
     // [START hopper_core]
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    GetBookRequest request = GetBookRequest.newBuilder()
-      .setName(name.toString())
-      .build();
-    ApiFuture<Operation> future = libraryClient.getBigBookCallable().futureCall(request);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      ApiFuture<Operation> future = libraryClient.getBigBookCallable().futureCall(request);
 
-    // Do something
+      // Do something
 
-    Operation response = future.get();
-    System.out.println(response);
+      Operation response = future.get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
     // [END hopper_core]
   }
 
@@ -7615,19 +7685,28 @@ public class GetBigBookCallableCallableWap {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.ShelfBookName;
+
 public class GetBigBookOperationCallableLongRunningCallableWap {
   public static void sampleGetBigBook() {
     // [START hopper_core]
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    GetBookRequest request = GetBookRequest.newBuilder()
-      .setName(name.toString())
-      .build();
-    OperationFuture<Operation> future = libraryClient.getBigBookOperationCallable().futureCall(request);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      OperationFuture<Operation> future = libraryClient.getBigBookOperationCallable().futureCall(request);
 
-    // Do something
+      // Do something
 
-    Book response = future.get();
-    System.out.println(response);
+      Book response = future.get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
     // [END hopper_core]
   }
 
@@ -7658,34 +7737,42 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.DiscussBookRequest;
+
 public class MonologAboutBookCallableCallableStreamingClientProg {
   public static void sampleMonologAboutBook() {
     // [START sample_core]
-    ApiStreamObserver<Comment> responseObserver =
-        new ApiStreamObserver<Comment>() {
-          @Override
-          public void onNext(Comment response) {
-            System.out.printf("The stage of the comment is: %s\n", response.getStage());
-          }
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ApiStreamObserver<Comment> responseObserver =
+          new ApiStreamObserver<Comment>() {
+            @Override
+            public void onNext(Comment response) {
+              System.out.printf("The stage of the comment is: %s\n", response.getStage());
+            }
 
-          @Override
-          public void onError(Throwable t) {
-            // Add error-handling
-          }
+            @Override
+            public void onError(Throwable t) {
+              // Add error-handling
+            }
 
-          @Override
-          public void onCompleted() {
-            // Do something when complete.
-          }
-        };
-    ApiStreamObserver<DiscussBookRequest> requestObserver =
-        libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
+            @Override
+            public void onCompleted() {
+              // Do something when complete.
+            }
+          };
+      ApiStreamObserver<DiscussBookRequest> requestObserver =
+          libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-    String name = "BASIC";
-    DiscussBookRequest request = DiscussBookRequest.newBuilder()
-      .setName(name)
-      .build();
-    requestObserver.onNext(request);
+      String name = "BASIC";
+      DiscussBookRequest request = DiscussBookRequest.newBuilder()
+        .setName(name)
+        .build();
+      requestObserver.onNext(request);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
     // [END sample_core]
   }
 
@@ -7716,26 +7803,38 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 public class PublishSeriesFlattenedPiVersion {
   public static void samplePublishSeries(String name, int edition) {
     // [START canonical_core]
-    // String name = "Math";
-    // int edition = 123;
-    Shelf shelf = Shelf.newBuilder()
-      .setName(name)
-      .build();
-    List<Book> books = new ArrayList<>();
-    String seriesString = "xyz3141592654";
-    SeriesUuid seriesUuid = SeriesUuid.newBuilder()
-      .setSeriesString(seriesString)
-      .build();
-    PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
-    for (String title : response.getBookNamesList()) {
-      System.out.printf("Title: %s\n", title);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String name = "Math";
+      // int edition = 123;
+      Shelf shelf = Shelf.newBuilder()
+        .setName(name)
+        .build();
+      List<Book> books = new ArrayList<>();
+      String seriesString = "xyz3141592654";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
+      for (String title : response.getBookNamesList()) {
+        System.out.printf("Title: %s\n", title);
+      }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.println("That's all!");
+      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
     }
-    System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
-    System.out.println("That's all!");
-    System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     // [END canonical_core]
   }
 
@@ -7785,15 +7884,27 @@ public class PublishSeriesFlattenedPiVersion {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 public class PublishSeriesFlattenedSecondEdition {
   public static void samplePublishSeries() {
     // [START canonical_core]
-    Shelf shelf = Shelf.newBuilder().build();
-    List<Book> books = new ArrayList<>();
-    int edition = 2;
-    SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
-    PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
-    System.out.println(response);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      int edition = 2;
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
+      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
     // [END canonical_core]
   }
 
@@ -7824,32 +7935,45 @@ public class PublishSeriesFlattenedSecondEdition {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 public class PublishSeriesRequestPiVersion {
   public static void samplePublishSeries(String name, int edition) {
     // [START canonical_core]
-    // String name = "Math";
-    // int edition = 123;
-    Shelf shelf = Shelf.newBuilder()
-      .setName(name)
-      .build();
-    List<Book> books = new ArrayList<>();
-    String seriesString = "xyz3141592654";
-    SeriesUuid seriesUuid = SeriesUuid.newBuilder()
-      .setSeriesString(seriesString)
-      .build();
-    PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-      .setShelf(shelf)
-      .addAllBooks(books)
-      .setSeriesUuid(seriesUuid)
-      .setEdition(edition)
-      .build();
-    PublishSeriesResponse response = libraryClient.publishSeries(request);
-    for (String title : response.getBookNamesList()) {
-      System.out.printf("Title: %s\n", title);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String name = "Math";
+      // int edition = 123;
+      Shelf shelf = Shelf.newBuilder()
+        .setName(name)
+        .build();
+      List<Book> books = new ArrayList<>();
+      String seriesString = "xyz3141592654";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(request);
+      for (String title : response.getBookNamesList()) {
+        System.out.printf("Title: %s\n", title);
+      }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.println("That's all!");
+      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
     }
-    System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
-    System.out.println("That's all!");
-    System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     // [END canonical_core]
   }
 
@@ -7899,21 +8023,34 @@ public class PublishSeriesRequestPiVersion {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 public class PublishSeriesRequestSecondEdition {
   public static void samplePublishSeries() {
     // [START canonical_core]
-    Shelf shelf = Shelf.newBuilder().build();
-    List<Book> books = new ArrayList<>();
-    SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
-    int edition = 2;
-    PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-      .setShelf(shelf)
-      .addAllBooks(books)
-      .setSeriesUuid(seriesUuid)
-      .setEdition(edition)
-      .build();
-    PublishSeriesResponse response = libraryClient.publishSeries(request);
-    System.out.println(response);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
+      int edition = 2;
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(request);
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
     // [END canonical_core]
   }
 
@@ -7944,36 +8081,49 @@ public class PublishSeriesRequestSecondEdition {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 public class PublishSeriesCallableCallablePiVersion {
   public static void samplePublishSeries(String name, int edition) {
     // [START canonical_core]
-    // String name = "Math";
-    // int edition = 123;
-    Shelf shelf = Shelf.newBuilder()
-      .setName(name)
-      .build();
-    List<Book> books = new ArrayList<>();
-    String seriesString = "xyz3141592654";
-    SeriesUuid seriesUuid = SeriesUuid.newBuilder()
-      .setSeriesString(seriesString)
-      .build();
-    PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-      .setShelf(shelf)
-      .addAllBooks(books)
-      .setSeriesUuid(seriesUuid)
-      .setEdition(edition)
-      .build();
-    ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String name = "Math";
+      // int edition = 123;
+      Shelf shelf = Shelf.newBuilder()
+        .setName(name)
+        .build();
+      List<Book> books = new ArrayList<>();
+      String seriesString = "xyz3141592654";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
 
-    // Do something
+      // Do something
 
-    PublishSeriesResponse response = future.get();
-    for (String title : response.getBookNamesList()) {
-      System.out.printf("Title: %s\n", title);
+      PublishSeriesResponse response = future.get();
+      for (String title : response.getBookNamesList()) {
+        System.out.printf("Title: %s\n", title);
+      }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.println("That's all!");
+      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
     }
-    System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
-    System.out.println("That's all!");
-    System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     // [END canonical_core]
   }
 
@@ -8023,25 +8173,38 @@ public class PublishSeriesCallableCallablePiVersion {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 public class PublishSeriesCallableCallableSecondEdition {
   public static void samplePublishSeries() {
     // [START canonical_core]
-    Shelf shelf = Shelf.newBuilder().build();
-    List<Book> books = new ArrayList<>();
-    SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
-    int edition = 2;
-    PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-      .setShelf(shelf)
-      .addAllBooks(books)
-      .setSeriesUuid(seriesUuid)
-      .setEdition(edition)
-      .build();
-    ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
+      int edition = 2;
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
 
-    // Do something
+      // Do something
 
-    PublishSeriesResponse response = future.get();
-    System.out.println(response);
+      PublishSeriesResponse response = future.get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
     // [END canonical_core]
   }
 
@@ -8072,17 +8235,25 @@ public class PublishSeriesCallableCallableSecondEdition {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.StreamBooksRequest;
+
 public class StreamBooksCallableCallableStreamingServerProg {
   public static void sampleStreamBooks() {
     // [START babbage_core]
-    String name = "BASIC";
-    StreamBooksRequest request = StreamBooksRequest.newBuilder()
-      .setName(name)
-      .build();
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      String name = "BASIC";
+      StreamBooksRequest request = StreamBooksRequest.newBuilder()
+        .setName(name)
+        .build();
 
-    ServerStream<Book> stream = libraryClient.streamBooksCallable().call(request);
-    for (Book responseItem : stream) {
-      System.out.println(responseItem);
+      ServerStream<Book> stream = libraryClient.streamBooksCallable().call(request);
+      for (Book responseItem : stream) {
+        System.out.println(responseItem);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
     }
     // [END babbage_core]
   }
@@ -8114,14 +8285,22 @@ public class StreamBooksCallableCallableStreamingServerProg {
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
+package com.google.gcloud.pubsub.v1;
+
+import com.google.example.library.v1.StreamShelvesRequest;
+
 public class StreamShelvesCallableCallableStreamingServerEmpty {
   public static void sampleStreamShelves() {
     // [START sample_core]
-    StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
 
-    ServerStream<StreamShelvesResponse> stream = libraryClient.streamShelvesCallable().call(request);
-    for (StreamShelvesResponse responseItem : stream) {
-      System.out.println(responseItem);
+      ServerStream<StreamShelvesResponse> stream = libraryClient.streamShelvesCallable().call(request);
+      for (StreamShelvesResponse responseItem : stream) {
+        System.out.println(responseItem);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
     }
     // [END sample_core]
   }


### PR DESCRIPTION
This PR makes Java standalone samples (almost) copy-paste compilable and executable from command line by:
- add imports
- change the existing main method to a static sample method and add a main method that calls the sample method
- handle CLIs using apache cli package
- add client initialization

Remaining work to make for Java standalone samples which will come in a following PR:
- remove the boilerplate code describing each sample
- add license
- correctly import the client (`LibraryClient`)
- put samples to the correct package and directory