### PR TITLE
Update test resources to use new Resource definitions

### DIFF
--- a/src/test/java/com/google/api/codegen/packagegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/packagegen/testdata/library.proto
@@ -152,7 +152,7 @@ message Book {
   // The name is ignored when creating a book.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource).path = "shelves/*/books/*"];
+    (google.api.resource).path = "shelves/{shelf_id}/books/{book_id}"];
 
   // The name of the book author.
   string author = 2;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
@@ -31,6 +31,7 @@ option (google.api.metadata) = {
   package_namespace: ["Google", "Example"]
 };
 
+// TODO(andrealin): Refer to a common resource for Project, once it exists.
 option (google.api.resource_definition) = {
   name: "Project"
   path: "projects/{project}"

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
@@ -31,6 +31,21 @@ option (google.api.metadata) = {
   package_namespace: ["Google", "Example"]
 };
 
+option (google.api.resource_definition) = {
+  name: "Project"
+  path: "projects/{project}"
+};
+
+option (google.api.resource_definition) = {
+  name: "Book"
+  path : "shelves/{shelf_id}/books/{book_id}"
+};
+
+option (google.api.resource_definition) = {
+  name: "ArchivedBook"
+  path : "archives/{archive_path}/books/{book_id=**}"
+};
+
 // This API represents a simple digital library.  It lets you manage Shelf
 // resources and Book resources in the library. It defines the following
 // resource model:
@@ -360,16 +375,19 @@ service LibraryService {
 // Message comment may include special characters: <>&"`'@.
 message Book {
   // The resource name of the book.
-  // Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+  // Book names have the form `shelves/{shelf_id}/books/{book_id}`.
   // Message field comment may include special characters: <>&"`'@.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_set) = {
-      name: "book_oneof"
+      name: "BookOneOf"
       resources: [
-        {name: "book"             path : "shelves/{shelf_id}/books/{book_id}"},
-        {name: "archived_book"    path : "archives/{archive_path}/books/{book_id=**}"}
+        {
+          name: "DeletedBook"
+          path : "_deleted-book_"
+        }
       ]
+      resource_references: ["ArchivedBook", "Book"]
     }
   ];
 
@@ -434,8 +452,7 @@ message BookFromArchive {
   // Book names have the form `archives/{archive_id}/books/{book_id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    // TODO(andrealin): Make this refer only to the archived_book path.
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "archived_book"];
 
   // The name of the book author.
   string author = 2;
@@ -495,7 +512,7 @@ message Shelf {
   // Shelf names have the form `shelves/{shelf_id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource).path = "shelves/*"];
+    (google.api.resource).path = "shelves/{shelf_id}"];
 
   // The theme of the shelf
   string theme = 2;
@@ -516,7 +533,8 @@ message GetShelfRequest {
   // The name of the shelf to retrieve.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
+    // Test that a resource name field can be referenced by its MessageType.
+    (google.api.resource_reference) = "Shelf"];
 
   // Field to verify that message-type query parameter gets flattened.
   SomeMessage message = 2;
@@ -644,8 +662,7 @@ message GetBookRequest {
   // The name of the book to retrieve.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    // TODO(andrealin): Make this refer only to the book resource.
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "Book"];
 }
 
 // Request message for LibraryService.ListBooks.
@@ -694,8 +711,7 @@ message UpdateBookRequest {
   // The name of the book to update.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "Book"];
 
   // An optional foo.
   string optional_foo = 2;
@@ -717,8 +733,7 @@ message DeleteBookRequest {
   // The name of the book to delete.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "Book"];
 }
 
 // Describes what book to move (name) and what shelf we're moving it
@@ -749,8 +764,7 @@ message ListStringsResponse {
 message AddCommentsRequest {
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    // TODO(andrealin): Make this refer only to the archived_book path.
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "Book"];
 
   repeated Comment comments = 2 [
     (google.api.field_behavior) = REQUIRED];
@@ -782,8 +796,7 @@ message GetBookFromArchiveRequest {
   // The name of the book to retrieve.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    // TODO(andrealin): Make this refer only to the archived_book path.
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "ArchivedBook"];
 }
 
 // Request message for LibraryService.GetBookFromAnywhere.
@@ -796,8 +809,7 @@ message GetBookFromAnywhereRequest {
   // An alternate book name, used to test restricting flattened field to a
   // single resource name type in a oneof.
   string alt_book_name = 2 [
-    // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "Book"];
 }
 
 // Request message for LibraryService.GetBookFromAbsolutelyAnywhere.
@@ -813,8 +825,7 @@ message UpdateBookIndexRequest {
   // The name of the book to update.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "Book"];
 
   // The name of the index for the book
   string index_name = 2 [
@@ -840,8 +851,7 @@ message DiscussBookRequest {
 message FindRelatedBooksRequest {
   repeated string names = 1 [
     (google.api.field_behavior) = REQUIRED,
-    // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "Book"];
   repeated string shelves = 2 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = "google.example.library.v1.Shelf"];
@@ -852,8 +862,7 @@ message FindRelatedBooksRequest {
 // Test repeated field with resource name format in page streaming response
 message FindRelatedBooksResponse {
   repeated string names = 1 [
-    // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "Book"];
   string next_page_token = 2;
 }
 
@@ -888,14 +897,13 @@ message TestOptionalRequiredFlatteningParamsRequest {
   bytes required_singular_bytes = 8 [(google.api.field_behavior) = REQUIRED];
   InnerMessage required_singular_message = 9 [(google.api.field_behavior) = REQUIRED];
   string required_singular_resource_name = 10 [(google.api.field_behavior) = REQUIRED,
-    // TODO(andrealin): Make this refer only to the book path.
-    (google.api.resource_reference) = "google.example.library.v1.Book"
+    (google.api.resource_reference) = "Book"
   ];
   string required_singular_resource_name_oneof = 11 [(google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = "google.example.library.v1.Book"
   ];
   string required_singular_resource_name_common = 14 [(google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = "google.api.Project"
+    (google.api.resource_reference) = "Project"
   ];
   fixed32 required_singular_fixed32 = 12 [(google.api.field_behavior) = REQUIRED];
   fixed64 required_singular_fixed64 = 13 [(google.api.field_behavior) = REQUIRED];
@@ -910,11 +918,11 @@ message TestOptionalRequiredFlatteningParamsRequest {
   repeated bytes required_repeated_bytes = 28 [(google.api.field_behavior) = REQUIRED];
   repeated InnerMessage required_repeated_message = 29 [(google.api.field_behavior) = REQUIRED];
   repeated string required_repeated_resource_name = 30 [(google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "Book"];
   repeated string required_repeated_resource_name_oneof = 31 [(google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = "google.example.library.v1.Book"];
+    (google.api.resource_reference) = "BookOneOf"];
   repeated string required_repeated_resource_name_common = 34 [(google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = "google.api.Project"
+    (google.api.resource_reference) = "Project"
   ];
   repeated fixed32 required_repeated_fixed32 = 32 [(google.api.field_behavior) = REQUIRED];
   repeated fixed64 required_repeated_fixed64 = 33 [(google.api.field_behavior) = REQUIRED];
@@ -931,13 +939,14 @@ message TestOptionalRequiredFlatteningParamsRequest {
   bytes optional_singular_bytes = 58;
   InnerMessage optional_singular_message = 59;
   string optional_singular_resource_name = 60 [
-    (google.api.resource_reference) = "google.example.library.v1.Book"
+    (google.api.resource_reference) = "Book"
   ];
   string optional_singular_resource_name_oneof = 61 [
+    // Test that we can reference Resource Name One Of by its name.
     (google.api.resource_reference) = "google.example.library.v1.Book"
   ];
   string optional_singular_resource_name_common = 64 [
-    (google.api.resource_reference) = "google.api.Project"
+    (google.api.resource_reference) = "Project"
   ];
   fixed32 optional_singular_fixed32 = 62;
   fixed64 optional_singular_fixed64 = 63;
@@ -952,13 +961,13 @@ message TestOptionalRequiredFlatteningParamsRequest {
   repeated bytes optional_repeated_bytes = 78;
   repeated InnerMessage optional_repeated_message = 79;
   repeated string optional_repeated_resource_name = 80 [
-    (google.api.resource_reference) = "google.example.library.v1.Book"
+    (google.api.resource_reference) = "Book"
   ];
   repeated string optional_repeated_resource_name_oneof = 81 [
     (google.api.resource_reference) = "google.example.library.v1.Book"
   ];
   repeated string optional_repeated_resource_name_common = 84 [
-    (google.api.resource_reference) = "google.api.Project"
+    (google.api.resource_reference) = "Project"
   ];
   repeated fixed32 optional_repeated_fixed32 = 82;
   repeated fixed64 optional_repeated_fixed64 = 83;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
@@ -452,7 +452,7 @@ message BookFromArchive {
   // Book names have the form `archives/{archive_id}/books/{book_id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = "archived_book"];
+    (google.api.resource_reference) = "ArchivedBook"];
 
   // The name of the book author.
   string author = 2;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library_gapic.yaml
@@ -2,7 +2,7 @@ type: com.google.api.codegen.ConfigProto
 config_schema_version: 1.0.0
 language_settings:
   java:
-    package_name: com.google.gcloud.pubsub.v1
+    package_name: com.google.example.library.v1
     interface_names:
       google.example.library.v1.LibraryService: Library
     release_level: GA
@@ -240,9 +240,9 @@ interfaces:
         - edition=123
         attributes:
         - parameter: shelf.name
-          sample_argument: true
+          sample_argument_name: name
         - parameter: edition
-          sample_argument: true
+          sample_argument_name: edition
       on_success:
       - loop:
           variable: title
@@ -251,6 +251,9 @@ interfaces:
             print:
               - "Title: %s"
               - title
+      - print:
+        - "The first book is: %s"
+        - $resp.book_names[0]
       - print:
         - "That's all!"
       - print:
@@ -599,6 +602,10 @@ interfaces:
       parameters:
         defaults:
         - name=BASIC
+      on_success:
+        - print:
+          - "The stage of the comment is: %s"
+          - $resp.stage
     samples:
       in_code:
       - calling_forms: ".*"
@@ -860,6 +867,7 @@ interfaces:
       optional_repeated_resource_name: book
       optional_repeated_resource_name_oneof: book_oneof
     timeout_millis: 60000
+  # Intentionally leave out PrivateGetBook method from GAPIC config.
 resource_name_generation:
 - message_name: Book
   field_entity_map:

--- a/src/test/java/com/google/api/codegen/testsrc/common/tagger.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/tagger.proto
@@ -34,10 +34,13 @@ message AddTagRequest {
   // REQUIRED: The resource which the tag is being added to.
   // Resource is usually specified as a path, such as,
   // projects/{project}/zones/{zone}/disks/{disk}.
-  string resource = 1;
+  string resource = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 
   // REQUIRED: The tag to add.
-  string tag = 2;
+  string tag = 2  [
+    (google.api.field_behavior) = REQUIRED];
 }
 
 message AddLabelRequest {

--- a/src/test/java/com/google/api/codegen/testsrc/showcase/echo.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/showcase/echo.proto
@@ -131,7 +131,7 @@ message ExpandRequest {
 // The request for Wait method.
 message WaitRequest {
   // The amount of time to wait before returning a response.
-  google.protobuf.Duration response_delay = 1; // [(google.api.required) = true];
+  google.protobuf.Duration response_delay = 1; // [(google.api.field_behavior) = REQUIRED];
 
   oneof response {
     // The error that will be returned by the server. If this code is specified
@@ -153,7 +153,7 @@ message WaitResponse {
 // The request for the Pagination methods.
 message PaginationRequest {
   // The maximum number that will be returned in the response.
-  int32 max_response = 1; // [(google.api.required) = true];
+  int32 max_response = 1; // [(google.api.field_behavior) = REQUIRED];
 
   // The amount of numbers to returned in the response.
   int32 page_size = 2;

--- a/src/test/java/com/google/api/codegen/util/ProtoParserTest.java
+++ b/src/test/java/com/google/api/codegen/util/ProtoParserTest.java
@@ -89,7 +89,7 @@ public class ProtoParserTest {
   public void testGetResourcePath() {
     Field shelfNameField =
         shelf.getFields().stream().filter(f -> f.getSimpleName().equals("name")).findFirst().get();
-    assertThat(protoParser.getResourcePath(shelfNameField)).isEqualTo("shelves/*");
+    assertThat(protoParser.getResourcePath(shelfNameField)).isEqualTo("shelves/{shelf_id}");
   }
 
   @Test
@@ -160,7 +160,7 @@ public class ProtoParserTest {
             .findFirst()
             .get();
     String shelfType = protoParser.getResourceType(shelves);
-    assertThat(shelfType).isEqualTo("google.example.library.v1.Shelf");
+    assertThat(shelfType).isEqualTo("Shelf");
   }
 
   @Test


### PR DESCRIPTION
- use the new resource_definition annotation
- make Resource.name and ResourceSet.name be CamelCase
- expand all paths to include resource identifiers as wildcards, e.g. `projects/{project}` instead of `projects/*`
- use resource_references in the ResourceSet
- temporarily remove references to `google.api.Project`, which has been deleted in https://github.com/googleapis/api-common-protos/pull/20/files
