### PR TITLE
Remove pending deprecation spew from unit tests.

### DIFF
--- a/showcase/python/nox.py
+++ b/showcase/python/nox.py
@@ -36,7 +36,7 @@ def showcase(session, py):
     session.virtualenv_dirname = 'showcase-' + py
 
     # Install all test dependencies, then install this package in-place.
-    session.install('pytest', 'mock')
+    session.install('pytest')
     session.install('--pre', 'googleapis-common-protos')
     session.install(
         '-e',
@@ -60,7 +60,7 @@ def unit(session, py):
     session.virtualenv_dirname = 'unit-' + py
 
     # Install all test dependencies, then install this package in-place.
-    session.install('pytest')
+    session.install('pytest', 'mock')
     session.install('--pre', 'googleapis-common-protos')
     session.install(
         '-e',

--- a/showcase/python/nox.py
+++ b/showcase/python/nox.py
@@ -36,7 +36,7 @@ def showcase(session, py):
     session.virtualenv_dirname = 'showcase-' + py
 
     # Install all test dependencies, then install this package in-place.
-    session.install('pytest')
+    session.install('pytest', 'mock')
     session.install('--pre', 'googleapis-common-protos')
     session.install(
         '-e',

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
@@ -224,7 +224,10 @@ public class PythonImportSectionTransformer implements ImportSectionTransformer 
   }
 
   private List<ImportFileView> generateTestStandardImports() {
-    return ImmutableList.of(createImport("pytest"));
+    ImmutableList.Builder<ImportFileView> imports = ImmutableList.builder();
+    imports.add(createImport("mock"));
+    imports.add(createImport("pytest"));
+    return imports.build();
   }
 
   private List<ImportFileView> generateSmokeTestStandardImports(boolean requireProjectId) {

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -70,8 +70,7 @@
             @end
         @end
         def __init__(self, transport=None, channel=None, credentials=None,
-                client_config={@api.clientConfigName}.config,
-                client_info=None):
+                client_config=None, client_info=None):
             """Constructor.
 
             Args:
@@ -103,12 +102,16 @@
                     your own client library.
             """
             @# Raise deprecation warnings for things we want to go away.
-            if client_config:
+            if client_config is not None:
                 warnings.warn('The `client_config` argument is deprecated.',
-                              PendingDeprecationWarning)
+                              PendingDeprecationWarning, stacklevel=2)
+            else:
+                client_config = {@api.clientConfigName}.config
+
             if channel:
                 warnings.warn('The `channel` argument is deprecated; use '
-                              '`transport` instead.', PendingDeprecationWarning)
+                              '`transport` instead.',
+                              PendingDeprecationWarning, stacklevel=2)
 
             @# Instantiate the transport.
             @# The transport is responsible for handling serialization and

--- a/src/main/resources/com/google/api/codegen/py/nox.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/nox.py.snip
@@ -43,7 +43,7 @@
         session.virtualenv_dirname = 'unit-' + py
 
         @# Install all test dependencies, then install this package in-place.
-        session.install('pytest')
+        session.install('pytest', 'mock')
         session.install('-e', '.')
 
         @# Run py.test against the unit tests.

--- a/src/main/resources/com/google/api/codegen/py/test.snip
+++ b/src/main/resources/com/google/api/codegen/py/test.snip
@@ -173,8 +173,7 @@ class CustomException(Exception):
 
         @# Mock the API response
         channel = ChannelStub(responses = [iter([expected_response])])
-        client = {@moduleName}.{@test.serviceConstructorName}(
-            channel=channel)
+        {@clientSetup(test, moduleName)}
 
         @# Setup Request
         {@initCode(test.initCode.lines)}
@@ -256,8 +255,7 @@ class CustomException(Exception):
     def {@test.nameWithException}(self):
         @# Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = {@moduleName}.{@test.serviceConstructorName}(
-             channel=channel)
+        {@clientSetup(test, moduleName)}
 
         @if test.hasRequestParameters
             @# Setup request
@@ -271,8 +269,7 @@ class CustomException(Exception):
 @private pagedStreamingTestWithException(test, moduleName)
     def {@test.nameWithException}(self):
         channel = ChannelStub(responses = [CustomException()])
-        client = {@moduleName}.{@test.serviceConstructorName}(
-            channel=channel)
+        {@clientSetup(test, moduleName)}
 
         @if test.hasRequestParameters
             @# Setup request
@@ -288,8 +285,7 @@ class CustomException(Exception):
     def {@test.nameWithException}(self):
         @# Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = {@moduleName}.{@test.serviceConstructorName}(
-             channel=channel)
+        {@clientSetup(test, moduleName)}
 
         @if test.hasRequestParameters
             @# Setup request
@@ -312,8 +308,7 @@ class CustomException(Exception):
 
         @# Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = {@moduleName}.{@test.serviceConstructorName}(
-            channel=channel)
+        {@clientSetup(test, moduleName)}
 
         @if test.hasRequestParameters
             @# Setup Request
@@ -336,8 +331,7 @@ class CustomException(Exception):
 
         @# Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = {@moduleName}.{@test.serviceConstructorName}(
-            channel=channel)
+        {@clientSetup(test, moduleName)}
 
         @if test.hasRequestParameters
             @# Setup Request
@@ -350,8 +344,10 @@ class CustomException(Exception):
 @end
 
 @private clientSetup(test, moduleName)
-    client = {@moduleName}.{@test.serviceConstructorName}(
-        channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = {@moduleName}.{@test.serviceConstructorName}()
 @end
 
 @private responseInitCode(test)

--- a/src/main/resources/com/google/api/codegen/py/test.snip
+++ b/src/main/resources/com/google/api/codegen/py/test.snip
@@ -344,7 +344,7 @@ class CustomException(Exception):
 @end
 
 @private clientSetup(test, moduleName)
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = {@moduleName}.{@test.serviceConstructorName}()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -1144,8 +1144,7 @@ class LibraryServiceClient(object):
         )
 
     def __init__(self, transport=None, channel=None, credentials=None,
-            client_config=library_service_client_config.config,
-            client_info=None):
+            client_config=None, client_info=None):
         """Constructor.
 
         Args:
@@ -1177,12 +1176,16 @@ class LibraryServiceClient(object):
                 your own client library.
         """
         # Raise deprecation warnings for things we want to go away.
-        if client_config:
+        if client_config is not None:
             warnings.warn('The `client_config` argument is deprecated.',
-                          PendingDeprecationWarning)
+                          PendingDeprecationWarning, stacklevel=2)
+        else:
+            client_config = library_service_client_config.config
+
         if channel:
             warnings.warn('The `channel` argument is deprecated; use '
-                          '`transport` instead.', PendingDeprecationWarning)
+                          '`transport` instead.',
+                          PendingDeprecationWarning, stacklevel=2)
 
         # Instantiate the transport.
         # The transport is responsible for handling serialization and
@@ -4075,7 +4078,7 @@ def unit(session, py):
     session.virtualenv_dirname = 'unit-' + py
 
     # Install all test dependencies, then install this package in-place.
-    session.install('pytest')
+    session.install('pytest', 'mock')
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -4783,6 +4786,7 @@ class TestSystemLibraryService(object):
 
 """Unit tests."""
 
+import mock
 import pytest
 
 from google.rpc import status_pb2
@@ -4856,8 +4860,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         shelf = {}
@@ -4873,8 +4879,10 @@ class TestLibraryServiceClient(object):
     def test_create_shelf_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         shelf = {}
@@ -4892,8 +4900,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.shelf_path('[SHELF_ID]')
@@ -4910,8 +4920,10 @@ class TestLibraryServiceClient(object):
     def test_get_shelf_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.shelf_path('[SHELF_ID]')
@@ -4930,8 +4942,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         paged_list_response = client.list_shelves()
         resources = list(paged_list_response)
@@ -4946,8 +4960,10 @@ class TestLibraryServiceClient(object):
 
     def test_list_shelves_exception(self):
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         paged_list_response = client.list_shelves()
         with pytest.raises(CustomException):
@@ -4955,8 +4971,10 @@ class TestLibraryServiceClient(object):
 
     def test_delete_shelf(self):
         channel = ChannelStub()
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.shelf_path('[SHELF_ID]')
@@ -4971,8 +4989,10 @@ class TestLibraryServiceClient(object):
     def test_delete_shelf_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.shelf_path('[SHELF_ID]')
@@ -4990,8 +5010,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.shelf_path('[SHELF_ID]')
@@ -5008,8 +5030,10 @@ class TestLibraryServiceClient(object):
     def test_merge_shelves_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.shelf_path('[SHELF_ID]')
@@ -5029,8 +5053,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.shelf_path('[SHELF_ID]')
@@ -5047,8 +5073,10 @@ class TestLibraryServiceClient(object):
     def test_create_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.shelf_path('[SHELF_ID]')
@@ -5066,8 +5094,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         shelf = {}
@@ -5086,8 +5116,10 @@ class TestLibraryServiceClient(object):
     def test_publish_series_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         shelf = {}
@@ -5109,8 +5141,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5126,8 +5160,10 @@ class TestLibraryServiceClient(object):
     def test_get_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5145,8 +5181,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.shelf_path('[SHELF_ID]')
@@ -5165,8 +5203,10 @@ class TestLibraryServiceClient(object):
 
     def test_list_books_exception(self):
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.shelf_path('[SHELF_ID]')
@@ -5178,8 +5218,10 @@ class TestLibraryServiceClient(object):
 
     def test_delete_book(self):
         channel = ChannelStub()
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5194,8 +5236,10 @@ class TestLibraryServiceClient(object):
     def test_delete_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5214,8 +5258,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5232,8 +5278,10 @@ class TestLibraryServiceClient(object):
     def test_update_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5253,8 +5301,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5271,8 +5321,10 @@ class TestLibraryServiceClient(object):
     def test_move_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5291,8 +5343,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         paged_list_response = client.list_strings()
         resources = list(paged_list_response)
@@ -5307,8 +5361,10 @@ class TestLibraryServiceClient(object):
 
     def test_list_strings_exception(self):
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         paged_list_response = client.list_strings()
         with pytest.raises(CustomException):
@@ -5316,8 +5372,10 @@ class TestLibraryServiceClient(object):
 
     def test_add_comments(self):
         channel = ChannelStub()
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5337,8 +5395,10 @@ class TestLibraryServiceClient(object):
     def test_add_comments_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5362,8 +5422,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK_ID]')
@@ -5379,8 +5441,10 @@ class TestLibraryServiceClient(object):
     def test_get_book_from_archive_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK_ID]')
@@ -5399,8 +5463,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5417,8 +5483,10 @@ class TestLibraryServiceClient(object):
     def test_get_book_from_anywhere_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5438,8 +5506,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5455,8 +5525,10 @@ class TestLibraryServiceClient(object):
     def test_get_book_from_absolutely_anywhere_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5466,8 +5538,10 @@ class TestLibraryServiceClient(object):
 
     def test_update_book_index(self):
         channel = ChannelStub()
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5485,8 +5559,10 @@ class TestLibraryServiceClient(object):
     def test_update_book_index_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5506,8 +5582,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [iter([expected_response])])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
 
         response = client.stream_shelves()
@@ -5523,8 +5601,10 @@ class TestLibraryServiceClient(object):
     def test_stream_shelves_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         with pytest.raises(CustomException):
             client.stream_shelves()
@@ -5540,8 +5620,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [iter([expected_response])])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
 
         # Setup Request
@@ -5560,8 +5642,10 @@ class TestLibraryServiceClient(object):
     def test_stream_books_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = 'name3373707'
@@ -5578,8 +5662,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [iter([expected_response])])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = 'name3373707'
@@ -5601,8 +5687,10 @@ class TestLibraryServiceClient(object):
     def test_discuss_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = 'name3373707'
@@ -5623,8 +5711,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = 'name3373707'
@@ -5644,8 +5734,10 @@ class TestLibraryServiceClient(object):
     def test_monolog_about_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         name = 'name3373707'
@@ -5667,8 +5759,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         names_element = 'namesElement-249113339'
@@ -5688,8 +5782,10 @@ class TestLibraryServiceClient(object):
 
     def test_find_related_books_exception(self):
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         names_element = 'namesElement-249113339'
@@ -5707,8 +5803,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5725,8 +5823,10 @@ class TestLibraryServiceClient(object):
     def test_add_tag_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5742,8 +5842,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5760,8 +5862,10 @@ class TestLibraryServiceClient(object):
     def test_add_label_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5783,8 +5887,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5807,8 +5913,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5826,8 +5934,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5850,8 +5960,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
@@ -5867,8 +5979,10 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        client = library_v1.LibraryServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup Request
         required_singular_int32 = 72313594
@@ -5912,8 +6026,10 @@ class TestLibraryServiceClient(object):
     def test_test_optional_required_flattening_params_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = library_v1.LibraryServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
 
         # Setup request
         required_singular_int32 = 72313594

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4860,7 +4860,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -4879,7 +4879,7 @@ class TestLibraryServiceClient(object):
     def test_create_shelf_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -4900,7 +4900,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -4920,7 +4920,7 @@ class TestLibraryServiceClient(object):
     def test_get_shelf_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -4942,7 +4942,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -4960,7 +4960,7 @@ class TestLibraryServiceClient(object):
 
     def test_list_shelves_exception(self):
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -4971,7 +4971,7 @@ class TestLibraryServiceClient(object):
 
     def test_delete_shelf(self):
         channel = ChannelStub()
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -4989,7 +4989,7 @@ class TestLibraryServiceClient(object):
     def test_delete_shelf_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5010,7 +5010,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5030,7 +5030,7 @@ class TestLibraryServiceClient(object):
     def test_merge_shelves_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5053,7 +5053,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5073,7 +5073,7 @@ class TestLibraryServiceClient(object):
     def test_create_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5094,7 +5094,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5116,7 +5116,7 @@ class TestLibraryServiceClient(object):
     def test_publish_series_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5141,7 +5141,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5160,7 +5160,7 @@ class TestLibraryServiceClient(object):
     def test_get_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5181,7 +5181,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5203,7 +5203,7 @@ class TestLibraryServiceClient(object):
 
     def test_list_books_exception(self):
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5218,7 +5218,7 @@ class TestLibraryServiceClient(object):
 
     def test_delete_book(self):
         channel = ChannelStub()
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5236,7 +5236,7 @@ class TestLibraryServiceClient(object):
     def test_delete_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5258,7 +5258,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5278,7 +5278,7 @@ class TestLibraryServiceClient(object):
     def test_update_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5301,7 +5301,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5321,7 +5321,7 @@ class TestLibraryServiceClient(object):
     def test_move_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5343,7 +5343,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5361,7 +5361,7 @@ class TestLibraryServiceClient(object):
 
     def test_list_strings_exception(self):
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5372,7 +5372,7 @@ class TestLibraryServiceClient(object):
 
     def test_add_comments(self):
         channel = ChannelStub()
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5395,7 +5395,7 @@ class TestLibraryServiceClient(object):
     def test_add_comments_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5422,7 +5422,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5441,7 +5441,7 @@ class TestLibraryServiceClient(object):
     def test_get_book_from_archive_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5463,7 +5463,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5483,7 +5483,7 @@ class TestLibraryServiceClient(object):
     def test_get_book_from_anywhere_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5506,7 +5506,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5525,7 +5525,7 @@ class TestLibraryServiceClient(object):
     def test_get_book_from_absolutely_anywhere_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5538,7 +5538,7 @@ class TestLibraryServiceClient(object):
 
     def test_update_book_index(self):
         channel = ChannelStub()
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5559,7 +5559,7 @@ class TestLibraryServiceClient(object):
     def test_update_book_index_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5582,7 +5582,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [iter([expected_response])])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5601,7 +5601,7 @@ class TestLibraryServiceClient(object):
     def test_stream_shelves_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5620,7 +5620,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [iter([expected_response])])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5642,7 +5642,7 @@ class TestLibraryServiceClient(object):
     def test_stream_books_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5662,7 +5662,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [iter([expected_response])])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5687,7 +5687,7 @@ class TestLibraryServiceClient(object):
     def test_discuss_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5711,7 +5711,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5734,7 +5734,7 @@ class TestLibraryServiceClient(object):
     def test_monolog_about_book_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5759,7 +5759,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5782,7 +5782,7 @@ class TestLibraryServiceClient(object):
 
     def test_find_related_books_exception(self):
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5803,7 +5803,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5823,7 +5823,7 @@ class TestLibraryServiceClient(object):
     def test_add_tag_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5842,7 +5842,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5862,7 +5862,7 @@ class TestLibraryServiceClient(object):
     def test_add_label_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5887,7 +5887,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5913,7 +5913,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5934,7 +5934,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5960,7 +5960,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -5979,7 +5979,7 @@ class TestLibraryServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses = [expected_response])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
@@ -6026,7 +6026,7 @@ class TestLibraryServiceClient(object):
     def test_test_optional_required_flattening_params_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -895,8 +895,7 @@ class DecrementerServiceClient(object):
     from_service_account_json = from_service_account_file
 
     def __init__(self, transport=None, channel=None, credentials=None,
-            client_config=decrementer_service_client_config.config,
-            client_info=None):
+            client_config=None, client_info=None):
         """Constructor.
 
         Args:
@@ -928,12 +927,16 @@ class DecrementerServiceClient(object):
                 your own client library.
         """
         # Raise deprecation warnings for things we want to go away.
-        if client_config:
+        if client_config is not None:
             warnings.warn('The `client_config` argument is deprecated.',
-                          PendingDeprecationWarning)
+                          PendingDeprecationWarning, stacklevel=2)
+        else:
+            client_config = decrementer_service_client_config.config
+
         if channel:
             warnings.warn('The `channel` argument is deprecated; use '
-                          '`transport` instead.', PendingDeprecationWarning)
+                          '`transport` instead.',
+                          PendingDeprecationWarning, stacklevel=2)
 
         # Instantiate the transport.
         # The transport is responsible for handling serialization and
@@ -1126,8 +1129,7 @@ class IncrementerServiceClient(object):
     from_service_account_json = from_service_account_file
 
     def __init__(self, transport=None, channel=None, credentials=None,
-            client_config=incrementer_service_client_config.config,
-            client_info=None):
+            client_config=None, client_info=None):
         """Constructor.
 
         Args:
@@ -1159,12 +1161,16 @@ class IncrementerServiceClient(object):
                 your own client library.
         """
         # Raise deprecation warnings for things we want to go away.
-        if client_config:
+        if client_config is not None:
             warnings.warn('The `client_config` argument is deprecated.',
-                          PendingDeprecationWarning)
+                          PendingDeprecationWarning, stacklevel=2)
+        else:
+            client_config = incrementer_service_client_config.config
+
         if channel:
             warnings.warn('The `channel` argument is deprecated; use '
-                          '`transport` instead.', PendingDeprecationWarning)
+                          '`transport` instead.',
+                          PendingDeprecationWarning, stacklevel=2)
 
         # Instantiate the transport.
         # The transport is responsible for handling serialization and
@@ -1634,7 +1640,7 @@ def unit(session, py):
     session.virtualenv_dirname = 'unit-' + py
 
     # Install all test dependencies, then install this package in-place.
-    session.install('pytest')
+    session.install('pytest', 'mock')
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -1753,6 +1759,7 @@ setuptools.setup(
 
 """Unit tests."""
 
+import mock
 import pytest
 
 from google.cloud import example_v1
@@ -1800,8 +1807,10 @@ class TestDecrementerServiceClient(object):
 
     def test_decrement(self):
         channel = ChannelStub()
-        client = example_v1.DecrementerServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = example_v1.DecrementerServiceClient()
 
         client.decrement()
 
@@ -1813,8 +1822,10 @@ class TestDecrementerServiceClient(object):
     def test_decrement_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = example_v1.DecrementerServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = example_v1.DecrementerServiceClient()
 
         with pytest.raises(CustomException):
             client.decrement()
@@ -1838,6 +1849,7 @@ class TestDecrementerServiceClient(object):
 
 """Unit tests."""
 
+import mock
 import pytest
 
 from google.cloud import example_v1
@@ -1885,8 +1897,10 @@ class TestIncrementerServiceClient(object):
 
     def test_increment(self):
         channel = ChannelStub()
-        client = example_v1.IncrementerServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = example_v1.IncrementerServiceClient()
 
         client.increment()
 
@@ -1898,8 +1912,10 @@ class TestIncrementerServiceClient(object):
     def test_increment_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = example_v1.IncrementerServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = example_v1.IncrementerServiceClient()
 
         with pytest.raises(CustomException):
             client.increment()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1807,7 +1807,7 @@ class TestDecrementerServiceClient(object):
 
     def test_decrement(self):
         channel = ChannelStub()
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = example_v1.DecrementerServiceClient()
@@ -1822,7 +1822,7 @@ class TestDecrementerServiceClient(object):
     def test_decrement_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = example_v1.DecrementerServiceClient()
@@ -1897,7 +1897,7 @@ class TestIncrementerServiceClient(object):
 
     def test_increment(self):
         channel = ChannelStub()
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = example_v1.IncrementerServiceClient()
@@ -1912,7 +1912,7 @@ class TestIncrementerServiceClient(object):
     def test_increment_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = example_v1.IncrementerServiceClient()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -838,8 +838,7 @@ class NoTemplatesAPIServiceClient(object):
     from_service_account_json = from_service_account_file
 
     def __init__(self, transport=None, channel=None, credentials=None,
-            client_config=no_templates_api_service_client_config.config,
-            client_info=None):
+            client_config=None, client_info=None):
         """Constructor.
 
         Args:
@@ -871,12 +870,16 @@ class NoTemplatesAPIServiceClient(object):
                 your own client library.
         """
         # Raise deprecation warnings for things we want to go away.
-        if client_config:
+        if client_config is not None:
             warnings.warn('The `client_config` argument is deprecated.',
-                          PendingDeprecationWarning)
+                          PendingDeprecationWarning, stacklevel=2)
+        else:
+            client_config = no_templates_api_service_client_config.config
+
         if channel:
             warnings.warn('The `channel` argument is deprecated; use '
-                          '`transport` instead.', PendingDeprecationWarning)
+                          '`transport` instead.',
+                          PendingDeprecationWarning, stacklevel=2)
 
         # Instantiate the transport.
         # The transport is responsible for handling serialization and
@@ -1232,7 +1235,7 @@ def unit(session, py):
     session.virtualenv_dirname = 'unit-' + py
 
     # Install all test dependencies, then install this package in-place.
-    session.install('pytest')
+    session.install('pytest', 'mock')
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -1351,6 +1354,7 @@ setuptools.setup(
 
 """Unit tests."""
 
+import mock
 import pytest
 
 from example.proto import no_path_templates_messages_pb2
@@ -1398,8 +1402,10 @@ class TestNoTemplatesAPIServiceClient(object):
 
     def test_increment(self):
         channel = ChannelStub()
-        client = example.NoTemplatesAPIServiceClient(
-            channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = example.NoTemplatesAPIServiceClient()
 
         client.increment()
 
@@ -1411,8 +1417,10 @@ class TestNoTemplatesAPIServiceClient(object):
     def test_increment_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        client = example.NoTemplatesAPIServiceClient(
-             channel=channel)
+        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = example.NoTemplatesAPIServiceClient()
 
         with pytest.raises(CustomException):
             client.increment()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1402,7 +1402,7 @@ class TestNoTemplatesAPIServiceClient(object):
 
     def test_increment(self):
         channel = ChannelStub()
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = example.NoTemplatesAPIServiceClient()
@@ -1417,7 +1417,7 @@ class TestNoTemplatesAPIServiceClient(object):
     def test_increment_exception(self):
         # Mock the API response
         channel = ChannelStub(responses = [CustomException()])
-        patch = mock.patch('google.cloud.api_core.grpc_helpers.create_channel')
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
         with patch as create_channel:
             create_channel.return_value = channel
             client = example.NoTemplatesAPIServiceClient()


### PR DESCRIPTION
- Add `stacklevel=2` to each emitted `PendingDeprecationWarning`.
- Fix detection of non-default `client_config` argument (make the default `None`, and assign in the body).
- Replace deprecation-emitting `channel=channel` arguments to client constructors with mocks of the `create_channel` utility function.

Closes #2389.