### PR TITLE
Fix: generate GapicInterfaceConfigs for named interfaces in GAPIC config 

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -442,11 +443,12 @@ public abstract class GapicProductConfig implements ProductConfig {
     }
 
     // Generate GapicInterfaceConfigs from the proto interfaces and interfaceConfigProtos.
-    for (String serviceFullName : protoInterfaces.keySet()) {
+    for (Entry<String, Interface> interfaceEntry : protoInterfaces.entrySet()) {
+      String serviceFullName = interfaceEntry.getKey();
       InterfaceConfigProto interfaceConfigProto =
           interfaceConfigProtos.getOrDefault(
               serviceFullName, InterfaceConfigProto.getDefaultInstance());
-      Interface apiInterface = protoInterfaces.get(serviceFullName);
+      Interface apiInterface = interfaceEntry.getValue();
       String interfaceNameOverride = languageSettings.getInterfaceNamesMap().get(serviceFullName);
 
       GapicInterfaceConfig interfaceConfig =

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -416,7 +416,6 @@ public abstract class GapicProductConfig implements ProductConfig {
 
     // Parse proto file for interfaces.
     for (ProtoFile file : sourceProtos) {
-      if (file.getProto().getServiceList().size() == 0) continue;
       for (DescriptorProtos.ServiceDescriptorProto service : file.getProto().getServiceList()) {
         String serviceFullName =
             String.format("%s.%s", file.getProto().getPackage(), service.getName());

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -407,6 +407,7 @@ public abstract class GapicProductConfig implements ProductConfig {
     // Return value; maps interface names to their InterfaceConfig.
     ImmutableMap.Builder<String, InterfaceConfig> interfaceConfigMap = ImmutableMap.builder();
 
+    // Insertion-ordered set of interface names for which we will create GapicInterfaceConfigs.
     Set<String> serviceNames = new LinkedHashSet<>();
     // Maps name of interfaces to found InterfaceConfigs from config yamls.
     Map<String, InterfaceConfigProto> interfaceConfigProtos = new HashMap<>();
@@ -430,7 +431,7 @@ public abstract class GapicProductConfig implements ProductConfig {
       }
     }
 
-    // Parse config for interfaceConfigProtos.
+    // Parse GAPIC config for interfaceConfigProtos and their corresponding proto interfaces.
     for (InterfaceConfigProto interfaceConfigProto : configProto.getInterfacesList()) {
       Interface apiInterface = symbolTable.lookupInterface(interfaceConfigProto.getName());
       if (apiInterface == null || !apiInterface.isReachable()) {
@@ -446,7 +447,7 @@ public abstract class GapicProductConfig implements ProductConfig {
       serviceNames.add(interfaceConfigProto.getName());
     }
 
-    // Generate GapicInterfaceConfigs for the found proto interfaces and interfaceConfigProtos
+    // Generate GapicInterfaceConfigs from the proto interfaces and interfaceConfigProtos.
     for (String serviceFullName : serviceNames) {
       InterfaceConfigProto interfaceConfigProto = interfaceConfigProtos.get(serviceFullName);
       Interface apiInterface = protoInterfaces.get(serviceFullName);


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator/issues/2454, a regression introduced by 1add5a8ba75e29a80613fb2a187a46c08887434a.

I forgot to also create GapicInterfaceConfigs for externally-packaged interfaces defined in the GAPIC config.

This had affected Container Analysis v1beta1, which requires library code to also be generated for the `grafeas.v1beta1.GrafeasV1Beta1` interface. The regression in gapic-generator had left that out.