### PR TITLE
Python: use 'ProtoFiles.getProtoFiles' to sort enums by filename.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
@@ -27,6 +27,7 @@ import com.google.api.codegen.config.ProtoApiModel;
 import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.gapic.GapicParser;
+import com.google.api.codegen.gapic.ProtoFiles;
 import com.google.api.codegen.transformer.DefaultFeatureConfig;
 import com.google.api.codegen.transformer.DynamicLangApiMethodTransformer;
 import com.google.api.codegen.transformer.FeatureConfig;
@@ -170,11 +171,19 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer<Pro
     }
 
     GrpcDocView enumFile =
-        generateEnumView(productConfig, modelTypeTable, namer, apiModel.getProtoModel().getFiles());
+        generateEnumView(productConfig, modelTypeTable, namer, getProtoFiles(productConfig));
     if (!enumFile.elementDocs().isEmpty()) {
       serviceSurfaces.add(enumFile);
     }
     return serviceSurfaces.build();
+  }
+
+  private List<ProtoFile> getProtoFiles(GapicProductConfig productConfig) {
+    ImmutableList.Builder<ProtoFile> files = ImmutableList.builder();
+    for (ProtoFile protoFile : ProtoFiles.getProtoFiles(productConfig)) {
+      files.add(protoFile);
+    }
+    return files.build();
   }
 
   private void addApiImports(GapicInterfaceContext context) {

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
@@ -179,11 +179,7 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer<Pro
   }
 
   private List<ProtoFile> getProtoFiles(GapicProductConfig productConfig) {
-    ImmutableList.Builder<ProtoFile> files = ImmutableList.builder();
-    for (ProtoFile protoFile : ProtoFiles.getProtoFiles(productConfig)) {
-      files.add(protoFile);
-    }
-    return files.build();
+    return ImmutableList.copyOf(ProtoFiles.getProtoFiles(productConfig));
   }
 
   private void addApiImports(GapicInterfaceContext context) {


### PR DESCRIPTION
Closes #2319.

I hope. :)