### PR TITLE
[Proto Annotations] ResourceName one ofs from ResourceSets

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -14,6 +14,8 @@
  */
 package com.google.api.codegen.config;
 
+import com.google.api.Resource;
+import com.google.api.ResourceSet;
 import com.google.api.codegen.CollectionConfigProto;
 import com.google.api.codegen.CollectionOneofProto;
 import com.google.api.codegen.ConfigProto;
@@ -28,13 +30,12 @@ import com.google.api.codegen.util.LicenseHeaderUtil;
 import com.google.api.codegen.util.ProtoParser;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
-import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.MessageType;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.ProtoFile;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.api.tools.framework.model.SymbolTable;
+import com.google.api.tools.framework.tools.ToolUtil;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -50,6 +51,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * GapicProductConfig represents client code-gen config for an API product contained in a
@@ -162,21 +164,38 @@ public abstract class GapicProductConfig implements ProductConfig {
     }
 
     ProtoParser protoParser = new ProtoParser();
+
+    DiagCollector diagCollector = model.getDiagReporter().getDiagCollector();
+
+    Map<Resource, ProtoFile> resourceDefs =
+        protoParser.getResourceDefs(sourceProtos, diagCollector);
+    Map<ResourceSet, ProtoFile> resourceSetDefs =
+        protoParser.getResourceSetDefs(sourceProtos, diagCollector);
+
+    // Get list of fields from proto
     ResourceNameMessageConfigs messageConfigs =
         ResourceNameMessageConfigs.createMessageResourceTypesConfig(
             sourceProtos,
-            model.getDiagReporter().getDiagCollector(),
+            diagCollector,
             configProto,
             defaultPackage,
+            resourceDefs,
+            resourceSetDefs,
             protoParser);
 
     ImmutableMap<String, ResourceNameConfig> resourceNameConfigs =
         createResourceNameConfigs(
-            model.getDiagReporter().getDiagCollector(),
+            diagCollector,
             configProto,
             sourceProtos,
             language,
+            resourceDefs,
+            resourceSetDefs,
             protoParser);
+
+    if (resourceNameConfigs == null) {
+      return null;
+    }
 
     TransportProtocol transportProtocol = TransportProtocol.GRPC;
 
@@ -436,52 +455,183 @@ public abstract class GapicProductConfig implements ProductConfig {
 
   private static ImmutableMap<String, ResourceNameConfig> createResourceNameConfigs(
       DiagCollector diagCollector, ConfigProto configProto, TargetLanguage language) {
-    return createResourceNameConfigs(diagCollector, configProto, null, language, null);
+    return createResourceNameConfigs(
+        diagCollector, configProto, null, language, ImmutableMap.of(), ImmutableMap.of(), null);
   }
 
+  /**
+   * Create all the ResourceNameOneofConfig from the protofile and GAPIC config, and let the GAPIC
+   * config resourceNames override the protofile resourceNames in event of clashes.
+   */
   @VisibleForTesting
+  @Nullable
   static ImmutableMap<String, ResourceNameConfig> createResourceNameConfigs(
       DiagCollector diagCollector,
       ConfigProto configProto,
       @Nullable List<ProtoFile> protoFiles,
       TargetLanguage language,
+      Map<Resource, ProtoFile> resourceDefs,
+      Map<ResourceSet, ProtoFile> resourceSetDefs,
       ProtoParser protoParser) {
     ProtoFile file = null;
     if (protoFiles != null) {
       file = protoFiles.get(0);
     }
-    ImmutableMap<String, SingleResourceNameConfig> singleResourceNameConfigs =
-        createSingleResourceNameConfigs(
-            diagCollector, configProto, protoFiles, language, protoParser);
+    ImmutableMap<String, SingleResourceNameConfig> singleResourceNameConfigsFromGapicConfig =
+        createSingleResourceNameConfigs(diagCollector, configProto, protoFiles, language);
     ImmutableMap<String, FixedResourceNameConfig> fixedResourceNameConfigs =
         createFixedResourceNameConfigs(
             diagCollector, configProto.getFixedResourceNameValuesList(), file);
-    ImmutableMap<String, ResourceNameOneofConfig> resourceNameOneofConfigs =
+    ImmutableMap<String, ResourceNameOneofConfig> resourceNameOneofConfigsFromGapicConfig =
         createResourceNameOneofConfigs(
             diagCollector,
             configProto.getCollectionOneofsList(),
-            singleResourceNameConfigs,
+            singleResourceNameConfigsFromGapicConfig,
             fixedResourceNameConfigs,
             file);
+    if (diagCollector.getErrorCount() > 0) {
+      ToolUtil.reportDiags(diagCollector, true);
+      return null;
+    }
 
-    ImmutableSortedMap.Builder<String, ResourceNameConfig> resourceCollectionMap =
+    ImmutableMap<String, SingleResourceNameConfig>
+        fullyQualifiedSingleResourceNameConfigsFromProtoFile =
+            createSingleResourceNameConfigsFromProtoFile(diagCollector, resourceDefs, protoParser);
+    ImmutableMap<String, ResourceNameOneofConfig> resourceNameOneofConfigsFromProtoFile =
+        createResourceNameOneofConfigsFromProtoFile(
+            diagCollector,
+            fullyQualifiedSingleResourceNameConfigsFromProtoFile,
+            resourceSetDefs,
+            protoParser);
+
+    // Populate a SingleResourceNameConfigs map, using just the unqualified names.
+    Map<String, SingleResourceNameConfig> singleResourceConfigsFromProtoFile =
+        new LinkedHashMap<>();
+    for (String fullName : fullyQualifiedSingleResourceNameConfigsFromProtoFile.keySet()) {
+      int periodIndex = fullName.lastIndexOf('.');
+      SingleResourceNameConfig config =
+          fullyQualifiedSingleResourceNameConfigsFromProtoFile.get(fullName);
+      singleResourceConfigsFromProtoFile.put(fullName.substring(periodIndex + 1), config);
+    }
+
+    // Combine the ResourceNameConfigs from the GAPIC and protofile.
+    Map<String, SingleResourceNameConfig> finalSingleResourceNameConfigs =
+        mergeResourceNameConfigs(
+            diagCollector,
+            singleResourceNameConfigsFromGapicConfig,
+            singleResourceConfigsFromProtoFile);
+    Map<String, ResourceNameOneofConfig> finalResourceOneofNameConfigs =
+        mergeResourceNameConfigs(
+            diagCollector,
+            resourceNameOneofConfigsFromGapicConfig,
+            resourceNameOneofConfigsFromProtoFile);
+
+    ImmutableMap.Builder<String, ResourceNameConfig> resourceNameConfigs =
         new ImmutableSortedMap.Builder<>(Comparator.naturalOrder());
-    resourceCollectionMap.putAll(singleResourceNameConfigs);
-    resourceCollectionMap.putAll(resourceNameOneofConfigs);
-    resourceCollectionMap.putAll(fixedResourceNameConfigs);
-    return resourceCollectionMap.build();
+    resourceNameConfigs.putAll(finalSingleResourceNameConfigs);
+    resourceNameConfigs.putAll(fixedResourceNameConfigs);
+    resourceNameConfigs.putAll(finalResourceOneofNameConfigs);
+    return resourceNameConfigs.build();
+  }
+
+  // Return map of fully qualified SingleResourceNameConfig name to its derived config.
+  private static ImmutableMap<String, SingleResourceNameConfig>
+      createSingleResourceNameConfigsFromProtoFile(
+          DiagCollector diagCollector,
+          Map<Resource, ProtoFile> resourceDefs,
+          ProtoParser protoParser) {
+
+    // Map of fully qualified Resource name to its derived config.
+    LinkedHashMap<String, SingleResourceNameConfig> fullyQualifiedSingleResources =
+        new LinkedHashMap<>();
+    // Create the SingleResourceNameConfigs.
+    for (Resource resource : resourceDefs.keySet()) {
+      String resourcePath = resource.getPath();
+      ProtoFile protoFile = resourceDefs.get(resource);
+      createSingleResourceNameConfig(
+          diagCollector,
+          resource,
+          protoFile,
+          resourcePath,
+          protoParser,
+          fullyQualifiedSingleResources);
+    }
+
+    if (diagCollector.getErrorCount() > 0) {
+      ToolUtil.reportDiags(diagCollector, true);
+      return null;
+    }
+    return ImmutableMap.copyOf(fullyQualifiedSingleResources);
+  }
+
+  // Return map of fully qualified ResourceNameOneofConfig name to its derived config.
+  private static ImmutableMap<String, ResourceNameOneofConfig>
+      createResourceNameOneofConfigsFromProtoFile(
+          DiagCollector diagCollector,
+          ImmutableMap<String, SingleResourceNameConfig> fullyQualifiedSingleResourcesFromProtoFile,
+          Map<ResourceSet, ProtoFile> resourceSetDefs,
+          ProtoParser protoParser) {
+
+    // Map of fully qualified ResourceSet name to its derived config.
+    ImmutableMap.Builder<String, ResourceNameOneofConfig> resourceOneOfConfigsFromProtoFile =
+        ImmutableMap.builder();
+
+    // Create the ResourceNameOneOfConfigs.
+    for (ResourceSet resourceSet : resourceSetDefs.keySet()) {
+      ProtoFile protoFile = resourceSetDefs.get(resourceSet);
+      String resourceSetName = resourceSet.getName();
+      ResourceNameOneofConfig resourceNameOneofConfig =
+          ResourceNameOneofConfig.createResourceNameOneof(
+              diagCollector,
+              resourceSet,
+              resourceSetName,
+              fullyQualifiedSingleResourcesFromProtoFile,
+              protoParser,
+              protoFile);
+      if (resourceNameOneofConfig == null) {
+        return null;
+      }
+      resourceOneOfConfigsFromProtoFile.put(resourceSetName, resourceNameOneofConfig);
+    }
+
+    if (diagCollector.getErrorCount() > 0) {
+      ToolUtil.reportDiags(diagCollector, true);
+      return null;
+    }
+
+    return resourceOneOfConfigsFromProtoFile.build();
+  }
+
+  private static <T extends ResourceNameConfig> ImmutableMap<String, T> mergeResourceNameConfigs(
+      DiagCollector diagCollector,
+      Map<String, T> configsFromGapicConfig,
+      Map<String, T> configsFromProtoFile) {
+    Map<String, T> mergedResourceNameConfigs = new HashMap<>(configsFromProtoFile);
+
+    // If protofile annotations clash with the configs from configProto, use the configProto.
+    for (T resourceFromGapicConfig : configsFromGapicConfig.values()) {
+      if (configsFromProtoFile.containsKey(resourceFromGapicConfig.getEntityId())) {
+        diagCollector.addDiag(
+            Diag.warning(
+                SimpleLocation.TOPLEVEL,
+                "Resource[Set] entity %s from protofile clashes with a"
+                    + " Resource[Set] of the same name from the GAPIC config."
+                    + " Using the GAPIC config entity.",
+                resourceFromGapicConfig.getEntityId()));
+      }
+      // Add the protofile resourceNameConfigs to the map of resourceNameConfigs.
+      mergedResourceNameConfigs.put(resourceFromGapicConfig.getEntityId(), resourceFromGapicConfig);
+    }
+    return ImmutableMap.copyOf(mergedResourceNameConfigs);
   }
 
   private static ImmutableMap<String, SingleResourceNameConfig> createSingleResourceNameConfigs(
       DiagCollector diagCollector,
       ConfigProto configProto,
       @Nullable List<ProtoFile> sourceProtos,
-      TargetLanguage language,
-      ProtoParser protoParser) {
+      TargetLanguage language) {
     ProtoFile file = null;
-    if (sourceProtos == null) {
-      sourceProtos = ImmutableList.of();
-    } else {
+    if (sourceProtos != null) {
       file = sourceProtos.get(0);
     }
     LinkedHashMap<String, SingleResourceNameConfig> singleResourceNameConfigsMap =
@@ -496,43 +646,6 @@ public abstract class GapicProductConfig implements ProductConfig {
         createSingleResourceNameConfig(
             diagCollector, collectionConfigProto, singleResourceNameConfigsMap, file, language);
       }
-    }
-
-    LinkedHashMap<String, SingleResourceNameConfig> resourceConfigsFromProtoFile =
-        new LinkedHashMap<>();
-    // Collect the ResourceNameConfigs from proto annotations.
-    for (ProtoFile protoFile : sourceProtos) {
-      for (MessageType messageType : protoFile.getMessages()) {
-        for (Field field : messageType.getFields()) {
-          String resourcePath = protoParser.getResourcePath(field);
-          if (resourcePath != null) {
-            createSingleResourceNameConfig(
-                diagCollector, field, resourceConfigsFromProtoFile, protoFile, protoParser);
-          }
-        }
-      }
-    }
-
-    // If protofile annotations clash with the configs from configProto, use the protofile.
-    for (SingleResourceNameConfig resourceFromProtoFile : resourceConfigsFromProtoFile.values()) {
-      if (singleResourceNameConfigsMap.containsKey(resourceFromProtoFile.getEntityId())) {
-        SingleResourceNameConfig otherConfig =
-            singleResourceNameConfigsMap.get(resourceFromProtoFile.getEntityId());
-        if (!resourceFromProtoFile.getNamePattern().equals(otherConfig.getNamePattern())) {
-          diagCollector.addDiag(
-              Diag.warning(
-                  SimpleLocation.TOPLEVEL,
-                  "For entity %s, resource path '%s'"
-                      + " from protofile clashes with GAPIC config resource path %s."
-                      + " Using path '%s' from protofile.",
-                  resourceFromProtoFile.getEntityId(),
-                  resourceFromProtoFile.getNamePattern(),
-                  otherConfig.getNamePattern(),
-                  resourceFromProtoFile.getEntityId()));
-        }
-      }
-      // Add the protofile resourceNameConfigs to the map of resourceNameConfigs.
-      singleResourceNameConfigsMap.put(resourceFromProtoFile.getEntityId(), resourceFromProtoFile);
     }
 
     if (diagCollector.getErrorCount() > 0) {
@@ -570,17 +683,18 @@ public abstract class GapicProductConfig implements ProductConfig {
     }
   }
 
+  // Construct a new SingleResourceNameConfig from the given Resource, and add the newly
+  // created config as a value to the map param, keyed on the package-qualified entity_id.
   private static void createSingleResourceNameConfig(
       DiagCollector diagCollector,
-      Field field,
-      LinkedHashMap<String, SingleResourceNameConfig> singleResourceNameConfigsMap,
+      Resource resource,
       ProtoFile file,
-      ProtoParser protoParser) {
+      String pathTemplate,
+      ProtoParser protoParser,
+      LinkedHashMap<String, SingleResourceNameConfig> singleResourceNameConfigsMap) {
     SingleResourceNameConfig singleResourceNameConfig =
-        SingleResourceNameConfig.createSingleResourceName(diagCollector, field, file, protoParser);
-    if (singleResourceNameConfig == null) {
-      return;
-    }
+        SingleResourceNameConfig.createSingleResourceName(
+            resource, pathTemplate, file, diagCollector);
     if (singleResourceNameConfigsMap.containsKey(singleResourceNameConfig.getEntityId())) {
       SingleResourceNameConfig otherConfig =
           singleResourceNameConfigsMap.get(singleResourceNameConfig.getEntityId());
@@ -592,8 +706,10 @@ public abstract class GapicProductConfig implements ProductConfig {
                     + singleResourceNameConfig.getEntityId()));
       }
     } else {
-      singleResourceNameConfigsMap.put(
-          singleResourceNameConfig.getEntityId(), singleResourceNameConfig);
+      String fullyQualifiedName = singleResourceNameConfig.getEntityId();
+      fullyQualifiedName =
+          StringUtils.prependIfMissing(fullyQualifiedName, protoParser.getProtoPackage(file) + ".");
+      singleResourceNameConfigsMap.put(fullyQualifiedName, singleResourceNameConfig);
     }
   }
 

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -506,7 +506,7 @@ public abstract class GapicProductConfig implements ProductConfig {
 
     // Populate a SingleResourceNameConfigs map, using just the unqualified names.
     Map<String, SingleResourceNameConfig> singleResourceConfigsFromProtoFile =
-        new LinkedHashMap<>();
+        new HashMap<>();
     for (String fullName : fullyQualifiedSingleResourceNameConfigsFromProtoFile.keySet()) {
       int periodIndex = fullName.lastIndexOf('.');
       SingleResourceNameConfig config =

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -505,8 +505,7 @@ public abstract class GapicProductConfig implements ProductConfig {
             protoParser);
 
     // Populate a SingleResourceNameConfigs map, using just the unqualified names.
-    Map<String, SingleResourceNameConfig> singleResourceConfigsFromProtoFile =
-        new HashMap<>();
+    Map<String, SingleResourceNameConfig> singleResourceConfigsFromProtoFile = new HashMap<>();
     for (String fullName : fullyQualifiedSingleResourceNameConfigsFromProtoFile.keySet()) {
       int periodIndex = fullName.lastIndexOf('.');
       SingleResourceNameConfig config =

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfig.java
@@ -14,11 +14,18 @@
  */
 package com.google.api.codegen.config;
 
+import com.google.api.Resource;
+import com.google.api.ResourceSet;
 import com.google.api.codegen.ResourceNameMessageConfigProto;
+import com.google.api.codegen.util.ProtoParser;
 import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Field;
+import com.google.api.tools.framework.model.MessageType;
+import com.google.api.tools.framework.model.ProtoFile;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 
 /** Configuration of the resource name types for fields of a single message. */
 @AutoValue
@@ -43,15 +50,36 @@ public abstract class ResourceNameMessageConfig {
     return new AutoValue_ResourceNameMessageConfig(fullyQualifiedMessageName, fieldEntityMap);
   }
 
-  public static ResourceNameMessageConfig createResourceNameMessageConfig(Field field) {
-    String messageName = field.getParent().getFullName();
-    ImmutableMap<String, String> fieldEntityMap =
-        ImmutableMap.of(field.getSimpleName(), field.getParent().getSimpleName());
+  static ResourceNameMessageConfig createResourceNameMessageConfig(
+      MessageType message,
+      Map<Resource, ProtoFile> allResources,
+      Map<ResourceSet, ProtoFile> allResourceSets,
+      ProtoParser protoParser) {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    for (Field field : message.getFields()) {
+      String baseName = protoParser.getResourceOrSetEntityName(field);
+      if (!Strings.isNullOrEmpty(baseName)) {
+        builder.put(field.getSimpleName(), baseName);
+        continue;
+      }
 
-    return new AutoValue_ResourceNameMessageConfig(messageName, fieldEntityMap);
+      String resourceType =
+          protoParser.getResourceReferenceName(field, allResources, allResourceSets);
+      if (!Strings.isNullOrEmpty(resourceType)) {
+        builder.put(field.getSimpleName(), resourceType);
+      }
+    }
+
+    ImmutableMap<String, String> fieldEntityMap = builder.build();
+    if (fieldEntityMap.isEmpty()) {
+      // Return a null config when no fields were resource types; this is so empty proto annotations
+      // don't override the GAPIC config resource name configs.
+      return null;
+    }
+    return new AutoValue_ResourceNameMessageConfig(message.getFullName(), fieldEntityMap);
   }
 
-  public static String getFullyQualifiedMessageName(String defaultPackage, String messageName) {
+  static String getFullyQualifiedMessageName(String defaultPackage, String messageName) {
     if (messageName.contains(".")) {
       return messageName;
     } else {
@@ -59,7 +87,7 @@ public abstract class ResourceNameMessageConfig {
     }
   }
 
-  public String getEntityNameForField(String fieldSimpleName) {
+  String getEntityNameForField(String fieldSimpleName) {
     return fieldEntityMap().get(fieldSimpleName);
   }
 }

--- a/src/main/java/com/google/api/codegen/config/SingleResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/SingleResourceNameConfig.java
@@ -14,16 +14,15 @@
  */
 package com.google.api.codegen.config;
 
+import com.google.api.Resource;
 import com.google.api.codegen.CollectionConfigProto;
 import com.google.api.codegen.CollectionLanguageOverridesProto;
 import com.google.api.codegen.common.TargetLanguage;
 import com.google.api.codegen.util.Inflector;
-import com.google.api.codegen.util.ProtoParser;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.pathtemplate.ValidationException;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
-import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.ProtoFile;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.auto.value.AutoValue;
@@ -103,23 +102,18 @@ public abstract class SingleResourceNameConfig implements ResourceNameConfig {
    * Creates an instance of SingleResourceNameConfig based on a field. On errors, null will be
    * returned, and diagnostics are reported to the diag collector.
    */
-  @Nullable
-  public static SingleResourceNameConfig createSingleResourceName(
-      DiagCollector diagCollector, Field resourceField, ProtoFile file, ProtoParser protoParser) {
-    String namePattern = protoParser.getResourcePath(resourceField);
+  static SingleResourceNameConfig createSingleResourceName(
+      Resource resource, String pathTemplate, ProtoFile file, DiagCollector diagCollector) {
     PathTemplate nameTemplate;
     try {
-      String nameTemplateString = escapePathTemplate(namePattern);
-      nameTemplate = PathTemplate.create(nameTemplateString);
+      nameTemplate = PathTemplate.create(pathTemplate);
     } catch (ValidationException e) {
       diagCollector.addDiag(Diag.error(SimpleLocation.TOPLEVEL, e.getMessage()));
       return null;
     }
-    String entityId = protoParser.getResourceEntityName(resourceField);
-    String entityName = entityId;
-    String commonResourceName = null;
+
     return new AutoValue_SingleResourceNameConfig(
-        namePattern, nameTemplate, entityId, entityName, commonResourceName, file);
+        pathTemplate, nameTemplate, resource.getName(), resource.getName(), null, file);
   }
 
   /** Returns the name pattern for the resource name config. */

--- a/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
@@ -15,8 +15,11 @@
 package com.google.api.codegen.config;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 
 import com.google.api.MethodSignature;
+import com.google.api.Resource;
+import com.google.api.ResourceSet;
 import com.google.api.codegen.CollectionConfigProto;
 import com.google.api.codegen.CollectionOneofProto;
 import com.google.api.codegen.ConfigProto;
@@ -42,6 +45,7 @@ import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,7 +54,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 public class ResourceNameMessageConfigsTest {
-  private static final ProtoParser protoParser = Mockito.mock(ProtoParser.class);
+  private static final ProtoParser protoParser = Mockito.spy(ProtoParser.class);
   private static ConfigProto configProto;
   private static final Field shelfName = Mockito.mock(Field.class);
   private static final Field shelfTheme = Mockito.mock(Field.class);
@@ -67,6 +71,20 @@ public class ResourceNameMessageConfigsTest {
   private static final String ARCHIVED_BOOK_PATH = "archives/{archive_path}/books/{book_id=**}";
   private static final String PROTO_SHELF_PATH = "shelves/{shelf}";
   private static final String PROTO_BOOK_PATH = "bookShelves/{book}";
+
+  private static final Map<Resource, ProtoFile> allResourceDefs =
+      ImmutableMap.of(
+          Resource.newBuilder().setName("Shelf").setPath(PROTO_SHELF_PATH).build(),
+          protoFile,
+          Resource.newBuilder().setName("Book").setPath(PROTO_BOOK_PATH).build(),
+          protoFile,
+          Resource.newBuilder()
+              .setName("archived_book")
+              .setPath("archives/{archive}/books/{book}")
+              .build(),
+          protoFile);
+
+  private static final Map<ResourceSet, ProtoFile> allResourceSetDefs = ImmutableMap.of();
 
   @BeforeClass
   public static void startUp() {
@@ -129,11 +147,11 @@ public class ResourceNameMessageConfigsTest {
     Mockito.when(bookMessage.getSimpleName()).thenReturn("Book");
     Mockito.when(bookMessage.getFields()).thenReturn(ImmutableList.of(bookAuthor, bookName));
 
-    Mockito.when(protoParser.getResourcePath(bookName)).thenReturn(PROTO_BOOK_PATH);
-    Mockito.when(protoParser.getResourcePath(shelfName)).thenReturn(PROTO_SHELF_PATH);
-
+    Mockito.doReturn(null).when(protoParser).getResourceSet(any());
     Mockito.when(protoFile.getSimpleName()).thenReturn("library");
     Mockito.when(protoFile.getMessages()).thenReturn(ImmutableList.of(bookMessage, shelfMessage));
+
+    Mockito.doReturn("library").when(protoParser).getProtoPackage(protoFile);
   }
 
   @Test
@@ -142,9 +160,22 @@ public class ResourceNameMessageConfigsTest {
     ConfigProto emptyConfigProto = ConfigProto.getDefaultInstance();
     String defaultPackage = "";
 
+    Mockito.doReturn(Resource.newBuilder().setPath(PROTO_BOOK_PATH).build())
+        .when(protoParser)
+        .getResource(bookName);
+    Mockito.doReturn(Resource.newBuilder().setPath(PROTO_SHELF_PATH).build())
+        .when(protoParser)
+        .getResource(shelfName);
+
     ResourceNameMessageConfigs messageConfigs =
         ResourceNameMessageConfigs.createMessageResourceTypesConfig(
-            sourceProtoFiles, diagCollector, emptyConfigProto, defaultPackage, protoParser);
+            sourceProtoFiles,
+            diagCollector,
+            emptyConfigProto,
+            defaultPackage,
+            allResourceDefs,
+            allResourceSetDefs,
+            protoParser);
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
 
     assertThat(messageConfigs.getResourceTypeConfigMap().size()).isEqualTo(2);
@@ -206,23 +237,42 @@ public class ResourceNameMessageConfigsTest {
   public void testCreateResourceNames() {
     DiagCollector diagCollector = new BoundedDiagCollector();
 
+    Map<ResourceSet, ProtoFile> resourceSetDefs = new HashMap<>();
     ResourceNameMessageConfigs messageConfigs =
         ResourceNameMessageConfigs.createMessageResourceTypesConfig(
-            sourceProtoFiles, diagCollector, configProto, DEFAULT_PACKAGE, protoParser);
+            sourceProtoFiles,
+            diagCollector,
+            configProto,
+            DEFAULT_PACKAGE,
+            allResourceDefs,
+            resourceSetDefs,
+            protoParser);
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
   }
 
   @Test
   public void testCreateResourceNameConfigs() {
-    Mockito.when(protoParser.getResourceEntityName(Mockito.any())).thenCallRealMethod();
     DiagCollector diagCollector = new BoundedDiagCollector();
+
     Map<String, ResourceNameConfig> resourceNameConfigs =
         GapicProductConfig.createResourceNameConfigs(
-            diagCollector, configProto, sourceProtoFiles, TargetLanguage.CSHARP, protoParser);
+            diagCollector,
+            configProto,
+            sourceProtoFiles,
+            TargetLanguage.CSHARP,
+            allResourceDefs,
+            allResourceSetDefs,
+            protoParser);
+
+    assertThat(diagCollector.getErrorCount()).isEqualTo(0);
     assertThat(resourceNameConfigs.size()).isEqualTo(7);
 
     assertThat(((SingleResourceNameConfig) resourceNameConfigs.get("Book")).getNamePattern())
         .isEqualTo(PROTO_BOOK_PATH);
+
+    // Both Protofile and GAPIC config have definitions for archived_book.
+    assertThat(diagCollector.getDiags().get(0).getMessage())
+        .contains("archived_book from protofile clashes with a Resource");
     assertThat(
             ((SingleResourceNameConfig) resourceNameConfigs.get("archived_book")).getNamePattern())
         .isEqualTo(ARCHIVED_BOOK_PATH);
@@ -239,6 +289,14 @@ public class ResourceNameMessageConfigsTest {
     assertThat(((SingleResourceNameConfig) resourceNameConfigs.get("Shelf")).getNamePattern())
         .isEqualTo(PROTO_SHELF_PATH);
 
+    // Use GAPIC_BOOK_PATH from gapic config.
+    assertThat(((SingleResourceNameConfig) resourceNameConfigs.get("book")).getNamePattern())
+        .isEqualTo(GAPIC_BOOK_PATH);
+
+    // "Book" is the name from the unnamed Resource in the Book message type.
+    SingleResourceNameConfig bookResourcenameConfigFromProtoFile =
+        (SingleResourceNameConfig) resourceNameConfigs.get("Book");
+    assertThat(bookResourcenameConfigFromProtoFile.getNamePattern()).isEqualTo(PROTO_BOOK_PATH);
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
   }
 
@@ -265,16 +323,19 @@ public class ResourceNameMessageConfigsTest {
     Mockito.when(nameField.getSimpleName()).thenReturn("name");
     Mockito.when(createShelvesRequest.lookupField("book")).thenReturn(bookField);
     Mockito.when(createShelvesRequest.lookupField("name")).thenReturn(nameField);
+    Mockito.when(createShelvesRequest.getFields())
+        .thenReturn(ImmutableList.of(bookField, nameField));
 
-    Mockito.when(protoParser.getResourceReference(bookField)).thenReturn("library.Book");
-    Mockito.when(protoParser.getResourceReference(nameField)).thenReturn("library.Shelf");
+    Mockito.doReturn("library.Book").when(protoParser).getResourceReference(bookField);
+    Mockito.doReturn("library.Shelf").when(protoParser).getResourceReference(nameField);
 
     // ProtoFile contributes flattenings {["name", "book"], ["name"]}.
-    Mockito.when(protoParser.getMethodSignatures(createShelvesMethod))
-        .thenReturn(
+    Mockito.doReturn(
             Arrays.asList(
                 MethodSignature.newBuilder().addFields("name").addFields("book").build(),
-                MethodSignature.newBuilder().addFields("name").build()));
+                MethodSignature.newBuilder().addFields("name").build()))
+        .when(protoParser)
+        .getMethodSignatures(createShelvesMethod);
 
     String flatteningConfigName = "flatteningGroupName";
     // Gapic config contributes flattenings {["book"]}.
@@ -299,16 +360,29 @@ public class ResourceNameMessageConfigsTest {
             .addResourceNameGeneration(
                 ResourceNameMessageConfigProto.newBuilder()
                     .setMessageName("CreateShelvesRequest")
-                    .putFieldEntityMap("name", "shelf"))
+                    .putFieldEntityMap("name", "shelf")
+                    .putFieldEntityMap("book", "book"))
             .build();
 
     DiagCollector diagCollector = new BoundedDiagCollector();
     ResourceNameMessageConfigs messageConfigs =
         ResourceNameMessageConfigs.createMessageResourceTypesConfig(
-            sourceProtoFiles, diagCollector, configProto, DEFAULT_PACKAGE, protoParser);
+            sourceProtoFiles,
+            diagCollector,
+            configProto,
+            DEFAULT_PACKAGE,
+            allResourceDefs,
+            allResourceSetDefs,
+            protoParser);
     ImmutableMap<String, ResourceNameConfig> resourceNameConfigs =
         GapicProductConfig.createResourceNameConfigs(
-            diagCollector, configProto, sourceProtoFiles, TargetLanguage.CSHARP, protoParser);
+            diagCollector,
+            configProto,
+            sourceProtoFiles,
+            TargetLanguage.CSHARP,
+            allResourceDefs,
+            allResourceSetDefs,
+            protoParser);
 
     List<FlatteningConfig> flatteningConfigs =
         new ArrayList<>(
@@ -365,6 +439,10 @@ public class ResourceNameMessageConfigsTest {
         .isEqualTo(GAPIC_SHELF_PATH);
 
     FieldConfig bookConfig = shelfAndBookFlattening.getFlattenedFieldConfigs().get("book");
+    assertThat(bookConfig.getResourceNameTreatment()).isEqualTo(ResourceNameTreatment.STATIC_TYPES);
+    // Use the resource name path from GAPIC config.
+    assertThat(((SingleResourceNameConfig) bookConfig.getResourceNameConfig()).getNamePattern())
+        .isEqualTo(GAPIC_BOOK_PATH);
     assertThat(((ProtoTypeRef) bookConfig.getField().getType()).getProtoType().getMessageType())
         .isEqualTo(bookType);
   }


### PR DESCRIPTION
Actually parse the path templates from a Resource to create FieldConfigs.

When a ResourceSet refers to resource definitions by name, find the referent Resource and make a ResourceNameOneofConfig from that.