### PR TITLE
CircleCI test for discogapic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,6 +465,44 @@ jobs:
           paths:
             - gapic-generator/artman-genfiles
             - reports
+  compute-discovery-test:
+    # Generate the Discovery Compute client and run its tests.
+    working_directory: /tmp/
+    environment:
+      # Directory to output the generated Compute client.
+      COMPUTE_OUT: /tmp/discogapic_out
+      # Commit hash to use the discover-artifact-manager repo from
+      DISCOVERY_REPO_VERSION: 661dacf3b5c7d2ca359d9788e5498025e6ce0437
+      DISCOVERY_REPO_PATH: https://raw.githubusercontent.com/googleapis/discovery-artifact-manager
+    docker:
+      - image: circleci/openjdk:8-jdk
+    steps:
+      - attach_workspace:
+          at: workspace
+      - run:
+          name: Download Discovery files
+          command: |
+            mkdir discovery
+            cd discovery
+            wget -K $DISCOVERY_REPO_PATH/$DISCOVERY_REPO_VERSION/discoveries/compute.v1.json
+            wget -K $DISCOVERY_REPO_PATH/$DISCOVERY_REPO_VERSION/gapic/google/compute/v1/compute_gapic.yaml
+      - run:
+          name: Generate and build the Java Compute client
+          command: |
+            java -Xmx1024m -cp workspace/gapic-generator/build/libs/gapic-generator-0.0.5-fatjar.jar \
+                com.google.api.codegen.GeneratorMain DISCOGAPIC_CODE \
+                --discovery_doc discovery/compute.v1.json -o $COMPUTE_OUT \
+                --gapic_yaml discovery/compute_gapic.yaml --language java
+      - run:
+          name: Copy over the build.gradle file for the generated client
+          command: |
+            cd workspace/gapic-generator
+            cp .circleci/discogapic_compute_build.gradle $COMPUTE_OUT/build.gradle
+      - run:
+          name: Run generated tests for Compute
+          command: |
+            cd $COMPUTE_OUT
+            gradle test
   java-openjdk8-test:
     working_directory: /tmp/
     environment:
@@ -682,6 +720,9 @@ workflows:
     jobs:
       - install-gapic-generator
       - test-baselines
+      - compute-discovery-test:
+          requires:
+            - install-gapic-generator
       - test-gapic-generator:
           requires:
             - test-baselines

--- a/.circleci/discogapic_compute_build.gradle
+++ b/.circleci/discogapic_compute_build.gradle
@@ -1,0 +1,66 @@
+// TODO: Use bazel instead of gradle for running the generated Compute client.
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
+apply plugin: 'java'
+
+description = 'GAPIC library for Discovery API'
+group = 'com.google.cloud'
+version = '0.0.0-SNAPSHOT'
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+compileJava.options.encoding = 'UTF-8'
+javadoc.options.encoding = 'UTF-8'
+
+dependencies {
+    compile 'com.google.api:gax:1.29.0'
+    testCompile 'com.google.api:gax:1.29.0:testlib'
+    compile 'com.google.api:gax-httpjson:0.51.0'
+    testCompile 'com.google.api:gax-httpjson:0.51.0:testlib'
+    testCompile 'io.grpc:grpc-netty-shaded:1.10.1'
+    testCompile 'junit:junit:4.12'
+}
+
+task smokeTest(type: Test) {
+    filter {
+        includeTestsMatching "*SmokeTest"
+        setFailOnNoMatchingTests false
+    }
+}
+
+test {
+    testLogging {
+        events "PASSED", "STARTED", "FAILED", "SKIPPED"
+    }
+
+    exclude "**/*SmokeTest*"
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src/main/java'
+        }
+    }
+}
+
+clean {
+    delete 'all-jars'
+}
+
+task allJars(type: Copy) {
+    dependsOn test, jar
+    into 'all-jars'
+    // Replace with `from configurations.testRuntime, jar` to include test dependencies
+    from configurations.runtime, jar
+}


### PR DESCRIPTION
Run the gapic-generator jar on the Compute API Discovery doc to generate a client, and then test it.

Use compute.v1.json and compute_gapic.yaml from a fetched versioned commit of discovery-artifact-manager.

Add a build.gradle to put in the generated Compute client so that we can use Gradle to test the *Test.java files.