### PR TITLE
Use newest api-common-protos:input-contract

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ ext {
     autovalue: 'com.google.auto.value:auto-value:1.6',
     autovalueAnnotation: 'com.google.auto.value:auto-value-annotations:1.6',
     commonmark: 'com.atlassian.commonmark:commonmark:0.9.0',
-    commonProtos: 'com.google.api.grpc:proto-google-common-protos:1.13.0-pre1',
+    commonProtos: 'com.google.api.grpc:proto-google-common-protos:1.13.0-pre2',
     commonsLang: 'org.apache.commons:commons-lang3:3.6',
     commonsCli: 'commons-cli:commons-cli:1.4',
     guava: 'com.google.guava:guava:26.0-jre',

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -148,7 +148,7 @@ def com_google_api_api_compiler():
 def com_google_api_grpc_proto_google_common_protos():
     native.maven_jar(
         name = "com_google_api_grpc_proto_google_common_protos",
-        artifact = "com.google.api.grpc:proto-google-common-protos:1.13.0-pre1",
+        artifact = "com.google.api.grpc:proto-google-common-protos:1.13.0-pre2",
     )
 
 def com_google_auto_value_auto_value():

--- a/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
@@ -314,8 +314,7 @@ public abstract class FlatteningConfig {
               messageConfigs, resourceNameConfigs, parameterField, resourceNameTreatment);
       flattenedFieldConfigBuilder.put(parameter, fieldConfig);
     }
-    return new AutoValue_FlatteningConfig(
-        flattenedFieldConfigBuilder.build(), methodSignature.getFunctionName());
+    return new AutoValue_FlatteningConfig(flattenedFieldConfigBuilder.build(), null);
   }
 
   public Iterable<FieldModel> getFlattenedFields() {

--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.config;
 
+import com.google.api.OperationData;
 import com.google.api.codegen.LongRunningConfigProto;
 import com.google.api.codegen.util.ProtoParser;
 import com.google.api.tools.framework.model.Diag;
@@ -23,7 +24,6 @@ import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.auto.value.AutoValue;
-import com.google.longrunning.OperationTypes;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -99,14 +99,14 @@ public abstract class LongRunningConfig {
     int preexistingErrors = diagCollector.getErrorCount();
 
     Model model = method.getModel();
-    OperationTypes operationTypes = protoParser.getLongRunningOperation(method);
+    OperationData operationTypes = protoParser.getLongRunningOperation(method);
     if (operationTypes == null
         || operationTypes.equals(operationTypes.getDefaultInstanceForType())) {
       return null;
     }
 
-    String responseTypeName = operationTypes.getResponse();
-    String metadataTypeName = operationTypes.getMetadata();
+    String responseTypeName = operationTypes.getResponseType();
+    String metadataTypeName = operationTypes.getMetadataType();
 
     if (responseTypeName.equals(longRunningConfigProto.getReturnType())
         && metadataTypeName.equals(longRunningConfigProto.getMetadataType())) {

--- a/src/main/java/com/google/api/codegen/config/RetryCodesConfig.java
+++ b/src/main/java/com/google/api/codegen/config/RetryCodesConfig.java
@@ -17,7 +17,6 @@ package com.google.api.codegen.config;
 import static com.google.api.codegen.configgen.mergers.RetryMerger.DEFAULT_RETRY_CODES;
 import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_CODES_IDEMPOTENT_NAME;
 
-import com.google.api.Retry;
 import com.google.api.codegen.InterfaceConfigProto;
 import com.google.api.codegen.MethodConfigProto;
 import com.google.api.codegen.RetryCodesDefinitionProto;
@@ -31,7 +30,6 @@ import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.rpc.Code;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -224,41 +222,20 @@ public class RetryCodesConfig {
         continue;
       }
 
-      Retry retry = protoParser.getRetry(method);
-      Set<String> retryCodes = new TreeSet<>();
-
+      String retryCodesName;
       if (protoParser.isHttpGetMethod(method)) {
-        // If this is analogous to HTTP GET, then automatically retry on `INTERNAL` and
-        // `UNAVAILABLE`.
-        retryCodes.addAll(RETRY_CODES_FOR_HTTP_GET);
-      }
-
-      if (retry.getCodesCount() == 0) {
-        String retryCodesName;
-        if (protoParser.isHttpGetMethod(method)) {
-          // It is a common case to have an HTTP GET method with no extra codes to retry on,
-          // so let's put them all under the same retry code name.
-          retryCodesName = httpGetRetryName;
-          retryCodesDefinition.put(httpGetRetryName, RETRY_CODES_FOR_HTTP_GET);
-        } else {
-          // It is a common case to have a method with no codes to retry on,
-          // so let's put these methods all under the same retry code name.
-          retryCodesName = noRetryName;
-          retryCodesDefinition.put(noRetryName, ImmutableList.of());
-        }
-
-        methodRetryNames.put(method.getSimpleName(), retryCodesName);
-
+        // It is a common case to have an HTTP GET method with no extra codes to retry on,
+        // so let's put them all under the same retry code name.
+        retryCodesName = httpGetRetryName;
+        retryCodesDefinition.put(httpGetRetryName, RETRY_CODES_FOR_HTTP_GET);
       } else {
-        // Add all retry codes defined in the Retry proto annotation.
-        retryCodes.addAll(
-            retry.getCodesList().stream().map(Code::name).collect(Collectors.toList()));
-
-        // Create a retryCode config internally.
-        String retryCodesName = symbolTable.getNewSymbol(getRetryCodesName(method));
-        methodRetryNames.put(method.getSimpleName(), retryCodesName);
-        retryCodesDefinition.put(retryCodesName, ImmutableList.copyOf(retryCodes));
+        // It is a common case to have a method with no codes to retry on,
+        // so let's put these methods all under the same retry code name.
+        retryCodesName = noRetryName;
+        retryCodesDefinition.put(noRetryName, ImmutableList.of());
       }
+
+      methodRetryNames.put(method.getSimpleName(), retryCodesName);
     }
   }
 

--- a/src/main/java/com/google/api/codegen/util/ProtoParser.java
+++ b/src/main/java/com/google/api/codegen/util/ProtoParser.java
@@ -73,13 +73,12 @@ public class ProtoParser {
   /* Return a list of method signatures, aka flattenings, specified on a given method.
    * This flattens the repeated additionalSignatures into the returned list of MethodSignatures. */
   public List<MethodSignature> getMethodSignatures(Method method) {
-    if (!method.getOptionFields().containsKey(AnnotationsProto.methodSignature.getDescriptor())) {
-      return ImmutableList.of();
-    }
-    // Variable methodSignature will always be nonnull, so we had to check for presence above.
     List<MethodSignature> methodSignatures =
         (List<MethodSignature>)
             method.getOptionFields().get(AnnotationsProto.methodSignature.getDescriptor());
+    if (methodSignatures == null) {
+      return ImmutableList.of();
+    }
     return ImmutableList.<MethodSignature>builder().addAll(methodSignatures).build();
   }
 

--- a/src/main/java/com/google/api/codegen/util/ProtoParser.java
+++ b/src/main/java/com/google/api/codegen/util/ProtoParser.java
@@ -79,7 +79,7 @@ public class ProtoParser {
     if (methodSignatures == null) {
       return ImmutableList.of();
     }
-    return ImmutableList.<MethodSignature>builder().addAll(methodSignatures).build();
+    return ImmutableList.copyOf(methodSignatures);
   }
 
   /** Return the names of required parameters of a method. */

--- a/src/main/java/com/google/api/codegen/util/ProtoParser.java
+++ b/src/main/java/com/google/api/codegen/util/ProtoParser.java
@@ -14,10 +14,13 @@
  */
 package com.google.api.codegen.util;
 
+import static com.google.api.FieldBehavior.REQUIRED;
+
 import com.google.api.AnnotationsProto;
+import com.google.api.FieldBehavior;
 import com.google.api.MethodSignature;
+import com.google.api.OperationData;
 import com.google.api.Resource;
-import com.google.api.Retry;
 import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.MessageType;
@@ -25,11 +28,8 @@ import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.longrunning.OperationTypes;
-import com.google.longrunning.OperationsProto;
 import com.google.protobuf.Api;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
@@ -65,8 +65,8 @@ public class ProtoParser {
   }
 
   /** Get long running settings. */
-  public OperationTypes getLongRunningOperation(Method method) {
-    return method.getDescriptor().getMethodAnnotation(OperationsProto.operationTypes);
+  public OperationData getLongRunningOperation(Method method) {
+    return method.getDescriptor().getMethodAnnotation(AnnotationsProto.operation);
   }
 
   /* Return a list of method signatures, aka flattenings, specified on a given method.
@@ -76,14 +76,10 @@ public class ProtoParser {
       return ImmutableList.of();
     }
     // Variable methodSignature will always be nonnull, so we had to check for presence above.
-    MethodSignature methodSignature =
-        method.getDescriptor().getMethodAnnotation(AnnotationsProto.methodSignature);
-    // Let's only recurse once when we look for additional MethodSignatures.
-    List<MethodSignature> additionalSignatures = methodSignature.getAdditionalSignaturesList();
-    return ImmutableList.<MethodSignature>builder()
-        .add(methodSignature)
-        .addAll(additionalSignatures)
-        .build();
+    List<MethodSignature> methodSignatures =
+        (List<MethodSignature>)
+            method.getOptionFields().get(AnnotationsProto.methodSignature.getDescriptor());
+    return ImmutableList.<MethodSignature>builder().addAll(methodSignatures).build();
   }
 
   /** Return the names of required parameters of a method. */
@@ -99,19 +95,15 @@ public class ProtoParser {
 
   /** Returns if a field is required, according to the proto annotations. */
   private boolean isFieldRequired(Field field) {
-    return Optional.ofNullable(
-            (Boolean) field.getOptionFields().get(AnnotationsProto.required.getDescriptor()))
-        .orElse(false);
-  }
-
-  /** Return the extra retry codes for the given method. */
-  public Retry getRetry(Method method) {
-    return method.getDescriptor().getMethodAnnotation(AnnotationsProto.retry);
+    List<FieldBehavior> fieldBehaviors =
+        (List<FieldBehavior>)
+            field.getOptionFields().get(AnnotationsProto.fieldBehavior.getDescriptor());
+    return fieldBehaviors != null && fieldBehaviors.contains(REQUIRED.getValueDescriptor());
   }
 
   /** Return the resource type for the given field. */
   public String getResourceType(Field field) {
-    return (String) field.getOptionFields().get(AnnotationsProto.resourceType.getDescriptor());
+    return (String) field.getOptionFields().get(AnnotationsProto.resourceReference.getDescriptor());
   }
 
   /** Return whether the method has the HttpRule for GET. */

--- a/src/main/java/com/google/api/codegen/util/ProtoParser.java
+++ b/src/main/java/com/google/api/codegen/util/ProtoParser.java
@@ -69,6 +69,7 @@ public class ProtoParser {
     return method.getDescriptor().getMethodAnnotation(AnnotationsProto.operation);
   }
 
+  @SuppressWarnings("unchecked")
   /* Return a list of method signatures, aka flattenings, specified on a given method.
    * This flattens the repeated additionalSignatures into the returned list of MethodSignatures. */
   public List<MethodSignature> getMethodSignatures(Method method) {
@@ -93,7 +94,8 @@ public class ProtoParser {
         .collect(Collectors.toList());
   }
 
-  /** Returns if a field is required, according to the proto annotations. */
+  @SuppressWarnings("unchecked")
+  /* Returns if a field is required, according to the proto annotations. */
   private boolean isFieldRequired(Field field) {
     List<FieldBehavior> fieldBehaviors =
         (List<FieldBehavior>)

--- a/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.config;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.api.OperationData;
 import com.google.api.codegen.LongRunningConfigProto;
 import com.google.api.codegen.util.ProtoParser;
 import com.google.api.tools.framework.model.BoundedDiagCollector;
@@ -25,7 +26,6 @@ import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.SymbolTable;
 import com.google.api.tools.framework.model.TypeRef;
-import com.google.longrunning.OperationTypes;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -84,9 +84,9 @@ public class LongRunningConfigTest {
 
     Mockito.when(protoParser.getLongRunningOperation(lroAnnotatedMethod))
         .thenReturn(
-            OperationTypes.newBuilder()
-                .setMetadata(ANNOTATIONS_METADATA_TYPE)
-                .setResponse(ANNOTATIONS_RETURN_TYPE_NAME)
+            OperationData.newBuilder()
+                .setMetadataType(ANNOTATIONS_METADATA_TYPE)
+                .setResponseType(ANNOTATIONS_RETURN_TYPE_NAME)
                 .build());
 
     Mockito.when(symbolTable.lookupType(GAPIC_CONFIG_METADATA_TYPE))

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -1966,28 +1966,6 @@ const CancelOperationRequest = {
 const DeleteOperationRequest = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
-
-/**
- * The protocol buffer types used to indirectly support this method.
- *
- * @property {string} response
- *   Required. The message name of the primary return type for this
- *   long-running operation.
- *   This type will be used to deserialize the LRO's response.
- *
- *   If the response is in a different package from the rpc, a fully-qualified
- *   message name must be used (e.g. "google.protobuf.Empty").
- *
- * @property {string} metadata
- *   The metadata message name for this long-running operation.
- *
- * @typedef OperationTypes
- * @memberof google.longrunning
- * @see [google.longrunning.OperationTypes definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto}
- */
-const OperationTypes = {
-  // This is for documentation. Actual contents will be loaded by gRPC.
-};
 ============== file: src/v1/doc/google/protobuf/doc_any.js ==============
 // Copyright 2018 Google LLC
 //

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -3955,11 +3955,10 @@ import sys
 
 from google.api_core.protobuf_helpers import get_messages
 
-from google.api import annotations_pb2
 from google.api import http_pb2
+from google.api import longrunning_pb2
 from google.api import metadata_pb2
 from google.api import resources_pb2
-from google.api import retry_pb2
 from google.api import signature_pb2
 from google.cloud.example.library_v1.proto import book_from_anywhere_pb2
 from google.cloud.example.library_v1.proto import errors_pb2
@@ -3981,11 +3980,10 @@ from google.rpc import status_pb2
 
 
 _shared_modules = [
-    annotations_pb2,
     http_pb2,
+    longrunning_pb2,
     metadata_pb2,
     resources_pb2,
-    retry_pb2,
     signature_pb2,
     other_shared_type_pb2,
     shared_type_pb2,

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1527,11 +1527,10 @@ import sys
 
 from google.api_core.protobuf_helpers import get_messages
 
-from google.api import annotations_pb2
 from google.api import http_pb2
+from google.api import longrunning_pb2
 from google.api import metadata_pb2
 from google.api import resources_pb2
-from google.api import retry_pb2
 from google.api import signature_pb2
 from google.cloud.example_v1.proto import other_shared_type_pb2
 from google.cloud.example_v1.proto.bar import different_submodule_pb2
@@ -1541,11 +1540,10 @@ from google.protobuf import empty_pb2
 
 
 _shared_modules = [
-    annotations_pb2,
     http_pb2,
+    longrunning_pb2,
     metadata_pb2,
     resources_pb2,
-    retry_pb2,
     signature_pb2,
     other_shared_type_pb2,
     different_submodule_pb2,

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1141,22 +1141,20 @@ import sys
 from google.api_core.protobuf_helpers import get_messages
 
 from example.proto import no_path_templates_messages_pb2
-from google.api import annotations_pb2
 from google.api import http_pb2
+from google.api import longrunning_pb2
 from google.api import metadata_pb2
 from google.api import resources_pb2
-from google.api import retry_pb2
 from google.api import signature_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import empty_pb2
 
 
 _shared_modules = [
-    annotations_pb2,
     http_pb2,
+    longrunning_pb2,
     metadata_pb2,
     resources_pb2,
-    retry_pb2,
     signature_pb2,
     descriptor_pb2,
     empty_pb2,

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -1115,20 +1115,6 @@ module Google
     #   @return [String]
     #     The name of the operation resource to be deleted.
     class DeleteOperationRequest; end
-
-    # The protocol buffer types used to indirectly support this method.
-    # @!attribute [rw] response
-    #   @return [String]
-    #     Required. The message name of the primary return type for this
-    #     long-running operation.
-    #     This type will be used to deserialize the LRO's response.
-    #
-    #     If the response is in a different package from the rpc, a fully-qualified
-    #     message name must be used (e.g. "google.protobuf.Empty").
-    # @!attribute [rw] metadata
-    #   @return [String]
-    #     The metadata message name for this long-running operation.
-    class OperationTypes; end
   end
 end
 ============== file: lib/library/v1/doc/google/protobuf/any.rb ==============

--- a/src/test/java/com/google/api/codegen/packagegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/packagegen/testdata/library.proto
@@ -151,7 +151,7 @@ message Book {
   // Book names have the form `shelves/{shelf_id}/books/{book_id}`.
   // The name is ignored when creating a book.
   string name = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     (google.api.resource).path = "shelves/*/books/*"];
 
   // The name of the book author.
@@ -170,7 +170,7 @@ message Shelf {
   // Shelf names have the form `shelves/{shelf_id}`.
   // The name is ignored when creating a shelf.
   string name = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     (google.api.resource).path = "shelves/*"];
 
   // The theme of the shelf
@@ -181,16 +181,16 @@ message Shelf {
 message CreateShelfRequest {
   // The shelf to create.
   Shelf shelf = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 }
 
 // Request message for LibraryService.GetShelf.
 message GetShelfRequest {
   // The name of the shelf to retrieve.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 }
 
 // Request message for LibraryService.ListShelves.
@@ -210,7 +210,7 @@ message ListShelvesRequest {
 message ListShelvesResponse {
   // The list of shelves.
   repeated Shelf shelves = 1 [
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 
   // A token to retrieve next page of results.
   // Pass this value in the
@@ -224,8 +224,8 @@ message ListShelvesResponse {
 message DeleteShelfRequest {
   // The name of the shelf to delete.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 }
 
 // Describes the shelf being removed (other_shelf_name) and updated
@@ -233,41 +233,41 @@ message DeleteShelfRequest {
 message MergeShelvesRequest {
   // The name of the shelf we're adding books to.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 
   // The name of the shelf we're removing books from and deleting.
   string other_shelf_name = 2 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 }
 
 // Request message for LibraryService.CreateBook.
 message CreateBookRequest {
   // The name of the shelf in which the book is created.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 
   // The book to create.
   Book book = 2 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 }
 
 // Request message for LibraryService.GetBook.
 message GetBookRequest {
   // The name of the book to retrieve.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 }
 
 // Request message for LibraryService.ListBooks.
 message ListBooksRequest {
   // The name of the shelf whose books we'd like to list.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 
   // Requested page size. Server may return fewer books than requested.
   // If unspecified, server will pick an appropriate default.
@@ -284,7 +284,7 @@ message ListBooksRequest {
 message ListBooksResponse {
   // The list of books.
   repeated Book books = 1 [
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 
   // A token to retrieve next page of results.
   // Pass this value in the
@@ -298,12 +298,12 @@ message ListBooksResponse {
 message UpdateBookRequest {
   // The name of the book to update.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 
   // The book to update with. The name must match or be empty.
   Book book = 2 [
-    (google.api.required) = true
+    (google.api.field_behavior) = REQUIRED
   ];
 }
 
@@ -311,8 +311,8 @@ message UpdateBookRequest {
 message DeleteBookRequest {
   // The name of the book to delete.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 }
 
 // Describes what book to move (name) and what shelf we're moving it
@@ -320,11 +320,11 @@ message DeleteBookRequest {
 message MoveBookRequest {
   // The name of the book to move.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 
   // The name of the destination shelf.
   string other_shelf_name = 2 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
@@ -67,10 +67,12 @@ service LibraryService {
     option (google.api.http) = { get: "/v1/{name=bookShelves/*}" };
     option (google.api.method_signature) = {
       fields: ["name"]
-      additional_signatures: [
-        {fields: ["name", "message"]},
-        {fields: ["name", "message", "string_builder"]}
-      ]
+    };
+    option (google.api.method_signature) = {
+      fields: ["name", "message"],
+    };
+    option (google.api.method_signature) = {
+      fields: ["name", "message", "string_builder"]
     };
   }
 
@@ -87,9 +89,6 @@ service LibraryService {
     option (google.api.http) = { delete: "/v1/{name=bookShelves/*}" };
     option (google.api.method_signature) = {
       fields: ["name"]
-    };
-    option (google.api.retry) = {
-      codes: [UNAVAILABLE, DEADLINE_EXCEEDED]
     };
   }
 
@@ -148,14 +147,9 @@ service LibraryService {
     option (google.api.http) = { put: "/v1/{name=bookShelves/*/books/*}" body: "book" };
     option (google.api.method_signature) = {
       fields: ["name", "book"]
-      function_name: "update_book_1"
-      additional_signatures: [{
-        fields: ["name", "optional_foo", "book", "update_mask", "physical_mask"]
-        function_name: "update_book_2"}
-      ]
     };
-    option (google.api.retry) = {
-      codes: [UNAVAILABLE, DEADLINE_EXCEEDED]
+    option (google.api.method_signature) = {
+      fields: ["name", "optional_foo", "book", "update_mask", "physical_mask"]
     };
   }
 
@@ -172,9 +166,9 @@ service LibraryService {
     option (google.api.http) = { get: "/v1/strings" };
     option (google.api.method_signature) = {
       fields: []
-      additional_signatures: [
-        {fields: ["name"]}
-      ]
+    };
+    option (google.api.method_signature) = {
+      fields: ["name"]
     };
   }
 
@@ -274,9 +268,9 @@ service LibraryService {
     option (google.api.method_signature) = {
       fields: ["name"]
     };
-    option (google.longrunning.operation_types) = {
-      response: "google.example.library.v1.Book"
-      metadata: "google.example.library.v1.GetBigBookMetadata"
+    option (google.api.operation) = {
+      response_type: "google.example.library.v1.Book"
+      metadata_type: "google.example.library.v1.GetBigBookMetadata"
     };
   }
 
@@ -286,9 +280,9 @@ service LibraryService {
     option (google.api.method_signature) = {
       fields: ["name"]
     };
-    option (google.longrunning.operation_types) = {
-      metadata: "google.example.library.v1.GetBigBookMetadata"
-      response: "google.protobuf.Empty"
+    option (google.api.operation) = {
+      metadata_type: "google.example.library.v1.GetBigBookMetadata"
+      response_type: "google.protobuf.Empty"
     };
   }
 
@@ -297,67 +291,67 @@ service LibraryService {
     option (google.api.http) = { post: "/v1/testofp" body: "*" };
     option (google.api.method_signature) = {
       fields: []
-      additional_signatures: {
-        fields: [
-          "required_singular_int32",
-          "required_singular_int64",
-          "required_singular_float",
-          "required_singular_double",
-          "required_singular_bool",
-          "required_singular_enum",
-          "required_singular_string",
-          "required_singular_bytes",
-          "required_singular_message",
-          "required_singular_resource_name",
-          "required_singular_resource_name_oneof",
-          "required_singular_resource_name_common",
-          "required_singular_fixed32",
-          "required_singular_fixed64",
-          "required_repeated_int32",
-          "required_repeated_int64",
-          "required_repeated_float",
-          "required_repeated_double",
-          "required_repeated_bool",
-          "required_repeated_enum",
-          "required_repeated_string",
-          "required_repeated_bytes",
-          "required_repeated_message",
-          "required_repeated_resource_name",
-          "required_repeated_resource_name_oneof",
-          "required_repeated_resource_name_common",
-          "required_repeated_fixed32",
-          "required_repeated_fixed64",
-          "required_map",
-          "optional_singular_int32",
-          "optional_singular_int64",
-          "optional_singular_float",
-          "optional_singular_double",
-          "optional_singular_bool",
-          "optional_singular_enum",
-          "optional_singular_string",
-          "optional_singular_bytes",
-          "optional_singular_message",
-          "optional_singular_resource_name",
-          "optional_singular_resource_name_oneof",
-          "optional_singular_resource_name_common",
-          "optional_singular_fixed32",
-          "optional_singular_fixed64",
-          "optional_repeated_int32",
-          "optional_repeated_int64",
-          "optional_repeated_float",
-          "optional_repeated_double",
-          "optional_repeated_bool",
-          "optional_repeated_enum",
-          "optional_repeated_string",
-          "optional_repeated_bytes",
-          "optional_repeated_message",
-          "optional_repeated_resource_name",
-          "optional_repeated_resource_name_oneof",
-          "optional_repeated_resource_name_common",
-          "optional_repeated_fixed32",
-          "optional_repeated_fixed64",
-          "optional_map"]
-      }
+    };
+    option (google.api.method_signature) = {
+      fields: [
+        "required_singular_int32",
+        "required_singular_int64",
+        "required_singular_float",
+        "required_singular_double",
+        "required_singular_bool",
+        "required_singular_enum",
+        "required_singular_string",
+        "required_singular_bytes",
+        "required_singular_message",
+        "required_singular_resource_name",
+        "required_singular_resource_name_oneof",
+        "required_singular_resource_name_common",
+        "required_singular_fixed32",
+        "required_singular_fixed64",
+        "required_repeated_int32",
+        "required_repeated_int64",
+        "required_repeated_float",
+        "required_repeated_double",
+        "required_repeated_bool",
+        "required_repeated_enum",
+        "required_repeated_string",
+        "required_repeated_bytes",
+        "required_repeated_message",
+        "required_repeated_resource_name",
+        "required_repeated_resource_name_oneof",
+        "required_repeated_resource_name_common",
+        "required_repeated_fixed32",
+        "required_repeated_fixed64",
+        "required_map",
+        "optional_singular_int32",
+        "optional_singular_int64",
+        "optional_singular_float",
+        "optional_singular_double",
+        "optional_singular_bool",
+        "optional_singular_enum",
+        "optional_singular_string",
+        "optional_singular_bytes",
+        "optional_singular_message",
+        "optional_singular_resource_name",
+        "optional_singular_resource_name_oneof",
+        "optional_singular_resource_name_common",
+        "optional_singular_fixed32",
+        "optional_singular_fixed64",
+        "optional_repeated_int32",
+        "optional_repeated_int64",
+        "optional_repeated_float",
+        "optional_repeated_double",
+        "optional_repeated_bool",
+        "optional_repeated_enum",
+        "optional_repeated_string",
+        "optional_repeated_bytes",
+        "optional_repeated_message",
+        "optional_repeated_resource_name",
+        "optional_repeated_resource_name_oneof",
+        "optional_repeated_resource_name_common",
+        "optional_repeated_fixed32",
+        "optional_repeated_fixed64",
+        "optional_map"]
     };
   }
 }
@@ -369,13 +363,12 @@ message Book {
   // Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
   // Message field comment may include special characters: <>&"`'@.
   string name = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     (google.api.resource_set) = {
-      base_name: "book_oneof"
+      name: "book_oneof"
       resources: [
-        {base_name: "book"             path : "shelves/*/books/*"},
-        {base_name: "archived_book"    path : "archives/*/books/**"},
-        {base_name: "deleted_book"     path : "_deleted-book_"}
+        {name: "book"             path : "shelves/{shelf_id}/books/{book_id}"},
+        {name: "archived_book"    path : "archives/{archive_path}/books/{book_id=**}"}
       ]
     }
   ];
@@ -440,9 +433,9 @@ message BookFromArchive {
   // The resource name of the book.
   // Book names have the form `archives/{archive_id}/books/{book_id}`.
   string name = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     // TODO(andrealin): Make this refer only to the archived_book path.
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 
   // The name of the book author.
   string author = 2;
@@ -501,7 +494,7 @@ message Shelf {
   // The resource name of the shelf.
   // Shelf names have the form `shelves/{shelf_id}`.
   string name = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     (google.api.resource).path = "shelves/*"];
 
   // The theme of the shelf
@@ -515,15 +508,15 @@ message Shelf {
 message CreateShelfRequest {
   // The shelf to create.
   Shelf shelf = 1 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 }
 
 // Request message for LibraryService.GetShelf.
 message GetShelfRequest {
   // The name of the shelf to retrieve.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 
   // Field to verify that message-type query parameter gets flattened.
   SomeMessage message = 2;
@@ -532,7 +525,7 @@ message GetShelfRequest {
 
   // To test 'options' parameter name conflict.
   string options = 4 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 }
 
 
@@ -571,15 +564,15 @@ message StreamShelvesRequest {
 message StreamShelvesResponse {
   // The list of shelves.
   repeated Shelf shelves = 1 [
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 }
 
 // Request message for LibraryService.DeleteShelf.
 message DeleteShelfRequest {
   // The name of the shelf to delete.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 }
 
 // Describes the shelf being removed (other_shelf_name) and updated
@@ -587,36 +580,36 @@ message DeleteShelfRequest {
 message MergeShelvesRequest {
   // The name of the shelf we're adding books to.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 
   // The name of the shelf we're removing books from and deleting.
   string other_shelf_name = 2 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 }
 
 // Request message for LibraryService.CreateBook.
 message CreateBookRequest {
   // The name of the shelf in which the book is created.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 
   // The book to create.
   Book book = 2 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 }
 
 // Request message for LibraryService.PublishSeries.
 message PublishSeriesRequest {
   // The shelf in which the series is created.
   Shelf shelf = 1 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 
   // The books to publish in the series.
   repeated Book books = 2 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 
   oneof versioning {
     // The edition of the series
@@ -628,7 +621,7 @@ message PublishSeriesRequest {
 
   // Uniquely identifies the series to the publishing house.
   SeriesUuid series_uuid = 5 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 }
 
 message SeriesUuid {
@@ -642,7 +635,7 @@ message SeriesUuid {
 message PublishSeriesResponse {
   // The names of the books in the series that were published
   repeated string book_names = 1 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
   SeriesUuid series_uuid = 2;
 }
 
@@ -650,17 +643,17 @@ message PublishSeriesResponse {
 message GetBookRequest {
   // The name of the book to retrieve.
   string name = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     // TODO(andrealin): Make this refer only to the book resource.
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 }
 
 // Request message for LibraryService.ListBooks.
 message ListBooksRequest {
   // The name of the shelf whose books we'd like to list.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 
   // Requested page size. Server may return fewer books than requested.
   // If unspecified, server will pick an appropriate default.
@@ -693,23 +686,23 @@ message ListBooksResponse {
 message StreamBooksRequest {
   // The name of the shelf whose books we'd like to list.
   string name = 1 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 }
 
 // Request message for LibraryService.UpdateBook.
 message UpdateBookRequest {
   // The name of the book to update.
   string name = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 
   // An optional foo.
   string optional_foo = 2;
 
   // The book to update with.
   Book book = 3 [
-    (google.api.required) = true
+    (google.api.field_behavior) = REQUIRED
   ];
 
   // A field mask to apply, rendered as an HTTP parameter.
@@ -723,9 +716,9 @@ message UpdateBookRequest {
 message DeleteBookRequest {
   // The name of the book to delete.
   string name = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 }
 
 // Describes what book to move (name) and what shelf we're moving it
@@ -733,13 +726,13 @@ message DeleteBookRequest {
 message MoveBookRequest {
   // The name of the book to move.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 
   // The name of the destination shelf.
   string other_shelf_name = 2 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 }
 
 message ListStringsRequest {
@@ -755,12 +748,12 @@ message ListStringsResponse {
 
 message AddCommentsRequest {
   string name = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     // TODO(andrealin): Make this refer only to the archived_book path.
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 
   repeated Comment comments = 2 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 }
 
 message Comment {
@@ -788,48 +781,48 @@ message Comment {
 message GetBookFromArchiveRequest {
   // The name of the book to retrieve.
   string name = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     // TODO(andrealin): Make this refer only to the archived_book path.
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 }
 
 // Request message for LibraryService.GetBookFromAnywhere.
 message GetBookFromAnywhereRequest {
   // The name of the book to retrieve.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 
   // An alternate book name, used to test restricting flattened field to a
   // single resource name type in a oneof.
   string alt_book_name = 2 [
     // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 }
 
 // Request message for LibraryService.GetBookFromAbsolutelyAnywhere.
 message GetBookFromAbsolutelyAnywhereRequest {
   // The name of the book to retrieve.
   string name = 1 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 }
 
 // Request message for LibraryService.UpdateBookIndex.
 message UpdateBookIndexRequest {
   // The name of the book to update.
   string name = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 
   // The name of the index for the book
   string index_name = 2 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 
   // The index to update the book with
   map<string, string> index_map = 3 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 }
 
 message DiscussBookRequest {
@@ -837,7 +830,7 @@ message DiscussBookRequest {
   // of the stream and this is not specified, the name in the previous
   // message will be reused.
   string name = 1 [
-    (google.api.required) = true];
+    (google.api.field_behavior) = REQUIRED];
 
   // The new comment.
   Comment comment = 2;
@@ -846,12 +839,12 @@ message DiscussBookRequest {
 // Test repeated field with resource name format in request
 message FindRelatedBooksRequest {
   repeated string names = 1 [
-    (google.api.required) = true,
+    (google.api.field_behavior) = REQUIRED,
     // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
   repeated string shelves = 2 [
-    (google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Shelf"];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
   int32 page_size = 4;
   string page_token = 5;
 }
@@ -860,7 +853,7 @@ message FindRelatedBooksRequest {
 message FindRelatedBooksResponse {
   repeated string names = 1 [
     // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_type) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
   string next_page_token = 2;
 }
 
@@ -885,48 +878,48 @@ message TestOptionalRequiredFlatteningParamsRequest {
   message InnerMessage {
   }
 
-  int32 required_singular_int32 = 1 [(google.api.required) = true];
-  int64 required_singular_int64 = 2 [(google.api.required) = true];
-  float required_singular_float = 3 [(google.api.required) = true];
-  double required_singular_double = 4 [(google.api.required) = true];
-  bool required_singular_bool = 5 [(google.api.required) = true];
-  InnerEnum required_singular_enum = 6 [(google.api.required) = true];
-  string required_singular_string = 7 [(google.api.required) = true];
-  bytes required_singular_bytes = 8 [(google.api.required) = true];
-  InnerMessage required_singular_message = 9 [(google.api.required) = true];
-  string required_singular_resource_name = 10 [(google.api.required) = true,
+  int32 required_singular_int32 = 1 [(google.api.field_behavior) = REQUIRED];
+  int64 required_singular_int64 = 2 [(google.api.field_behavior) = REQUIRED];
+  float required_singular_float = 3 [(google.api.field_behavior) = REQUIRED];
+  double required_singular_double = 4 [(google.api.field_behavior) = REQUIRED];
+  bool required_singular_bool = 5 [(google.api.field_behavior) = REQUIRED];
+  InnerEnum required_singular_enum = 6 [(google.api.field_behavior) = REQUIRED];
+  string required_singular_string = 7 [(google.api.field_behavior) = REQUIRED];
+  bytes required_singular_bytes = 8 [(google.api.field_behavior) = REQUIRED];
+  InnerMessage required_singular_message = 9 [(google.api.field_behavior) = REQUIRED];
+  string required_singular_resource_name = 10 [(google.api.field_behavior) = REQUIRED,
     // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_type) = "google.example.library.v1.Book"
+    (google.api.resource_reference) = "google.example.library.v1.Book"
   ];
-  string required_singular_resource_name_oneof = 11 [(google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"
+  string required_singular_resource_name_oneof = 11 [(google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"
   ];
-  string required_singular_resource_name_common = 14 [(google.api.required) = true,
-    (google.api.resource_type) = "google.api.Project"
+  string required_singular_resource_name_common = 14 [(google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.api.Project"
   ];
-  fixed32 required_singular_fixed32 = 12 [(google.api.required) = true];
-  fixed64 required_singular_fixed64 = 13 [(google.api.required) = true];
+  fixed32 required_singular_fixed32 = 12 [(google.api.field_behavior) = REQUIRED];
+  fixed64 required_singular_fixed64 = 13 [(google.api.field_behavior) = REQUIRED];
 
-  repeated int32 required_repeated_int32 = 21 [(google.api.required) = true];
-  repeated int64 required_repeated_int64 = 22 [(google.api.required) = true];
-  repeated float required_repeated_float = 23 [(google.api.required) = true];
-  repeated double required_repeated_double = 24 [(google.api.required) = true];
-  repeated bool required_repeated_bool = 25 [(google.api.required) = true];
-  repeated InnerEnum required_repeated_enum = 26 [(google.api.required) = true];
-  repeated string required_repeated_string = 27 [(google.api.required) = true];
-  repeated bytes required_repeated_bytes = 28 [(google.api.required) = true];
-  repeated InnerMessage required_repeated_message = 29 [(google.api.required) = true];
-  repeated string required_repeated_resource_name = 30 [(google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
-  repeated string required_repeated_resource_name_oneof = 31 [(google.api.required) = true,
-    (google.api.resource_type) = "google.example.library.v1.Book"];
-  repeated string required_repeated_resource_name_common = 34 [(google.api.required) = true,
-    (google.api.resource_type) = "google.api.Project"
+  repeated int32 required_repeated_int32 = 21 [(google.api.field_behavior) = REQUIRED];
+  repeated int64 required_repeated_int64 = 22 [(google.api.field_behavior) = REQUIRED];
+  repeated float required_repeated_float = 23 [(google.api.field_behavior) = REQUIRED];
+  repeated double required_repeated_double = 24 [(google.api.field_behavior) = REQUIRED];
+  repeated bool required_repeated_bool = 25 [(google.api.field_behavior) = REQUIRED];
+  repeated InnerEnum required_repeated_enum = 26 [(google.api.field_behavior) = REQUIRED];
+  repeated string required_repeated_string = 27 [(google.api.field_behavior) = REQUIRED];
+  repeated bytes required_repeated_bytes = 28 [(google.api.field_behavior) = REQUIRED];
+  repeated InnerMessage required_repeated_message = 29 [(google.api.field_behavior) = REQUIRED];
+  repeated string required_repeated_resource_name = 30 [(google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
+  repeated string required_repeated_resource_name_oneof = 31 [(google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
+  repeated string required_repeated_resource_name_common = 34 [(google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.api.Project"
   ];
-  repeated fixed32 required_repeated_fixed32 = 32 [(google.api.required) = true];
-  repeated fixed64 required_repeated_fixed64 = 33 [(google.api.required) = true];
+  repeated fixed32 required_repeated_fixed32 = 32 [(google.api.field_behavior) = REQUIRED];
+  repeated fixed64 required_repeated_fixed64 = 33 [(google.api.field_behavior) = REQUIRED];
 
-  map<int32, string> required_map = 41 [(google.api.required) = true];
+  map<int32, string> required_map = 41 [(google.api.field_behavior) = REQUIRED];
 
   int32 optional_singular_int32 = 51;
   int64 optional_singular_int64 = 52;
@@ -938,13 +931,13 @@ message TestOptionalRequiredFlatteningParamsRequest {
   bytes optional_singular_bytes = 58;
   InnerMessage optional_singular_message = 59;
   string optional_singular_resource_name = 60 [
-    (google.api.resource_type) = "google.example.library.v1.Book"
+    (google.api.resource_reference) = "google.example.library.v1.Book"
   ];
   string optional_singular_resource_name_oneof = 61 [
-    (google.api.resource_type) = "google.example.library.v1.Book"
+    (google.api.resource_reference) = "google.example.library.v1.Book"
   ];
   string optional_singular_resource_name_common = 64 [
-    (google.api.resource_type) = "google.api.Project"
+    (google.api.resource_reference) = "google.api.Project"
   ];
   fixed32 optional_singular_fixed32 = 62;
   fixed64 optional_singular_fixed64 = 63;
@@ -959,13 +952,13 @@ message TestOptionalRequiredFlatteningParamsRequest {
   repeated bytes optional_repeated_bytes = 78;
   repeated InnerMessage optional_repeated_message = 79;
   repeated string optional_repeated_resource_name = 80 [
-    (google.api.resource_type) = "google.example.library.v1.Book"
+    (google.api.resource_reference) = "google.example.library.v1.Book"
   ];
   repeated string optional_repeated_resource_name_oneof = 81 [
-    (google.api.resource_type) = "google.example.library.v1.Book"
+    (google.api.resource_reference) = "google.example.library.v1.Book"
   ];
   repeated string optional_repeated_resource_name_common = 84 [
-    (google.api.resource_type) = "google.api.Project"
+    (google.api.resource_reference) = "google.api.Project"
   ];
   repeated fixed32 optional_repeated_fixed32 = 82;
   repeated fixed64 optional_repeated_fixed64 = 83;

--- a/src/test/java/com/google/api/codegen/transformer/RetryDefinitionsTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/RetryDefinitionsTransformerTest.java
@@ -16,11 +16,8 @@ package com.google.api.codegen.transformer;
 
 import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_CODES_IDEMPOTENT_NAME;
 import static com.google.api.codegen.configgen.transformer.RetryTransformer.RETRY_CODES_NON_IDEMPOTENT_NAME;
-import static com.google.rpc.Code.CANCELLED;
-import static com.google.rpc.Code.PERMISSION_DENIED;
 import static com.google.rpc.Code.RESOURCE_EXHAUSTED;
 
-import com.google.api.Retry;
 import com.google.api.codegen.InterfaceConfigProto;
 import com.google.api.codegen.MethodConfigProto;
 import com.google.api.codegen.RetryCodesDefinitionProto;
@@ -43,7 +40,6 @@ public class RetryDefinitionsTransformerTest {
 
   private static final ProtoParser protoParser = Mockito.mock(ProtoParser.class);
   private static final Method httpGetMethod = Mockito.mock(Method.class);
-  private static final Method cancelledMethod = Mockito.mock(Method.class);
   private static final Method nonIdempotentMethod = Mockito.mock(Method.class);
   private static final Method permissionDeniedMethod = Mockito.mock(Method.class);
   private static final Interface apiInterface = Mockito.mock(Interface.class);
@@ -52,7 +48,6 @@ public class RetryDefinitionsTransformerTest {
   private static final String IDEMPOTENT_METHOD_NAME = "IdempotentMethod";
   private static final String NON_IDEMPOTENT_METHOD_NAME = "NonIdempotentMethod";
   private static final String PERMISSION_DENIED_METHOD_NAME = "PermissionDeniedMethod";
-  private static final String CANCELED_METHOD_NAME = "CanceledMethod";
 
   private static InterfaceConfigProto interfaceConfigProto;
 
@@ -61,24 +56,13 @@ public class RetryDefinitionsTransformerTest {
     Mockito.when(httpGetMethod.getSimpleName()).thenReturn(GET_HTTP_METHOD_NAME);
     Mockito.when(nonIdempotentMethod.getSimpleName()).thenReturn(NON_IDEMPOTENT_METHOD_NAME);
     Mockito.when(permissionDeniedMethod.getSimpleName()).thenReturn(PERMISSION_DENIED_METHOD_NAME);
-    Mockito.when(cancelledMethod.getSimpleName()).thenReturn(CANCELED_METHOD_NAME);
 
     Mockito.when(protoParser.isHttpGetMethod(httpGetMethod)).thenReturn(true);
 
-    Mockito.when(protoParser.getRetry(httpGetMethod)).thenReturn(Retry.getDefaultInstance());
-    Mockito.when(protoParser.getRetry(nonIdempotentMethod)).thenReturn(Retry.getDefaultInstance());
-    Mockito.when(protoParser.getRetry(permissionDeniedMethod))
-        .thenReturn(Retry.newBuilder().addCodes(PERMISSION_DENIED).build());
-    Mockito.when(protoParser.getRetry(cancelledMethod))
-        .thenReturn(Retry.newBuilder().addCodes(CANCELLED).build());
-
     // Protofile Interface only contains methods with names
-    // [GET_HTTP_METHOD_NAME, NON_IDEMPOTENT_METHOD_NAME, PERMISSION_DENIED_METHOD_NAME,
-    // CANCELED_METHOD_NAME].
+    // [GET_HTTP_METHOD_NAME, NON_IDEMPOTENT_METHOD_NAME, PERMISSION_DENIED_METHOD_NAME.
     Mockito.when(apiInterface.getMethods())
-        .thenReturn(
-            ImmutableList.of(
-                httpGetMethod, nonIdempotentMethod, permissionDeniedMethod, cancelledMethod));
+        .thenReturn(ImmutableList.of(httpGetMethod, nonIdempotentMethod, permissionDeniedMethod));
 
     // ConfigProto only contains methods with names
     // [GET_HTTP_METHOD_NAME, NON_IDEMPOTENT_METHOD_NAME, PERMISSION_DENIED_METHOD_NAME,
@@ -133,7 +117,6 @@ public class RetryDefinitionsTransformerTest {
     String nonIdempotentRetryName = retryCodesMap.get(NON_IDEMPOTENT_METHOD_NAME);
     String permissionDeniedRetryName = retryCodesMap.get(PERMISSION_DENIED_METHOD_NAME);
     String idempotentRetryName = retryCodesMap.get(IDEMPOTENT_METHOD_NAME);
-    // CANCELED_METHOD_NAME won't have a retry code because it wasn't defined in GAPIC config.
 
     // GET_HTTP_METHOD_NAME had to be escaped because it was defined in the config proto retry code
     // map already.
@@ -154,8 +137,6 @@ public class RetryDefinitionsTransformerTest {
     // For permissionDeniedMethod, Config proto gives [] and proto method gives [PERMISSION_DENIED].
     Truth.assertThat(retryCodesDef.get(permissionDeniedRetryName).size()).isEqualTo(0);
 
-    // cancelledMethod is not contained in Config proto.
-
     Truth.assertThat(retryCodesDef.get(idempotentRetryName).iterator().next())
         .isEqualTo(RESOURCE_EXHAUSTED.name());
   }
@@ -169,7 +150,6 @@ public class RetryDefinitionsTransformerTest {
             .addMethods(MethodConfigProto.newBuilder().setName(GET_HTTP_METHOD_NAME))
             .addMethods(MethodConfigProto.newBuilder().setName(NON_IDEMPOTENT_METHOD_NAME))
             .addMethods(MethodConfigProto.newBuilder().setName(PERMISSION_DENIED_METHOD_NAME))
-            .addMethods(MethodConfigProto.newBuilder().setName(CANCELED_METHOD_NAME))
             .build();
 
     DiagCollector diagCollector = new BoundedDiagCollector();
@@ -180,18 +160,16 @@ public class RetryDefinitionsTransformerTest {
     Map<String, ImmutableList<String>> retryCodesDef = retryCodesConfig.getRetryCodesDefinition();
     Map<String, String> retryCodesMap = retryCodesConfig.getMethodRetryNames();
 
-    Truth.assertThat(retryCodesMap.size()).isEqualTo(4);
+    Truth.assertThat(retryCodesMap.size()).isEqualTo(3);
     String getHttpRetryName = retryCodesMap.get(GET_HTTP_METHOD_NAME);
     String nonIdempotentRetryName = retryCodesMap.get(NON_IDEMPOTENT_METHOD_NAME);
     String permissionDeniedRetryName = retryCodesMap.get(PERMISSION_DENIED_METHOD_NAME);
-    String cancelledRetryName = retryCodesMap.get(CANCELED_METHOD_NAME);
 
     // GET_HTTP_METHOD_NAME had to be escaped because it was defined in the config proto retry code
     // map already.
     Truth.assertThat(getHttpRetryName).isEqualTo(RetryCodesConfig.HTTP_RETRY_CODE_DEF_NAME);
     Truth.assertThat(nonIdempotentRetryName).isEqualTo(RetryCodesConfig.NO_RETRY_CODE_DEF_NAME);
-    Truth.assertThat(permissionDeniedRetryName).isEqualTo("permissiondeniedmethod_retry_code");
-    Truth.assertThat(cancelledRetryName).isEqualTo("canceledmethod_retry_code");
+    Truth.assertThat(permissionDeniedRetryName).isEqualTo("no_retry");
 
     // httpGetMethod was an HTTP Get method, so it has two codes by default; config proto didn't
     // have a retry config.
@@ -203,12 +181,8 @@ public class RetryDefinitionsTransformerTest {
     Truth.assertThat(retryCodesDef.get(nonIdempotentRetryName).size()).isEqualTo(0);
 
     // For permissionDeniedMethod, proto method gives [PERMISSION_DENIED].
-    Truth.assertThat(retryCodesDef.get(permissionDeniedRetryName).size()).isEqualTo(1);
-    Truth.assertThat(retryCodesDef.get(permissionDeniedRetryName).iterator().next())
-        .isEqualTo(PERMISSION_DENIED.name());
-
-    // cancelledMethod is not contained in Config proto, and the proto method gives [CANCELLED].
-    Truth.assertThat(retryCodesDef.get(cancelledRetryName).iterator().next())
-        .isEqualTo(CANCELLED.name());
+    Truth.assertThat(retryCodesDef.get(permissionDeniedRetryName).size()).isEqualTo(0);
+    // Truth.assertThat(retryCodesDef.get(permissionDeniedRetryName).iterator().next())
+    //     .isEqualTo(PERMISSION_DENIED.name());
   }
 }

--- a/src/test/java/com/google/api/codegen/transformer/RetryDefinitionsTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/RetryDefinitionsTransformerTest.java
@@ -160,7 +160,7 @@ public class RetryDefinitionsTransformerTest {
     Map<String, ImmutableList<String>> retryCodesDef = retryCodesConfig.getRetryCodesDefinition();
     Map<String, String> retryCodesMap = retryCodesConfig.getMethodRetryNames();
 
-    Truth.assertThat(retryCodesMap.size()).isEqualTo(3);
+    Truth.assertThat(retryCodesMap).hasSize(3);
     String getHttpRetryName = retryCodesMap.get(GET_HTTP_METHOD_NAME);
     String nonIdempotentRetryName = retryCodesMap.get(NON_IDEMPOTENT_METHOD_NAME);
     String permissionDeniedRetryName = retryCodesMap.get(PERMISSION_DENIED_METHOD_NAME);

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto.proto
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto.proto
@@ -16,11 +16,8 @@ service Gopher {
   // Returns Operation, but doesn't have long_running config in gapic.yaml
   rpc NotLroMethod(SimpleRequest) returns (google.longrunning.Operation);
 
-  rpc RetryMethod(SimpleRequest) returns (SimpleResponse) {
-    option (google.api.retry) = {
-      codes: [INTERNAL, UNAVAILABLE]
-    };
-  }
+  rpc RetryMethod(SimpleRequest) returns (SimpleResponse);
+
   rpc PageStreamMethod(PageStreamRequest) returns (PageStreamResponse);
 
   rpc ServerStreamMethod(SimpleRequest) returns (stream SimpleResponse);

--- a/src/test/java/com/google/api/codegen/util/ProtoParserTest.java
+++ b/src/test/java/com/google/api/codegen/util/ProtoParserTest.java
@@ -17,7 +17,7 @@ package com.google.api.codegen.util;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.MethodSignature;
-import com.google.api.Retry;
+import com.google.api.OperationData;
 import com.google.api.codegen.CodegenTestUtil;
 import com.google.api.codegen.protoannotations.GapicCodeGeneratorAnnotationsTest;
 import com.google.api.tools.framework.model.Field;
@@ -27,8 +27,6 @@ import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.ProtoFile;
 import com.google.api.tools.framework.model.testing.TestDataLocator;
-import com.google.longrunning.OperationTypes;
-import com.google.rpc.Code;
 import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -116,22 +114,14 @@ public class ProtoParserTest {
 
   @Test
   public void getLongRunningOperation() {
-    OperationTypes operationTypes = protoParser.getLongRunningOperation(getBigBookMethod);
+    OperationData operationTypes = protoParser.getLongRunningOperation(getBigBookMethod);
 
-    OperationTypes expected =
-        OperationTypes.newBuilder()
-            .setResponse("google.example.library.v1.Book")
-            .setMetadata("google.example.library.v1.GetBigBookMetadata")
+    OperationData expected =
+        OperationData.newBuilder()
+            .setResponseType("google.example.library.v1.Book")
+            .setMetadataType("google.example.library.v1.GetBigBookMetadata")
             .build();
     assertThat(operationTypes).isEqualTo(expected);
-  }
-
-  @Test
-  public void testGetRetryOnExplicitRetryCodes() {
-    Retry deleteShelfRetry = protoParser.getRetry(deleteShelfMethod);
-    Retry expectedDeleteShelfRetry =
-        Retry.newBuilder().addCodes(Code.UNAVAILABLE).addCodes(Code.DEADLINE_EXCEEDED).build();
-    assertThat(deleteShelfRetry).isEqualTo(expectedDeleteShelfRetry);
   }
 
   @Test


### PR DESCRIPTION
This pulls in the newest api-common-protos v1.13.0-pre2 from the input-contract branch, notably PRs 
- [Refactor LRO annotation](https://github.com/googleapis/api-common-protos/pull/16/files)
- [Updates to API annotations](https://github.com/googleapis/api-common-protos/pull/20/files)

Those updates were breaking changes, so using this newest version of common protos resulted in some find-and-replaces:
- OperationType -> OperationData
- Retries from proto annotations are completely removed
- MethodSignature method annotation just returns a List of MethodSignatures, instead of forever calling MethodSignature.additionalSignatures()
- Longrunning is no longer an import
- `google.api.required = true` is now `google.api.field_behavior = REQUIRED`
- `google.api.resource_type` -> `google.api.resource_reference`
