### PR TITLE
Samplegen: read from files

### DIFF
--- a/src/main/java/com/google/api/codegen/config/SampleParameterConfig.java
+++ b/src/main/java/com/google/api/codegen/config/SampleParameterConfig.java
@@ -15,7 +15,6 @@
 package com.google.api.codegen.config;
 
 import com.google.auto.value.AutoValue;
-import javax.annotation.Nullable;
 
 /** SampleParameterConfig represents the configuration for standalone sample parameters. */
 @AutoValue
@@ -32,21 +31,20 @@ public abstract class SampleParameterConfig {
    *
    * <p>If the parameter is a bytes field, the value set to this parameter will be the file name.
    *
-   * <p>If the parameter is a repeated bytes field, the value set to this parameter will be the a
-   * list of file names separated by comma. For example, "foo.jpg,bar.jpg,baz.jpg".
+   * <p>If the parameter is a repeated bytes field, the value set to this parameter will be a list
+   * of comma separated file names. For example, "foo.jpg,bar.jpg,baz.jpg".
    */
   public abstract boolean readFromFile();
 
   /** If true, the parameter will be an argument passed to the sample function. */
   public boolean isSampleArgument() {
-    return sampleArgumentName() != null && !sampleArgumentName().isEmpty();
+    return !sampleArgumentName().isEmpty();
   }
 
   /**
-   * If not null, the parameter will be an argument passed to the sample function. Returns the name
+   * If not empty, the parameter will be an argument passed to the sample function. Returns the name
    * of the argument.
    */
-  @Nullable
   public abstract String sampleArgumentName();
 
   public static Builder newBuilder() {

--- a/src/main/java/com/google/api/codegen/config/SampleParameterConfig.java
+++ b/src/main/java/com/google/api/codegen/config/SampleParameterConfig.java
@@ -1,0 +1,67 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.config;
+
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+
+/** SampleParameterConfig represents the configuration for standalone sample parameters. */
+@AutoValue
+public abstract class SampleParameterConfig {
+
+  /** The identifier of the parameter, usually a protobuf field path. */
+  public abstract String identifier();
+
+  /**
+   * Configured by attributes.parameter.read_file in the spec. If true, the value of this parameter
+   * will be replaced by the contents of the file with the name that equals to the original value of
+   * this parameter. Only allowed when the parameter represents a bytes field or a repeated bytes
+   * field.
+   *
+   * <p>If the parameter is a bytes field, the value set to this parameter will be the file name.
+   *
+   * <p>If the parameter is a repeated bytes field, the value set to this parameter will be the a
+   * list of file names separated by comma. For example, "foo.jpg,bar.jpg,baz.jpg".
+   */
+  public abstract boolean readFromFile();
+
+  /** If true, the parameter will be an argument passed to the sample function. */
+  public boolean isSampleArgument() {
+    return sampleArgumentName() != null && !sampleArgumentName().isEmpty();
+  }
+
+  /**
+   * If not null, the parameter will be an argument passed to the sample function. Returns the name
+   * of the argument.
+   */
+  @Nullable
+  public abstract String sampleArgumentName();
+
+  public static Builder newBuilder() {
+    return new AutoValue_SampleParameterConfig.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder identifier(String val);
+
+    public abstract Builder readFromFile(boolean val);
+
+    public abstract Builder sampleArgumentName(String val);
+
+    public abstract SampleParameterConfig build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
@@ -102,7 +102,7 @@ public abstract class InitCodeContext {
         .outputType(InitCodeOutputType.SingleObject)
         .additionalInitCodeNodes(ImmutableList.of())
         .initFieldConfigStrings(ImmutableList.of())
-        .sampleParamConfigMap(ImmutableMap.<String, SampleParameterConfig>of());
+        .sampleParamConfigMap(ImmutableMap.of());
   }
 
   @AutoValue.Builder

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.metacode;
 
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
+import com.google.api.codegen.config.SampleParameterConfig;
 import com.google.api.codegen.config.TypeModel;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
@@ -65,11 +66,21 @@ public abstract class InitCodeContext {
   /** Returns init config strings. */
   public abstract List<String> initFieldConfigStrings();
 
+  /** Configuration for the sample arguments. */
+  public abstract ImmutableMap<String, SampleParameterConfig> sampleParamConfigMap();
+
   /**
    * When generating samples, the sample function accept these parts of the request object as
    * arguments.
    */
-  public abstract ImmutableList<String> sampleArgStrings();
+  public ImmutableList<String> sampleArgStrings() {
+    return sampleParamConfigMap()
+        .values()
+        .stream()
+        .filter(SampleParameterConfig::isSampleArgument)
+        .map(SampleParameterConfig::identifier)
+        .collect(ImmutableList.toImmutableList());
+  }
 
   /**
    * Allows additional InitCodeNode objects which will be placed into the generated subtrees. This
@@ -91,7 +102,7 @@ public abstract class InitCodeContext {
         .outputType(InitCodeOutputType.SingleObject)
         .additionalInitCodeNodes(ImmutableList.of())
         .initFieldConfigStrings(ImmutableList.of())
-        .sampleArgStrings(ImmutableList.of());
+        .sampleParamConfigMap(ImmutableMap.<String, SampleParameterConfig>of());
   }
 
   @AutoValue.Builder
@@ -110,7 +121,8 @@ public abstract class InitCodeContext {
 
     public abstract Builder initFieldConfigStrings(List<String> configStrings);
 
-    public abstract Builder sampleArgStrings(ImmutableList<String> val);
+    public abstract Builder sampleParamConfigMap(
+        ImmutableMap<String, SampleParameterConfig> configs);
 
     public abstract Builder initValueConfigMap(Map<String, InitValueConfig> configMap);
 

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeLineType.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeLineType.java
@@ -20,5 +20,6 @@ public enum InitCodeLineType {
   ListInitLine,
   SimpleInitLine,
   MapInitLine,
+  ReadFileInitLine,
   Unknown
 }

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -42,7 +42,7 @@ import java.util.Set;
  */
 public class InitCodeNode {
   private static final TypeModel INT_TYPE = ProtoTypeRef.create(TypeRef.of(Type.TYPE_UINT64));
-
+  private static final String ROOT_KEY = "root";
   private String key;
   private InitCodeLineType lineType;
   private InitValueConfig initValueConfig;
@@ -162,7 +162,7 @@ public class InitCodeNode {
 
   /** Creates a node to be used as the root of the initialization tree. */
   public static InitCodeNode newRoot() {
-    return new InitCodeNode("root", InitCodeLineType.StructureInitLine, InitValueConfig.create());
+    return new InitCodeNode(ROOT_KEY, InitCodeLineType.StructureInitLine, InitValueConfig.create());
   }
 
   /**
@@ -371,15 +371,15 @@ public class InitCodeNode {
    * Attach {@code sampleParamConfig} to the nodes in this tree. Also sets lineType to {@code
    * InitCodeLineType.ReadFileInitLine} if specified in {@code sampleParamConfig}.
    *
-   * @param parentFieldPath The full path of the parent object of {@code typeRef}. Set to empty
+   * @param parentFieldPath The full path of the parent object of {@code typeRef}. Set to an empty
    *     string if {@code typeRef} is a top level proto object. We need to keep track of this
-   *     because the keys in {@code sampleParamConfigMap} are full paths while {@code key} is the
+   *     because the keys in {@code sampleParamConfigMap} are full paths while {@code key} is a
    *     simple field name.
    */
   private void resolveSampleParamConfigs(
       ImmutableMap<String, SampleParameterConfig> sampleParamConfigMap, String parentFieldPath) {
     String fieldPath;
-    if ("root".equals(key)) {
+    if (ROOT_KEY.equals(key)) {
       fieldPath = "";
     } else if (parentFieldPath.isEmpty()) {
       fieldPath = key;

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -492,8 +492,8 @@ public class InitCodeTransformer {
     ImportTypeTable typeTable = context.getTypeTable();
     checkState(
         item.getType().isBytesType(),
-        "Error setting init code node %s to reading from file. "
-            + "Replacing field value with file contents only allowed for bytes type, "
+        "Error setting %s to be read from file. "
+            + "Replacing field value with file contents is only allowed for fields of type 'bytes', "
             + "but the type is %s.",
         item.getIdentifier(),
         item.getType());

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -497,6 +497,7 @@ public class InitCodeTransformer {
             + "but the type is %s.",
         item.getIdentifier(),
         item.getType());
+    typeTable.getAndSaveNicknameFor(item.getType());
     String value = item.getInitValueConfig().getInitialValue().getValue();
     switch (item.getInitValueConfig().getInitialValue().getType()) {
       case Literal:
@@ -513,7 +514,6 @@ public class InitCodeTransformer {
     }
     return surfaceLine
         .identifier(namer.localVarName(item.getIdentifier()))
-        .typeName(typeTable.getAndSaveNicknameFor(item.getType()))
         .fileName(SimpleInitValueView.newBuilder().initialValue(value).build())
         .build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -14,7 +14,10 @@
  */
 package com.google.api.codegen.transformer;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.api.codegen.config.FieldConfig;
+import com.google.api.codegen.config.ProtoTypeRef;
 import com.google.api.codegen.config.ResourceNameConfig;
 import com.google.api.codegen.config.ResourceNameOneofConfig;
 import com.google.api.codegen.config.ResourceNameType;
@@ -38,6 +41,7 @@ import com.google.api.codegen.viewmodel.ListInitCodeLineView;
 import com.google.api.codegen.viewmodel.MapEntryView;
 import com.google.api.codegen.viewmodel.MapInitCodeLineView;
 import com.google.api.codegen.viewmodel.OneofConfigView;
+import com.google.api.codegen.viewmodel.ReadFileInitCodeLineView;
 import com.google.api.codegen.viewmodel.RepeatedResourceNameInitValueView;
 import com.google.api.codegen.viewmodel.ResourceNameInitValueView;
 import com.google.api.codegen.viewmodel.ResourceNameOneofInitValueView;
@@ -46,6 +50,7 @@ import com.google.api.codegen.viewmodel.SimpleInitValueView;
 import com.google.api.codegen.viewmodel.StructureInitCodeLineView;
 import com.google.api.codegen.viewmodel.testing.ClientTestAssertView;
 import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -375,6 +380,8 @@ public class InitCodeTransformer {
         return generateSimpleInitCodeLine(context, specItemNode, isFirstItem);
       case MapInitLine:
         return generateMapInitCodeLine(context, specItemNode);
+      case ReadFileInitLine:
+        return generateReadFileInitCodeLine(context, specItemNode, isFirstItem);
       default:
         throw new RuntimeException("unhandled line type: " + specItemNode.getLineType());
     }
@@ -476,6 +483,41 @@ public class InitCodeTransformer {
     surfaceLine.initEntries(entries);
 
     return surfaceLine.build();
+  }
+
+  private InitCodeLineView generateReadFileInitCodeLine(
+      MethodContext context, InitCodeNode item, boolean isFirstItem) {
+    ReadFileInitCodeLineView.Builder surfaceLine = ReadFileInitCodeLineView.newBuilder();
+    SurfaceNamer namer = context.getNamer();
+    ImportTypeTable typeTable = context.getTypeTable();
+    checkState(
+        item.getType().isBytesType(),
+        "Error setting init code node %s to read from file. "
+            + "Replacing field value with file contents only allowed for bytes type, "
+            + "but the type is %s.",
+        item.getIdentifier(),
+        item.getType());
+    String value = item.getInitValueConfig().getInitialValue().getValue();
+    switch (item.getInitValueConfig().getInitialValue().getType()) {
+      case Literal:
+        value =
+            context
+                .getTypeTable()
+                .renderPrimitiveValue(
+                    ProtoTypeRef.create(TypeRef.fromPrimitiveName("string")), value);
+        break;
+      case Variable:
+        value = context.getNamer().localVarReference(Name.anyLower(value));
+        break;
+      default:
+        throw new IllegalArgumentException("Unhandled init value type");
+    }
+    return surfaceLine
+        .identifier(namer.localVarName(item.getIdentifier()))
+        .needsLeadingNewline(!isFirstItem)
+        .typeName(typeTable.getAndSaveNicknameFor(item.getType()))
+        .fileName(SimpleInitValueView.newBuilder().initialValue(value).build())
+        .build();
   }
 
   private void setInitValueAndComments(

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -485,6 +485,7 @@ public class InitCodeTransformer {
     return surfaceLine.build();
   }
 
+  // TODO(hzyi): generate necessary imports
   private InitCodeLineView generateReadFileInitCodeLine(MethodContext context, InitCodeNode item) {
     ReadFileInitCodeLineView.Builder surfaceLine = ReadFileInitCodeLineView.newBuilder();
     SurfaceNamer namer = context.getNamer();

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -15,11 +15,11 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.OutputSpec;
-import com.google.api.codegen.SampleInitAttribute;
 import com.google.api.codegen.SampleParameters;
 import com.google.api.codegen.SampleValueSet;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.SampleParameterConfig;
 import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.config.SampleSpec.ValueSetAndTags;
 import com.google.api.codegen.metacode.InitCodeContext;
@@ -34,6 +34,7 @@ import com.google.api.codegen.viewmodel.SampleValueSetView;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -237,10 +238,17 @@ public class SampleTransformer {
                       .getParameters()
                       .getAttributesList()
                       .stream()
+
                       // TODO(#2366) honor the configured name.
-                      .filter(attr -> !attr.getSampleArgumentName().isEmpty())
-                      .map(SampleInitAttribute::getParameter)
-                      .collect(ImmutableList.toImmutableList()));
+                      .collect(
+                          ImmutableMap.toImmutableMap(
+                              attr -> attr.getParameter(),
+                              attr ->
+                                  SampleParameterConfig.newBuilder()
+                                      .identifier(attr.getParameter())
+                                      .readFromFile(attr.getReadFile())
+                                      .sampleArgumentName(attr.getSampleArgumentName())
+                                      .build())));
         }
         InitCodeView initCodeView = sampleGenerator.generate(thisContext);
         List<OutputSpec> outputs = valueSet.getOnSuccessList();
@@ -296,12 +304,12 @@ public class SampleTransformer {
       Collection<FieldConfig> fieldConfigs,
       InitCodeOutputType initCodeOutputType,
       List<String> sampleCodeDefaultValues,
-      List<String> sampleFunctionArguments) {
+      ImmutableMap<String, SampleParameterConfig> sampleParamConfigMap) {
     return InitCodeContext.newBuilder()
         .initObjectType(context.getMethodModel().getInputType())
         .suggestedName(Name.from("request"))
         .initFieldConfigStrings(sampleCodeDefaultValues)
-        .sampleArgStrings(ImmutableList.copyOf(sampleFunctionArguments))
+        .sampleParamConfigMap(sampleParamConfigMap)
         .initValueConfigMap(InitCodeTransformer.createCollectionMap(context))
         .initFields(FieldConfig.toFieldTypeIterable(fieldConfigs))
         .outputType(initCodeOutputType)

--- a/src/main/java/com/google/api/codegen/viewmodel/ReadFileInitCodeLineView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ReadFileInitCodeLineView.java
@@ -23,8 +23,6 @@ public abstract class ReadFileInitCodeLineView implements InitCodeLineView {
     return InitCodeLineType.ReadFileInitLine;
   }
 
-  public abstract String typeName();
-
   public abstract String identifier();
 
   public abstract InitValueView fileName();
@@ -35,8 +33,6 @@ public abstract class ReadFileInitCodeLineView implements InitCodeLineView {
 
   @AutoValue.Builder
   public abstract static class Builder {
-
-    public abstract Builder typeName(String val);
 
     public abstract Builder identifier(String val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/ReadFileInitCodeLineView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ReadFileInitCodeLineView.java
@@ -1,0 +1,52 @@
+/* Copyright 2016 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel;
+
+import com.google.api.codegen.metacode.InitCodeLineType;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class ReadFileInitCodeLineView implements InitCodeLineView {
+  public InitCodeLineType lineType() {
+    return InitCodeLineType.ReadFileInitLine;
+  }
+
+  public abstract String typeName();
+
+  public abstract String identifier();
+
+  public abstract InitValueView fileName();
+
+  /** @return if a newline should be added above this line */
+  public abstract boolean needsLeadingNewline();
+
+  public static Builder newBuilder() {
+    return new AutoValue_ReadFileInitCodeLineView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder typeName(String val);
+
+    public abstract Builder identifier(String val);
+
+    public abstract Builder fileName(InitValueView val);
+
+    public abstract Builder needsLeadingNewline(boolean val);
+
+    public abstract ReadFileInitCodeLineView build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/viewmodel/ReadFileInitCodeLineView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ReadFileInitCodeLineView.java
@@ -1,4 +1,4 @@
-/* Copyright 2016 Google LLC
+/* Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,6 @@ public abstract class ReadFileInitCodeLineView implements InitCodeLineView {
 
   public abstract InitValueView fileName();
 
-  /** @return if a newline should be added above this line */
-  public abstract boolean needsLeadingNewline();
-
   public static Builder newBuilder() {
     return new AutoValue_ReadFileInitCodeLineView.Builder();
   }
@@ -44,8 +41,6 @@ public abstract class ReadFileInitCodeLineView implements InitCodeLineView {
     public abstract Builder identifier(String val);
 
     public abstract Builder fileName(InitValueView val);
-
-    public abstract Builder needsLeadingNewline(boolean val);
 
     public abstract ReadFileInitCodeLineView build();
   }

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -355,9 +355,13 @@ message SampleInitAttribute {
   // should be accepted as a parameter, with the given name, to the sample function.
   string sample_argument_name = 2;
 
-  // If `read_file` is true, in the initialization part of the sample, the value of this 
+  // If `read_file` is true, then during sample initialization, the value of this 
   // attribute gets replaced by the contents of the local file with the given name.
   // This is only allowed when this parameter is a bytes field.
+  // If this parameter is required or optional, the original value of this parameter
+  // is the file name.
+  // If this parameter is repeated, the original value of this parameter is a list of
+  // comma separated file names.
   bool read_file = 3;
 }
 

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -361,7 +361,7 @@ message SampleInitAttribute {
   // If this parameter is required or optional, the original value of this parameter
   // is the file name.
   // If this parameter is repeated, the original value of this parameter is a list of
-  // comma-separated file names.
+  // comma-separated list of file names.
   bool read_file = 3;
 }
 

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -361,7 +361,7 @@ message SampleInitAttribute {
   // If this parameter is required or optional, the original value of this parameter
   // is the file name.
   // If this parameter is repeated, the original value of this parameter is a list of
-  // comma separated file names.
+  // comma-separated file names.
   bool read_file = 3;
 }
 

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -354,6 +354,11 @@ message SampleInitAttribute {
   // If `sample_argument_name` is not empty, the part of the request object specified by `path`
   // should be accepted as a parameter, with the given name, to the sample function.
   string sample_argument_name = 2;
+
+  // If `read_file` is true, in the initialization part of the sample, the value of this 
+  // attribute gets replaced by the contents of the local file with the given name.
+  // This is only allowed when this parameter is a bytes field.
+  bool read_file = 3;
 }
 
 // `SampleConfiguration` defines combinations of "calling forms"

--- a/src/main/resources/com/google/api/codegen/java/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/java/initcode.snip
@@ -58,7 +58,7 @@
   String fileName = {@renderInitValue(line.fileName)};
   Path path = Paths.get(fileName);
   byte[] data = Files.readAllBytes(path);
-  {@line.typeName} {@line.identifier} = ByteString.copyFrom(data);
+  ByteString {@line.identifier} = ByteString.copyFrom(data);
 @end
 
 @snippet renderInitValue(initValue)

--- a/src/main/resources/com/google/api/codegen/java/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/java/initcode.snip
@@ -98,8 +98,3 @@
     .{@fieldSetting.formatMethodName}()
   @end
 @end
-
-@private renderFileInitValueView(initValue)
-   ByteString.copyFrom(Files.readAllBytes(Paths.get(initValue.filePath)))
-@end
-

--- a/src/main/resources/com/google/api/codegen/java/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/java/initcode.snip
@@ -73,8 +73,6 @@
     {@renderResourceName(initValue.specificResourceNameView)}
   @case "RepeatedResourceNameInitValueView"
     new ArrayList<>()
-  @case "FileInitValueView"
-    {@renderFileInitValueView(initValue)}
   @default
     $unhandledCase: {@initValue.type}$
   @end

--- a/src/main/resources/com/google/api/codegen/java/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/java/initcode.snip
@@ -22,6 +22,8 @@
       {@initLineMap(line)}
     @case "SimpleInitLine"
       {@initLineSimple(line)}
+    @case "ReadFileInitLine"
+      {@initLineReadFile(line)}
     @default
       $unhandledCase: {@line.lineType.toString}$
     @end
@@ -52,6 +54,13 @@
   {@line.typeName} {@line.identifier} = {@renderInitValue(line.initValue)};
 @end
 
+@private initLineReadFile(line)
+  String fileName = {@renderInitValue(line.fileName)};
+  Path path = Paths.get(fileName);
+  byte[] data = Files.readAllBytes(path);
+  {@line.typeName} {@line.identifier} = ByteString.copyFrom(data);
+@end
+
 @snippet renderInitValue(initValue)
   @switch initValue.type
   @case "SimpleInitValueView"
@@ -64,6 +73,8 @@
     {@renderResourceName(initValue.specificResourceNameView)}
   @case "RepeatedResourceNameInitValueView"
     new ArrayList<>()
+  @case "FileInitValueView"
+    {@renderFileInitValueView(initValue)}
   @default
     $unhandledCase: {@initValue.type}$
   @end
@@ -87,3 +98,8 @@
     .{@fieldSetting.formatMethodName}()
   @end
 @end
+
+@private renderFileInitValueView(initValue)
+   ByteString.copyFrom(Files.readAllBytes(Paths.get(initValue.filePath)))
+@end
+

--- a/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
@@ -368,10 +368,17 @@
       {@initLineMap(line)}
     @case "SimpleInitLine"
       {@initLineSimple(line)}
+    @case "ReadFileInitLine"
+      {@initLineReadFile(line)}
     @default
       $unhandledCase: {@line.lineType.toString}$
     @end
   @end
+@end
+
+@private initLineReadFile(line)
+  const fileName = {@renderInitValue(line.fileName)};
+  const {@line.identifier} = fs.readFileSync(fileName).toString('base64');
 @end
 
 @private initLineStructure(line)

--- a/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
@@ -285,6 +285,8 @@
             {@initLineMap(line)}
         @case "SimpleInitLine"
             {@initLineSimple(line, apiVariableName)}
+        @case "ReadFileInitLine"
+            {@initLineReadFile(line, apiVariableName)}
         @default
             $unhandledCase: {@line.lineType}$
         @end
@@ -342,6 +344,10 @@
 
 @private initLineSimple(line, apiVariableName)
     ${@line.identifier} = {@renderInitValue(line.initValue, apiVariableName)};
+@end
+
+@private initLineReadFile(line, apiVariableName)
+    {@variable(line.identifier)} = file_get_contents({@renderInitValue(line.fileName, apiVariableName)});
 @end
 
 @private renderInitValue(initValue, apiVariableName)

--- a/src/main/resources/com/google/api/codegen/py/sample_init.snip
+++ b/src/main/resources/com/google/api/codegen/py/sample_init.snip
@@ -55,7 +55,7 @@
 @end
 
 @private initLineReadFile(line)
-  file_name = {@renderInitValue(line.fileName)})
+  file_name = {@renderInitValue(line.fileName)}
   with io.open(file_name, 'rb') as f:
     {@line.identifier} = f.read()
 @end

--- a/src/main/resources/com/google/api/codegen/py/sample_init.snip
+++ b/src/main/resources/com/google/api/codegen/py/sample_init.snip
@@ -55,7 +55,7 @@
 @end
 
 @private initLineReadFile(line)
-  file_name = os.path.join(os.path.dirname(__file__), {@renderInitValue(line.fileName)})
+  file_name = {@renderInitValue(line.fileName)})
   with io.open(file_name, 'rb') as f:
     {@line.identifier} = f.read()
 @end

--- a/src/main/resources/com/google/api/codegen/py/sample_init.snip
+++ b/src/main/resources/com/google/api/codegen/py/sample_init.snip
@@ -12,6 +12,8 @@
       {@initLineSimple(line)}
     @case "MapInitLine"
       {@initLineMap(line)}
+    @case "ReadFileInitLine"
+      {@initLineReadFile(line)}
     @default
       {@unhandledCase()}
     @end
@@ -50,6 +52,12 @@
 # Generate a Map argument
 @private initLineMap(line)
   {@line.identifier} = {{@renderInitMap(line)}}
+@end
+
+@private initLineReadFile(line)
+  file_name = os.path.join(os.path.dirname(__file__), {@renderInitValue(line.fileName)})
+  with io.open(file_name, 'rb') as f:
+    {@line.identifier} = f.read()
 @end
 
 # Helper method for initLineMap()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -7255,14 +7255,16 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 //         className: "DiscussBookCallableCallableStreamingBidiProg"
 //          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//        [name=BASIC]
+//        [name=BASIC, comment.comment=comment_file]
 //      apiMethod "discussBookCallable" of type "CallableMethod"
 
 // FIXME: Insert here code to prepare the request fields, make the call, process the response.
 
 package com.google.gcloud.pubsub.v1;
 
+import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
+import com.google.protobuf.ByteString;
 
 public class DiscussBookCallableCallableStreamingBidiProg {
   public static void sampleDiscussBook() {
@@ -7272,8 +7274,16 @@ public class DiscussBookCallableCallableStreamingBidiProg {
           libraryClient.discussBookCallable().call();
 
       String name = "BASIC";
+      String fileName = "comment_file";
+      Path path = Paths.get(fileName);
+      byte[] data = Files.readAllBytes(path);
+      ByteString comment = ByteString.copyFrom(data);
+      Comment comment2 = Comment.newBuilder()
+        .setComment(comment)
+        .build();
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name)
+        .setComment(comment2)
         .build();
       bidiStream.send(request);
       for (Comment responseItem : bidiStream) {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -7166,9 +7166,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 package com.google.example.examples.library.v1.snippets;
 
 // [START turing_prog_callable_streaming_bidi]
+import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-
 import com.google.protobuf.ByteString;
 
 public class DiscussBookCallableCallableStreamingBidiProg {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -263,7 +263,7 @@ module.exports.default = Object.assign({}, module.exports);
 //         className: "DiscussBookRequestStreamingBidiProg"
 //          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//        [name=BASIC]
+//        [name=BASIC, comment.comment=comment_file]
 //      apiMethod "discussBook" of type "OptionalArrayMethod"
 
 // [START turing_prog_request_streaming_bidi_core]
@@ -275,8 +275,14 @@ const stream = client.discussBook().on('data', response => {
   // doThingsWith(response)
 });
 const name = 'BASIC';
+const fileName = 'comment_file';
+const comment = fs.readFileSync(fileName).toString('base64');
+const comment2 = {
+  comment: comment,
+};
 const request = {
   name: name,
+  comment: comment2,
 };
 // Write request objects.
 stream.write(request);

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -2748,6 +2748,7 @@ return [
 require __DIR__ . '/../../../../vendor/autoload.php';
 
 use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Comment;
 use Google\Example\Library\V1\DiscussBookRequest;
 
 function sampleDiscussBook()
@@ -2757,8 +2758,12 @@ function sampleDiscussBook()
     $libraryServiceClient = new LibraryServiceClient();
 
     $name = 'BASIC';
+    $comment = file_get_contents('comment_file');
+    $comment2 = new Comment();
+    $comment2->setComment($comment);
     $request = new DiscussBookRequest();
     $request->setName($name);
+    $request->setComment($comment2);
 
     try {
         // Write requests individually, making read() calls if
@@ -2813,6 +2818,7 @@ sampleDiscussBook();
 require __DIR__ . '/../../../../vendor/autoload.php';
 
 use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Comment;
 use Google\Example\Library\V1\DiscussBookRequest;
 
 function sampleDiscussBook()
@@ -2822,8 +2828,12 @@ function sampleDiscussBook()
     $libraryServiceClient = new LibraryServiceClient();
 
     $name = 'BASIC';
+    $comment = file_get_contents('comment_file');
+    $comment2 = new Comment();
+    $comment2->setComment($comment);
     $request = new DiscussBookRequest();
     $request->setName($name);
+    $request->setComment($comment2);
 
     try {
         // Write all requests to the server, then read all responses until the

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4144,7 +4144,11 @@ def sample_discuss_book():
   client = library_v1.LibraryServiceClient()
 
   name = 'BASIC'
-  request = {'name': name}
+  file_name = os.path.join(os.path.dirname(__file__), 'comment_file')
+  with io.open(file_name, 'rb') as f:
+    comment = f.read()
+  comment_2 = {'comment': comment}
+  request = {'name': name, 'comment': comment_2}
 
   requests = [request]
   for response_item in client.discuss_book(requests):

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4153,7 +4153,7 @@ def sample_discuss_book():
   client = library_v1.LibraryServiceClient()
 
   name = 'BASIC'
-  file_name = os.path.join(os.path.dirname(__file__), 'comment_file')
+  file_name = 'comment_file'
   with io.open(file_name, 'rb') as f:
     comment = f.read()
   comment_2 = {'comment': comment}

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -574,6 +574,10 @@ interfaces:
       parameters:
         defaults:
         - name=BASIC
+        - comment.comment=comment_file
+        attributes:
+        - parameter: comment.comment
+          read_file: true
     samples:
       in_code:
       - calling_forms: ".*"


### PR DESCRIPTION
Set up infrastructure for standalone samples to be able to read from files and assign the file content to a local variable. 

- Does not yet work for sample function parameters.
- IO utils are not yet imported in any languages.