### PR TITLE
Only grpc-related classes need LRO java import

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -896,7 +896,6 @@ public class JavaSurfaceTransformer {
     typeTable.saveNicknameFor("com.google.api.gax.rpc.UnaryCallSettings");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.PagedCallSettings");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.BatchingCallSettings");
-    typeTable.saveNicknameFor("com.google.longrunning.Operation");
 
     switch (context.getProductConfig().getTransportProtocol()) {
       case GRPC:

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -901,6 +901,7 @@ public class JavaSurfaceTransformer {
       case GRPC:
         typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcCallableFactory");
         typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcStubCallableFactory");
+        typeTable.saveNicknameFor("com.google.longrunning.Operation");
         typeTable.saveNicknameFor("com.google.longrunning.stub.OperationsStub");
         break;
       case HTTP:

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -13705,7 +13705,6 @@ import com.google.cloud.simplecompute.v1.ProjectName;
 import com.google.cloud.simplecompute.v1.ProjectsGetDummyObjectResources;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-import com.google.longrunning.Operation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -550,6 +550,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.noPathTemplates.v1.IncrementRequest;
 import com.google.gcloud.example.NoTemplatesApiServiceSettings;
+import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protobuf.Empty;
 import io.grpc.MethodDescriptor;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -550,7 +550,6 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.noPathTemplates.v1.IncrementRequest;
 import com.google.gcloud.example.NoTemplatesApiServiceSettings;
-import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protobuf.Empty;
 import io.grpc.MethodDescriptor;


### PR DESCRIPTION
HTTP-based clients don't need the LRO import. This had been causing problems when trying to compile the discogapic output before removing unused imports (of which LRO was one).