### PR TITLE
Avoid Indexoutofbounds when getting enum typename

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaModelTypeNameConverter.java
@@ -224,7 +224,11 @@ public class JavaModelTypeNameConverter extends ModelTypeNameConverter {
   private TypeName getEnumTypeName(ProtoElement elem) {
     String packageName = getProtoElementPackage(elem);
     String shortName = getShortName(elem);
-    String importName = packageName + "." + shortName.substring(0, shortName.indexOf("."));
+    int indexOfSeparator = shortName.indexOf(".");
+    if (indexOfSeparator < 0) {
+      indexOfSeparator = shortName.length();
+    }
+    String importName = packageName + "." + shortName.substring(0, indexOfSeparator);
     String longName = packageName + "." + shortName;
 
     return TypeName.createOuterTypeName(longName, shortName, importName);


### PR DESCRIPTION
Fixes https://circleci.com/gh/googleapis/artman/8422#artifacts/containers/0 and the [issue raised by ArrayOutOfBounds](https://github.com/googleapis/gapic-generator/pull/2430#discussion_r233606133).

Tested by running `artman --local generate java_gapic` on some of the failing jobs in https://circleci.com/gh/googleapis/artman/8422#artifacts/containers/0, e.g. `google/cloud/language/artman_language_v1beta2.yaml`

Hopefully soon we'll run all artman smoketests (https://github.com/googleapis/gapic-generator/pull/2443) on gapic-generator:master to catch errors like these and prevent firedrills on artman releases.