### PR TITLE
Copy over java_library.baseline to protoannotations testdata

### DIFF
--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -1,0 +1,10952 @@
+============== file: ../build.gradle ==============
+Static or binary file content is not shown.
+============== file: ../gradle/wrapper/gradle-wrapper.jar ==============
+Static or binary file content is not shown.
+============== file: ../gradle/wrapper/gradle-wrapper.properties ==============
+Static or binary file content is not shown.
+============== file: ../gradlew ==============
+Static or binary file content is not shown.
+============== file: ../gradlew.bat ==============
+Static or binary file content is not shown.
+============== file: ../settings.gradle ==============
+Static or binary file content is not shown.
+============== file: build.gradle ==============
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+apply plugin: 'java'
+
+description = 'GAPIC library for google-cloud-library-v1'
+group = 'com.google.cloud'
+version = '0.0.0-SNAPSHOT'
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+repositories {
+  mavenCentral()
+  mavenLocal()
+}
+
+compileJava.options.encoding = 'UTF-8'
+javadoc.options.encoding = 'UTF-8'
+
+dependencies {
+  compile 'com.google.api:gax:1.0.0'
+  testCompile 'com.google.api:gax:1.0.0:testlib'
+  compile 'com.google.api:gax-grpc:0.18.0'
+  testCompile 'com.google.api:gax-grpc:0.18.0:testlib'
+  testCompile 'io.grpc:grpc-netty-shaded:1.9.0'
+  testCompile 'junit:junit:4.12'
+  // Remove this line if you are bundling your proto-generated classes together with your client classes
+  compile project(':proto-google-cloud-library-v1')
+  // Remove this line if you are bundling your proto-generated classes together with your client classes
+  testCompile project(':grpc-google-cloud-library-v1')
+  testCompile 'com.google.api.grpc:grpc-google-some-test-package-v1:0.0.0'
+}
+
+task smokeTest(type: Test) {
+  filter {
+    includeTestsMatching "*SmokeTest"
+    setFailOnNoMatchingTests false
+  }
+}
+
+test {
+  exclude "**/*SmokeTest*"
+}
+
+sourceSets {
+  main {
+    java {
+      srcDir 'src/main/java'
+    }
+  }
+}
+
+clean {
+  delete 'all-jars'
+}
+
+task allJars(type: Copy) {
+  dependsOn test, jar
+  into 'all-jars'
+  // Replace with `from configurations.testRuntime, jar` to include test dependencies
+  from configurations.runtime, jar
+}
+============== file: src/main/java/com/google/example/library/v1/LibraryClient.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.paging.AbstractFixedSizeCollection;
+import com.google.api.gax.paging.AbstractPage;
+import com.google.api.gax.paging.AbstractPagedListResponse;
+import com.google.api.gax.paging.FixedSizeCollection;
+import com.google.api.gax.paging.Page;
+import com.google.api.gax.rpc.ApiExceptions;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.PageContext;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.resourcenames.ResourceName;
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
+import com.google.example.library.v1.stub.LibraryServiceStub;
+import com.google.example.library.v1.stub.LibraryServiceStubSettings;
+import com.google.longrunning.Operation;
+import com.google.longrunning.OperationsClient;
+import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Empty;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
+import com.google.tagger.v1.TaggerProto.AddLabelRequest;
+import com.google.tagger.v1.TaggerProto.AddLabelResponse;
+import com.google.tagger.v1.TaggerProto.AddTagRequest;
+import com.google.tagger.v1.TaggerProto.AddTagResponse;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND SERVICE
+/**
+ * Service Description: This API represents a simple digital library.  It lets you manage Shelf
+ * resources and Book resources in the library. It defines the following
+ * resource model:
+ *
+ * - The API has a collection of [Shelf][google.example.library.v1.Shelf]
+ *   resources, named ``bookShelves/&#42;``
+ *
+ * - Each Shelf has a collection of [Book][google.example.library.v1.Book]
+ *   resources, named `bookShelves/&#42;/books/&#42;`
+ *
+ * Check out [cloud docs!](/library/example/link).
+ * This is [not a cloud link](http://www.google.com).
+ *
+ * Service comment may include special characters: &lt;&gt;&amp;"`'{@literal @}.
+ *
+ * Also see this awesome doc there! and there! and everywhere!
+ *
+ * <p>This class provides the ability to make remote calls to the backing service through method
+ * calls that map to API methods. Sample code to get started:
+ *
+ * <pre>
+ * <code>
+ * try (LibraryClient libraryClient = LibraryClient.create()) {
+ *   Shelf shelf = Shelf.newBuilder().build();
+ *   Shelf response = libraryClient.createShelf(shelf);
+ * }
+ * </code>
+ * </pre>
+ *
+ * <p>Note: close() needs to be called on the libraryClient object to clean up resources such
+ * as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's methods:
+ *
+ * <ol>
+ * <li> A "flattened" method. With this type of method, the fields of the request type have been
+ * converted into function parameters. It may be the case that not all fields are available
+ * as parameters, and not every API method will have a flattened method entry point.
+ * <li> A "request object" method. This type of method only takes one parameter, a request
+ * object, which must be constructed before the call. Not every API method will have a request
+ * object method.
+ * <li> A "callable" method. This type of method takes no parameters and returns an immutable
+ * API callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist
+ * with these names, this class includes a format method for each type of name, and additionally
+ * a parse method to extract the individual identifiers contained within names that are
+ * returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of LibrarySettings to
+ * create(). For example:
+ *
+ * To customize credentials:
+ *
+ * <pre>
+ * <code>
+ * LibrarySettings librarySettings =
+ *     LibrarySettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * LibraryClient libraryClient =
+ *     LibraryClient.create(librarySettings);
+ * </code>
+ * </pre>
+ *
+ * To customize the endpoint:
+ *
+ * <pre>
+ * <code>
+ * LibrarySettings librarySettings =
+ *     LibrarySettings.newBuilder().setEndpoint(myEndpoint).build();
+ * LibraryClient libraryClient =
+ *     LibraryClient.create(librarySettings);
+ * </code>
+ * </pre>
+ */
+@Generated("by gapic-generator")
+public class LibraryClient implements BackgroundResource {
+  private final LibrarySettings settings;
+  private final LibraryServiceStub stub;
+  private final OperationsClient operationsClient;
+
+
+
+  /**
+   * Constructs an instance of LibraryClient with default settings.
+   */
+  public static final LibraryClient create() throws IOException {
+    return create(LibrarySettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of LibraryClient, using the given settings.
+   * The channels are created based on the settings passed in, or defaults for any
+   * settings that are not set.
+   */
+  public static final LibraryClient create(LibrarySettings settings) throws IOException {
+    return new LibraryClient(settings);
+  }
+
+  /**
+   * Constructs an instance of LibraryClient, using the given stub for making calls. This is for
+   * advanced usage - prefer to use LibrarySettings}.
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final LibraryClient create(LibraryServiceStub stub) {
+    return new LibraryClient(stub);
+  }
+
+  /**
+   * Constructs an instance of LibraryClient, using the given settings.
+   * This is protected so that it is easy to make a subclass, but otherwise, the static
+   * factory methods should be preferred.
+   */
+  protected LibraryClient(LibrarySettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((LibraryServiceStubSettings) settings.getStubSettings()).createStub();
+    this.operationsClient = OperationsClient.create(this.stub.getOperationsStub());
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected LibraryClient(LibraryServiceStub stub) {
+    this.settings = null;
+    this.stub = stub;
+    this.operationsClient = OperationsClient.create(this.stub.getOperationsStub());
+  }
+
+  public final LibrarySettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public LibraryServiceStub getStub() {
+    return stub;
+  }
+
+  /**
+   * Returns the OperationsClient that can be used to query the status of a long-running
+   * operation returned by another API method call.
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationsClient getOperationsClient() {
+    return operationsClient;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates a shelf, and returns the new Shelf.
+   * RPC method comment may include special characters: &lt;&gt;&amp;"`'{@literal @}.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   Shelf shelf = Shelf.newBuilder().build();
+   *   Shelf response = libraryClient.createShelf(shelf);
+   * }
+   * </code></pre>
+   *
+   * @param shelf The shelf to create.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Shelf createShelf(Shelf shelf) {
+
+    CreateShelfRequest request =
+        CreateShelfRequest.newBuilder()
+        .setShelf(shelf)
+        .build();
+    return createShelf(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates a shelf, and returns the new Shelf.
+   * RPC method comment may include special characters: &lt;&gt;&amp;"`'{@literal @}.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   Shelf shelf = Shelf.newBuilder().build();
+   *   CreateShelfRequest request = CreateShelfRequest.newBuilder()
+   *     .setShelf(shelf)
+   *     .build();
+   *   Shelf response = libraryClient.createShelf(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Shelf createShelf(CreateShelfRequest request) {
+    return createShelfCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates a shelf, and returns the new Shelf.
+   * RPC method comment may include special characters: &lt;&gt;&amp;"`'{@literal @}.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   Shelf shelf = Shelf.newBuilder().build();
+   *   CreateShelfRequest request = CreateShelfRequest.newBuilder()
+   *     .setShelf(shelf)
+   *     .build();
+   *   ApiFuture&lt;Shelf&gt; future = libraryClient.createShelfCallable().futureCall(request);
+   *   // Do something
+   *   Shelf response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<CreateShelfRequest, Shelf> createShelfCallable() {
+    return stub.createShelfCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   Shelf response = libraryClient.getShelf(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the shelf to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Shelf getShelf(ShelfName name) {
+
+    GetShelfRequest request =
+        GetShelfRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .build();
+    return getShelf(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   Shelf response = libraryClient.getShelf(name.toString());
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the shelf to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Shelf getShelf(String name) {
+
+    GetShelfRequest request =
+        GetShelfRequest.newBuilder()
+        .setName(name)
+        .build();
+    return getShelf(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedName = ShelfName.format("[SHELF_ID]");
+   *   SomeMessage message = SomeMessage.newBuilder().build();
+   *   Shelf response = libraryClient.getShelf(formattedName, message);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the shelf to retrieve.
+   * @param message Field to verify that message-type query parameter gets flattened.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Shelf getShelf(String name, SomeMessage message) {
+
+    GetShelfRequest request =
+        GetShelfRequest.newBuilder()
+        .setName(name)
+        .setMessage(message)
+        .build();
+    return getShelf(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedName = ShelfName.format("[SHELF_ID]");
+   *   SomeMessage message = SomeMessage.newBuilder().build();
+   *   com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
+   *   Shelf response = libraryClient.getShelf(formattedName, message, stringBuilder);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the shelf to retrieve.
+   * @param message Field to verify that message-type query parameter gets flattened.
+   * @param stringBuilder
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Shelf getShelf(String name, SomeMessage message, com.google.example.library.v1.StringBuilder stringBuilder) {
+
+    GetShelfRequest request =
+        GetShelfRequest.newBuilder()
+        .setName(name)
+        .setMessage(message)
+        .setStringBuilder(stringBuilder)
+        .build();
+    return getShelf(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedName = ShelfName.format("[SHELF_ID]");
+   *   String options = "";
+   *   GetShelfRequest request = GetShelfRequest.newBuilder()
+   *     .setName(formattedName)
+   *     .setOptions(options)
+   *     .build();
+   *   Shelf response = libraryClient.getShelf(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Shelf getShelf(GetShelfRequest request) {
+    return getShelfCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedName = ShelfName.format("[SHELF_ID]");
+   *   String options = "";
+   *   GetShelfRequest request = GetShelfRequest.newBuilder()
+   *     .setName(formattedName)
+   *     .setOptions(options)
+   *     .build();
+   *   ApiFuture&lt;Shelf&gt; future = libraryClient.getShelfCallable().futureCall(request);
+   *   // Do something
+   *   Shelf response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GetShelfRequest, Shelf> getShelfCallable() {
+    return stub.getShelfCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists shelves.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *
+   *   for (Shelf element : libraryClient.listShelves().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListShelvesPagedResponse listShelves() {
+    ListShelvesRequest request =
+        ListShelvesRequest.newBuilder()
+
+        .build();
+    return listShelves(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists shelves.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ListShelvesRequest request = ListShelvesRequest.newBuilder().build();
+   *   for (Shelf element : libraryClient.listShelves(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListShelvesPagedResponse listShelves(ListShelvesRequest request) {
+    return listShelvesPagedCallable()
+        .call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists shelves.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ListShelvesRequest request = ListShelvesRequest.newBuilder().build();
+   *   ApiFuture&lt;ListShelvesPagedResponse&gt; future = libraryClient.listShelvesPagedCallable().futureCall(request);
+   *   // Do something
+   *   for (Shelf element : future.get().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ListShelvesRequest, ListShelvesPagedResponse> listShelvesPagedCallable() {
+    return stub.listShelvesPagedCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists shelves.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ListShelvesRequest request = ListShelvesRequest.newBuilder().build();
+   *   while (true) {
+   *     ListShelvesResponse response = libraryClient.listShelvesCallable().call(request);
+   *     for (Shelf element : response.getShelvesList()) {
+   *       // doThingsWith(element);
+   *     }
+   *     String nextPageToken = response.getNextPageToken();
+   *     if (!Strings.isNullOrEmpty(nextPageToken)) {
+   *       request = request.toBuilder().setPageToken(nextPageToken).build();
+   *     } else {
+   *       break;
+   *     }
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ListShelvesRequest, ListShelvesResponse> listShelvesCallable() {
+    return stub.listShelvesCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Deletes a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   libraryClient.deleteShelf(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the shelf to delete.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void deleteShelf(ShelfName name) {
+
+    DeleteShelfRequest request =
+        DeleteShelfRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .build();
+    deleteShelf(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Deletes a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   libraryClient.deleteShelf(name.toString());
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the shelf to delete.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void deleteShelf(String name) {
+
+    DeleteShelfRequest request =
+        DeleteShelfRequest.newBuilder()
+        .setName(name)
+        .build();
+    deleteShelf(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Deletes a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   libraryClient.deleteShelf(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void deleteShelf(DeleteShelfRequest request) {
+    deleteShelfCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Deletes a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   ApiFuture&lt;Void&gt; future = libraryClient.deleteShelfCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<DeleteShelfRequest, Empty> deleteShelfCallable() {
+    return stub.deleteShelfCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Merges two shelves by adding all books from the shelf named
+   * `other_shelf_name` to shelf `name`, and deletes
+   * `other_shelf_name`. Returns the updated shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   Shelf response = libraryClient.mergeShelves(name, otherShelfName);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the shelf we're adding books to.
+   * @param otherShelfName The name of the shelf we're removing books from and deleting.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Shelf mergeShelves(ShelfName name, ShelfName otherShelfName) {
+
+    MergeShelvesRequest request =
+        MergeShelvesRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .setOtherShelfName(otherShelfName == null ? null : otherShelfName.toString())
+        .build();
+    return mergeShelves(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Merges two shelves by adding all books from the shelf named
+   * `other_shelf_name` to shelf `name`, and deletes
+   * `other_shelf_name`. Returns the updated shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   Shelf response = libraryClient.mergeShelves(name.toString(), otherShelfName.toString());
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the shelf we're adding books to.
+   * @param otherShelfName The name of the shelf we're removing books from and deleting.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Shelf mergeShelves(String name, String otherShelfName) {
+
+    MergeShelvesRequest request =
+        MergeShelvesRequest.newBuilder()
+        .setName(name)
+        .setOtherShelfName(otherShelfName)
+        .build();
+    return mergeShelves(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Merges two shelves by adding all books from the shelf named
+   * `other_shelf_name` to shelf `name`, and deletes
+   * `other_shelf_name`. Returns the updated shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setOtherShelfName(otherShelfName.toString())
+   *     .build();
+   *   Shelf response = libraryClient.mergeShelves(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Shelf mergeShelves(MergeShelvesRequest request) {
+    return mergeShelvesCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Merges two shelves by adding all books from the shelf named
+   * `other_shelf_name` to shelf `name`, and deletes
+   * `other_shelf_name`. Returns the updated shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setOtherShelfName(otherShelfName.toString())
+   *     .build();
+   *   ApiFuture&lt;Shelf&gt; future = libraryClient.mergeShelvesCallable().futureCall(request);
+   *   // Do something
+   *   Shelf response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MergeShelvesRequest, Shelf> mergeShelvesCallable() {
+    return stub.mergeShelvesCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedName = ShelfName.format("[SHELF_ID]");
+   *   Book book = Book.newBuilder().build();
+   *   Book response = libraryClient.createBook(formattedName, book);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the shelf in which the book is created.
+   * @param book The book to create.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book createBook(String name, Book book) {
+
+    CreateBookRequest request =
+        CreateBookRequest.newBuilder()
+        .setName(name)
+        .setBook(book)
+        .build();
+    return createBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedName = ShelfName.format("[SHELF_ID]");
+   *   Book book = Book.newBuilder().build();
+   *   CreateBookRequest request = CreateBookRequest.newBuilder()
+   *     .setName(formattedName)
+   *     .setBook(book)
+   *     .build();
+   *   Book response = libraryClient.createBook(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book createBook(CreateBookRequest request) {
+    return createBookCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedName = ShelfName.format("[SHELF_ID]");
+   *   Book book = Book.newBuilder().build();
+   *   CreateBookRequest request = CreateBookRequest.newBuilder()
+   *     .setName(formattedName)
+   *     .setBook(book)
+   *     .build();
+   *   ApiFuture&lt;Book&gt; future = libraryClient.createBookCallable().futureCall(request);
+   *   // Do something
+   *   Book response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<CreateBookRequest, Book> createBookCallable() {
+    return stub.createBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates a series of books.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   Shelf shelf = Shelf.newBuilder().build();
+   *   List&lt;Book&gt; books = new ArrayList&lt;&gt;();
+   *   int edition = 0;
+   *   String seriesString = "foobar";
+   *   SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+   *     .setSeriesString(seriesString)
+   *     .build();
+   *   PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
+   * }
+   * </code></pre>
+   *
+   * @param shelf The shelf in which the series is created.
+   * @param books The books to publish in the series.
+   * @param edition The edition of the series
+   * @param seriesUuid Uniquely identifies the series to the publishing house.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final PublishSeriesResponse publishSeries(Shelf shelf, List<Book> books, int edition, SeriesUuid seriesUuid) {
+
+    PublishSeriesRequest request =
+        PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setEdition(edition)
+        .setSeriesUuid(seriesUuid)
+        .build();
+    return publishSeries(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates a series of books.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   Shelf shelf = Shelf.newBuilder().build();
+   *   List&lt;Book&gt; books = new ArrayList&lt;&gt;();
+   *   String seriesString = "foobar";
+   *   SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+   *     .setSeriesString(seriesString)
+   *     .build();
+   *   PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+   *     .setShelf(shelf)
+   *     .addAllBooks(books)
+   *     .setSeriesUuid(seriesUuid)
+   *     .build();
+   *   PublishSeriesResponse response = libraryClient.publishSeries(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final PublishSeriesResponse publishSeries(PublishSeriesRequest request) {
+    return publishSeriesCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates a series of books.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   Shelf shelf = Shelf.newBuilder().build();
+   *   List&lt;Book&gt; books = new ArrayList&lt;&gt;();
+   *   String seriesString = "foobar";
+   *   SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+   *     .setSeriesString(seriesString)
+   *     .build();
+   *   PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+   *     .setShelf(shelf)
+   *     .addAllBooks(books)
+   *     .setSeriesUuid(seriesUuid)
+   *     .build();
+   *   ApiFuture&lt;PublishSeriesResponse&gt; future = libraryClient.publishSeriesCallable().futureCall(request);
+   *   // Do something
+   *   PublishSeriesResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<PublishSeriesRequest, PublishSeriesResponse> publishSeriesCallable() {
+    return stub.publishSeriesCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   Book response = libraryClient.getBook(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book getBook(ShelfBookName name) {
+
+    GetBookRequest request =
+        GetBookRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .build();
+    return getBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   Book response = libraryClient.getBook(name.toString());
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book getBook(String name) {
+
+    GetBookRequest request =
+        GetBookRequest.newBuilder()
+        .setName(name)
+        .build();
+    return getBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   Book response = libraryClient.getBook(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book getBook(GetBookRequest request) {
+    return getBookCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   ApiFuture&lt;Book&gt; future = libraryClient.getBookCallable().futureCall(request);
+   *   // Do something
+   *   Book response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GetBookRequest, Book> getBookCallable() {
+    return stub.getBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists books in a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   String filter = "book-filter-string";
+   *   for (Book element : libraryClient.listBooks(name, filter).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the shelf whose books we'd like to list.
+   * @param filter To test python built-in wrapping.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListBooksPagedResponse listBooks(ShelfName name, String filter) {
+    ListBooksRequest request =
+        ListBooksRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .setFilter(filter)
+        .build();
+    return listBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists books in a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   String filter = "book-filter-string";
+   *   for (Book element : libraryClient.listBooks(name.toString(), filter).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the shelf whose books we'd like to list.
+   * @param filter To test python built-in wrapping.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListBooksPagedResponse listBooks(String name, String filter) {
+    ListBooksRequest request =
+        ListBooksRequest.newBuilder()
+        .setName(name)
+        .setFilter(filter)
+        .build();
+    return listBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists books in a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   String filter = "book-filter-string";
+   *   ListBooksRequest request = ListBooksRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setFilter(filter)
+   *     .build();
+   *   for (Book element : libraryClient.listBooks(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListBooksPagedResponse listBooks(ListBooksRequest request) {
+    return listBooksPagedCallable()
+        .call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists books in a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   String filter = "book-filter-string";
+   *   ListBooksRequest request = ListBooksRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setFilter(filter)
+   *     .build();
+   *   ApiFuture&lt;ListBooksPagedResponse&gt; future = libraryClient.listBooksPagedCallable().futureCall(request);
+   *   // Do something
+   *   for (Book element : future.get().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ListBooksRequest, ListBooksPagedResponse> listBooksPagedCallable() {
+    return stub.listBooksPagedCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists books in a shelf.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   String filter = "book-filter-string";
+   *   ListBooksRequest request = ListBooksRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setFilter(filter)
+   *     .build();
+   *   while (true) {
+   *     ListBooksResponse response = libraryClient.listBooksCallable().call(request);
+   *     for (Book element : response.getBooksList()) {
+   *       // doThingsWith(element);
+   *     }
+   *     String nextPageToken = response.getNextPageToken();
+   *     if (!Strings.isNullOrEmpty(nextPageToken)) {
+   *       request = request.toBuilder().setPageToken(nextPageToken).build();
+   *     } else {
+   *       break;
+   *     }
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ListBooksRequest, ListBooksResponse> listBooksCallable() {
+    return stub.listBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Deletes a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   libraryClient.deleteBook(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to delete.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void deleteBook(ShelfBookName name) {
+
+    DeleteBookRequest request =
+        DeleteBookRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .build();
+    deleteBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Deletes a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   libraryClient.deleteBook(name.toString());
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to delete.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void deleteBook(String name) {
+
+    DeleteBookRequest request =
+        DeleteBookRequest.newBuilder()
+        .setName(name)
+        .build();
+    deleteBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Deletes a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   libraryClient.deleteBook(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void deleteBook(DeleteBookRequest request) {
+    deleteBookCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Deletes a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   ApiFuture&lt;Void&gt; future = libraryClient.deleteBookCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<DeleteBookRequest, Empty> deleteBookCallable() {
+    return stub.deleteBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Updates a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   Book book = Book.newBuilder().build();
+   *   Book response = libraryClient.updateBook(name, book);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to update.
+   * @param book The book to update with.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book updateBook(ShelfBookName name, Book book) {
+
+    UpdateBookRequest request =
+        UpdateBookRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .setBook(book)
+        .build();
+    return updateBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Updates a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   Book book = Book.newBuilder().build();
+   *   Book response = libraryClient.updateBook(name.toString(), book);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to update.
+   * @param book The book to update with.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book updateBook(String name, Book book) {
+
+    UpdateBookRequest request =
+        UpdateBookRequest.newBuilder()
+        .setName(name)
+        .setBook(book)
+        .build();
+    return updateBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Updates a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   String optionalFoo = "";
+   *   Book book = Book.newBuilder().build();
+   *   FieldMask updateMask = FieldMask.newBuilder().build();
+   *   com.google.example.library.v1.FieldMask physicalMask = com.google.example.library.v1.FieldMask.newBuilder().build();
+   *   Book response = libraryClient.updateBook(name, optionalFoo, book, updateMask, physicalMask);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to update.
+   * @param optionalFoo An optional foo.
+   * @param book The book to update with.
+   * @param updateMask A field mask to apply, rendered as an HTTP parameter.
+   * @param physicalMask To test Python import clash resolution.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book updateBook(ShelfBookName name, String optionalFoo, Book book, FieldMask updateMask, com.google.example.library.v1.FieldMask physicalMask) {
+
+    UpdateBookRequest request =
+        UpdateBookRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .setOptionalFoo(optionalFoo)
+        .setBook(book)
+        .setUpdateMask(updateMask)
+        .setPhysicalMask(physicalMask)
+        .build();
+    return updateBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Updates a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   String optionalFoo = "";
+   *   Book book = Book.newBuilder().build();
+   *   FieldMask updateMask = FieldMask.newBuilder().build();
+   *   com.google.example.library.v1.FieldMask physicalMask = com.google.example.library.v1.FieldMask.newBuilder().build();
+   *   Book response = libraryClient.updateBook(name.toString(), optionalFoo, book, updateMask, physicalMask);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to update.
+   * @param optionalFoo An optional foo.
+   * @param book The book to update with.
+   * @param updateMask A field mask to apply, rendered as an HTTP parameter.
+   * @param physicalMask To test Python import clash resolution.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book updateBook(String name, String optionalFoo, Book book, FieldMask updateMask, com.google.example.library.v1.FieldMask physicalMask) {
+
+    UpdateBookRequest request =
+        UpdateBookRequest.newBuilder()
+        .setName(name)
+        .setOptionalFoo(optionalFoo)
+        .setBook(book)
+        .setUpdateMask(updateMask)
+        .setPhysicalMask(physicalMask)
+        .build();
+    return updateBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Updates a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   Book book = Book.newBuilder().build();
+   *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setBook(book)
+   *     .build();
+   *   Book response = libraryClient.updateBook(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book updateBook(UpdateBookRequest request) {
+    return updateBookCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Updates a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   Book book = Book.newBuilder().build();
+   *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setBook(book)
+   *     .build();
+   *   ApiFuture&lt;Book&gt; future = libraryClient.updateBookCallable().futureCall(request);
+   *   // Do something
+   *   Book response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<UpdateBookRequest, Book> updateBookCallable() {
+    return stub.updateBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Moves a book to another shelf, and returns the new book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   Book response = libraryClient.moveBook(name, otherShelfName);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to move.
+   * @param otherShelfName The name of the destination shelf.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book moveBook(ShelfBookName name, ShelfName otherShelfName) {
+
+    MoveBookRequest request =
+        MoveBookRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .setOtherShelfName(otherShelfName == null ? null : otherShelfName.toString())
+        .build();
+    return moveBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Moves a book to another shelf, and returns the new book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   Book response = libraryClient.moveBook(name.toString(), otherShelfName.toString());
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to move.
+   * @param otherShelfName The name of the destination shelf.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book moveBook(String name, String otherShelfName) {
+
+    MoveBookRequest request =
+        MoveBookRequest.newBuilder()
+        .setName(name)
+        .setOtherShelfName(otherShelfName)
+        .build();
+    return moveBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Moves a book to another shelf, and returns the new book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   MoveBookRequest request = MoveBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setOtherShelfName(otherShelfName.toString())
+   *     .build();
+   *   Book response = libraryClient.moveBook(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Book moveBook(MoveBookRequest request) {
+    return moveBookCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Moves a book to another shelf, and returns the new book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   MoveBookRequest request = MoveBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setOtherShelfName(otherShelfName.toString())
+   *     .build();
+   *   ApiFuture&lt;Book&gt; future = libraryClient.moveBookCallable().futureCall(request);
+   *   // Do something
+   *   Book response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MoveBookRequest, Book> moveBookCallable() {
+    return stub.moveBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *
+   *   for (ResourceName element : libraryClient.listStrings().iterateAllAsResourceName()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListStringsPagedResponse listStrings() {
+    ListStringsRequest request =
+        ListStringsRequest.newBuilder()
+
+        .build();
+    return listStrings(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   for (ResourceName element : libraryClient.listStrings(name).iterateAllAsResourceName()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param name
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListStringsPagedResponse listStrings(ResourceName name) {
+    ListStringsRequest request =
+        ListStringsRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .build();
+    return listStrings(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   for (ResourceName element : libraryClient.listStrings(name.toString()).iterateAllAsResourceName()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param name
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListStringsPagedResponse listStrings(String name) {
+    ListStringsRequest request =
+        ListStringsRequest.newBuilder()
+        .setName(name)
+        .build();
+    return listStrings(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ListStringsRequest request = ListStringsRequest.newBuilder().build();
+   *   for (ResourceName element : libraryClient.listStrings(request).iterateAllAsResourceName()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListStringsPagedResponse listStrings(ListStringsRequest request) {
+    return listStringsPagedCallable()
+        .call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ListStringsRequest request = ListStringsRequest.newBuilder().build();
+   *   ApiFuture&lt;ListStringsPagedResponse&gt; future = libraryClient.listStringsPagedCallable().futureCall(request);
+   *   // Do something
+   *   for (ResourceName element : future.get().iterateAllAsResourceName()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ListStringsRequest, ListStringsPagedResponse> listStringsPagedCallable() {
+    return stub.listStringsPagedCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ListStringsRequest request = ListStringsRequest.newBuilder().build();
+   *   while (true) {
+   *     ListStringsResponse response = libraryClient.listStringsCallable().call(request);
+   *     for (ResourceName element : UntypedResourceName.parseList(response.getStringsList())) {
+   *       // doThingsWith(element);
+   *     }
+   *     String nextPageToken = response.getNextPageToken();
+   *     if (!Strings.isNullOrEmpty(nextPageToken)) {
+   *       request = request.toBuilder().setPageToken(nextPageToken).build();
+   *     } else {
+   *       break;
+   *     }
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ListStringsRequest, ListStringsResponse> listStringsCallable() {
+    return stub.listStringsCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Adds comments to a book
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedName = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   ByteString comment = ByteString.copyFromUtf8("");
+   *   Comment.Stage stage = Comment.Stage.UNSET;
+   *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
+   *   Comment commentsElement = Comment.newBuilder()
+   *     .setComment(comment)
+   *     .setStage(stage)
+   *     .setAlignment(alignment)
+   *     .build();
+   *   List&lt;Comment&gt; comments = Arrays.asList(commentsElement);
+   *   libraryClient.addComments(formattedName, comments);
+   * }
+   * </code></pre>
+   *
+   * @param name
+   * @param comments
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void addComments(String name, List<Comment> comments) {
+
+    AddCommentsRequest request =
+        AddCommentsRequest.newBuilder()
+        .setName(name)
+        .addAllComments(comments)
+        .build();
+    addComments(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Adds comments to a book
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedName = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   ByteString comment = ByteString.copyFromUtf8("");
+   *   Comment.Stage stage = Comment.Stage.UNSET;
+   *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
+   *   Comment commentsElement = Comment.newBuilder()
+   *     .setComment(comment)
+   *     .setStage(stage)
+   *     .setAlignment(alignment)
+   *     .build();
+   *   List&lt;Comment&gt; comments = Arrays.asList(commentsElement);
+   *   AddCommentsRequest request = AddCommentsRequest.newBuilder()
+   *     .setName(formattedName)
+   *     .addAllComments(comments)
+   *     .build();
+   *   libraryClient.addComments(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void addComments(AddCommentsRequest request) {
+    addCommentsCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Adds comments to a book
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedName = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   ByteString comment = ByteString.copyFromUtf8("");
+   *   Comment.Stage stage = Comment.Stage.UNSET;
+   *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
+   *   Comment commentsElement = Comment.newBuilder()
+   *     .setComment(comment)
+   *     .setStage(stage)
+   *     .setAlignment(alignment)
+   *     .build();
+   *   List&lt;Comment&gt; comments = Arrays.asList(commentsElement);
+   *   AddCommentsRequest request = AddCommentsRequest.newBuilder()
+   *     .setName(formattedName)
+   *     .addAllComments(comments)
+   *     .build();
+   *   ApiFuture&lt;Void&gt; future = libraryClient.addCommentsCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<AddCommentsRequest, Empty> addCommentsCallable() {
+    return stub.addCommentsCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book from an archive.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   BookFromArchive response = libraryClient.getBookFromArchive(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final BookFromArchive getBookFromArchive(ArchivedBookName name) {
+
+    GetBookFromArchiveRequest request =
+        GetBookFromArchiveRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .build();
+    return getBookFromArchive(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book from an archive.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   BookFromArchive response = libraryClient.getBookFromArchive(name.toString());
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final BookFromArchive getBookFromArchive(String name) {
+
+    GetBookFromArchiveRequest request =
+        GetBookFromArchiveRequest.newBuilder()
+        .setName(name)
+        .build();
+    return getBookFromArchive(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book from an archive.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   GetBookFromArchiveRequest request = GetBookFromArchiveRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   BookFromArchive response = libraryClient.getBookFromArchive(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final BookFromArchive getBookFromArchive(GetBookFromArchiveRequest request) {
+    return getBookFromArchiveCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book from an archive.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   GetBookFromArchiveRequest request = GetBookFromArchiveRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   ApiFuture&lt;BookFromArchive&gt; future = libraryClient.getBookFromArchiveCallable().futureCall(request);
+   *   // Do something
+   *   BookFromArchive response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveCallable() {
+    return stub.getBookFromArchiveCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book from a shelf or archive.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name, altBookName);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @param altBookName An alternate book name, used to test restricting flattened field to a
+   * single resource name type in a oneof.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final BookFromAnywhere getBookFromAnywhere(BookName name, ShelfBookName altBookName) {
+
+    GetBookFromAnywhereRequest request =
+        GetBookFromAnywhereRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .setAltBookName(altBookName == null ? null : altBookName.toString())
+        .build();
+    return getBookFromAnywhere(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book from a shelf or archive.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name.toString(), altBookName.toString());
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @param altBookName An alternate book name, used to test restricting flattened field to a
+   * single resource name type in a oneof.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final BookFromAnywhere getBookFromAnywhere(String name, String altBookName) {
+
+    GetBookFromAnywhereRequest request =
+        GetBookFromAnywhereRequest.newBuilder()
+        .setName(name)
+        .setAltBookName(altBookName)
+        .build();
+    return getBookFromAnywhere(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book from a shelf or archive.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setAltBookName(altBookName.toString())
+   *     .build();
+   *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final BookFromAnywhere getBookFromAnywhere(GetBookFromAnywhereRequest request) {
+    return getBookFromAnywhereCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets a book from a shelf or archive.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setAltBookName(altBookName.toString())
+   *     .build();
+   *   ApiFuture&lt;BookFromAnywhere&gt; future = libraryClient.getBookFromAnywhereCallable().futureCall(request);
+   *   // Do something
+   *   BookFromAnywhere response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereCallable() {
+    return stub.getBookFromAnywhereCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test proper OneOf-Any resource name mapping
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final BookFromAnywhere getBookFromAbsolutelyAnywhere(BookName name) {
+
+    GetBookFromAbsolutelyAnywhereRequest request =
+        GetBookFromAbsolutelyAnywhereRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .build();
+    return getBookFromAbsolutelyAnywhere(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test proper OneOf-Any resource name mapping
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name.toString());
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final BookFromAnywhere getBookFromAbsolutelyAnywhere(String name) {
+
+    GetBookFromAbsolutelyAnywhereRequest request =
+        GetBookFromAbsolutelyAnywhereRequest.newBuilder()
+        .setName(name)
+        .build();
+    return getBookFromAbsolutelyAnywhere(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test proper OneOf-Any resource name mapping
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ResourceName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final BookFromAnywhere getBookFromAbsolutelyAnywhere(GetBookFromAbsolutelyAnywhereRequest request) {
+    return getBookFromAbsolutelyAnywhereCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test proper OneOf-Any resource name mapping
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ResourceName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   ApiFuture&lt;BookFromAnywhere&gt; future = libraryClient.getBookFromAbsolutelyAnywhereCallable().futureCall(request);
+   *   // Do something
+   *   BookFromAnywhere response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereCallable() {
+    return stub.getBookFromAbsolutelyAnywhereCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Updates the index of a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   String indexName = "default index";
+   *   String indexMapItem = "";
+   *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
+   *   indexMap.put("default_key", indexMapItem);
+   *   libraryClient.updateBookIndex(name, indexName, indexMap);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to update.
+   * @param indexName The name of the index for the book
+   * @param indexMap The index to update the book with
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void updateBookIndex(ShelfBookName name, String indexName, Map<String, String> indexMap) {
+
+    UpdateBookIndexRequest request =
+        UpdateBookIndexRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .setIndexName(indexName)
+        .putAllIndexMap(indexMap)
+        .build();
+    updateBookIndex(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Updates the index of a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   String indexName = "default index";
+   *   String indexMapItem = "";
+   *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
+   *   indexMap.put("default_key", indexMapItem);
+   *   libraryClient.updateBookIndex(name.toString(), indexName, indexMap);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to update.
+   * @param indexName The name of the index for the book
+   * @param indexMap The index to update the book with
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void updateBookIndex(String name, String indexName, Map<String, String> indexMap) {
+
+    UpdateBookIndexRequest request =
+        UpdateBookIndexRequest.newBuilder()
+        .setName(name)
+        .setIndexName(indexName)
+        .putAllIndexMap(indexMap)
+        .build();
+    updateBookIndex(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Updates the index of a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   String indexName = "default index";
+   *   String indexMapItem = "";
+   *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
+   *   indexMap.put("default_key", indexMapItem);
+   *   UpdateBookIndexRequest request = UpdateBookIndexRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setIndexName(indexName)
+   *     .putAllIndexMap(indexMap)
+   *     .build();
+   *   libraryClient.updateBookIndex(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void updateBookIndex(UpdateBookIndexRequest request) {
+    updateBookIndexCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Updates the index of a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   String indexName = "default index";
+   *   String indexMapItem = "";
+   *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
+   *   indexMap.put("default_key", indexMapItem);
+   *   UpdateBookIndexRequest request = UpdateBookIndexRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .setIndexName(indexName)
+   *     .putAllIndexMap(indexMap)
+   *     .build();
+   *   ApiFuture&lt;Void&gt; future = libraryClient.updateBookIndexCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<UpdateBookIndexRequest, Empty> updateBookIndexCallable() {
+    return stub.updateBookIndexCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test server streaming
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+   *
+   *   ServerStream&lt;StreamShelvesResponse&gt; stream = libraryClient.streamShelvesCallable().call(request);
+   *   for (StreamShelvesResponse response : stream) {
+   *     // Do something when receive a response
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable() {
+    return stub.streamShelvesCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test server streaming, non-paged responses.
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String name = "";
+   *   StreamBooksRequest request = StreamBooksRequest.newBuilder()
+   *     .setName(name)
+   *     .build();
+   *
+   *   ServerStream&lt;Book&gt; stream = libraryClient.streamBooksCallable().call(request);
+   *   for (Book response : stream) {
+   *     // Do something when receive a response
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final ServerStreamingCallable<StreamBooksRequest, Book> streamBooksCallable() {
+    return stub.streamBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test bidi-streaming.
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
+   *       libraryClient.discussBookCallable().call();
+   *
+   *   String name = "";
+   *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
+   *     .setName(name)
+   *     .build();
+   *   bidiStream.send(request);
+   *   for (Comment response : bidiStream) {
+   *     // Do something when receive a response
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final BidiStreamingCallable<DiscussBookRequest, Comment> discussBookCallable() {
+    return stub.discussBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test client streaming.
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ApiStreamObserver&lt;Comment&gt; responseObserver =
+   *       new ApiStreamObserver&lt;Comment&gt;() {
+   *         {@literal @}Override
+   *         public void onNext(Comment response) {
+   *           // Do something when receive a response
+   *         }
+   *
+   *         {@literal @}Override
+   *         public void onError(Throwable t) {
+   *           // Add error-handling
+   *         }
+   *
+   *         {@literal @}Override
+   *         public void onCompleted() {
+   *           // Do something when complete.
+   *         }
+   *       };
+   *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
+   *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
+   *
+   *   String name = "";
+   *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
+   *     .setName(name)
+   *     .build();
+   *   requestObserver.onNext(request);
+   * }
+   * </code></pre>
+   */
+  public final ClientStreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable() {
+    return stub.monologAboutBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String namesElement = "";
+   *   List&lt;String&gt; names = Arrays.asList(namesElement);
+   *   List&lt;String&gt; shelves = new ArrayList&lt;&gt;();
+   *   for (ShelfBookName element : libraryClient.findRelatedBooks(names, shelves).iterateAllAsShelfBookName()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param names
+   * @param shelves
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final FindRelatedBooksPagedResponse findRelatedBooks(List<String> names, List<String> shelves) {
+    FindRelatedBooksRequest request =
+        FindRelatedBooksRequest.newBuilder()
+        .addAllNames(names)
+        .addAllShelves(shelves)
+        .build();
+    return findRelatedBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
+   *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
+   *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+   *     .addAllNames(ShelfBookName.toStringList(names))
+   *     .addAllShelves(ShelfName.toStringList(shelves))
+   *     .build();
+   *   for (ShelfBookName element : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final FindRelatedBooksPagedResponse findRelatedBooks(FindRelatedBooksRequest request) {
+    return findRelatedBooksPagedCallable()
+        .call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
+   *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
+   *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+   *     .addAllNames(ShelfBookName.toStringList(names))
+   *     .addAllShelves(ShelfName.toStringList(shelves))
+   *     .build();
+   *   ApiFuture&lt;FindRelatedBooksPagedResponse&gt; future = libraryClient.findRelatedBooksPagedCallable().futureCall(request);
+   *   // Do something
+   *   for (ShelfBookName element : future.get().iterateAllAsShelfBookName()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksPagedResponse> findRelatedBooksPagedCallable() {
+    return stub.findRelatedBooksPagedCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
+   *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
+   *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+   *     .addAllNames(ShelfBookName.toStringList(names))
+   *     .addAllShelves(ShelfName.toStringList(shelves))
+   *     .build();
+   *   while (true) {
+   *     FindRelatedBooksResponse response = libraryClient.findRelatedBooksCallable().call(request);
+   *     for (ShelfBookName element : ShelfBookName.parseList(response.getNamesList())) {
+   *       // doThingsWith(element);
+   *     }
+   *     String nextPageToken = response.getNextPageToken();
+   *     if (!Strings.isNullOrEmpty(nextPageToken)) {
+   *       request = request.toBuilder().setPageToken(nextPageToken).build();
+   *     } else {
+   *       break;
+   *     }
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> findRelatedBooksCallable() {
+    return stub.findRelatedBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Adds a tag to the book. This RPC is a mixin.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedResource = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   String tag = "";
+   *   AddTagResponse response = libraryClient.addTag(formattedResource, tag);
+   * }
+   * </code></pre>
+   *
+   * @param resource REQUIRED: The resource which the tag is being added to.
+   * Resource is usually specified as a path, such as,
+   * projects/{project}/zones/{zone}/disks/{disk}.
+   * @param tag REQUIRED: The tag to add.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final AddTagResponse addTag(String resource, String tag) {
+
+    AddTagRequest request =
+        AddTagRequest.newBuilder()
+        .setResource(resource)
+        .setTag(tag)
+        .build();
+    return addTag(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Adds a tag to the book. This RPC is a mixin.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedResource = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   String tag = "";
+   *   AddTagRequest request = AddTagRequest.newBuilder()
+   *     .setResource(formattedResource)
+   *     .setTag(tag)
+   *     .build();
+   *   AddTagResponse response = libraryClient.addTag(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final AddTagResponse addTag(AddTagRequest request) {
+    return addTagCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Adds a tag to the book. This RPC is a mixin.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedResource = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   String tag = "";
+   *   AddTagRequest request = AddTagRequest.newBuilder()
+   *     .setResource(formattedResource)
+   *     .setTag(tag)
+   *     .build();
+   *   ApiFuture&lt;AddTagResponse&gt; future = libraryClient.addTagCallable().futureCall(request);
+   *   // Do something
+   *   AddTagResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<AddTagRequest, AddTagResponse> addTagCallable() {
+    return stub.addTagCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Adds a label to the entity.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedResource = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   String label = "";
+   *   AddLabelResponse response = libraryClient.addLabel(formattedResource, label);
+   * }
+   * </code></pre>
+   *
+   * @param resource REQUIRED: The resource which the label is being added to.
+   * Resource is usually specified as a path, such as,
+   * projects/{project}/zones/{zone}/disks/{disk}.
+   * @param label REQUIRED: The label to add.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @Deprecated
+  /* package-private */ final AddLabelResponse addLabel(String resource, String label) {
+
+    AddLabelRequest request =
+        AddLabelRequest.newBuilder()
+        .setResource(resource)
+        .setLabel(label)
+        .build();
+    return addLabel(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Adds a label to the entity.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedResource = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   String label = "";
+   *   AddLabelRequest request = AddLabelRequest.newBuilder()
+   *     .setResource(formattedResource)
+   *     .setLabel(label)
+   *     .build();
+   *   AddLabelResponse response = libraryClient.addLabel(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @Deprecated
+  /* package-private */ final AddLabelResponse addLabel(AddLabelRequest request) {
+    return addLabelCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Adds a label to the entity.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String formattedResource = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   String label = "";
+   *   AddLabelRequest request = AddLabelRequest.newBuilder()
+   *     .setResource(formattedResource)
+   *     .setLabel(label)
+   *     .build();
+   *   ApiFuture&lt;AddLabelResponse&gt; future = libraryClient.addLabelCallable().futureCall(request);
+   *   // Do something
+   *   AddLabelResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  @Deprecated
+  /* package-private */ final UnaryCallable<AddLabelRequest, AddLabelResponse> addLabelCallable() {
+    return stub.addLabelCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   Book response = libraryClient.getBigBookAsync(name).get();
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<Book, GetBigBookMetadata> getBigBookAsync(ShelfBookName name) {
+
+    GetBookRequest request =
+        GetBookRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .build();
+    return getBigBookAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   Book response = libraryClient.getBigBookAsync(name.toString()).get();
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<Book, GetBigBookMetadata> getBigBookAsync(String name) {
+
+    GetBookRequest request =
+        GetBookRequest.newBuilder()
+        .setName(name)
+        .build();
+    return getBigBookAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   Book response = libraryClient.getBigBookAsync(request).get();
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<Book, GetBigBookMetadata> getBigBookAsync(GetBookRequest request) {
+    return getBigBookOperationCallable().futureCall(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   OperationFuture&lt;Operation&gt; future = libraryClient.getBigBookOperationCallable().futureCall(request);
+   *   // Do something
+   *   Book response = future.get();
+   * }
+   * </code></pre>
+   */
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public final OperationCallable<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationCallable() {
+    return stub.getBigBookOperationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   ApiFuture&lt;Operation&gt; future = libraryClient.getBigBookCallable().futureCall(request);
+   *   // Do something
+   *   Operation response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GetBookRequest, Operation> getBigBookCallable() {
+    return stub.getBigBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations with empty return type.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   Empty response = libraryClient.getBigNothingAsync(name).get();
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<Empty, GetBigBookMetadata> getBigNothingAsync(ShelfBookName name) {
+
+    GetBookRequest request =
+        GetBookRequest.newBuilder()
+        .setName(name == null ? null : name.toString())
+        .build();
+    return getBigNothingAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations with empty return type.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   Empty response = libraryClient.getBigNothingAsync(name.toString()).get();
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<Empty, GetBigBookMetadata> getBigNothingAsync(String name) {
+
+    GetBookRequest request =
+        GetBookRequest.newBuilder()
+        .setName(name)
+        .build();
+    return getBigNothingAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations with empty return type.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   Empty response = libraryClient.getBigNothingAsync(request).get();
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<Empty, GetBigBookMetadata> getBigNothingAsync(GetBookRequest request) {
+    return getBigNothingOperationCallable().futureCall(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations with empty return type.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   OperationFuture&lt;Operation&gt; future = libraryClient.getBigNothingOperationCallable().futureCall(request);
+   *   // Do something
+   *   Empty response = future.get();
+   * }
+   * </code></pre>
+   */
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public final OperationCallable<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationCallable() {
+    return stub.getBigNothingOperationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations with empty return type.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   ApiFuture&lt;Operation&gt; future = libraryClient.getBigNothingCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable() {
+    return stub.getBigNothingCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test optional flattening parameters of all types
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *
+   *   TestOptionalRequiredFlatteningParamsResponse response = libraryClient.testOptionalRequiredFlatteningParams();
+   * }
+   * </code></pre>
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final TestOptionalRequiredFlatteningParamsResponse testOptionalRequiredFlatteningParams() {
+
+    TestOptionalRequiredFlatteningParamsRequest request =
+        TestOptionalRequiredFlatteningParamsRequest.newBuilder()
+
+        .build();
+    return testOptionalRequiredFlatteningParams(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test optional flattening parameters of all types
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   int requiredSingularInt32 = 0;
+   *   long requiredSingularInt64 = 0L;
+   *   float requiredSingularFloat = 0.0F;
+   *   double requiredSingularDouble = 0.0;
+   *   boolean requiredSingularBool = false;
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   *   String requiredSingularString = "";
+   *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+   *   int requiredSingularFixed32 = 0;
+   *   long requiredSingularFixed64 = 0L;
+   *   List&lt;Integer&gt; requiredRepeatedInt32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedInt64 = new ArrayList&lt;&gt;();
+   *   List&lt;Float&gt; requiredRepeatedFloat = new ArrayList&lt;&gt;();
+   *   List&lt;Double&gt; requiredRepeatedDouble = new ArrayList&lt;&gt;();
+   *   List&lt;Boolean&gt; requiredRepeatedBool = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerEnum&gt; requiredRepeatedEnum = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; requiredRepeatedString = new ArrayList&lt;&gt;();
+   *   List&lt;ByteString&gt; requiredRepeatedBytes = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedRequiredRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedRequiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; requiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
+   *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
+   *   Map&lt;Integer, String&gt; requiredMap = new HashMap&lt;&gt;();
+   *   int optionalSingularInt32 = 0;
+   *   long optionalSingularInt64 = 0L;
+   *   float optionalSingularFloat = 0.0F;
+   *   double optionalSingularDouble = 0.0;
+   *   boolean optionalSingularBool = false;
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   *   String optionalSingularString = "";
+   *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+   *   ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+   *   int optionalSingularFixed32 = 0;
+   *   long optionalSingularFixed64 = 0L;
+   *   List&lt;Integer&gt; optionalRepeatedInt32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; optionalRepeatedInt64 = new ArrayList&lt;&gt;();
+   *   List&lt;Float&gt; optionalRepeatedFloat = new ArrayList&lt;&gt;();
+   *   List&lt;Double&gt; optionalRepeatedDouble = new ArrayList&lt;&gt;();
+   *   List&lt;Boolean&gt; optionalRepeatedBool = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerEnum&gt; optionalRepeatedEnum = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; optionalRepeatedString = new ArrayList&lt;&gt;();
+   *   List&lt;ByteString&gt; optionalRepeatedBytes = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; optionalRepeatedMessage = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedOptionalRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedOptionalRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; optionalRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
+   *   List&lt;Integer&gt; optionalRepeatedFixed32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; optionalRepeatedFixed64 = new ArrayList&lt;&gt;();
+   *   Map&lt;Integer, String&gt; optionalMap = new HashMap&lt;&gt;();
+   *   Any anyValue = Any.newBuilder().build();
+   *   Struct structValue = Struct.newBuilder().build();
+   *   Value valueValue = Value.newBuilder().build();
+   *   ListValue listValueValue = ListValue.newBuilder().build();
+   *   Timestamp timeValue = Timestamp.newBuilder().build();
+   *   Duration durationValue = Duration.newBuilder().build();
+   *   FieldMask fieldMaskValue = FieldMask.newBuilder().build();
+   *   Int32Value int32Value = Int32Value.newBuilder().build();
+   *   UInt32Value uint32Value = UInt32Value.newBuilder().build();
+   *   Int64Value int64Value = Int64Value.newBuilder().build();
+   *   UInt64Value uint64Value = UInt64Value.newBuilder().build();
+   *   FloatValue floatValue = FloatValue.newBuilder().build();
+   *   DoubleValue doubleValue = DoubleValue.newBuilder().build();
+   *   StringValue stringValue = StringValue.newBuilder().build();
+   *   BoolValue boolValue = BoolValue.newBuilder().build();
+   *   BytesValue bytesValue = BytesValue.newBuilder().build();
+   *   List&lt;Any&gt; repeatedAnyValue = new ArrayList&lt;&gt;();
+   *   List&lt;Struct&gt; repeatedStructValue = new ArrayList&lt;&gt;();
+   *   List&lt;Value&gt; repeatedValueValue = new ArrayList&lt;&gt;();
+   *   List&lt;ListValue&gt; repeatedListValueValue = new ArrayList&lt;&gt;();
+   *   List&lt;Timestamp&gt; repeatedTimeValue = new ArrayList&lt;&gt;();
+   *   List&lt;Duration&gt; repeatedDurationValue = new ArrayList&lt;&gt;();
+   *   List&lt;FieldMask&gt; repeatedFieldMaskValue = new ArrayList&lt;&gt;();
+   *   List&lt;Int32Value&gt; repeatedInt32Value = new ArrayList&lt;&gt;();
+   *   List&lt;UInt32Value&gt; repeatedUint32Value = new ArrayList&lt;&gt;();
+   *   List&lt;Int64Value&gt; repeatedInt64Value = new ArrayList&lt;&gt;();
+   *   List&lt;UInt64Value&gt; repeatedUint64Value = new ArrayList&lt;&gt;();
+   *   List&lt;FloatValue&gt; repeatedFloatValue = new ArrayList&lt;&gt;();
+   *   List&lt;DoubleValue&gt; repeatedDoubleValue = new ArrayList&lt;&gt;();
+   *   List&lt;StringValue&gt; repeatedStringValue = new ArrayList&lt;&gt;();
+   *   List&lt;BoolValue&gt; repeatedBoolValue = new ArrayList&lt;&gt;();
+   *   List&lt;BytesValue&gt; repeatedBytesValue = new ArrayList&lt;&gt;();
+   *   TestOptionalRequiredFlatteningParamsResponse response = libraryClient.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName.toString(), requiredSingularResourceNameOneof.toString(), requiredSingularResourceNameCommon.toString(), requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, formattedRequiredRepeatedResourceName, formattedRequiredRepeatedResourceNameOneof, requiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName.toString(), optionalSingularResourceNameOneof.toString(), optionalSingularResourceNameCommon.toString(), optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, formattedOptionalRepeatedResourceName, formattedOptionalRepeatedResourceNameOneof, optionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap, anyValue, structValue, valueValue, listValueValue, timeValue, durationValue, fieldMaskValue, int32Value, uint32Value, int64Value, uint64Value, floatValue, doubleValue, stringValue, boolValue, bytesValue, repeatedAnyValue, repeatedStructValue, repeatedValueValue, repeatedListValueValue, repeatedTimeValue, repeatedDurationValue, repeatedFieldMaskValue, repeatedInt32Value, repeatedUint32Value, repeatedInt64Value, repeatedUint64Value, repeatedFloatValue, repeatedDoubleValue, repeatedStringValue, repeatedBoolValue, repeatedBytesValue);
+   * }
+   * </code></pre>
+   *
+   * @param requiredSingularInt32
+   * @param requiredSingularInt64
+   * @param requiredSingularFloat
+   * @param requiredSingularDouble
+   * @param requiredSingularBool
+   * @param requiredSingularEnum
+   * @param requiredSingularString
+   * @param requiredSingularBytes
+   * @param requiredSingularMessage
+   * @param requiredSingularResourceName
+   * @param requiredSingularResourceNameOneof
+   * @param requiredSingularResourceNameCommon
+   * @param requiredSingularFixed32
+   * @param requiredSingularFixed64
+   * @param requiredRepeatedInt32
+   * @param requiredRepeatedInt64
+   * @param requiredRepeatedFloat
+   * @param requiredRepeatedDouble
+   * @param requiredRepeatedBool
+   * @param requiredRepeatedEnum
+   * @param requiredRepeatedString
+   * @param requiredRepeatedBytes
+   * @param requiredRepeatedMessage
+   * @param requiredRepeatedResourceName
+   * @param requiredRepeatedResourceNameOneof
+   * @param requiredRepeatedResourceNameCommon
+   * @param requiredRepeatedFixed32
+   * @param requiredRepeatedFixed64
+   * @param requiredMap
+   * @param optionalSingularInt32
+   * @param optionalSingularInt64
+   * @param optionalSingularFloat
+   * @param optionalSingularDouble
+   * @param optionalSingularBool
+   * @param optionalSingularEnum
+   * @param optionalSingularString
+   * @param optionalSingularBytes
+   * @param optionalSingularMessage
+   * @param optionalSingularResourceName
+   * @param optionalSingularResourceNameOneof
+   * @param optionalSingularResourceNameCommon
+   * @param optionalSingularFixed32
+   * @param optionalSingularFixed64
+   * @param optionalRepeatedInt32
+   * @param optionalRepeatedInt64
+   * @param optionalRepeatedFloat
+   * @param optionalRepeatedDouble
+   * @param optionalRepeatedBool
+   * @param optionalRepeatedEnum
+   * @param optionalRepeatedString
+   * @param optionalRepeatedBytes
+   * @param optionalRepeatedMessage
+   * @param optionalRepeatedResourceName
+   * @param optionalRepeatedResourceNameOneof
+   * @param optionalRepeatedResourceNameCommon
+   * @param optionalRepeatedFixed32
+   * @param optionalRepeatedFixed64
+   * @param optionalMap
+   * @param anyValue
+   * @param structValue
+   * @param valueValue
+   * @param listValueValue
+   * @param timeValue
+   * @param durationValue
+   * @param fieldMaskValue
+   * @param int32Value
+   * @param uint32Value
+   * @param int64Value
+   * @param uint64Value
+   * @param floatValue
+   * @param doubleValue
+   * @param stringValue
+   * @param boolValue
+   * @param bytesValue
+   * @param repeatedAnyValue
+   * @param repeatedStructValue
+   * @param repeatedValueValue
+   * @param repeatedListValueValue
+   * @param repeatedTimeValue
+   * @param repeatedDurationValue
+   * @param repeatedFieldMaskValue
+   * @param repeatedInt32Value
+   * @param repeatedUint32Value
+   * @param repeatedInt64Value
+   * @param repeatedUint64Value
+   * @param repeatedFloatValue
+   * @param repeatedDoubleValue
+   * @param repeatedStringValue
+   * @param repeatedBoolValue
+   * @param repeatedBytesValue
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final TestOptionalRequiredFlatteningParamsResponse testOptionalRequiredFlatteningParams(int requiredSingularInt32, long requiredSingularInt64, float requiredSingularFloat, double requiredSingularDouble, boolean requiredSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum, String requiredSingularString, ByteString requiredSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage, String requiredSingularResourceName, String requiredSingularResourceNameOneof, String requiredSingularResourceNameCommon, int requiredSingularFixed32, long requiredSingularFixed64, List<Integer> requiredRepeatedInt32, List<Long> requiredRepeatedInt64, List<Float> requiredRepeatedFloat, List<Double> requiredRepeatedDouble, List<Boolean> requiredRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum, List<String> requiredRepeatedString, List<ByteString> requiredRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage, List<String> requiredRepeatedResourceName, List<String> requiredRepeatedResourceNameOneof, List<String> requiredRepeatedResourceNameCommon, List<Integer> requiredRepeatedFixed32, List<Long> requiredRepeatedFixed64, Map<Integer, String> requiredMap, int optionalSingularInt32, long optionalSingularInt64, float optionalSingularFloat, double optionalSingularDouble, boolean optionalSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum, String optionalSingularString, ByteString optionalSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage, String optionalSingularResourceName, String optionalSingularResourceNameOneof, String optionalSingularResourceNameCommon, int optionalSingularFixed32, long optionalSingularFixed64, List<Integer> optionalRepeatedInt32, List<Long> optionalRepeatedInt64, List<Float> optionalRepeatedFloat, List<Double> optionalRepeatedDouble, List<Boolean> optionalRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum, List<String> optionalRepeatedString, List<ByteString> optionalRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage, List<String> optionalRepeatedResourceName, List<String> optionalRepeatedResourceNameOneof, List<String> optionalRepeatedResourceNameCommon, List<Integer> optionalRepeatedFixed32, List<Long> optionalRepeatedFixed64, Map<Integer, String> optionalMap, Any anyValue, Struct structValue, Value valueValue, ListValue listValueValue, Timestamp timeValue, Duration durationValue, FieldMask fieldMaskValue, Int32Value int32Value, UInt32Value uint32Value, Int64Value int64Value, UInt64Value uint64Value, FloatValue floatValue, DoubleValue doubleValue, StringValue stringValue, BoolValue boolValue, BytesValue bytesValue, List<Any> repeatedAnyValue, List<Struct> repeatedStructValue, List<Value> repeatedValueValue, List<ListValue> repeatedListValueValue, List<Timestamp> repeatedTimeValue, List<Duration> repeatedDurationValue, List<FieldMask> repeatedFieldMaskValue, List<Int32Value> repeatedInt32Value, List<UInt32Value> repeatedUint32Value, List<Int64Value> repeatedInt64Value, List<UInt64Value> repeatedUint64Value, List<FloatValue> repeatedFloatValue, List<DoubleValue> repeatedDoubleValue, List<StringValue> repeatedStringValue, List<BoolValue> repeatedBoolValue, List<BytesValue> repeatedBytesValue) {
+
+    TestOptionalRequiredFlatteningParamsRequest request =
+        TestOptionalRequiredFlatteningParamsRequest.newBuilder()
+        .setRequiredSingularInt32(requiredSingularInt32)
+        .setRequiredSingularInt64(requiredSingularInt64)
+        .setRequiredSingularFloat(requiredSingularFloat)
+        .setRequiredSingularDouble(requiredSingularDouble)
+        .setRequiredSingularBool(requiredSingularBool)
+        .setRequiredSingularEnum(requiredSingularEnum)
+        .setRequiredSingularString(requiredSingularString)
+        .setRequiredSingularBytes(requiredSingularBytes)
+        .setRequiredSingularMessage(requiredSingularMessage)
+        .setRequiredSingularResourceName(requiredSingularResourceName)
+        .setRequiredSingularResourceNameOneof(requiredSingularResourceNameOneof)
+        .setRequiredSingularResourceNameCommon(requiredSingularResourceNameCommon)
+        .setRequiredSingularFixed32(requiredSingularFixed32)
+        .setRequiredSingularFixed64(requiredSingularFixed64)
+        .addAllRequiredRepeatedInt32(requiredRepeatedInt32)
+        .addAllRequiredRepeatedInt64(requiredRepeatedInt64)
+        .addAllRequiredRepeatedFloat(requiredRepeatedFloat)
+        .addAllRequiredRepeatedDouble(requiredRepeatedDouble)
+        .addAllRequiredRepeatedBool(requiredRepeatedBool)
+        .addAllRequiredRepeatedEnum(requiredRepeatedEnum)
+        .addAllRequiredRepeatedString(requiredRepeatedString)
+        .addAllRequiredRepeatedBytes(requiredRepeatedBytes)
+        .addAllRequiredRepeatedMessage(requiredRepeatedMessage)
+        .addAllRequiredRepeatedResourceName(requiredRepeatedResourceName)
+        .addAllRequiredRepeatedResourceNameOneof(requiredRepeatedResourceNameOneof)
+        .addAllRequiredRepeatedResourceNameCommon(requiredRepeatedResourceNameCommon)
+        .addAllRequiredRepeatedFixed32(requiredRepeatedFixed32)
+        .addAllRequiredRepeatedFixed64(requiredRepeatedFixed64)
+        .putAllRequiredMap(requiredMap)
+        .setOptionalSingularInt32(optionalSingularInt32)
+        .setOptionalSingularInt64(optionalSingularInt64)
+        .setOptionalSingularFloat(optionalSingularFloat)
+        .setOptionalSingularDouble(optionalSingularDouble)
+        .setOptionalSingularBool(optionalSingularBool)
+        .setOptionalSingularEnum(optionalSingularEnum)
+        .setOptionalSingularString(optionalSingularString)
+        .setOptionalSingularBytes(optionalSingularBytes)
+        .setOptionalSingularMessage(optionalSingularMessage)
+        .setOptionalSingularResourceName(optionalSingularResourceName)
+        .setOptionalSingularResourceNameOneof(optionalSingularResourceNameOneof)
+        .setOptionalSingularResourceNameCommon(optionalSingularResourceNameCommon)
+        .setOptionalSingularFixed32(optionalSingularFixed32)
+        .setOptionalSingularFixed64(optionalSingularFixed64)
+        .addAllOptionalRepeatedInt32(optionalRepeatedInt32)
+        .addAllOptionalRepeatedInt64(optionalRepeatedInt64)
+        .addAllOptionalRepeatedFloat(optionalRepeatedFloat)
+        .addAllOptionalRepeatedDouble(optionalRepeatedDouble)
+        .addAllOptionalRepeatedBool(optionalRepeatedBool)
+        .addAllOptionalRepeatedEnum(optionalRepeatedEnum)
+        .addAllOptionalRepeatedString(optionalRepeatedString)
+        .addAllOptionalRepeatedBytes(optionalRepeatedBytes)
+        .addAllOptionalRepeatedMessage(optionalRepeatedMessage)
+        .addAllOptionalRepeatedResourceName(optionalRepeatedResourceName)
+        .addAllOptionalRepeatedResourceNameOneof(optionalRepeatedResourceNameOneof)
+        .addAllOptionalRepeatedResourceNameCommon(optionalRepeatedResourceNameCommon)
+        .addAllOptionalRepeatedFixed32(optionalRepeatedFixed32)
+        .addAllOptionalRepeatedFixed64(optionalRepeatedFixed64)
+        .putAllOptionalMap(optionalMap)
+        .setAnyValue(anyValue)
+        .setStructValue(structValue)
+        .setValueValue(valueValue)
+        .setListValueValue(listValueValue)
+        .setTimeValue(timeValue)
+        .setDurationValue(durationValue)
+        .setFieldMaskValue(fieldMaskValue)
+        .setInt32Value(int32Value)
+        .setUint32Value(uint32Value)
+        .setInt64Value(int64Value)
+        .setUint64Value(uint64Value)
+        .setFloatValue(floatValue)
+        .setDoubleValue(doubleValue)
+        .setStringValue(stringValue)
+        .setBoolValue(boolValue)
+        .setBytesValue(bytesValue)
+        .addAllRepeatedAnyValue(repeatedAnyValue)
+        .addAllRepeatedStructValue(repeatedStructValue)
+        .addAllRepeatedValueValue(repeatedValueValue)
+        .addAllRepeatedListValueValue(repeatedListValueValue)
+        .addAllRepeatedTimeValue(repeatedTimeValue)
+        .addAllRepeatedDurationValue(repeatedDurationValue)
+        .addAllRepeatedFieldMaskValue(repeatedFieldMaskValue)
+        .addAllRepeatedInt32Value(repeatedInt32Value)
+        .addAllRepeatedUint32Value(repeatedUint32Value)
+        .addAllRepeatedInt64Value(repeatedInt64Value)
+        .addAllRepeatedUint64Value(repeatedUint64Value)
+        .addAllRepeatedFloatValue(repeatedFloatValue)
+        .addAllRepeatedDoubleValue(repeatedDoubleValue)
+        .addAllRepeatedStringValue(repeatedStringValue)
+        .addAllRepeatedBoolValue(repeatedBoolValue)
+        .addAllRepeatedBytesValue(repeatedBytesValue)
+        .build();
+    return testOptionalRequiredFlatteningParams(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test optional flattening parameters of all types
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   int requiredSingularInt32 = 0;
+   *   long requiredSingularInt64 = 0L;
+   *   float requiredSingularFloat = 0.0F;
+   *   double requiredSingularDouble = 0.0;
+   *   boolean requiredSingularBool = false;
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   *   String requiredSingularString = "";
+   *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+   *   String requiredSingularResourceName = "";
+   *   String requiredSingularResourceNameOneof = "";
+   *   String requiredSingularResourceNameCommon = "";
+   *   int requiredSingularFixed32 = 0;
+   *   long requiredSingularFixed64 = 0L;
+   *   List&lt;Integer&gt; requiredRepeatedInt32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedInt64 = new ArrayList&lt;&gt;();
+   *   List&lt;Float&gt; requiredRepeatedFloat = new ArrayList&lt;&gt;();
+   *   List&lt;Double&gt; requiredRepeatedDouble = new ArrayList&lt;&gt;();
+   *   List&lt;Boolean&gt; requiredRepeatedBool = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerEnum&gt; requiredRepeatedEnum = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; requiredRepeatedString = new ArrayList&lt;&gt;();
+   *   List&lt;ByteString&gt; requiredRepeatedBytes = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedRequiredRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedRequiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; requiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
+   *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
+   *   Map&lt;Integer, String&gt; requiredMap = new HashMap&lt;&gt;();
+   *   int optionalSingularInt32 = 0;
+   *   long optionalSingularInt64 = 0L;
+   *   float optionalSingularFloat = 0.0F;
+   *   double optionalSingularDouble = 0.0;
+   *   boolean optionalSingularBool = false;
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   *   String optionalSingularString = "";
+   *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+   *   String optionalSingularResourceName = "";
+   *   String optionalSingularResourceNameOneof = "";
+   *   String optionalSingularResourceNameCommon = "";
+   *   int optionalSingularFixed32 = 0;
+   *   long optionalSingularFixed64 = 0L;
+   *   List&lt;Integer&gt; optionalRepeatedInt32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; optionalRepeatedInt64 = new ArrayList&lt;&gt;();
+   *   List&lt;Float&gt; optionalRepeatedFloat = new ArrayList&lt;&gt;();
+   *   List&lt;Double&gt; optionalRepeatedDouble = new ArrayList&lt;&gt;();
+   *   List&lt;Boolean&gt; optionalRepeatedBool = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerEnum&gt; optionalRepeatedEnum = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; optionalRepeatedString = new ArrayList&lt;&gt;();
+   *   List&lt;ByteString&gt; optionalRepeatedBytes = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; optionalRepeatedMessage = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedOptionalRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedOptionalRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; optionalRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
+   *   List&lt;Integer&gt; optionalRepeatedFixed32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; optionalRepeatedFixed64 = new ArrayList&lt;&gt;();
+   *   Map&lt;Integer, String&gt; optionalMap = new HashMap&lt;&gt;();
+   *   Any anyValue = Any.newBuilder().build();
+   *   Struct structValue = Struct.newBuilder().build();
+   *   Value valueValue = Value.newBuilder().build();
+   *   ListValue listValueValue = ListValue.newBuilder().build();
+   *   Timestamp timeValue = Timestamp.newBuilder().build();
+   *   Duration durationValue = Duration.newBuilder().build();
+   *   FieldMask fieldMaskValue = FieldMask.newBuilder().build();
+   *   Int32Value int32Value = Int32Value.newBuilder().build();
+   *   UInt32Value uint32Value = UInt32Value.newBuilder().build();
+   *   Int64Value int64Value = Int64Value.newBuilder().build();
+   *   UInt64Value uint64Value = UInt64Value.newBuilder().build();
+   *   FloatValue floatValue = FloatValue.newBuilder().build();
+   *   DoubleValue doubleValue = DoubleValue.newBuilder().build();
+   *   StringValue stringValue = StringValue.newBuilder().build();
+   *   BoolValue boolValue = BoolValue.newBuilder().build();
+   *   BytesValue bytesValue = BytesValue.newBuilder().build();
+   *   List&lt;Any&gt; repeatedAnyValue = new ArrayList&lt;&gt;();
+   *   List&lt;Struct&gt; repeatedStructValue = new ArrayList&lt;&gt;();
+   *   List&lt;Value&gt; repeatedValueValue = new ArrayList&lt;&gt;();
+   *   List&lt;ListValue&gt; repeatedListValueValue = new ArrayList&lt;&gt;();
+   *   List&lt;Timestamp&gt; repeatedTimeValue = new ArrayList&lt;&gt;();
+   *   List&lt;Duration&gt; repeatedDurationValue = new ArrayList&lt;&gt;();
+   *   List&lt;FieldMask&gt; repeatedFieldMaskValue = new ArrayList&lt;&gt;();
+   *   List&lt;Int32Value&gt; repeatedInt32Value = new ArrayList&lt;&gt;();
+   *   List&lt;UInt32Value&gt; repeatedUint32Value = new ArrayList&lt;&gt;();
+   *   List&lt;Int64Value&gt; repeatedInt64Value = new ArrayList&lt;&gt;();
+   *   List&lt;UInt64Value&gt; repeatedUint64Value = new ArrayList&lt;&gt;();
+   *   List&lt;FloatValue&gt; repeatedFloatValue = new ArrayList&lt;&gt;();
+   *   List&lt;DoubleValue&gt; repeatedDoubleValue = new ArrayList&lt;&gt;();
+   *   List&lt;StringValue&gt; repeatedStringValue = new ArrayList&lt;&gt;();
+   *   List&lt;BoolValue&gt; repeatedBoolValue = new ArrayList&lt;&gt;();
+   *   List&lt;BytesValue&gt; repeatedBytesValue = new ArrayList&lt;&gt;();
+   *   TestOptionalRequiredFlatteningParamsResponse response = libraryClient.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, formattedRequiredRepeatedResourceName, formattedRequiredRepeatedResourceNameOneof, requiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, formattedOptionalRepeatedResourceName, formattedOptionalRepeatedResourceNameOneof, optionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap, anyValue, structValue, valueValue, listValueValue, timeValue, durationValue, fieldMaskValue, int32Value, uint32Value, int64Value, uint64Value, floatValue, doubleValue, stringValue, boolValue, bytesValue, repeatedAnyValue, repeatedStructValue, repeatedValueValue, repeatedListValueValue, repeatedTimeValue, repeatedDurationValue, repeatedFieldMaskValue, repeatedInt32Value, repeatedUint32Value, repeatedInt64Value, repeatedUint64Value, repeatedFloatValue, repeatedDoubleValue, repeatedStringValue, repeatedBoolValue, repeatedBytesValue);
+   * }
+   * </code></pre>
+   *
+   * @param requiredSingularInt32
+   * @param requiredSingularInt64
+   * @param requiredSingularFloat
+   * @param requiredSingularDouble
+   * @param requiredSingularBool
+   * @param requiredSingularEnum
+   * @param requiredSingularString
+   * @param requiredSingularBytes
+   * @param requiredSingularMessage
+   * @param requiredSingularResourceName
+   * @param requiredSingularResourceNameOneof
+   * @param requiredSingularResourceNameCommon
+   * @param requiredSingularFixed32
+   * @param requiredSingularFixed64
+   * @param requiredRepeatedInt32
+   * @param requiredRepeatedInt64
+   * @param requiredRepeatedFloat
+   * @param requiredRepeatedDouble
+   * @param requiredRepeatedBool
+   * @param requiredRepeatedEnum
+   * @param requiredRepeatedString
+   * @param requiredRepeatedBytes
+   * @param requiredRepeatedMessage
+   * @param requiredRepeatedResourceName
+   * @param requiredRepeatedResourceNameOneof
+   * @param requiredRepeatedResourceNameCommon
+   * @param requiredRepeatedFixed32
+   * @param requiredRepeatedFixed64
+   * @param requiredMap
+   * @param optionalSingularInt32
+   * @param optionalSingularInt64
+   * @param optionalSingularFloat
+   * @param optionalSingularDouble
+   * @param optionalSingularBool
+   * @param optionalSingularEnum
+   * @param optionalSingularString
+   * @param optionalSingularBytes
+   * @param optionalSingularMessage
+   * @param optionalSingularResourceName
+   * @param optionalSingularResourceNameOneof
+   * @param optionalSingularResourceNameCommon
+   * @param optionalSingularFixed32
+   * @param optionalSingularFixed64
+   * @param optionalRepeatedInt32
+   * @param optionalRepeatedInt64
+   * @param optionalRepeatedFloat
+   * @param optionalRepeatedDouble
+   * @param optionalRepeatedBool
+   * @param optionalRepeatedEnum
+   * @param optionalRepeatedString
+   * @param optionalRepeatedBytes
+   * @param optionalRepeatedMessage
+   * @param optionalRepeatedResourceName
+   * @param optionalRepeatedResourceNameOneof
+   * @param optionalRepeatedResourceNameCommon
+   * @param optionalRepeatedFixed32
+   * @param optionalRepeatedFixed64
+   * @param optionalMap
+   * @param anyValue
+   * @param structValue
+   * @param valueValue
+   * @param listValueValue
+   * @param timeValue
+   * @param durationValue
+   * @param fieldMaskValue
+   * @param int32Value
+   * @param uint32Value
+   * @param int64Value
+   * @param uint64Value
+   * @param floatValue
+   * @param doubleValue
+   * @param stringValue
+   * @param boolValue
+   * @param bytesValue
+   * @param repeatedAnyValue
+   * @param repeatedStructValue
+   * @param repeatedValueValue
+   * @param repeatedListValueValue
+   * @param repeatedTimeValue
+   * @param repeatedDurationValue
+   * @param repeatedFieldMaskValue
+   * @param repeatedInt32Value
+   * @param repeatedUint32Value
+   * @param repeatedInt64Value
+   * @param repeatedUint64Value
+   * @param repeatedFloatValue
+   * @param repeatedDoubleValue
+   * @param repeatedStringValue
+   * @param repeatedBoolValue
+   * @param repeatedBytesValue
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final TestOptionalRequiredFlatteningParamsResponse testOptionalRequiredFlatteningParams(int requiredSingularInt32, long requiredSingularInt64, float requiredSingularFloat, double requiredSingularDouble, boolean requiredSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum, String requiredSingularString, ByteString requiredSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage, String requiredSingularResourceName, String requiredSingularResourceNameOneof, String requiredSingularResourceNameCommon, int requiredSingularFixed32, long requiredSingularFixed64, List<Integer> requiredRepeatedInt32, List<Long> requiredRepeatedInt64, List<Float> requiredRepeatedFloat, List<Double> requiredRepeatedDouble, List<Boolean> requiredRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum, List<String> requiredRepeatedString, List<ByteString> requiredRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage, List<String> requiredRepeatedResourceName, List<String> requiredRepeatedResourceNameOneof, List<String> requiredRepeatedResourceNameCommon, List<Integer> requiredRepeatedFixed32, List<Long> requiredRepeatedFixed64, Map<Integer, String> requiredMap, int optionalSingularInt32, long optionalSingularInt64, float optionalSingularFloat, double optionalSingularDouble, boolean optionalSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum, String optionalSingularString, ByteString optionalSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage, String optionalSingularResourceName, String optionalSingularResourceNameOneof, String optionalSingularResourceNameCommon, int optionalSingularFixed32, long optionalSingularFixed64, List<Integer> optionalRepeatedInt32, List<Long> optionalRepeatedInt64, List<Float> optionalRepeatedFloat, List<Double> optionalRepeatedDouble, List<Boolean> optionalRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum, List<String> optionalRepeatedString, List<ByteString> optionalRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage, List<String> optionalRepeatedResourceName, List<String> optionalRepeatedResourceNameOneof, List<String> optionalRepeatedResourceNameCommon, List<Integer> optionalRepeatedFixed32, List<Long> optionalRepeatedFixed64, Map<Integer, String> optionalMap, Any anyValue, Struct structValue, Value valueValue, ListValue listValueValue, Timestamp timeValue, Duration durationValue, FieldMask fieldMaskValue, Int32Value int32Value, UInt32Value uint32Value, Int64Value int64Value, UInt64Value uint64Value, FloatValue floatValue, DoubleValue doubleValue, StringValue stringValue, BoolValue boolValue, BytesValue bytesValue, List<Any> repeatedAnyValue, List<Struct> repeatedStructValue, List<Value> repeatedValueValue, List<ListValue> repeatedListValueValue, List<Timestamp> repeatedTimeValue, List<Duration> repeatedDurationValue, List<FieldMask> repeatedFieldMaskValue, List<Int32Value> repeatedInt32Value, List<UInt32Value> repeatedUint32Value, List<Int64Value> repeatedInt64Value, List<UInt64Value> repeatedUint64Value, List<FloatValue> repeatedFloatValue, List<DoubleValue> repeatedDoubleValue, List<StringValue> repeatedStringValue, List<BoolValue> repeatedBoolValue, List<BytesValue> repeatedBytesValue) {
+
+    TestOptionalRequiredFlatteningParamsRequest request =
+        TestOptionalRequiredFlatteningParamsRequest.newBuilder()
+        .setRequiredSingularInt32(requiredSingularInt32)
+        .setRequiredSingularInt64(requiredSingularInt64)
+        .setRequiredSingularFloat(requiredSingularFloat)
+        .setRequiredSingularDouble(requiredSingularDouble)
+        .setRequiredSingularBool(requiredSingularBool)
+        .setRequiredSingularEnum(requiredSingularEnum)
+        .setRequiredSingularString(requiredSingularString)
+        .setRequiredSingularBytes(requiredSingularBytes)
+        .setRequiredSingularMessage(requiredSingularMessage)
+        .setRequiredSingularResourceName(requiredSingularResourceName)
+        .setRequiredSingularResourceNameOneof(requiredSingularResourceNameOneof)
+        .setRequiredSingularResourceNameCommon(requiredSingularResourceNameCommon)
+        .setRequiredSingularFixed32(requiredSingularFixed32)
+        .setRequiredSingularFixed64(requiredSingularFixed64)
+        .addAllRequiredRepeatedInt32(requiredRepeatedInt32)
+        .addAllRequiredRepeatedInt64(requiredRepeatedInt64)
+        .addAllRequiredRepeatedFloat(requiredRepeatedFloat)
+        .addAllRequiredRepeatedDouble(requiredRepeatedDouble)
+        .addAllRequiredRepeatedBool(requiredRepeatedBool)
+        .addAllRequiredRepeatedEnum(requiredRepeatedEnum)
+        .addAllRequiredRepeatedString(requiredRepeatedString)
+        .addAllRequiredRepeatedBytes(requiredRepeatedBytes)
+        .addAllRequiredRepeatedMessage(requiredRepeatedMessage)
+        .addAllRequiredRepeatedResourceName(requiredRepeatedResourceName)
+        .addAllRequiredRepeatedResourceNameOneof(requiredRepeatedResourceNameOneof)
+        .addAllRequiredRepeatedResourceNameCommon(requiredRepeatedResourceNameCommon)
+        .addAllRequiredRepeatedFixed32(requiredRepeatedFixed32)
+        .addAllRequiredRepeatedFixed64(requiredRepeatedFixed64)
+        .putAllRequiredMap(requiredMap)
+        .setOptionalSingularInt32(optionalSingularInt32)
+        .setOptionalSingularInt64(optionalSingularInt64)
+        .setOptionalSingularFloat(optionalSingularFloat)
+        .setOptionalSingularDouble(optionalSingularDouble)
+        .setOptionalSingularBool(optionalSingularBool)
+        .setOptionalSingularEnum(optionalSingularEnum)
+        .setOptionalSingularString(optionalSingularString)
+        .setOptionalSingularBytes(optionalSingularBytes)
+        .setOptionalSingularMessage(optionalSingularMessage)
+        .setOptionalSingularResourceName(optionalSingularResourceName)
+        .setOptionalSingularResourceNameOneof(optionalSingularResourceNameOneof)
+        .setOptionalSingularResourceNameCommon(optionalSingularResourceNameCommon)
+        .setOptionalSingularFixed32(optionalSingularFixed32)
+        .setOptionalSingularFixed64(optionalSingularFixed64)
+        .addAllOptionalRepeatedInt32(optionalRepeatedInt32)
+        .addAllOptionalRepeatedInt64(optionalRepeatedInt64)
+        .addAllOptionalRepeatedFloat(optionalRepeatedFloat)
+        .addAllOptionalRepeatedDouble(optionalRepeatedDouble)
+        .addAllOptionalRepeatedBool(optionalRepeatedBool)
+        .addAllOptionalRepeatedEnum(optionalRepeatedEnum)
+        .addAllOptionalRepeatedString(optionalRepeatedString)
+        .addAllOptionalRepeatedBytes(optionalRepeatedBytes)
+        .addAllOptionalRepeatedMessage(optionalRepeatedMessage)
+        .addAllOptionalRepeatedResourceName(optionalRepeatedResourceName)
+        .addAllOptionalRepeatedResourceNameOneof(optionalRepeatedResourceNameOneof)
+        .addAllOptionalRepeatedResourceNameCommon(optionalRepeatedResourceNameCommon)
+        .addAllOptionalRepeatedFixed32(optionalRepeatedFixed32)
+        .addAllOptionalRepeatedFixed64(optionalRepeatedFixed64)
+        .putAllOptionalMap(optionalMap)
+        .setAnyValue(anyValue)
+        .setStructValue(structValue)
+        .setValueValue(valueValue)
+        .setListValueValue(listValueValue)
+        .setTimeValue(timeValue)
+        .setDurationValue(durationValue)
+        .setFieldMaskValue(fieldMaskValue)
+        .setInt32Value(int32Value)
+        .setUint32Value(uint32Value)
+        .setInt64Value(int64Value)
+        .setUint64Value(uint64Value)
+        .setFloatValue(floatValue)
+        .setDoubleValue(doubleValue)
+        .setStringValue(stringValue)
+        .setBoolValue(boolValue)
+        .setBytesValue(bytesValue)
+        .addAllRepeatedAnyValue(repeatedAnyValue)
+        .addAllRepeatedStructValue(repeatedStructValue)
+        .addAllRepeatedValueValue(repeatedValueValue)
+        .addAllRepeatedListValueValue(repeatedListValueValue)
+        .addAllRepeatedTimeValue(repeatedTimeValue)
+        .addAllRepeatedDurationValue(repeatedDurationValue)
+        .addAllRepeatedFieldMaskValue(repeatedFieldMaskValue)
+        .addAllRepeatedInt32Value(repeatedInt32Value)
+        .addAllRepeatedUint32Value(repeatedUint32Value)
+        .addAllRepeatedInt64Value(repeatedInt64Value)
+        .addAllRepeatedUint64Value(repeatedUint64Value)
+        .addAllRepeatedFloatValue(repeatedFloatValue)
+        .addAllRepeatedDoubleValue(repeatedDoubleValue)
+        .addAllRepeatedStringValue(repeatedStringValue)
+        .addAllRepeatedBoolValue(repeatedBoolValue)
+        .addAllRepeatedBytesValue(repeatedBytesValue)
+        .build();
+    return testOptionalRequiredFlatteningParams(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test optional flattening parameters of all types
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   int requiredSingularInt32 = 0;
+   *   long requiredSingularInt64 = 0L;
+   *   float requiredSingularFloat = 0.0F;
+   *   double requiredSingularDouble = 0.0;
+   *   boolean requiredSingularBool = false;
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   *   String requiredSingularString = "";
+   *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+   *   int requiredSingularFixed32 = 0;
+   *   long requiredSingularFixed64 = 0L;
+   *   List&lt;Integer&gt; requiredRepeatedInt32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedInt64 = new ArrayList&lt;&gt;();
+   *   List&lt;Float&gt; requiredRepeatedFloat = new ArrayList&lt;&gt;();
+   *   List&lt;Double&gt; requiredRepeatedDouble = new ArrayList&lt;&gt;();
+   *   List&lt;Boolean&gt; requiredRepeatedBool = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerEnum&gt; requiredRepeatedEnum = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; requiredRepeatedString = new ArrayList&lt;&gt;();
+   *   List&lt;ByteString&gt; requiredRepeatedBytes = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
+   *   List&lt;ShelfBookName&gt; requiredRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;BookName&gt; requiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;ProjectName&gt; requiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
+   *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
+   *   Map&lt;Integer, String&gt; requiredMap = new HashMap&lt;&gt;();
+   *   TestOptionalRequiredFlatteningParamsRequest request = TestOptionalRequiredFlatteningParamsRequest.newBuilder()
+   *     .setRequiredSingularInt32(requiredSingularInt32)
+   *     .setRequiredSingularInt64(requiredSingularInt64)
+   *     .setRequiredSingularFloat(requiredSingularFloat)
+   *     .setRequiredSingularDouble(requiredSingularDouble)
+   *     .setRequiredSingularBool(requiredSingularBool)
+   *     .setRequiredSingularEnum(requiredSingularEnum)
+   *     .setRequiredSingularString(requiredSingularString)
+   *     .setRequiredSingularBytes(requiredSingularBytes)
+   *     .setRequiredSingularMessage(requiredSingularMessage)
+   *     .setRequiredSingularResourceName(requiredSingularResourceName.toString())
+   *     .setRequiredSingularResourceNameOneof(requiredSingularResourceNameOneof.toString())
+   *     .setRequiredSingularResourceNameCommon(requiredSingularResourceNameCommon.toString())
+   *     .setRequiredSingularFixed32(requiredSingularFixed32)
+   *     .setRequiredSingularFixed64(requiredSingularFixed64)
+   *     .addAllRequiredRepeatedInt32(requiredRepeatedInt32)
+   *     .addAllRequiredRepeatedInt64(requiredRepeatedInt64)
+   *     .addAllRequiredRepeatedFloat(requiredRepeatedFloat)
+   *     .addAllRequiredRepeatedDouble(requiredRepeatedDouble)
+   *     .addAllRequiredRepeatedBool(requiredRepeatedBool)
+   *     .addAllRequiredRepeatedEnum(requiredRepeatedEnum)
+   *     .addAllRequiredRepeatedString(requiredRepeatedString)
+   *     .addAllRequiredRepeatedBytes(requiredRepeatedBytes)
+   *     .addAllRequiredRepeatedMessage(requiredRepeatedMessage)
+   *     .addAllRequiredRepeatedResourceName(ShelfBookName.toStringList(requiredRepeatedResourceName))
+   *     .addAllRequiredRepeatedResourceNameOneof(BookName.toStringList(requiredRepeatedResourceNameOneof))
+   *     .addAllRequiredRepeatedResourceNameCommon(ProjectName.toStringList(requiredRepeatedResourceNameCommon))
+   *     .addAllRequiredRepeatedFixed32(requiredRepeatedFixed32)
+   *     .addAllRequiredRepeatedFixed64(requiredRepeatedFixed64)
+   *     .putAllRequiredMap(requiredMap)
+   *     .build();
+   *   TestOptionalRequiredFlatteningParamsResponse response = libraryClient.testOptionalRequiredFlatteningParams(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final TestOptionalRequiredFlatteningParamsResponse testOptionalRequiredFlatteningParams(TestOptionalRequiredFlatteningParamsRequest request) {
+    return testOptionalRequiredFlatteningParamsCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test optional flattening parameters of all types
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   int requiredSingularInt32 = 0;
+   *   long requiredSingularInt64 = 0L;
+   *   float requiredSingularFloat = 0.0F;
+   *   double requiredSingularDouble = 0.0;
+   *   boolean requiredSingularBool = false;
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   *   String requiredSingularString = "";
+   *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+   *   int requiredSingularFixed32 = 0;
+   *   long requiredSingularFixed64 = 0L;
+   *   List&lt;Integer&gt; requiredRepeatedInt32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedInt64 = new ArrayList&lt;&gt;();
+   *   List&lt;Float&gt; requiredRepeatedFloat = new ArrayList&lt;&gt;();
+   *   List&lt;Double&gt; requiredRepeatedDouble = new ArrayList&lt;&gt;();
+   *   List&lt;Boolean&gt; requiredRepeatedBool = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerEnum&gt; requiredRepeatedEnum = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; requiredRepeatedString = new ArrayList&lt;&gt;();
+   *   List&lt;ByteString&gt; requiredRepeatedBytes = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
+   *   List&lt;ShelfBookName&gt; requiredRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;BookName&gt; requiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;ProjectName&gt; requiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
+   *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
+   *   Map&lt;Integer, String&gt; requiredMap = new HashMap&lt;&gt;();
+   *   TestOptionalRequiredFlatteningParamsRequest request = TestOptionalRequiredFlatteningParamsRequest.newBuilder()
+   *     .setRequiredSingularInt32(requiredSingularInt32)
+   *     .setRequiredSingularInt64(requiredSingularInt64)
+   *     .setRequiredSingularFloat(requiredSingularFloat)
+   *     .setRequiredSingularDouble(requiredSingularDouble)
+   *     .setRequiredSingularBool(requiredSingularBool)
+   *     .setRequiredSingularEnum(requiredSingularEnum)
+   *     .setRequiredSingularString(requiredSingularString)
+   *     .setRequiredSingularBytes(requiredSingularBytes)
+   *     .setRequiredSingularMessage(requiredSingularMessage)
+   *     .setRequiredSingularResourceName(requiredSingularResourceName.toString())
+   *     .setRequiredSingularResourceNameOneof(requiredSingularResourceNameOneof.toString())
+   *     .setRequiredSingularResourceNameCommon(requiredSingularResourceNameCommon.toString())
+   *     .setRequiredSingularFixed32(requiredSingularFixed32)
+   *     .setRequiredSingularFixed64(requiredSingularFixed64)
+   *     .addAllRequiredRepeatedInt32(requiredRepeatedInt32)
+   *     .addAllRequiredRepeatedInt64(requiredRepeatedInt64)
+   *     .addAllRequiredRepeatedFloat(requiredRepeatedFloat)
+   *     .addAllRequiredRepeatedDouble(requiredRepeatedDouble)
+   *     .addAllRequiredRepeatedBool(requiredRepeatedBool)
+   *     .addAllRequiredRepeatedEnum(requiredRepeatedEnum)
+   *     .addAllRequiredRepeatedString(requiredRepeatedString)
+   *     .addAllRequiredRepeatedBytes(requiredRepeatedBytes)
+   *     .addAllRequiredRepeatedMessage(requiredRepeatedMessage)
+   *     .addAllRequiredRepeatedResourceName(ShelfBookName.toStringList(requiredRepeatedResourceName))
+   *     .addAllRequiredRepeatedResourceNameOneof(BookName.toStringList(requiredRepeatedResourceNameOneof))
+   *     .addAllRequiredRepeatedResourceNameCommon(ProjectName.toStringList(requiredRepeatedResourceNameCommon))
+   *     .addAllRequiredRepeatedFixed32(requiredRepeatedFixed32)
+   *     .addAllRequiredRepeatedFixed64(requiredRepeatedFixed64)
+   *     .putAllRequiredMap(requiredMap)
+   *     .build();
+   *   ApiFuture&lt;TestOptionalRequiredFlatteningParamsResponse&gt; future = libraryClient.testOptionalRequiredFlatteningParamsCallable().futureCall(request);
+   *   // Do something
+   *   TestOptionalRequiredFlatteningParamsResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
+    return stub.testOptionalRequiredFlatteningParamsCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+
+  public static class ListShelvesPagedResponse extends AbstractPagedListResponse<
+      ListShelvesRequest,
+      ListShelvesResponse,
+      Shelf,
+      ListShelvesPage,
+      ListShelvesFixedSizeCollection> {
+
+    public static ApiFuture<ListShelvesPagedResponse> createAsync(
+        PageContext<ListShelvesRequest, ListShelvesResponse, Shelf> context,
+        ApiFuture<ListShelvesResponse> futureResponse) {
+      ApiFuture<ListShelvesPage> futurePage =
+          ListShelvesPage.createEmptyPage().createPageAsync(context, futureResponse);
+      return ApiFutures.transform(
+          futurePage,
+          new ApiFunction<ListShelvesPage, ListShelvesPagedResponse>() {
+            @Override
+            public ListShelvesPagedResponse apply(ListShelvesPage input) {
+              return new ListShelvesPagedResponse(input);
+            }
+          });
+    }
+
+    private ListShelvesPagedResponse(ListShelvesPage page) {
+      super(page, ListShelvesFixedSizeCollection.createEmptyCollection());
+    }
+
+
+  }
+
+  public static class ListShelvesPage extends AbstractPage<
+      ListShelvesRequest,
+      ListShelvesResponse,
+      Shelf,
+      ListShelvesPage> {
+
+    private ListShelvesPage(
+        PageContext<ListShelvesRequest, ListShelvesResponse, Shelf> context,
+        ListShelvesResponse response) {
+      super(context, response);
+    }
+
+    private static ListShelvesPage createEmptyPage() {
+      return new ListShelvesPage(null, null);
+    }
+
+    @Override
+    protected ListShelvesPage createPage(
+        PageContext<ListShelvesRequest, ListShelvesResponse, Shelf> context,
+        ListShelvesResponse response) {
+      return new ListShelvesPage(context, response);
+    }
+
+    @Override
+    public ApiFuture<ListShelvesPage> createPageAsync(
+        PageContext<ListShelvesRequest, ListShelvesResponse, Shelf> context,
+        ApiFuture<ListShelvesResponse> futureResponse) {
+      return super.createPageAsync(context, futureResponse);
+    }
+
+
+
+
+  }
+
+  public static class ListShelvesFixedSizeCollection extends AbstractFixedSizeCollection<
+      ListShelvesRequest,
+      ListShelvesResponse,
+      Shelf,
+      ListShelvesPage,
+      ListShelvesFixedSizeCollection> {
+
+    private ListShelvesFixedSizeCollection(List<ListShelvesPage> pages, int collectionSize) {
+      super(pages, collectionSize);
+    }
+
+    private static ListShelvesFixedSizeCollection createEmptyCollection() {
+      return new ListShelvesFixedSizeCollection(null, 0);
+    }
+
+    @Override
+    protected ListShelvesFixedSizeCollection createCollection(
+        List<ListShelvesPage> pages, int collectionSize) {
+      return new ListShelvesFixedSizeCollection(pages, collectionSize);
+    }
+
+
+  }
+  public static class ListBooksPagedResponse extends AbstractPagedListResponse<
+      ListBooksRequest,
+      ListBooksResponse,
+      Book,
+      ListBooksPage,
+      ListBooksFixedSizeCollection> {
+
+    public static ApiFuture<ListBooksPagedResponse> createAsync(
+        PageContext<ListBooksRequest, ListBooksResponse, Book> context,
+        ApiFuture<ListBooksResponse> futureResponse) {
+      ApiFuture<ListBooksPage> futurePage =
+          ListBooksPage.createEmptyPage().createPageAsync(context, futureResponse);
+      return ApiFutures.transform(
+          futurePage,
+          new ApiFunction<ListBooksPage, ListBooksPagedResponse>() {
+            @Override
+            public ListBooksPagedResponse apply(ListBooksPage input) {
+              return new ListBooksPagedResponse(input);
+            }
+          });
+    }
+
+    private ListBooksPagedResponse(ListBooksPage page) {
+      super(page, ListBooksFixedSizeCollection.createEmptyCollection());
+    }
+
+
+  }
+
+  public static class ListBooksPage extends AbstractPage<
+      ListBooksRequest,
+      ListBooksResponse,
+      Book,
+      ListBooksPage> {
+
+    private ListBooksPage(
+        PageContext<ListBooksRequest, ListBooksResponse, Book> context,
+        ListBooksResponse response) {
+      super(context, response);
+    }
+
+    private static ListBooksPage createEmptyPage() {
+      return new ListBooksPage(null, null);
+    }
+
+    @Override
+    protected ListBooksPage createPage(
+        PageContext<ListBooksRequest, ListBooksResponse, Book> context,
+        ListBooksResponse response) {
+      return new ListBooksPage(context, response);
+    }
+
+    @Override
+    public ApiFuture<ListBooksPage> createPageAsync(
+        PageContext<ListBooksRequest, ListBooksResponse, Book> context,
+        ApiFuture<ListBooksResponse> futureResponse) {
+      return super.createPageAsync(context, futureResponse);
+    }
+
+
+
+
+  }
+
+  public static class ListBooksFixedSizeCollection extends AbstractFixedSizeCollection<
+      ListBooksRequest,
+      ListBooksResponse,
+      Book,
+      ListBooksPage,
+      ListBooksFixedSizeCollection> {
+
+    private ListBooksFixedSizeCollection(List<ListBooksPage> pages, int collectionSize) {
+      super(pages, collectionSize);
+    }
+
+    private static ListBooksFixedSizeCollection createEmptyCollection() {
+      return new ListBooksFixedSizeCollection(null, 0);
+    }
+
+    @Override
+    protected ListBooksFixedSizeCollection createCollection(
+        List<ListBooksPage> pages, int collectionSize) {
+      return new ListBooksFixedSizeCollection(pages, collectionSize);
+    }
+
+
+  }
+  public static class ListStringsPagedResponse extends AbstractPagedListResponse<
+      ListStringsRequest,
+      ListStringsResponse,
+      String,
+      ListStringsPage,
+      ListStringsFixedSizeCollection> {
+
+    public static ApiFuture<ListStringsPagedResponse> createAsync(
+        PageContext<ListStringsRequest, ListStringsResponse, String> context,
+        ApiFuture<ListStringsResponse> futureResponse) {
+      ApiFuture<ListStringsPage> futurePage =
+          ListStringsPage.createEmptyPage().createPageAsync(context, futureResponse);
+      return ApiFutures.transform(
+          futurePage,
+          new ApiFunction<ListStringsPage, ListStringsPagedResponse>() {
+            @Override
+            public ListStringsPagedResponse apply(ListStringsPage input) {
+              return new ListStringsPagedResponse(input);
+            }
+          });
+    }
+
+    private ListStringsPagedResponse(ListStringsPage page) {
+      super(page, ListStringsFixedSizeCollection.createEmptyCollection());
+    }
+    public Iterable<ResourceName> iterateAllAsResourceName() {
+      return Iterables.transform(iterateAll(), new Function<String, ResourceName>() {
+          @Override
+          public ResourceName apply(String arg0) {
+            return UntypedResourceName.parse(arg0);
+          }
+        }
+      );
+    }
+
+  }
+
+  public static class ListStringsPage extends AbstractPage<
+      ListStringsRequest,
+      ListStringsResponse,
+      String,
+      ListStringsPage> {
+
+    private ListStringsPage(
+        PageContext<ListStringsRequest, ListStringsResponse, String> context,
+        ListStringsResponse response) {
+      super(context, response);
+    }
+
+    private static ListStringsPage createEmptyPage() {
+      return new ListStringsPage(null, null);
+    }
+
+    @Override
+    protected ListStringsPage createPage(
+        PageContext<ListStringsRequest, ListStringsResponse, String> context,
+        ListStringsResponse response) {
+      return new ListStringsPage(context, response);
+    }
+
+    @Override
+    public ApiFuture<ListStringsPage> createPageAsync(
+        PageContext<ListStringsRequest, ListStringsResponse, String> context,
+        ApiFuture<ListStringsResponse> futureResponse) {
+      return super.createPageAsync(context, futureResponse);
+    }
+    public Iterable<ResourceName> iterateAllAsResourceName() {
+      return Iterables.transform(iterateAll(), new Function<String, ResourceName>() {
+          @Override
+          public ResourceName apply(String arg0) {
+            return UntypedResourceName.parse(arg0);
+          }
+        }
+      );
+    }
+
+    public Iterable<ResourceName> getValuesAsResourceName() {
+      return Iterables.transform(getValues(), new Function<String, ResourceName>() {
+          @Override
+          public ResourceName apply(String arg0) {
+            return UntypedResourceName.parse(arg0);
+          }
+        }
+      );
+    }
+
+  }
+
+  public static class ListStringsFixedSizeCollection extends AbstractFixedSizeCollection<
+      ListStringsRequest,
+      ListStringsResponse,
+      String,
+      ListStringsPage,
+      ListStringsFixedSizeCollection> {
+
+    private ListStringsFixedSizeCollection(List<ListStringsPage> pages, int collectionSize) {
+      super(pages, collectionSize);
+    }
+
+    private static ListStringsFixedSizeCollection createEmptyCollection() {
+      return new ListStringsFixedSizeCollection(null, 0);
+    }
+
+    @Override
+    protected ListStringsFixedSizeCollection createCollection(
+        List<ListStringsPage> pages, int collectionSize) {
+      return new ListStringsFixedSizeCollection(pages, collectionSize);
+    }
+    public Iterable<ResourceName> getValuesAsResourceName() {
+      return Iterables.transform(getValues(), new Function<String, ResourceName>() {
+          @Override
+          public ResourceName apply(String arg0) {
+            return UntypedResourceName.parse(arg0);
+          }
+        }
+      );
+    }
+
+  }
+  public static class FindRelatedBooksPagedResponse extends AbstractPagedListResponse<
+      FindRelatedBooksRequest,
+      FindRelatedBooksResponse,
+      String,
+      FindRelatedBooksPage,
+      FindRelatedBooksFixedSizeCollection> {
+
+    public static ApiFuture<FindRelatedBooksPagedResponse> createAsync(
+        PageContext<FindRelatedBooksRequest, FindRelatedBooksResponse, String> context,
+        ApiFuture<FindRelatedBooksResponse> futureResponse) {
+      ApiFuture<FindRelatedBooksPage> futurePage =
+          FindRelatedBooksPage.createEmptyPage().createPageAsync(context, futureResponse);
+      return ApiFutures.transform(
+          futurePage,
+          new ApiFunction<FindRelatedBooksPage, FindRelatedBooksPagedResponse>() {
+            @Override
+            public FindRelatedBooksPagedResponse apply(FindRelatedBooksPage input) {
+              return new FindRelatedBooksPagedResponse(input);
+            }
+          });
+    }
+
+    private FindRelatedBooksPagedResponse(FindRelatedBooksPage page) {
+      super(page, FindRelatedBooksFixedSizeCollection.createEmptyCollection());
+    }
+    public Iterable<ShelfBookName> iterateAllAsShelfBookName() {
+      return Iterables.transform(iterateAll(), new Function<String, ShelfBookName>() {
+          @Override
+          public ShelfBookName apply(String arg0) {
+            return ShelfBookName.parse(arg0);
+          }
+        }
+      );
+    }
+
+  }
+
+  public static class FindRelatedBooksPage extends AbstractPage<
+      FindRelatedBooksRequest,
+      FindRelatedBooksResponse,
+      String,
+      FindRelatedBooksPage> {
+
+    private FindRelatedBooksPage(
+        PageContext<FindRelatedBooksRequest, FindRelatedBooksResponse, String> context,
+        FindRelatedBooksResponse response) {
+      super(context, response);
+    }
+
+    private static FindRelatedBooksPage createEmptyPage() {
+      return new FindRelatedBooksPage(null, null);
+    }
+
+    @Override
+    protected FindRelatedBooksPage createPage(
+        PageContext<FindRelatedBooksRequest, FindRelatedBooksResponse, String> context,
+        FindRelatedBooksResponse response) {
+      return new FindRelatedBooksPage(context, response);
+    }
+
+    @Override
+    public ApiFuture<FindRelatedBooksPage> createPageAsync(
+        PageContext<FindRelatedBooksRequest, FindRelatedBooksResponse, String> context,
+        ApiFuture<FindRelatedBooksResponse> futureResponse) {
+      return super.createPageAsync(context, futureResponse);
+    }
+    public Iterable<ShelfBookName> iterateAllAsShelfBookName() {
+      return Iterables.transform(iterateAll(), new Function<String, ShelfBookName>() {
+          @Override
+          public ShelfBookName apply(String arg0) {
+            return ShelfBookName.parse(arg0);
+          }
+        }
+      );
+    }
+
+    public Iterable<ShelfBookName> getValuesAsShelfBookName() {
+      return Iterables.transform(getValues(), new Function<String, ShelfBookName>() {
+          @Override
+          public ShelfBookName apply(String arg0) {
+            return ShelfBookName.parse(arg0);
+          }
+        }
+      );
+    }
+
+  }
+
+  public static class FindRelatedBooksFixedSizeCollection extends AbstractFixedSizeCollection<
+      FindRelatedBooksRequest,
+      FindRelatedBooksResponse,
+      String,
+      FindRelatedBooksPage,
+      FindRelatedBooksFixedSizeCollection> {
+
+    private FindRelatedBooksFixedSizeCollection(List<FindRelatedBooksPage> pages, int collectionSize) {
+      super(pages, collectionSize);
+    }
+
+    private static FindRelatedBooksFixedSizeCollection createEmptyCollection() {
+      return new FindRelatedBooksFixedSizeCollection(null, 0);
+    }
+
+    @Override
+    protected FindRelatedBooksFixedSizeCollection createCollection(
+        List<FindRelatedBooksPage> pages, int collectionSize) {
+      return new FindRelatedBooksFixedSizeCollection(pages, collectionSize);
+    }
+    public Iterable<ShelfBookName> getValuesAsShelfBookName() {
+      return Iterables.transform(getValues(), new Function<String, ShelfBookName>() {
+          @Override
+          public ShelfBookName apply(String arg0) {
+            return ShelfBookName.parse(arg0);
+          }
+        }
+      );
+    }
+
+  }
+}
+============== file: src/main/java/com/google/example/library/v1/LibrarySettings.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.api.gax.batching.FlowController;
+import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
+import com.google.api.gax.batching.PartitionKey;
+import com.google.api.gax.batching.RequestBuilder;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.GaxProperties;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.grpc.OperationFuture;
+import com.google.api.gax.grpc.ProtoOperationTransformers;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.BatchedRequestIssuer;
+import com.google.api.gax.rpc.BatchingCallSettings;
+import com.google.api.gax.rpc.BatchingDescriptor;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientSettings;
+import com.google.api.gax.rpc.HeaderProvider;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.PageContext;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.PagedListDescriptor;
+import com.google.api.gax.rpc.PagedListResponseFactory;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StreamingCallSettings;
+import com.google.api.gax.rpc.StubSettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.auth.Credentials;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListStringsPagedResponse;
+import com.google.example.library.v1.stub.LibraryServiceStubSettings;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Empty;
+import com.google.tagger.v1.LabelerGrpc;
+import com.google.tagger.v1.TaggerProto.AddLabelRequest;
+import com.google.tagger.v1.TaggerProto.AddLabelResponse;
+import com.google.tagger.v1.TaggerProto.AddTagRequest;
+import com.google.tagger.v1.TaggerProto.AddTagResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.Generated;
+import org.threeten.bp.Duration;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Settings class to configure an instance of {@link LibraryClient}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ * <li>The default service address (library-example.googleapis.com) and default port (1234)
+ * are used.
+ * <li>Credentials are acquired automatically through Application Default Credentials.
+ * <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders.
+ * When build() is called, the tree of builders is called to create the complete settings
+ * object. For example, to set the total timeout of createShelf to 30 seconds:
+ *
+ * <pre>
+ * <code>
+ * LibrarySettings.Builder librarySettingsBuilder =
+ *     LibrarySettings.newBuilder();
+ * librarySettingsBuilder.createShelfSettings().getRetrySettings().toBuilder()
+ *     .setTotalTimeout(Duration.ofSeconds(30));
+ * LibrarySettings librarySettings = librarySettingsBuilder.build();
+ * </code>
+ * </pre>
+ */
+@Generated("by gapic-generator")
+public class LibrarySettings extends ClientSettings<LibrarySettings> {
+  /**
+   * Returns the object with the settings used for calls to createShelf.
+   */
+  public UnaryCallSettings<CreateShelfRequest, Shelf> createShelfSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).createShelfSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getShelf.
+   */
+  public UnaryCallSettings<GetShelfRequest, Shelf> getShelfSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).getShelfSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to listShelves.
+   */
+  public PagedCallSettings<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).listShelvesSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to deleteShelf.
+   */
+  public UnaryCallSettings<DeleteShelfRequest, Empty> deleteShelfSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).deleteShelfSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to mergeShelves.
+   */
+  public UnaryCallSettings<MergeShelvesRequest, Shelf> mergeShelvesSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).mergeShelvesSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to createBook.
+   */
+  public UnaryCallSettings<CreateBookRequest, Book> createBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).createBookSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to publishSeries.
+   */
+  public BatchingCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).publishSeriesSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBook.
+   */
+  public UnaryCallSettings<GetBookRequest, Book> getBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).getBookSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to listBooks.
+   */
+  public PagedCallSettings<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).listBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to deleteBook.
+   */
+  public UnaryCallSettings<DeleteBookRequest, Empty> deleteBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).deleteBookSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to updateBook.
+   */
+  public UnaryCallSettings<UpdateBookRequest, Book> updateBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).updateBookSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to moveBook.
+   */
+  public UnaryCallSettings<MoveBookRequest, Book> moveBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).moveBookSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to listStrings.
+   */
+  public PagedCallSettings<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).listStringsSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to addComments.
+   */
+  public BatchingCallSettings<AddCommentsRequest, Empty> addCommentsSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).addCommentsSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBookFromArchive.
+   */
+  public UnaryCallSettings<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).getBookFromArchiveSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBookFromAnywhere.
+   */
+  public UnaryCallSettings<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).getBookFromAnywhereSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBookFromAbsolutelyAnywhere.
+   */
+  public UnaryCallSettings<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).getBookFromAbsolutelyAnywhereSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to updateBookIndex.
+   */
+  public UnaryCallSettings<UpdateBookIndexRequest, Empty> updateBookIndexSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).updateBookIndexSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamShelves.
+   */
+  public ServerStreamingCallSettings<StreamShelvesRequest, StreamShelvesResponse> streamShelvesSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).streamShelvesSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamBooks.
+   */
+  public ServerStreamingCallSettings<StreamBooksRequest, Book> streamBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).streamBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to discussBook.
+   */
+  public StreamingCallSettings<DiscussBookRequest, Comment> discussBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).discussBookSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to monologAboutBook.
+   */
+  public StreamingCallSettings<DiscussBookRequest, Comment> monologAboutBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).monologAboutBookSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to findRelatedBooks.
+   */
+  public PagedCallSettings<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).findRelatedBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to addTag.
+   */
+  public UnaryCallSettings<AddTagRequest, AddTagResponse> addTagSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).addTagSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to addLabel.
+   */
+  /* package-private */ UnaryCallSettings<AddLabelRequest, AddLabelResponse> addLabelSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).addLabelSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBigBook.
+   */
+  public UnaryCallSettings<GetBookRequest, Operation> getBigBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).getBigBookSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBigBook.
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public OperationCallSettings<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).getBigBookOperationSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBigNothing.
+   */
+  public UnaryCallSettings<GetBookRequest, Operation> getBigNothingSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).getBigNothingSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBigNothing.
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public OperationCallSettings<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).getBigNothingOperationSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to testOptionalRequiredFlatteningParams.
+   */
+  public UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).testOptionalRequiredFlatteningParamsSettings();
+  }
+
+
+  public static final LibrarySettings create(LibraryServiceStubSettings stub) throws IOException {
+    return new LibrarySettings.Builder(stub.toBuilder()).build();
+  }
+
+  /**
+   * Returns a builder for the default ExecutorProvider for this service.
+   */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return LibraryServiceStubSettings.defaultExecutorProviderBuilder();
+  }
+
+  /**
+   * Returns the default service endpoint.
+   */
+   public static String getDefaultEndpoint() {
+     return LibraryServiceStubSettings.getDefaultEndpoint();
+   }
+
+
+  /**
+   * Returns the default service scopes.
+   */
+  public static List<String> getDefaultServiceScopes() {
+    return LibraryServiceStubSettings.getDefaultServiceScopes();
+  }
+
+
+  /**
+   * Returns a builder for the default credentials for this service.
+   */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return LibraryServiceStubSettings.defaultCredentialsProviderBuilder();
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder() {
+    return LibraryServiceStubSettings.defaultGrpcTransportProviderBuilder();
+  }
+
+  public static TransportChannelProvider defaultTransportChannelProvider() {
+    return LibraryServiceStubSettings.defaultTransportChannelProvider();
+  }
+
+  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
+  public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
+    return LibraryServiceStubSettings.defaultApiClientHeaderProviderBuilder();
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder() {
+    return Builder.createDefault();
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /**
+   * Returns a builder containing all the values of this settings class.
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  protected LibrarySettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+  }
+
+  /**
+   * Builder for LibrarySettings.
+   */
+  public static class Builder extends ClientSettings.Builder<LibrarySettings, Builder> {
+    protected Builder() throws IOException {
+      this((ClientContext) null);
+    }
+
+    protected Builder(ClientContext clientContext) {
+      super(LibraryServiceStubSettings.newBuilder(clientContext));
+    }
+
+    private static Builder createDefault() {
+      return new Builder(LibraryServiceStubSettings.newBuilder());
+    }
+
+    protected Builder(LibrarySettings settings) {
+      super(settings.getStubSettings().toBuilder());
+    }
+
+    protected Builder(LibraryServiceStubSettings.Builder stubSettings) {
+      super(stubSettings);
+    }
+
+
+    public LibraryServiceStubSettings.Builder getStubSettingsBuilder() {
+      return ((LibraryServiceStubSettings.Builder) getStubSettings());
+    }
+
+    // NEXT_MAJOR_VER: remove 'throws Exception'
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) throws Exception {
+      super.applyToAllUnaryMethods(getStubSettingsBuilder().unaryMethodSettingsBuilders(), settingsUpdater);
+      return this;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to createShelf.
+     */
+    public UnaryCallSettings.Builder<CreateShelfRequest, Shelf> createShelfSettings() {
+      return getStubSettingsBuilder().createShelfSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getShelf.
+     */
+    public UnaryCallSettings.Builder<GetShelfRequest, Shelf> getShelfSettings() {
+      return getStubSettingsBuilder().getShelfSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to listShelves.
+     */
+    public PagedCallSettings.Builder<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings() {
+      return getStubSettingsBuilder().listShelvesSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to deleteShelf.
+     */
+    public UnaryCallSettings.Builder<DeleteShelfRequest, Empty> deleteShelfSettings() {
+      return getStubSettingsBuilder().deleteShelfSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to mergeShelves.
+     */
+    public UnaryCallSettings.Builder<MergeShelvesRequest, Shelf> mergeShelvesSettings() {
+      return getStubSettingsBuilder().mergeShelvesSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to createBook.
+     */
+    public UnaryCallSettings.Builder<CreateBookRequest, Book> createBookSettings() {
+      return getStubSettingsBuilder().createBookSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to publishSeries.
+     */
+    public BatchingCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
+      return getStubSettingsBuilder().publishSeriesSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBook.
+     */
+    public UnaryCallSettings.Builder<GetBookRequest, Book> getBookSettings() {
+      return getStubSettingsBuilder().getBookSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to listBooks.
+     */
+    public PagedCallSettings.Builder<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings() {
+      return getStubSettingsBuilder().listBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to deleteBook.
+     */
+    public UnaryCallSettings.Builder<DeleteBookRequest, Empty> deleteBookSettings() {
+      return getStubSettingsBuilder().deleteBookSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to updateBook.
+     */
+    public UnaryCallSettings.Builder<UpdateBookRequest, Book> updateBookSettings() {
+      return getStubSettingsBuilder().updateBookSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBook.
+     */
+    public UnaryCallSettings.Builder<MoveBookRequest, Book> moveBookSettings() {
+      return getStubSettingsBuilder().moveBookSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to listStrings.
+     */
+    public PagedCallSettings.Builder<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings() {
+      return getStubSettingsBuilder().listStringsSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to addComments.
+     */
+    public BatchingCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings() {
+      return getStubSettingsBuilder().addCommentsSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBookFromArchive.
+     */
+    public UnaryCallSettings.Builder<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveSettings() {
+      return getStubSettingsBuilder().getBookFromArchiveSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBookFromAnywhere.
+     */
+    public UnaryCallSettings.Builder<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings() {
+      return getStubSettingsBuilder().getBookFromAnywhereSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBookFromAbsolutelyAnywhere.
+     */
+    public UnaryCallSettings.Builder<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereSettings() {
+      return getStubSettingsBuilder().getBookFromAbsolutelyAnywhereSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to updateBookIndex.
+     */
+    public UnaryCallSettings.Builder<UpdateBookIndexRequest, Empty> updateBookIndexSettings() {
+      return getStubSettingsBuilder().updateBookIndexSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamShelves.
+     */
+    public ServerStreamingCallSettings.Builder<StreamShelvesRequest, StreamShelvesResponse> streamShelvesSettings() {
+      return getStubSettingsBuilder().streamShelvesSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamBooks.
+     */
+    public ServerStreamingCallSettings.Builder<StreamBooksRequest, Book> streamBooksSettings() {
+      return getStubSettingsBuilder().streamBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to discussBook.
+     */
+    public StreamingCallSettings.Builder<DiscussBookRequest, Comment> discussBookSettings() {
+      return getStubSettingsBuilder().discussBookSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to monologAboutBook.
+     */
+    public StreamingCallSettings.Builder<DiscussBookRequest, Comment> monologAboutBookSettings() {
+      return getStubSettingsBuilder().monologAboutBookSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to findRelatedBooks.
+     */
+    public PagedCallSettings.Builder<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings() {
+      return getStubSettingsBuilder().findRelatedBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to addTag.
+     */
+    public UnaryCallSettings.Builder<AddTagRequest, AddTagResponse> addTagSettings() {
+      return getStubSettingsBuilder().addTagSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to addLabel.
+     */
+    /* package-private */ UnaryCallSettings.Builder<AddLabelRequest, AddLabelResponse> addLabelSettings() {
+      return getStubSettingsBuilder().addLabelSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBigBook.
+     */
+    public UnaryCallSettings.Builder<GetBookRequest, Operation> getBigBookSettings() {
+      return getStubSettingsBuilder().getBigBookSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBigBook.
+     */
+    @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+    public OperationCallSettings.Builder<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationSettings() {
+      return getStubSettingsBuilder().getBigBookOperationSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBigNothing.
+     */
+    public UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings() {
+      return getStubSettingsBuilder().getBigNothingSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBigNothing.
+     */
+    @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+    public OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings() {
+      return getStubSettingsBuilder().getBigNothingOperationSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to testOptionalRequiredFlatteningParams.
+     */
+    public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
+      return getStubSettingsBuilder().testOptionalRequiredFlatteningParamsSettings();
+    }
+
+    @Override
+    public LibrarySettings build() throws IOException {
+      return new LibrarySettings(this);
+    }
+  }
+}
+============== file: src/main/java/com/google/example/library/v1/package-info.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A client to Google Example Library API.
+ *
+ * The interfaces provided are listed below, along with usage samples.
+ *
+ * =============
+ * LibraryClient
+ * =============
+ *
+ * Service Description: This API represents a simple digital library.  It lets you manage Shelf
+ * resources and Book resources in the library. It defines the following
+ * resource model:
+ *
+ * - The API has a collection of [Shelf][google.example.library.v1.Shelf]
+ *   resources, named ``bookShelves/&#42;``
+ *
+ * - Each Shelf has a collection of [Book][google.example.library.v1.Book]
+ *   resources, named `bookShelves/&#42;/books/&#42;`
+ *
+ * Check out [cloud docs!](/library/example/link).
+ * This is [not a cloud link](http://www.google.com).
+ *
+ * Service comment may include special characters: &lt;&gt;&amp;"`'{@literal @}.
+ *
+ * Also see this awesome doc there! and there! and everywhere!
+ *
+ * Sample for LibraryClient:
+ * <pre>
+ * <code>
+ * try (LibraryClient libraryClient = LibraryClient.create()) {
+ *   Shelf shelf = Shelf.newBuilder().build();
+ *   Shelf response = libraryClient.createShelf(shelf);
+ * }
+ * </code>
+ * </pre>
+ *
+ */
+
+package com.google.example.library.v1;
+============== file: src/main/java/com/google/example/library/v1/stub/GrpcLibraryServiceCallableFactory.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1.stub;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.core.BackgroundResourceAggregation;
+import com.google.api.gax.grpc.GrpcCallSettings;
+import com.google.api.gax.grpc.GrpcCallableFactory;
+import com.google.api.gax.grpc.GrpcStubCallableFactory;
+import com.google.api.gax.grpc.OperationFuture;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.rpc.BatchingCallSettings;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.RequestParamsExtractor;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StreamingCallSettings;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.resourcenames.ResourceName;
+import com.google.common.collect.ImmutableMap;
+import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchivedBookName;
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookFromArchive;
+import com.google.example.library.v1.BookName;
+import com.google.example.library.v1.Comment;
+import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateShelfRequest;
+import com.google.example.library.v1.DeleteBookRequest;
+import com.google.example.library.v1.DeleteShelfRequest;
+import com.google.example.library.v1.DiscussBookRequest;
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.FindRelatedBooksResponse;
+import com.google.example.library.v1.GetBigBookMetadata;
+import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+import com.google.example.library.v1.GetBookFromAnywhereRequest;
+import com.google.example.library.v1.GetBookFromArchiveRequest;
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.GetShelfRequest;
+import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListStringsPagedResponse;
+import com.google.example.library.v1.LibrarySettings;
+import com.google.example.library.v1.ListBooksRequest;
+import com.google.example.library.v1.ListBooksResponse;
+import com.google.example.library.v1.ListShelvesRequest;
+import com.google.example.library.v1.ListShelvesResponse;
+import com.google.example.library.v1.ListStringsRequest;
+import com.google.example.library.v1.ListStringsResponse;
+import com.google.example.library.v1.MergeShelvesRequest;
+import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+import com.google.example.library.v1.SomeMessage;
+import com.google.example.library.v1.StreamBooksRequest;
+import com.google.example.library.v1.StreamShelvesRequest;
+import com.google.example.library.v1.StreamShelvesResponse;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
+import com.google.example.library.v1.UpdateBookIndexRequest;
+import com.google.example.library.v1.UpdateBookRequest;
+import com.google.longrunning.Operation;
+import com.google.longrunning.stub.GrpcOperationsStub;
+import com.google.longrunning.stub.OperationsStub;
+import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Empty;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
+import com.google.tagger.v1.TaggerProto.AddLabelRequest;
+import com.google.tagger.v1.TaggerProto.AddLabelResponse;
+import com.google.tagger.v1.TaggerProto.AddTagRequest;
+import com.google.tagger.v1.TaggerProto.AddTagResponse;
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.ProtoUtils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * gRPC callable factory implementation for Google Example Library API.
+ *
+ * <p>This class is for advanced usage.
+ */
+@Generated("by gapic-generator")
+@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+public class GrpcLibraryServiceCallableFactory implements GrpcStubCallableFactory {
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      UnaryCallSettings<RequestT, ResponseT> callSettings, ClientContext clientContext) {
+    return GrpcCallableFactory.createUnaryCallable(grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT, PagedListResponseT> UnaryCallable<RequestT, PagedListResponseT> createPagedCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      PagedCallSettings<RequestT, ResponseT, PagedListResponseT> pagedCallSettings,
+      ClientContext clientContext) {
+    return GrpcCallableFactory.createPagedCallable(grpcCallSettings, pagedCallSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      BatchingCallSettings<RequestT, ResponseT> batchingCallSettings, ClientContext clientContext) {
+    return GrpcCallableFactory.createBatchingCallable(grpcCallSettings, batchingCallSettings, clientContext);
+  }
+
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  @Override
+  public <RequestT, ResponseT, MetadataT> OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+      GrpcCallSettings<RequestT, com.google.longrunning.Operation> grpcCallSettings,
+      OperationCallSettings<RequestT, ResponseT, MetadataT> operationCallSettings,
+      ClientContext clientContext, OperationsStub operationsStub) {
+    return GrpcCallableFactory.createOperationCallable(grpcCallSettings, operationCallSettings, clientContext, operationsStub);
+  }
+
+  @Override
+  public <RequestT, ResponseT> BidiStreamingCallable<RequestT, ResponseT> createBidiStreamingCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
+      ClientContext clientContext) {
+    return GrpcCallableFactory.createBidiStreamingCallable(grpcCallSettings, streamingCallSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT> ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      ServerStreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
+      ClientContext clientContext) {
+    return GrpcCallableFactory.createServerStreamingCallable(grpcCallSettings, streamingCallSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT> ClientStreamingCallable<RequestT, ResponseT> createClientStreamingCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      StreamingCallSettings<RequestT, ResponseT> streamingCallSettings,
+      ClientContext clientContext) {
+    return GrpcCallableFactory.createClientStreamingCallable(grpcCallSettings, streamingCallSettings, clientContext);
+  }
+}
+============== file: src/main/java/com/google/example/library/v1/stub/GrpcLibraryServiceStub.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1.stub;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.core.BackgroundResourceAggregation;
+import com.google.api.gax.grpc.GrpcCallSettings;
+import com.google.api.gax.grpc.GrpcCallableFactory;
+import com.google.api.gax.grpc.GrpcStubCallableFactory;
+import com.google.api.gax.grpc.OperationFuture;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.RequestParamsExtractor;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.resourcenames.ResourceName;
+import com.google.common.collect.ImmutableMap;
+import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchivedBookName;
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookFromArchive;
+import com.google.example.library.v1.BookName;
+import com.google.example.library.v1.Comment;
+import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateShelfRequest;
+import com.google.example.library.v1.DeleteBookRequest;
+import com.google.example.library.v1.DeleteShelfRequest;
+import com.google.example.library.v1.DiscussBookRequest;
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.FindRelatedBooksResponse;
+import com.google.example.library.v1.GetBigBookMetadata;
+import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+import com.google.example.library.v1.GetBookFromAnywhereRequest;
+import com.google.example.library.v1.GetBookFromArchiveRequest;
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.GetShelfRequest;
+import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListStringsPagedResponse;
+import com.google.example.library.v1.LibrarySettings;
+import com.google.example.library.v1.ListBooksRequest;
+import com.google.example.library.v1.ListBooksResponse;
+import com.google.example.library.v1.ListShelvesRequest;
+import com.google.example.library.v1.ListShelvesResponse;
+import com.google.example.library.v1.ListStringsRequest;
+import com.google.example.library.v1.ListStringsResponse;
+import com.google.example.library.v1.MergeShelvesRequest;
+import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+import com.google.example.library.v1.SomeMessage;
+import com.google.example.library.v1.StreamBooksRequest;
+import com.google.example.library.v1.StreamShelvesRequest;
+import com.google.example.library.v1.StreamShelvesResponse;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
+import com.google.example.library.v1.UpdateBookIndexRequest;
+import com.google.example.library.v1.UpdateBookRequest;
+import com.google.longrunning.Operation;
+import com.google.longrunning.stub.GrpcOperationsStub;
+import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Empty;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
+import com.google.tagger.v1.TaggerProto.AddLabelRequest;
+import com.google.tagger.v1.TaggerProto.AddLabelResponse;
+import com.google.tagger.v1.TaggerProto.AddTagRequest;
+import com.google.tagger.v1.TaggerProto.AddTagResponse;
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.ProtoUtils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * gRPC stub implementation for Google Example Library API.
+ *
+ * <p>This class is for advanced usage and reflects the underlying API directly.
+ */
+@Generated("by gapic-generator")
+@BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+public class GrpcLibraryServiceStub extends LibraryServiceStub {
+
+  private static final MethodDescriptor<CreateShelfRequest, Shelf> createShelfMethodDescriptor =
+      MethodDescriptor.<CreateShelfRequest, Shelf>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/CreateShelf")
+          .setRequestMarshaller(ProtoUtils.marshaller(CreateShelfRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Shelf.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<GetShelfRequest, Shelf> getShelfMethodDescriptor =
+      MethodDescriptor.<GetShelfRequest, Shelf>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/GetShelf")
+          .setRequestMarshaller(ProtoUtils.marshaller(GetShelfRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Shelf.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ListShelvesRequest, ListShelvesResponse> listShelvesMethodDescriptor =
+      MethodDescriptor.<ListShelvesRequest, ListShelvesResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/ListShelves")
+          .setRequestMarshaller(ProtoUtils.marshaller(ListShelvesRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ListShelvesResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<DeleteShelfRequest, Empty> deleteShelfMethodDescriptor =
+      MethodDescriptor.<DeleteShelfRequest, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/DeleteShelf")
+          .setRequestMarshaller(ProtoUtils.marshaller(DeleteShelfRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<MergeShelvesRequest, Shelf> mergeShelvesMethodDescriptor =
+      MethodDescriptor.<MergeShelvesRequest, Shelf>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/MergeShelves")
+          .setRequestMarshaller(ProtoUtils.marshaller(MergeShelvesRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Shelf.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<CreateBookRequest, Book> createBookMethodDescriptor =
+      MethodDescriptor.<CreateBookRequest, Book>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/CreateBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(CreateBookRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Book.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<PublishSeriesRequest, PublishSeriesResponse> publishSeriesMethodDescriptor =
+      MethodDescriptor.<PublishSeriesRequest, PublishSeriesResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/PublishSeries")
+          .setRequestMarshaller(ProtoUtils.marshaller(PublishSeriesRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(PublishSeriesResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<GetBookRequest, Book> getBookMethodDescriptor =
+      MethodDescriptor.<GetBookRequest, Book>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/GetBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(GetBookRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Book.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ListBooksRequest, ListBooksResponse> listBooksMethodDescriptor =
+      MethodDescriptor.<ListBooksRequest, ListBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/ListBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ListBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ListBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<DeleteBookRequest, Empty> deleteBookMethodDescriptor =
+      MethodDescriptor.<DeleteBookRequest, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/DeleteBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(DeleteBookRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<UpdateBookRequest, Book> updateBookMethodDescriptor =
+      MethodDescriptor.<UpdateBookRequest, Book>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/UpdateBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(UpdateBookRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Book.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<MoveBookRequest, Book> moveBookMethodDescriptor =
+      MethodDescriptor.<MoveBookRequest, Book>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/MoveBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(MoveBookRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Book.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ListStringsRequest, ListStringsResponse> listStringsMethodDescriptor =
+      MethodDescriptor.<ListStringsRequest, ListStringsResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/ListStrings")
+          .setRequestMarshaller(ProtoUtils.marshaller(ListStringsRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ListStringsResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<AddCommentsRequest, Empty> addCommentsMethodDescriptor =
+      MethodDescriptor.<AddCommentsRequest, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/AddComments")
+          .setRequestMarshaller(ProtoUtils.marshaller(AddCommentsRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveMethodDescriptor =
+      MethodDescriptor.<GetBookFromArchiveRequest, BookFromArchive>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/GetBookFromArchive")
+          .setRequestMarshaller(ProtoUtils.marshaller(GetBookFromArchiveRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(BookFromArchive.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereMethodDescriptor =
+      MethodDescriptor.<GetBookFromAnywhereRequest, BookFromAnywhere>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/GetBookFromAnywhere")
+          .setRequestMarshaller(ProtoUtils.marshaller(GetBookFromAnywhereRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(BookFromAnywhere.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereMethodDescriptor =
+      MethodDescriptor.<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/GetBookFromAbsolutelyAnywhere")
+          .setRequestMarshaller(ProtoUtils.marshaller(GetBookFromAbsolutelyAnywhereRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(BookFromAnywhere.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<UpdateBookIndexRequest, Empty> updateBookIndexMethodDescriptor =
+      MethodDescriptor.<UpdateBookIndexRequest, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/UpdateBookIndex")
+          .setRequestMarshaller(ProtoUtils.marshaller(UpdateBookIndexRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<StreamShelvesRequest, StreamShelvesResponse> streamShelvesMethodDescriptor =
+      MethodDescriptor.<StreamShelvesRequest, StreamShelvesResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
+          .setFullMethodName("google.example.library.v1.LibraryService/StreamShelves")
+          .setRequestMarshaller(ProtoUtils.marshaller(StreamShelvesRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(StreamShelvesResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<StreamBooksRequest, Book> streamBooksMethodDescriptor =
+      MethodDescriptor.<StreamBooksRequest, Book>newBuilder()
+          .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
+          .setFullMethodName("google.example.library.v1.LibraryService/StreamBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(StreamBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Book.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<DiscussBookRequest, Comment> discussBookMethodDescriptor =
+      MethodDescriptor.<DiscussBookRequest, Comment>newBuilder()
+          .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+          .setFullMethodName("google.example.library.v1.LibraryService/DiscussBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(DiscussBookRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Comment.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<DiscussBookRequest, Comment> monologAboutBookMethodDescriptor =
+      MethodDescriptor.<DiscussBookRequest, Comment>newBuilder()
+          .setType(MethodDescriptor.MethodType.CLIENT_STREAMING)
+          .setFullMethodName("google.example.library.v1.LibraryService/MonologAboutBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(DiscussBookRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Comment.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<FindRelatedBooksRequest, FindRelatedBooksResponse> findRelatedBooksMethodDescriptor =
+      MethodDescriptor.<FindRelatedBooksRequest, FindRelatedBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/FindRelatedBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(FindRelatedBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(FindRelatedBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<AddTagRequest, AddTagResponse> addTagMethodDescriptor =
+      MethodDescriptor.<AddTagRequest, AddTagResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/AddTag")
+          .setRequestMarshaller(ProtoUtils.marshaller(AddTagRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(AddTagResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<AddLabelRequest, AddLabelResponse> addLabelMethodDescriptor =
+      MethodDescriptor.<AddLabelRequest, AddLabelResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.tagger.v1.Labeler/AddLabel")
+          .setRequestMarshaller(ProtoUtils.marshaller(AddLabelRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(AddLabelResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<GetBookRequest, Operation> getBigBookMethodDescriptor =
+      MethodDescriptor.<GetBookRequest, Operation>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/GetBigBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(GetBookRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<GetBookRequest, Operation> getBigNothingMethodDescriptor =
+      MethodDescriptor.<GetBookRequest, Operation>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/GetBigNothing")
+          .setRequestMarshaller(ProtoUtils.marshaller(GetBookRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsMethodDescriptor =
+      MethodDescriptor.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/TestOptionalRequiredFlatteningParams")
+          .setRequestMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsResponse.getDefaultInstance()))
+          .build();
+
+
+  private final BackgroundResource backgroundResources;
+  private final GrpcOperationsStub operationsStub;
+
+  private final UnaryCallable<CreateShelfRequest, Shelf> createShelfCallable;
+  private final UnaryCallable<GetShelfRequest, Shelf> getShelfCallable;
+  private final UnaryCallable<ListShelvesRequest, ListShelvesResponse> listShelvesCallable;
+  private final UnaryCallable<ListShelvesRequest, ListShelvesPagedResponse> listShelvesPagedCallable;
+  private final UnaryCallable<DeleteShelfRequest, Empty> deleteShelfCallable;
+  private final UnaryCallable<MergeShelvesRequest, Shelf> mergeShelvesCallable;
+  private final UnaryCallable<CreateBookRequest, Book> createBookCallable;
+  private final UnaryCallable<PublishSeriesRequest, PublishSeriesResponse> publishSeriesCallable;
+  private final UnaryCallable<GetBookRequest, Book> getBookCallable;
+  private final UnaryCallable<ListBooksRequest, ListBooksResponse> listBooksCallable;
+  private final UnaryCallable<ListBooksRequest, ListBooksPagedResponse> listBooksPagedCallable;
+  private final UnaryCallable<DeleteBookRequest, Empty> deleteBookCallable;
+  private final UnaryCallable<UpdateBookRequest, Book> updateBookCallable;
+  private final UnaryCallable<MoveBookRequest, Book> moveBookCallable;
+  private final UnaryCallable<ListStringsRequest, ListStringsResponse> listStringsCallable;
+  private final UnaryCallable<ListStringsRequest, ListStringsPagedResponse> listStringsPagedCallable;
+  private final UnaryCallable<AddCommentsRequest, Empty> addCommentsCallable;
+  private final UnaryCallable<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveCallable;
+  private final UnaryCallable<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereCallable;
+  private final UnaryCallable<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereCallable;
+  private final UnaryCallable<UpdateBookIndexRequest, Empty> updateBookIndexCallable;
+  private final ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable;
+  private final ServerStreamingCallable<StreamBooksRequest, Book> streamBooksCallable;
+  private final BidiStreamingCallable<DiscussBookRequest, Comment> discussBookCallable;
+  private final ClientStreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable;
+  private final UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> findRelatedBooksCallable;
+  private final UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksPagedResponse> findRelatedBooksPagedCallable;
+  private final UnaryCallable<AddTagRequest, AddTagResponse> addTagCallable;
+  private final UnaryCallable<AddLabelRequest, AddLabelResponse> addLabelCallable;
+  private final UnaryCallable<GetBookRequest, Operation> getBigBookCallable;
+  private final OperationCallable<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationCallable;
+  private final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable;
+  private final OperationCallable<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationCallable;
+  private final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable;
+
+  private final GrpcStubCallableFactory callableFactory;
+
+  public static final GrpcLibraryServiceStub create(LibraryServiceStubSettings settings) throws IOException {
+    return new GrpcLibraryServiceStub(settings, ClientContext.create(settings));
+  }
+
+  public static final GrpcLibraryServiceStub create(ClientContext clientContext) throws IOException {
+    return new GrpcLibraryServiceStub(LibraryServiceStubSettings.newBuilder().build(), clientContext);
+  }
+
+  public static final GrpcLibraryServiceStub create(ClientContext clientContext, GrpcStubCallableFactory callableFactory) throws IOException {
+    return new GrpcLibraryServiceStub(LibraryServiceStubSettings.newBuilder().build(), clientContext, callableFactory);
+  }
+
+  /**
+   * Constructs an instance of GrpcLibraryServiceStub, using the given settings.
+   * This is protected so that it is easy to make a subclass, but otherwise, the static
+   * factory methods should be preferred.
+   */
+  protected GrpcLibraryServiceStub(LibraryServiceStubSettings settings, ClientContext clientContext) throws IOException {
+    this(settings, clientContext, new GrpcLibraryServiceCallableFactory());
+  }
+
+  /**
+   * Constructs an instance of GrpcLibraryServiceStub, using the given settings.
+   * This is protected so that it is easy to make a subclass, but otherwise, the static
+   * factory methods should be preferred.
+   */
+  protected GrpcLibraryServiceStub(LibraryServiceStubSettings settings, ClientContext clientContext, GrpcStubCallableFactory callableFactory) throws IOException {
+    this.callableFactory = callableFactory;
+    this.operationsStub = GrpcOperationsStub.create(clientContext, callableFactory);
+
+    GrpcCallSettings<CreateShelfRequest, Shelf> createShelfTransportSettings =
+        GrpcCallSettings.<CreateShelfRequest, Shelf>newBuilder()
+            .setMethodDescriptor(createShelfMethodDescriptor)
+            .build();
+    GrpcCallSettings<GetShelfRequest, Shelf> getShelfTransportSettings =
+        GrpcCallSettings.<GetShelfRequest, Shelf>newBuilder()
+            .setMethodDescriptor(getShelfMethodDescriptor)
+            .build();
+    GrpcCallSettings<ListShelvesRequest, ListShelvesResponse> listShelvesTransportSettings =
+        GrpcCallSettings.<ListShelvesRequest, ListShelvesResponse>newBuilder()
+            .setMethodDescriptor(listShelvesMethodDescriptor)
+            .build();
+    GrpcCallSettings<DeleteShelfRequest, Empty> deleteShelfTransportSettings =
+        GrpcCallSettings.<DeleteShelfRequest, Empty>newBuilder()
+            .setMethodDescriptor(deleteShelfMethodDescriptor)
+            .build();
+    GrpcCallSettings<MergeShelvesRequest, Shelf> mergeShelvesTransportSettings =
+        GrpcCallSettings.<MergeShelvesRequest, Shelf>newBuilder()
+            .setMethodDescriptor(mergeShelvesMethodDescriptor)
+            .build();
+    GrpcCallSettings<CreateBookRequest, Book> createBookTransportSettings =
+        GrpcCallSettings.<CreateBookRequest, Book>newBuilder()
+            .setMethodDescriptor(createBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<CreateBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(CreateBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    params.put("book.read", String.valueOf(request.getBook().getRead()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesTransportSettings =
+        GrpcCallSettings.<PublishSeriesRequest, PublishSeriesResponse>newBuilder()
+            .setMethodDescriptor(publishSeriesMethodDescriptor)
+            .build();
+    GrpcCallSettings<GetBookRequest, Book> getBookTransportSettings =
+        GrpcCallSettings.<GetBookRequest, Book>newBuilder()
+            .setMethodDescriptor(getBookMethodDescriptor)
+            .build();
+    GrpcCallSettings<ListBooksRequest, ListBooksResponse> listBooksTransportSettings =
+        GrpcCallSettings.<ListBooksRequest, ListBooksResponse>newBuilder()
+            .setMethodDescriptor(listBooksMethodDescriptor)
+            .build();
+    GrpcCallSettings<DeleteBookRequest, Empty> deleteBookTransportSettings =
+        GrpcCallSettings.<DeleteBookRequest, Empty>newBuilder()
+            .setMethodDescriptor(deleteBookMethodDescriptor)
+            .build();
+    GrpcCallSettings<UpdateBookRequest, Book> updateBookTransportSettings =
+        GrpcCallSettings.<UpdateBookRequest, Book>newBuilder()
+            .setMethodDescriptor(updateBookMethodDescriptor)
+            .build();
+    GrpcCallSettings<MoveBookRequest, Book> moveBookTransportSettings =
+        GrpcCallSettings.<MoveBookRequest, Book>newBuilder()
+            .setMethodDescriptor(moveBookMethodDescriptor)
+            .build();
+    GrpcCallSettings<ListStringsRequest, ListStringsResponse> listStringsTransportSettings =
+        GrpcCallSettings.<ListStringsRequest, ListStringsResponse>newBuilder()
+            .setMethodDescriptor(listStringsMethodDescriptor)
+            .build();
+    GrpcCallSettings<AddCommentsRequest, Empty> addCommentsTransportSettings =
+        GrpcCallSettings.<AddCommentsRequest, Empty>newBuilder()
+            .setMethodDescriptor(addCommentsMethodDescriptor)
+            .build();
+    GrpcCallSettings<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveTransportSettings =
+        GrpcCallSettings.<GetBookFromArchiveRequest, BookFromArchive>newBuilder()
+            .setMethodDescriptor(getBookFromArchiveMethodDescriptor)
+            .build();
+    GrpcCallSettings<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereTransportSettings =
+        GrpcCallSettings.<GetBookFromAnywhereRequest, BookFromAnywhere>newBuilder()
+            .setMethodDescriptor(getBookFromAnywhereMethodDescriptor)
+            .build();
+    GrpcCallSettings<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereTransportSettings =
+        GrpcCallSettings.<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere>newBuilder()
+            .setMethodDescriptor(getBookFromAbsolutelyAnywhereMethodDescriptor)
+            .build();
+    GrpcCallSettings<UpdateBookIndexRequest, Empty> updateBookIndexTransportSettings =
+        GrpcCallSettings.<UpdateBookIndexRequest, Empty>newBuilder()
+            .setMethodDescriptor(updateBookIndexMethodDescriptor)
+            .build();
+    GrpcCallSettings<StreamShelvesRequest, StreamShelvesResponse> streamShelvesTransportSettings =
+        GrpcCallSettings.<StreamShelvesRequest, StreamShelvesResponse>newBuilder()
+            .setMethodDescriptor(streamShelvesMethodDescriptor)
+            .build();
+    GrpcCallSettings<StreamBooksRequest, Book> streamBooksTransportSettings =
+        GrpcCallSettings.<StreamBooksRequest, Book>newBuilder()
+            .setMethodDescriptor(streamBooksMethodDescriptor)
+            .build();
+    GrpcCallSettings<DiscussBookRequest, Comment> discussBookTransportSettings =
+        GrpcCallSettings.<DiscussBookRequest, Comment>newBuilder()
+            .setMethodDescriptor(discussBookMethodDescriptor)
+            .build();
+    GrpcCallSettings<DiscussBookRequest, Comment> monologAboutBookTransportSettings =
+        GrpcCallSettings.<DiscussBookRequest, Comment>newBuilder()
+            .setMethodDescriptor(monologAboutBookMethodDescriptor)
+            .build();
+    GrpcCallSettings<FindRelatedBooksRequest, FindRelatedBooksResponse> findRelatedBooksTransportSettings =
+        GrpcCallSettings.<FindRelatedBooksRequest, FindRelatedBooksResponse>newBuilder()
+            .setMethodDescriptor(findRelatedBooksMethodDescriptor)
+            .build();
+    GrpcCallSettings<AddTagRequest, AddTagResponse> addTagTransportSettings =
+        GrpcCallSettings.<AddTagRequest, AddTagResponse>newBuilder()
+            .setMethodDescriptor(addTagMethodDescriptor)
+            .build();
+    GrpcCallSettings<AddLabelRequest, AddLabelResponse> addLabelTransportSettings =
+        GrpcCallSettings.<AddLabelRequest, AddLabelResponse>newBuilder()
+            .setMethodDescriptor(addLabelMethodDescriptor)
+            .build();
+    GrpcCallSettings<GetBookRequest, Operation> getBigBookTransportSettings =
+        GrpcCallSettings.<GetBookRequest, Operation>newBuilder()
+            .setMethodDescriptor(getBigBookMethodDescriptor)
+            .build();
+    GrpcCallSettings<GetBookRequest, Operation> getBigNothingTransportSettings =
+        GrpcCallSettings.<GetBookRequest, Operation>newBuilder()
+            .setMethodDescriptor(getBigNothingMethodDescriptor)
+            .build();
+    GrpcCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsTransportSettings =
+        GrpcCallSettings.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
+            .setMethodDescriptor(testOptionalRequiredFlatteningParamsMethodDescriptor)
+            .build();
+
+    this.createShelfCallable = callableFactory.createUnaryCallable(createShelfTransportSettings,settings.createShelfSettings(), clientContext);
+    this.getShelfCallable = callableFactory.createUnaryCallable(getShelfTransportSettings,settings.getShelfSettings(), clientContext);
+    this.listShelvesCallable = callableFactory.createUnaryCallable(listShelvesTransportSettings,settings.listShelvesSettings(), clientContext);
+    this.listShelvesPagedCallable = callableFactory.createPagedCallable(listShelvesTransportSettings,settings.listShelvesSettings(), clientContext);
+    this.deleteShelfCallable = callableFactory.createUnaryCallable(deleteShelfTransportSettings,settings.deleteShelfSettings(), clientContext);
+    this.mergeShelvesCallable = callableFactory.createUnaryCallable(mergeShelvesTransportSettings,settings.mergeShelvesSettings(), clientContext);
+    this.createBookCallable = callableFactory.createUnaryCallable(createBookTransportSettings,settings.createBookSettings(), clientContext);
+    this.publishSeriesCallable = callableFactory.createBatchingCallable(publishSeriesTransportSettings,settings.publishSeriesSettings(), clientContext);
+    this.getBookCallable = callableFactory.createUnaryCallable(getBookTransportSettings,settings.getBookSettings(), clientContext);
+    this.listBooksCallable = callableFactory.createUnaryCallable(listBooksTransportSettings,settings.listBooksSettings(), clientContext);
+    this.listBooksPagedCallable = callableFactory.createPagedCallable(listBooksTransportSettings,settings.listBooksSettings(), clientContext);
+    this.deleteBookCallable = callableFactory.createUnaryCallable(deleteBookTransportSettings,settings.deleteBookSettings(), clientContext);
+    this.updateBookCallable = callableFactory.createUnaryCallable(updateBookTransportSettings,settings.updateBookSettings(), clientContext);
+    this.moveBookCallable = callableFactory.createUnaryCallable(moveBookTransportSettings,settings.moveBookSettings(), clientContext);
+    this.listStringsCallable = callableFactory.createUnaryCallable(listStringsTransportSettings,settings.listStringsSettings(), clientContext);
+    this.listStringsPagedCallable = callableFactory.createPagedCallable(listStringsTransportSettings,settings.listStringsSettings(), clientContext);
+    this.addCommentsCallable = callableFactory.createBatchingCallable(addCommentsTransportSettings,settings.addCommentsSettings(), clientContext);
+    this.getBookFromArchiveCallable = callableFactory.createUnaryCallable(getBookFromArchiveTransportSettings,settings.getBookFromArchiveSettings(), clientContext);
+    this.getBookFromAnywhereCallable = callableFactory.createUnaryCallable(getBookFromAnywhereTransportSettings,settings.getBookFromAnywhereSettings(), clientContext);
+    this.getBookFromAbsolutelyAnywhereCallable = callableFactory.createUnaryCallable(getBookFromAbsolutelyAnywhereTransportSettings,settings.getBookFromAbsolutelyAnywhereSettings(), clientContext);
+    this.updateBookIndexCallable = callableFactory.createUnaryCallable(updateBookIndexTransportSettings,settings.updateBookIndexSettings(), clientContext);
+    this.streamShelvesCallable = callableFactory.createServerStreamingCallable(streamShelvesTransportSettings,settings.streamShelvesSettings(), clientContext);
+    this.streamBooksCallable = callableFactory.createServerStreamingCallable(streamBooksTransportSettings,settings.streamBooksSettings(), clientContext);
+    this.discussBookCallable = callableFactory.createBidiStreamingCallable(discussBookTransportSettings,settings.discussBookSettings(), clientContext);
+    this.monologAboutBookCallable = callableFactory.createClientStreamingCallable(monologAboutBookTransportSettings,settings.monologAboutBookSettings(), clientContext);
+    this.findRelatedBooksCallable = callableFactory.createUnaryCallable(findRelatedBooksTransportSettings,settings.findRelatedBooksSettings(), clientContext);
+    this.findRelatedBooksPagedCallable = callableFactory.createPagedCallable(findRelatedBooksTransportSettings,settings.findRelatedBooksSettings(), clientContext);
+    this.addTagCallable = callableFactory.createUnaryCallable(addTagTransportSettings,settings.addTagSettings(), clientContext);
+    this.addLabelCallable = callableFactory.createUnaryCallable(addLabelTransportSettings,settings.addLabelSettings(), clientContext);
+    this.getBigBookCallable = callableFactory.createUnaryCallable(getBigBookTransportSettings,settings.getBigBookSettings(), clientContext);
+    this.getBigBookOperationCallable = callableFactory.createOperationCallable(
+        getBigBookTransportSettings,settings.getBigBookOperationSettings(), clientContext, this.operationsStub);
+    this.getBigNothingCallable = callableFactory.createUnaryCallable(getBigNothingTransportSettings,settings.getBigNothingSettings(), clientContext);
+    this.getBigNothingOperationCallable = callableFactory.createOperationCallable(
+        getBigNothingTransportSettings,settings.getBigNothingOperationSettings(), clientContext, this.operationsStub);
+    this.testOptionalRequiredFlatteningParamsCallable = callableFactory.createUnaryCallable(testOptionalRequiredFlatteningParamsTransportSettings,settings.testOptionalRequiredFlatteningParamsSettings(), clientContext);
+
+    backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
+  }
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public GrpcOperationsStub getOperationsStub() {
+    return operationsStub;
+  }
+  public UnaryCallable<CreateShelfRequest, Shelf> createShelfCallable() {
+    return createShelfCallable;
+  }
+
+  public UnaryCallable<GetShelfRequest, Shelf> getShelfCallable() {
+    return getShelfCallable;
+  }
+
+  public UnaryCallable<ListShelvesRequest, ListShelvesPagedResponse> listShelvesPagedCallable() {
+    return listShelvesPagedCallable;
+  }
+
+  public UnaryCallable<ListShelvesRequest, ListShelvesResponse> listShelvesCallable() {
+    return listShelvesCallable;
+  }
+
+  public UnaryCallable<DeleteShelfRequest, Empty> deleteShelfCallable() {
+    return deleteShelfCallable;
+  }
+
+  public UnaryCallable<MergeShelvesRequest, Shelf> mergeShelvesCallable() {
+    return mergeShelvesCallable;
+  }
+
+  public UnaryCallable<CreateBookRequest, Book> createBookCallable() {
+    return createBookCallable;
+  }
+
+  public UnaryCallable<PublishSeriesRequest, PublishSeriesResponse> publishSeriesCallable() {
+    return publishSeriesCallable;
+  }
+
+  public UnaryCallable<GetBookRequest, Book> getBookCallable() {
+    return getBookCallable;
+  }
+
+  public UnaryCallable<ListBooksRequest, ListBooksPagedResponse> listBooksPagedCallable() {
+    return listBooksPagedCallable;
+  }
+
+  public UnaryCallable<ListBooksRequest, ListBooksResponse> listBooksCallable() {
+    return listBooksCallable;
+  }
+
+  public UnaryCallable<DeleteBookRequest, Empty> deleteBookCallable() {
+    return deleteBookCallable;
+  }
+
+  public UnaryCallable<UpdateBookRequest, Book> updateBookCallable() {
+    return updateBookCallable;
+  }
+
+  public UnaryCallable<MoveBookRequest, Book> moveBookCallable() {
+    return moveBookCallable;
+  }
+
+  public UnaryCallable<ListStringsRequest, ListStringsPagedResponse> listStringsPagedCallable() {
+    return listStringsPagedCallable;
+  }
+
+  public UnaryCallable<ListStringsRequest, ListStringsResponse> listStringsCallable() {
+    return listStringsCallable;
+  }
+
+  public UnaryCallable<AddCommentsRequest, Empty> addCommentsCallable() {
+    return addCommentsCallable;
+  }
+
+  public UnaryCallable<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveCallable() {
+    return getBookFromArchiveCallable;
+  }
+
+  public UnaryCallable<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereCallable() {
+    return getBookFromAnywhereCallable;
+  }
+
+  public UnaryCallable<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereCallable() {
+    return getBookFromAbsolutelyAnywhereCallable;
+  }
+
+  public UnaryCallable<UpdateBookIndexRequest, Empty> updateBookIndexCallable() {
+    return updateBookIndexCallable;
+  }
+
+  public ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable() {
+    return streamShelvesCallable;
+  }
+
+  public ServerStreamingCallable<StreamBooksRequest, Book> streamBooksCallable() {
+    return streamBooksCallable;
+  }
+
+  public BidiStreamingCallable<DiscussBookRequest, Comment> discussBookCallable() {
+    return discussBookCallable;
+  }
+
+  public ClientStreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable() {
+    return monologAboutBookCallable;
+  }
+
+  public UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksPagedResponse> findRelatedBooksPagedCallable() {
+    return findRelatedBooksPagedCallable;
+  }
+
+  public UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> findRelatedBooksCallable() {
+    return findRelatedBooksCallable;
+  }
+
+  public UnaryCallable<AddTagRequest, AddTagResponse> addTagCallable() {
+    return addTagCallable;
+  }
+
+  @Deprecated
+  public UnaryCallable<AddLabelRequest, AddLabelResponse> addLabelCallable() {
+    return addLabelCallable;
+  }
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallable<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationCallable() {
+    return getBigBookOperationCallable;
+  }
+
+  public UnaryCallable<GetBookRequest, Operation> getBigBookCallable() {
+    return getBigBookCallable;
+  }
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallable<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationCallable() {
+    return getBigNothingOperationCallable;
+  }
+
+  public UnaryCallable<GetBookRequest, Operation> getBigNothingCallable() {
+    return getBigNothingCallable;
+  }
+
+  public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
+    return testOptionalRequiredFlatteningParamsCallable;
+  }
+
+  @Override
+  public final void close() {
+    shutdown();
+  }
+
+  @Override
+  public void shutdown() {
+    backgroundResources.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return backgroundResources.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return backgroundResources.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    backgroundResources.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return backgroundResources.awaitTermination(duration, unit);
+  }
+
+}
+============== file: src/main/java/com/google/example/library/v1/stub/LibraryServiceStub.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1.stub;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.grpc.OperationFuture;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.resourcenames.ResourceName;
+import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchivedBookName;
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookFromArchive;
+import com.google.example.library.v1.BookName;
+import com.google.example.library.v1.Comment;
+import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateShelfRequest;
+import com.google.example.library.v1.DeleteBookRequest;
+import com.google.example.library.v1.DeleteShelfRequest;
+import com.google.example.library.v1.DiscussBookRequest;
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.FindRelatedBooksResponse;
+import com.google.example.library.v1.GetBigBookMetadata;
+import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+import com.google.example.library.v1.GetBookFromAnywhereRequest;
+import com.google.example.library.v1.GetBookFromArchiveRequest;
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.GetShelfRequest;
+import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListStringsPagedResponse;
+import com.google.example.library.v1.ListBooksRequest;
+import com.google.example.library.v1.ListBooksResponse;
+import com.google.example.library.v1.ListShelvesRequest;
+import com.google.example.library.v1.ListShelvesResponse;
+import com.google.example.library.v1.ListStringsRequest;
+import com.google.example.library.v1.ListStringsResponse;
+import com.google.example.library.v1.MergeShelvesRequest;
+import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+import com.google.example.library.v1.SomeMessage;
+import com.google.example.library.v1.StreamBooksRequest;
+import com.google.example.library.v1.StreamShelvesRequest;
+import com.google.example.library.v1.StreamShelvesResponse;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
+import com.google.example.library.v1.UpdateBookIndexRequest;
+import com.google.example.library.v1.UpdateBookRequest;
+import com.google.longrunning.Operation;
+import com.google.longrunning.stub.OperationsStub;
+import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Empty;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
+import com.google.tagger.v1.TaggerProto.AddLabelRequest;
+import com.google.tagger.v1.TaggerProto.AddLabelResponse;
+import com.google.tagger.v1.TaggerProto.AddTagRequest;
+import com.google.tagger.v1.TaggerProto.AddTagResponse;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Base stub class for Google Example Library API.
+ *
+ * <p>This class is for advanced usage and reflects the underlying API directly.
+ */
+@Generated("by gapic-generator")
+@BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+public abstract class LibraryServiceStub implements BackgroundResource {
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationsStub getOperationsStub() {
+    throw new UnsupportedOperationException("Not implemented: getOperationsStub()");
+  }
+
+  public UnaryCallable<CreateShelfRequest, Shelf> createShelfCallable() {
+    throw new UnsupportedOperationException("Not implemented: createShelfCallable()");
+  }
+
+  public UnaryCallable<GetShelfRequest, Shelf> getShelfCallable() {
+    throw new UnsupportedOperationException("Not implemented: getShelfCallable()");
+  }
+
+  public UnaryCallable<ListShelvesRequest, ListShelvesPagedResponse> listShelvesPagedCallable() {
+    throw new UnsupportedOperationException("Not implemented: listShelvesPagedCallable()");
+  }
+
+  public UnaryCallable<ListShelvesRequest, ListShelvesResponse> listShelvesCallable() {
+    throw new UnsupportedOperationException("Not implemented: listShelvesCallable()");
+  }
+
+  public UnaryCallable<DeleteShelfRequest, Empty> deleteShelfCallable() {
+    throw new UnsupportedOperationException("Not implemented: deleteShelfCallable()");
+  }
+
+  public UnaryCallable<MergeShelvesRequest, Shelf> mergeShelvesCallable() {
+    throw new UnsupportedOperationException("Not implemented: mergeShelvesCallable()");
+  }
+
+  public UnaryCallable<CreateBookRequest, Book> createBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: createBookCallable()");
+  }
+
+  public UnaryCallable<PublishSeriesRequest, PublishSeriesResponse> publishSeriesCallable() {
+    throw new UnsupportedOperationException("Not implemented: publishSeriesCallable()");
+  }
+
+  public UnaryCallable<GetBookRequest, Book> getBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: getBookCallable()");
+  }
+
+  public UnaryCallable<ListBooksRequest, ListBooksPagedResponse> listBooksPagedCallable() {
+    throw new UnsupportedOperationException("Not implemented: listBooksPagedCallable()");
+  }
+
+  public UnaryCallable<ListBooksRequest, ListBooksResponse> listBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: listBooksCallable()");
+  }
+
+  public UnaryCallable<DeleteBookRequest, Empty> deleteBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: deleteBookCallable()");
+  }
+
+  public UnaryCallable<UpdateBookRequest, Book> updateBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: updateBookCallable()");
+  }
+
+  public UnaryCallable<MoveBookRequest, Book> moveBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: moveBookCallable()");
+  }
+
+  public UnaryCallable<ListStringsRequest, ListStringsPagedResponse> listStringsPagedCallable() {
+    throw new UnsupportedOperationException("Not implemented: listStringsPagedCallable()");
+  }
+
+  public UnaryCallable<ListStringsRequest, ListStringsResponse> listStringsCallable() {
+    throw new UnsupportedOperationException("Not implemented: listStringsCallable()");
+  }
+
+  public UnaryCallable<AddCommentsRequest, Empty> addCommentsCallable() {
+    throw new UnsupportedOperationException("Not implemented: addCommentsCallable()");
+  }
+
+  public UnaryCallable<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveCallable() {
+    throw new UnsupportedOperationException("Not implemented: getBookFromArchiveCallable()");
+  }
+
+  public UnaryCallable<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereCallable() {
+    throw new UnsupportedOperationException("Not implemented: getBookFromAnywhereCallable()");
+  }
+
+  public UnaryCallable<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereCallable() {
+    throw new UnsupportedOperationException("Not implemented: getBookFromAbsolutelyAnywhereCallable()");
+  }
+
+  public UnaryCallable<UpdateBookIndexRequest, Empty> updateBookIndexCallable() {
+    throw new UnsupportedOperationException("Not implemented: updateBookIndexCallable()");
+  }
+
+  public ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable() {
+    throw new UnsupportedOperationException("Not implemented: streamShelvesCallable()");
+  }
+
+  public ServerStreamingCallable<StreamBooksRequest, Book> streamBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: streamBooksCallable()");
+  }
+
+  public BidiStreamingCallable<DiscussBookRequest, Comment> discussBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: discussBookCallable()");
+  }
+
+  public ClientStreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: monologAboutBookCallable()");
+  }
+
+  public UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksPagedResponse> findRelatedBooksPagedCallable() {
+    throw new UnsupportedOperationException("Not implemented: findRelatedBooksPagedCallable()");
+  }
+
+  public UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> findRelatedBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: findRelatedBooksCallable()");
+  }
+
+  public UnaryCallable<AddTagRequest, AddTagResponse> addTagCallable() {
+    throw new UnsupportedOperationException("Not implemented: addTagCallable()");
+  }
+
+  @Deprecated
+  public UnaryCallable<AddLabelRequest, AddLabelResponse> addLabelCallable() {
+    throw new UnsupportedOperationException("Not implemented: addLabelCallable()");
+  }
+
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallable<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationCallable() {
+    throw new UnsupportedOperationException("Not implemented: getBigBookOperationCallable()");
+  }
+
+  public UnaryCallable<GetBookRequest, Operation> getBigBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: getBigBookCallable()");
+  }
+
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallable<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationCallable() {
+    throw new UnsupportedOperationException("Not implemented: getBigNothingOperationCallable()");
+  }
+
+  public UnaryCallable<GetBookRequest, Operation> getBigNothingCallable() {
+    throw new UnsupportedOperationException("Not implemented: getBigNothingCallable()");
+  }
+
+  public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
+    throw new UnsupportedOperationException("Not implemented: testOptionalRequiredFlatteningParamsCallable()");
+  }
+
+  @Override
+  public abstract void close();
+}
+============== file: src/main/java/com/google/example/library/v1/stub/LibraryServiceStubSettings.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1.stub;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.api.gax.batching.FlowController;
+import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
+import com.google.api.gax.batching.PartitionKey;
+import com.google.api.gax.batching.RequestBuilder;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.GaxProperties;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.grpc.OperationFuture;
+import com.google.api.gax.grpc.ProtoOperationTransformers;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.BatchedRequestIssuer;
+import com.google.api.gax.rpc.BatchingCallSettings;
+import com.google.api.gax.rpc.BatchingDescriptor;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientSettings;
+import com.google.api.gax.rpc.HeaderProvider;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.PageContext;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.PagedListDescriptor;
+import com.google.api.gax.rpc.PagedListResponseFactory;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StreamingCallSettings;
+import com.google.api.gax.rpc.StubSettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.auth.Credentials;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookFromArchive;
+import com.google.example.library.v1.Comment;
+import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateShelfRequest;
+import com.google.example.library.v1.DeleteBookRequest;
+import com.google.example.library.v1.DeleteShelfRequest;
+import com.google.example.library.v1.DiscussBookRequest;
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.FindRelatedBooksResponse;
+import com.google.example.library.v1.GetBigBookMetadata;
+import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+import com.google.example.library.v1.GetBookFromAnywhereRequest;
+import com.google.example.library.v1.GetBookFromArchiveRequest;
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.GetShelfRequest;
+import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListStringsPagedResponse;
+import com.google.example.library.v1.LibraryServiceGrpc;
+import com.google.example.library.v1.ListBooksRequest;
+import com.google.example.library.v1.ListBooksResponse;
+import com.google.example.library.v1.ListShelvesRequest;
+import com.google.example.library.v1.ListShelvesResponse;
+import com.google.example.library.v1.ListStringsRequest;
+import com.google.example.library.v1.ListStringsResponse;
+import com.google.example.library.v1.MergeShelvesRequest;
+import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.Shelf;
+import com.google.example.library.v1.StreamBooksRequest;
+import com.google.example.library.v1.StreamShelvesRequest;
+import com.google.example.library.v1.StreamShelvesResponse;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
+import com.google.example.library.v1.UpdateBookIndexRequest;
+import com.google.example.library.v1.UpdateBookRequest;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Empty;
+import com.google.tagger.v1.LabelerGrpc;
+import com.google.tagger.v1.TaggerProto.AddLabelRequest;
+import com.google.tagger.v1.TaggerProto.AddLabelResponse;
+import com.google.tagger.v1.TaggerProto.AddTagRequest;
+import com.google.tagger.v1.TaggerProto.AddTagResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.Generated;
+import org.threeten.bp.Duration;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Settings class to configure an instance of {@link LibraryServiceStub}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ * <li>The default service address (library-example.googleapis.com) and default port (1234)
+ * are used.
+ * <li>Credentials are acquired automatically through Application Default Credentials.
+ * <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders.
+ * When build() is called, the tree of builders is called to create the complete settings
+ * object. For example, to set the total timeout of createShelf to 30 seconds:
+ *
+ * <pre>
+ * <code>
+ * LibraryServiceStubSettings.Builder librarySettingsBuilder =
+ *     LibraryServiceStubSettings.newBuilder();
+ * librarySettingsBuilder.createShelfSettings().getRetrySettings().toBuilder()
+ *     .setTotalTimeout(Duration.ofSeconds(30));
+ * LibraryServiceStubSettings librarySettings = librarySettingsBuilder.build();
+ * </code>
+ * </pre>
+ */
+@Generated("by gapic-generator")
+public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubSettings> {
+  /**
+   * The default scopes of the service.
+   */
+  private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES = ImmutableList.<String>builder()
+      .add("https://www.googleapis.com/auth/cloud-platform")
+      .add("https://www.googleapis.com/auth/library")
+      .build();
+
+  private final UnaryCallSettings<CreateShelfRequest, Shelf> createShelfSettings;
+  private final UnaryCallSettings<GetShelfRequest, Shelf> getShelfSettings;
+  private final PagedCallSettings<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings;
+  private final UnaryCallSettings<DeleteShelfRequest, Empty> deleteShelfSettings;
+  private final UnaryCallSettings<MergeShelvesRequest, Shelf> mergeShelvesSettings;
+  private final UnaryCallSettings<CreateBookRequest, Book> createBookSettings;
+  private final BatchingCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
+  private final UnaryCallSettings<GetBookRequest, Book> getBookSettings;
+  private final PagedCallSettings<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings;
+  private final UnaryCallSettings<DeleteBookRequest, Empty> deleteBookSettings;
+  private final UnaryCallSettings<UpdateBookRequest, Book> updateBookSettings;
+  private final UnaryCallSettings<MoveBookRequest, Book> moveBookSettings;
+  private final PagedCallSettings<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings;
+  private final BatchingCallSettings<AddCommentsRequest, Empty> addCommentsSettings;
+  private final UnaryCallSettings<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveSettings;
+  private final UnaryCallSettings<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings;
+  private final UnaryCallSettings<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereSettings;
+  private final UnaryCallSettings<UpdateBookIndexRequest, Empty> updateBookIndexSettings;
+  private final ServerStreamingCallSettings<StreamShelvesRequest, StreamShelvesResponse> streamShelvesSettings;
+  private final ServerStreamingCallSettings<StreamBooksRequest, Book> streamBooksSettings;
+  private final StreamingCallSettings<DiscussBookRequest, Comment> discussBookSettings;
+  private final StreamingCallSettings<DiscussBookRequest, Comment> monologAboutBookSettings;
+  private final PagedCallSettings<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings;
+  private final UnaryCallSettings<AddTagRequest, AddTagResponse> addTagSettings;
+  private final UnaryCallSettings<AddLabelRequest, AddLabelResponse> addLabelSettings;
+  private final UnaryCallSettings<GetBookRequest, Operation> getBigBookSettings;
+  private final OperationCallSettings<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationSettings;
+  private final UnaryCallSettings<GetBookRequest, Operation> getBigNothingSettings;
+  private final OperationCallSettings<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
+  private final UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+
+  /**
+   * Returns the object with the settings used for calls to createShelf.
+   */
+  public UnaryCallSettings<CreateShelfRequest, Shelf> createShelfSettings() {
+    return createShelfSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getShelf.
+   */
+  public UnaryCallSettings<GetShelfRequest, Shelf> getShelfSettings() {
+    return getShelfSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to listShelves.
+   */
+  public PagedCallSettings<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings() {
+    return listShelvesSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to deleteShelf.
+   */
+  public UnaryCallSettings<DeleteShelfRequest, Empty> deleteShelfSettings() {
+    return deleteShelfSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to mergeShelves.
+   */
+  public UnaryCallSettings<MergeShelvesRequest, Shelf> mergeShelvesSettings() {
+    return mergeShelvesSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to createBook.
+   */
+  public UnaryCallSettings<CreateBookRequest, Book> createBookSettings() {
+    return createBookSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to publishSeries.
+   */
+  public BatchingCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
+    return publishSeriesSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBook.
+   */
+  public UnaryCallSettings<GetBookRequest, Book> getBookSettings() {
+    return getBookSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to listBooks.
+   */
+  public PagedCallSettings<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings() {
+    return listBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to deleteBook.
+   */
+  public UnaryCallSettings<DeleteBookRequest, Empty> deleteBookSettings() {
+    return deleteBookSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to updateBook.
+   */
+  public UnaryCallSettings<UpdateBookRequest, Book> updateBookSettings() {
+    return updateBookSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to moveBook.
+   */
+  public UnaryCallSettings<MoveBookRequest, Book> moveBookSettings() {
+    return moveBookSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to listStrings.
+   */
+  public PagedCallSettings<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings() {
+    return listStringsSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to addComments.
+   */
+  public BatchingCallSettings<AddCommentsRequest, Empty> addCommentsSettings() {
+    return addCommentsSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBookFromArchive.
+   */
+  public UnaryCallSettings<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveSettings() {
+    return getBookFromArchiveSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBookFromAnywhere.
+   */
+  public UnaryCallSettings<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings() {
+    return getBookFromAnywhereSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBookFromAbsolutelyAnywhere.
+   */
+  public UnaryCallSettings<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereSettings() {
+    return getBookFromAbsolutelyAnywhereSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to updateBookIndex.
+   */
+  public UnaryCallSettings<UpdateBookIndexRequest, Empty> updateBookIndexSettings() {
+    return updateBookIndexSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamShelves.
+   */
+  public ServerStreamingCallSettings<StreamShelvesRequest, StreamShelvesResponse> streamShelvesSettings() {
+    return streamShelvesSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamBooks.
+   */
+  public ServerStreamingCallSettings<StreamBooksRequest, Book> streamBooksSettings() {
+    return streamBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to discussBook.
+   */
+  public StreamingCallSettings<DiscussBookRequest, Comment> discussBookSettings() {
+    return discussBookSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to monologAboutBook.
+   */
+  public StreamingCallSettings<DiscussBookRequest, Comment> monologAboutBookSettings() {
+    return monologAboutBookSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to findRelatedBooks.
+   */
+  public PagedCallSettings<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings() {
+    return findRelatedBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to addTag.
+   */
+  public UnaryCallSettings<AddTagRequest, AddTagResponse> addTagSettings() {
+    return addTagSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to addLabel.
+   */
+  public UnaryCallSettings<AddLabelRequest, AddLabelResponse> addLabelSettings() {
+    return addLabelSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBigBook.
+   */
+  public UnaryCallSettings<GetBookRequest, Operation> getBigBookSettings() {
+    return getBigBookSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBigBook.
+   */
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallSettings<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationSettings() {
+    return getBigBookOperationSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBigNothing.
+   */
+  public UnaryCallSettings<GetBookRequest, Operation> getBigNothingSettings() {
+    return getBigNothingSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getBigNothing.
+   */
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallSettings<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings() {
+    return getBigNothingOperationSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to testOptionalRequiredFlatteningParams.
+   */
+  public UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
+    return testOptionalRequiredFlatteningParamsSettings;
+  }
+
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public LibraryServiceStub createStub() throws IOException {
+    if (getTransportChannelProvider()
+        .getTransportName()
+        .equals(GrpcTransportChannel.getGrpcTransportName())) {
+      return GrpcLibraryServiceStub.create(this);
+    } else {
+      throw new UnsupportedOperationException(
+          "Transport not supported: " + getTransportChannelProvider().getTransportName());
+    }
+  }
+
+  /**
+   * Returns a builder for the default ExecutorProvider for this service.
+   */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return InstantiatingExecutorProvider.newBuilder();
+  }
+
+  /**
+   * Returns the default service endpoint.
+   */
+  public static String getDefaultEndpoint() {
+    return "library-example.googleapis.com:1234";
+  }
+
+
+  /**
+   * Returns the default service scopes.
+   */
+  public static List<String> getDefaultServiceScopes() {
+    return DEFAULT_SERVICE_SCOPES;
+  }
+
+
+  /**
+   * Returns a builder for the default credentials for this service.
+   */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        ;
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder() {
+    return InstantiatingGrpcChannelProvider.newBuilder();
+  }
+
+  public static TransportChannelProvider defaultTransportChannelProvider() {
+    return defaultGrpcTransportProviderBuilder().build();
+  }
+
+  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
+  public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(LibraryServiceStubSettings.class))
+        .setTransportToken(GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder() {
+    return Builder.createDefault();
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /**
+   * Returns a builder containing all the values of this settings class.
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  protected LibraryServiceStubSettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+
+    createShelfSettings = settingsBuilder.createShelfSettings().build();
+    getShelfSettings = settingsBuilder.getShelfSettings().build();
+    listShelvesSettings = settingsBuilder.listShelvesSettings().build();
+    deleteShelfSettings = settingsBuilder.deleteShelfSettings().build();
+    mergeShelvesSettings = settingsBuilder.mergeShelvesSettings().build();
+    createBookSettings = settingsBuilder.createBookSettings().build();
+    publishSeriesSettings = settingsBuilder.publishSeriesSettings().build();
+    getBookSettings = settingsBuilder.getBookSettings().build();
+    listBooksSettings = settingsBuilder.listBooksSettings().build();
+    deleteBookSettings = settingsBuilder.deleteBookSettings().build();
+    updateBookSettings = settingsBuilder.updateBookSettings().build();
+    moveBookSettings = settingsBuilder.moveBookSettings().build();
+    listStringsSettings = settingsBuilder.listStringsSettings().build();
+    addCommentsSettings = settingsBuilder.addCommentsSettings().build();
+    getBookFromArchiveSettings = settingsBuilder.getBookFromArchiveSettings().build();
+    getBookFromAnywhereSettings = settingsBuilder.getBookFromAnywhereSettings().build();
+    getBookFromAbsolutelyAnywhereSettings = settingsBuilder.getBookFromAbsolutelyAnywhereSettings().build();
+    updateBookIndexSettings = settingsBuilder.updateBookIndexSettings().build();
+    streamShelvesSettings = settingsBuilder.streamShelvesSettings().build();
+    streamBooksSettings = settingsBuilder.streamBooksSettings().build();
+    discussBookSettings = settingsBuilder.discussBookSettings().build();
+    monologAboutBookSettings = settingsBuilder.monologAboutBookSettings().build();
+    findRelatedBooksSettings = settingsBuilder.findRelatedBooksSettings().build();
+    addTagSettings = settingsBuilder.addTagSettings().build();
+    addLabelSettings = settingsBuilder.addLabelSettings().build();
+    getBigBookSettings = settingsBuilder.getBigBookSettings().build();
+    getBigBookOperationSettings = settingsBuilder.getBigBookOperationSettings().build();
+    getBigNothingSettings = settingsBuilder.getBigNothingSettings().build();
+    getBigNothingOperationSettings = settingsBuilder.getBigNothingOperationSettings().build();
+    testOptionalRequiredFlatteningParamsSettings = settingsBuilder.testOptionalRequiredFlatteningParamsSettings().build();
+  }
+
+  private static final PagedListDescriptor<ListShelvesRequest, ListShelvesResponse, Shelf> LIST_SHELVES_PAGE_STR_DESC =
+      new PagedListDescriptor<ListShelvesRequest, ListShelvesResponse, Shelf>() {
+        @Override
+        public String emptyToken() {
+          return "";
+        }
+        @Override
+        public ListShelvesRequest injectToken(ListShelvesRequest payload, String token) {
+          return ListShelvesRequest
+            .newBuilder(payload)
+            .setPageToken(token)
+            .build();
+        }
+        @Override
+        public ListShelvesRequest injectPageSize(ListShelvesRequest payload, int pageSize) {
+          throw new UnsupportedOperationException("page size is not supported by this API method");
+        }
+        @Override
+        public Integer extractPageSize(ListShelvesRequest payload) {
+          throw new UnsupportedOperationException("page size is not supported by this API method");
+        }
+        @Override
+        public String extractNextToken(ListShelvesResponse payload) {
+          return payload.getNextPageToken();
+        }
+        @Override
+        public Iterable<Shelf> extractResources(ListShelvesResponse payload) {
+          return payload.getShelvesList() != null ? payload.getShelvesList() :
+            ImmutableList.<Shelf>of();
+        }
+      };
+
+  private static final PagedListDescriptor<ListBooksRequest, ListBooksResponse, Book> LIST_BOOKS_PAGE_STR_DESC =
+      new PagedListDescriptor<ListBooksRequest, ListBooksResponse, Book>() {
+        @Override
+        public String emptyToken() {
+          return "";
+        }
+        @Override
+        public ListBooksRequest injectToken(ListBooksRequest payload, String token) {
+          return ListBooksRequest
+            .newBuilder(payload)
+            .setPageToken(token)
+            .build();
+        }
+        @Override
+        public ListBooksRequest injectPageSize(ListBooksRequest payload, int pageSize) {
+          return ListBooksRequest
+            .newBuilder(payload)
+            .setPageSize(pageSize)
+            .build();
+        }
+        @Override
+        public Integer extractPageSize(ListBooksRequest payload) {
+          return payload.getPageSize();
+        }
+        @Override
+        public String extractNextToken(ListBooksResponse payload) {
+          return payload.getNextPageToken();
+        }
+        @Override
+        public Iterable<Book> extractResources(ListBooksResponse payload) {
+          return payload.getBooksList() != null ? payload.getBooksList() :
+            ImmutableList.<Book>of();
+        }
+      };
+
+  private static final PagedListDescriptor<ListStringsRequest, ListStringsResponse, String> LIST_STRINGS_PAGE_STR_DESC =
+      new PagedListDescriptor<ListStringsRequest, ListStringsResponse, String>() {
+        @Override
+        public String emptyToken() {
+          return "";
+        }
+        @Override
+        public ListStringsRequest injectToken(ListStringsRequest payload, String token) {
+          return ListStringsRequest
+            .newBuilder(payload)
+            .setPageToken(token)
+            .build();
+        }
+        @Override
+        public ListStringsRequest injectPageSize(ListStringsRequest payload, int pageSize) {
+          return ListStringsRequest
+            .newBuilder(payload)
+            .setPageSize(pageSize)
+            .build();
+        }
+        @Override
+        public Integer extractPageSize(ListStringsRequest payload) {
+          return payload.getPageSize();
+        }
+        @Override
+        public String extractNextToken(ListStringsResponse payload) {
+          return payload.getNextPageToken();
+        }
+        @Override
+        public Iterable<String> extractResources(ListStringsResponse payload) {
+          return payload.getStringsList() != null ? payload.getStringsList() :
+            ImmutableList.<String>of();
+        }
+      };
+
+  private static final PagedListDescriptor<FindRelatedBooksRequest, FindRelatedBooksResponse, String> FIND_RELATED_BOOKS_PAGE_STR_DESC =
+      new PagedListDescriptor<FindRelatedBooksRequest, FindRelatedBooksResponse, String>() {
+        @Override
+        public String emptyToken() {
+          return "";
+        }
+        @Override
+        public FindRelatedBooksRequest injectToken(FindRelatedBooksRequest payload, String token) {
+          return FindRelatedBooksRequest
+            .newBuilder(payload)
+            .setPageToken(token)
+            .build();
+        }
+        @Override
+        public FindRelatedBooksRequest injectPageSize(FindRelatedBooksRequest payload, int pageSize) {
+          return FindRelatedBooksRequest
+            .newBuilder(payload)
+            .setPageSize(pageSize)
+            .build();
+        }
+        @Override
+        public Integer extractPageSize(FindRelatedBooksRequest payload) {
+          return payload.getPageSize();
+        }
+        @Override
+        public String extractNextToken(FindRelatedBooksResponse payload) {
+          return payload.getNextPageToken();
+        }
+        @Override
+        public Iterable<String> extractResources(FindRelatedBooksResponse payload) {
+          return payload.getNamesList() != null ? payload.getNamesList() :
+            ImmutableList.<String>of();
+        }
+      };
+
+  private static final PagedListResponseFactory<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> LIST_SHELVES_PAGE_STR_FACT =
+      new PagedListResponseFactory<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse>() {
+        @Override
+        public ApiFuture<ListShelvesPagedResponse> getFuturePagedResponse(
+            UnaryCallable<ListShelvesRequest, ListShelvesResponse> callable,
+            ListShelvesRequest request,
+            ApiCallContext context,
+            ApiFuture<ListShelvesResponse> futureResponse) {
+          PageContext<ListShelvesRequest, ListShelvesResponse, Shelf> pageContext =
+              PageContext.create(callable, LIST_SHELVES_PAGE_STR_DESC, request, context);
+          return ListShelvesPagedResponse.createAsync(pageContext, futureResponse);
+        }
+      };
+
+  private static final PagedListResponseFactory<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> LIST_BOOKS_PAGE_STR_FACT =
+      new PagedListResponseFactory<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse>() {
+        @Override
+        public ApiFuture<ListBooksPagedResponse> getFuturePagedResponse(
+            UnaryCallable<ListBooksRequest, ListBooksResponse> callable,
+            ListBooksRequest request,
+            ApiCallContext context,
+            ApiFuture<ListBooksResponse> futureResponse) {
+          PageContext<ListBooksRequest, ListBooksResponse, Book> pageContext =
+              PageContext.create(callable, LIST_BOOKS_PAGE_STR_DESC, request, context);
+          return ListBooksPagedResponse.createAsync(pageContext, futureResponse);
+        }
+      };
+
+  private static final PagedListResponseFactory<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> LIST_STRINGS_PAGE_STR_FACT =
+      new PagedListResponseFactory<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse>() {
+        @Override
+        public ApiFuture<ListStringsPagedResponse> getFuturePagedResponse(
+            UnaryCallable<ListStringsRequest, ListStringsResponse> callable,
+            ListStringsRequest request,
+            ApiCallContext context,
+            ApiFuture<ListStringsResponse> futureResponse) {
+          PageContext<ListStringsRequest, ListStringsResponse, String> pageContext =
+              PageContext.create(callable, LIST_STRINGS_PAGE_STR_DESC, request, context);
+          return ListStringsPagedResponse.createAsync(pageContext, futureResponse);
+        }
+      };
+
+  private static final PagedListResponseFactory<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> FIND_RELATED_BOOKS_PAGE_STR_FACT =
+      new PagedListResponseFactory<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse>() {
+        @Override
+        public ApiFuture<FindRelatedBooksPagedResponse> getFuturePagedResponse(
+            UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> callable,
+            FindRelatedBooksRequest request,
+            ApiCallContext context,
+            ApiFuture<FindRelatedBooksResponse> futureResponse) {
+          PageContext<FindRelatedBooksRequest, FindRelatedBooksResponse, String> pageContext =
+              PageContext.create(callable, FIND_RELATED_BOOKS_PAGE_STR_DESC, request, context);
+          return FindRelatedBooksPagedResponse.createAsync(pageContext, futureResponse);
+        }
+      };
+
+  private static final BatchingDescriptor<PublishSeriesRequest, PublishSeriesResponse> PUBLISH_SERIES_BATCHING_DESC =
+      new BatchingDescriptor<PublishSeriesRequest, PublishSeriesResponse>() {
+        @Override
+        public PartitionKey getBatchPartitionKey(PublishSeriesRequest request) {
+          return new PartitionKey(request.getEdition(), request.getName());
+        }
+
+        @Override
+        public RequestBuilder<PublishSeriesRequest> getRequestBuilder() {
+          return new RequestBuilder<PublishSeriesRequest>() {
+            private PublishSeriesRequest.Builder builder;
+            @Override
+            public void appendRequest(PublishSeriesRequest request) {
+              if (builder == null) {
+                builder = request.toBuilder();
+              } else {
+                builder.addAllBooks(request.getBooksList());
+              }
+            }
+            @Override
+            public PublishSeriesRequest build() {
+              return builder.build();
+            }
+          };
+        }
+
+        @Override
+        public void splitResponse(
+            PublishSeriesResponse batchResponse,
+            Collection<? extends BatchedRequestIssuer<PublishSeriesResponse>> batch) {
+          int batchMessageIndex = 0;
+          for (BatchedRequestIssuer<PublishSeriesResponse> responder : batch) {
+            List<String> subresponseElements = new ArrayList<>();
+            long subresponseCount = responder.getMessageCount();
+            for (int i = 0; i < subresponseCount; i++) {
+              subresponseElements.add(batchResponse.getBookNames(batchMessageIndex));
+              batchMessageIndex += 1;
+            }
+            PublishSeriesResponse response =
+                PublishSeriesResponse.newBuilder().addAllBookNames(subresponseElements).build();
+            responder.setResponse(response);
+          }
+        }
+
+        @Override
+        public void splitException(
+            Throwable throwable,
+            Collection<? extends BatchedRequestIssuer<PublishSeriesResponse>> batch) {
+          for (BatchedRequestIssuer<PublishSeriesResponse> responder : batch) {
+            responder.setException(throwable);
+          }
+        }
+
+        @Override
+        public long countElements(PublishSeriesRequest request) {
+          return request.getBooksCount();
+        }
+
+        @Override
+        public long countBytes(PublishSeriesRequest request) {
+          return request.getSerializedSize();
+        }
+      };
+
+  private static final BatchingDescriptor<AddCommentsRequest, Empty> ADD_COMMENTS_BATCHING_DESC =
+      new BatchingDescriptor<AddCommentsRequest, Empty>() {
+        @Override
+        public PartitionKey getBatchPartitionKey(AddCommentsRequest request) {
+          return new PartitionKey(request.getName());
+        }
+
+        @Override
+        public RequestBuilder<AddCommentsRequest> getRequestBuilder() {
+          return new RequestBuilder<AddCommentsRequest>() {
+            private AddCommentsRequest.Builder builder;
+            @Override
+            public void appendRequest(AddCommentsRequest request) {
+              if (builder == null) {
+                builder = request.toBuilder();
+              } else {
+                builder.addAllComments(request.getCommentsList());
+              }
+            }
+            @Override
+            public AddCommentsRequest build() {
+              return builder.build();
+            }
+          };
+        }
+
+        @Override
+        public void splitResponse(
+            Empty batchResponse,
+            Collection<? extends BatchedRequestIssuer<Empty>> batch) {
+          int batchMessageIndex = 0;
+          for (BatchedRequestIssuer<Empty> responder : batch) {
+            Empty response =
+                Empty.newBuilder().build();
+            responder.setResponse(response);
+          }
+        }
+
+        @Override
+        public void splitException(
+            Throwable throwable,
+            Collection<? extends BatchedRequestIssuer<Empty>> batch) {
+          for (BatchedRequestIssuer<Empty> responder : batch) {
+            responder.setException(throwable);
+          }
+        }
+
+        @Override
+        public long countElements(AddCommentsRequest request) {
+          return request.getCommentsCount();
+        }
+
+        @Override
+        public long countBytes(AddCommentsRequest request) {
+          return request.getSerializedSize();
+        }
+      };
+
+  /**
+   * Builder for LibraryServiceStubSettings.
+   */
+  public static class Builder extends StubSettings.Builder<LibraryServiceStubSettings, Builder> {
+    private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
+
+    private final UnaryCallSettings.Builder<CreateShelfRequest, Shelf> createShelfSettings;
+    private final UnaryCallSettings.Builder<GetShelfRequest, Shelf> getShelfSettings;
+    private final PagedCallSettings.Builder<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings;
+    private final UnaryCallSettings.Builder<DeleteShelfRequest, Empty> deleteShelfSettings;
+    private final UnaryCallSettings.Builder<MergeShelvesRequest, Shelf> mergeShelvesSettings;
+    private final UnaryCallSettings.Builder<CreateBookRequest, Book> createBookSettings;
+    private final BatchingCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
+    private final UnaryCallSettings.Builder<GetBookRequest, Book> getBookSettings;
+    private final PagedCallSettings.Builder<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings;
+    private final UnaryCallSettings.Builder<DeleteBookRequest, Empty> deleteBookSettings;
+    private final UnaryCallSettings.Builder<UpdateBookRequest, Book> updateBookSettings;
+    private final UnaryCallSettings.Builder<MoveBookRequest, Book> moveBookSettings;
+    private final PagedCallSettings.Builder<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings;
+    private final BatchingCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings;
+    private final UnaryCallSettings.Builder<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveSettings;
+    private final UnaryCallSettings.Builder<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings;
+    private final UnaryCallSettings.Builder<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereSettings;
+    private final UnaryCallSettings.Builder<UpdateBookIndexRequest, Empty> updateBookIndexSettings;
+    private final ServerStreamingCallSettings.Builder<StreamShelvesRequest, StreamShelvesResponse> streamShelvesSettings;
+    private final ServerStreamingCallSettings.Builder<StreamBooksRequest, Book> streamBooksSettings;
+    private final StreamingCallSettings.Builder<DiscussBookRequest, Comment> discussBookSettings;
+    private final StreamingCallSettings.Builder<DiscussBookRequest, Comment> monologAboutBookSettings;
+    private final PagedCallSettings.Builder<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings;
+    private final UnaryCallSettings.Builder<AddTagRequest, AddTagResponse> addTagSettings;
+    private final UnaryCallSettings.Builder<AddLabelRequest, AddLabelResponse> addLabelSettings;
+    private final UnaryCallSettings.Builder<GetBookRequest, Operation> getBigBookSettings;
+    private final OperationCallSettings.Builder<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationSettings;
+    private final UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings;
+    private final OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
+    private final UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+
+    private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
+      definitions.put(
+          "idempotent",
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+      definitions.put(
+          "non_idempotent",
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      RETRYABLE_CODE_DEFINITIONS = definitions.build();
+    }
+
+    private static final ImmutableMap<String, RetrySettings> RETRY_PARAM_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, RetrySettings> definitions = ImmutableMap.builder();
+      RetrySettings settings = null;
+      settings = RetrySettings.newBuilder()
+          .setInitialRetryDelay(Duration.ofMillis(100L))
+          .setRetryDelayMultiplier(1.2)
+          .setMaxRetryDelay(Duration.ofMillis(1000L))
+          .setInitialRpcTimeout(Duration.ofMillis(300L))
+          .setRpcTimeoutMultiplier(1.3)
+          .setMaxRpcTimeout(Duration.ofMillis(3000L))
+          .setTotalTimeout(Duration.ofMillis(30000L))
+          .build();
+      definitions.put("default", settings);
+      RETRY_PARAM_DEFINITIONS = definitions.build();
+    }
+
+    protected Builder() {
+      this((ClientContext) null);
+    }
+
+    protected Builder(ClientContext clientContext) {
+      super(clientContext);
+
+      createShelfSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      getShelfSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      listShelvesSettings = PagedCallSettings.newBuilder(
+          LIST_SHELVES_PAGE_STR_FACT);
+
+      deleteShelfSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      mergeShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      createBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      publishSeriesSettings = BatchingCallSettings.newBuilder(
+          PUBLISH_SERIES_BATCHING_DESC)
+              .setBatchingSettings(BatchingSettings.newBuilder().build());
+
+      getBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      listBooksSettings = PagedCallSettings.newBuilder(
+          LIST_BOOKS_PAGE_STR_FACT);
+
+      deleteBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      updateBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      moveBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      listStringsSettings = PagedCallSettings.newBuilder(
+          LIST_STRINGS_PAGE_STR_FACT);
+
+      addCommentsSettings = BatchingCallSettings.newBuilder(
+          ADD_COMMENTS_BATCHING_DESC)
+              .setBatchingSettings(BatchingSettings.newBuilder().build());
+
+      getBookFromArchiveSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      getBookFromAnywhereSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      getBookFromAbsolutelyAnywhereSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      updateBookIndexSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      streamShelvesSettings = ServerStreamingCallSettings.newBuilder();
+
+      streamBooksSettings = ServerStreamingCallSettings.newBuilder();
+
+      discussBookSettings = StreamingCallSettings.newBuilder();
+
+      monologAboutBookSettings = StreamingCallSettings.newBuilder();
+
+      findRelatedBooksSettings = PagedCallSettings.newBuilder(
+          FIND_RELATED_BOOKS_PAGE_STR_FACT);
+
+      addTagSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      addLabelSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      getBigBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      getBigBookOperationSettings = OperationCallSettings.newBuilder();
+
+      getBigNothingSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      getBigNothingOperationSettings = OperationCallSettings.newBuilder();
+
+      testOptionalRequiredFlatteningParamsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+          createShelfSettings,
+          getShelfSettings,
+          listShelvesSettings,
+          deleteShelfSettings,
+          mergeShelvesSettings,
+          createBookSettings,
+          publishSeriesSettings,
+          getBookSettings,
+          listBooksSettings,
+          deleteBookSettings,
+          updateBookSettings,
+          moveBookSettings,
+          listStringsSettings,
+          addCommentsSettings,
+          getBookFromArchiveSettings,
+          getBookFromAnywhereSettings,
+          getBookFromAbsolutelyAnywhereSettings,
+          updateBookIndexSettings,
+          findRelatedBooksSettings,
+          addTagSettings,
+          addLabelSettings,
+          getBigBookSettings,
+          getBigNothingSettings,
+          testOptionalRequiredFlatteningParamsSettings
+      );
+
+      initDefaults(this);
+    }
+
+    private static Builder createDefault() {
+      Builder builder = new Builder((ClientContext) null);
+      builder.setTransportChannelProvider(defaultTransportChannelProvider());
+      builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setEndpoint(getDefaultEndpoint());
+      return initDefaults(builder);
+    }
+
+    private static Builder initDefaults(Builder builder) {
+
+      builder.createShelfSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.getShelfSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.listShelvesSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.deleteShelfSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.mergeShelvesSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.createBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.publishSeriesSettings().setBatchingSettings(
+          BatchingSettings.newBuilder()
+          .setElementCountThreshold(6L)
+          .setRequestByteThreshold(100000L)
+          .setDelayThreshold(Duration.ofMillis(500))
+          .setFlowControlSettings(
+            FlowControlSettings.newBuilder()
+              .setLimitExceededBehavior(LimitExceededBehavior.Ignore)
+              .build())
+          .build());
+      builder.publishSeriesSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.getBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.listBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.deleteBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.updateBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.moveBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.listStringsSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.addCommentsSettings().setBatchingSettings(
+          BatchingSettings.newBuilder()
+          .setElementCountThreshold(6L)
+          .setRequestByteThreshold(100000L)
+          .setDelayThreshold(Duration.ofMillis(500))
+          .setFlowControlSettings(
+            FlowControlSettings.newBuilder()
+              .setLimitExceededBehavior(LimitExceededBehavior.Ignore)
+              .build())
+          .build());
+      builder.addCommentsSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.getBookFromArchiveSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.getBookFromAnywhereSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.getBookFromAbsolutelyAnywhereSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.updateBookIndexSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.streamShelvesSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.streamBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.findRelatedBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.addTagSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.addLabelSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.getBigBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.getBigNothingSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.testOptionalRequiredFlatteningParamsSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+      builder
+          .getBigBookOperationSettings()
+          .setInitialCallSettings(
+              UnaryCallSettings.<GetBookRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
+                  .build())
+          .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create(Book.class))
+          .setMetadataTransformer(ProtoOperationTransformers.MetadataTransformer.create(GetBigBookMetadata.class))
+          .setPollingAlgorithm(
+              OperationTimedPollAlgorithm.create(
+                  RetrySettings.newBuilder()
+                     .setInitialRetryDelay(Duration.ofMillis(3000L))
+                     .setRetryDelayMultiplier(1.3)
+                     .setMaxRetryDelay(Duration.ofMillis(30000L))
+                     .setInitialRpcTimeout(Duration.ZERO) // ignored
+                     .setRpcTimeoutMultiplier(1.0) // ignored
+                     .setMaxRpcTimeout(Duration.ZERO) // ignored
+                     .setTotalTimeout(Duration.ofMillis(86400000L))
+                     .build()));
+      builder
+          .getBigNothingOperationSettings()
+          .setInitialCallSettings(
+              UnaryCallSettings.<GetBookRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
+                  .build())
+          .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create(Empty.class))
+          .setMetadataTransformer(ProtoOperationTransformers.MetadataTransformer.create(GetBigBookMetadata.class))
+          .setPollingAlgorithm(
+              OperationTimedPollAlgorithm.create(
+                  RetrySettings.newBuilder()
+                     .setInitialRetryDelay(Duration.ofMillis(3000L))
+                     .setRetryDelayMultiplier(1.3)
+                     .setMaxRetryDelay(Duration.ofMillis(60000L))
+                     .setInitialRpcTimeout(Duration.ZERO) // ignored
+                     .setRpcTimeoutMultiplier(1.0) // ignored
+                     .setMaxRpcTimeout(Duration.ZERO) // ignored
+                     .setTotalTimeout(Duration.ofMillis(600000L))
+                     .build()));
+
+      return builder;
+    }
+
+    protected Builder(LibraryServiceStubSettings settings) {
+      super(settings);
+
+      createShelfSettings = settings.createShelfSettings.toBuilder();
+      getShelfSettings = settings.getShelfSettings.toBuilder();
+      listShelvesSettings = settings.listShelvesSettings.toBuilder();
+      deleteShelfSettings = settings.deleteShelfSettings.toBuilder();
+      mergeShelvesSettings = settings.mergeShelvesSettings.toBuilder();
+      createBookSettings = settings.createBookSettings.toBuilder();
+      publishSeriesSettings = settings.publishSeriesSettings.toBuilder();
+      getBookSettings = settings.getBookSettings.toBuilder();
+      listBooksSettings = settings.listBooksSettings.toBuilder();
+      deleteBookSettings = settings.deleteBookSettings.toBuilder();
+      updateBookSettings = settings.updateBookSettings.toBuilder();
+      moveBookSettings = settings.moveBookSettings.toBuilder();
+      listStringsSettings = settings.listStringsSettings.toBuilder();
+      addCommentsSettings = settings.addCommentsSettings.toBuilder();
+      getBookFromArchiveSettings = settings.getBookFromArchiveSettings.toBuilder();
+      getBookFromAnywhereSettings = settings.getBookFromAnywhereSettings.toBuilder();
+      getBookFromAbsolutelyAnywhereSettings = settings.getBookFromAbsolutelyAnywhereSettings.toBuilder();
+      updateBookIndexSettings = settings.updateBookIndexSettings.toBuilder();
+      streamShelvesSettings = settings.streamShelvesSettings.toBuilder();
+      streamBooksSettings = settings.streamBooksSettings.toBuilder();
+      discussBookSettings = settings.discussBookSettings.toBuilder();
+      monologAboutBookSettings = settings.monologAboutBookSettings.toBuilder();
+      findRelatedBooksSettings = settings.findRelatedBooksSettings.toBuilder();
+      addTagSettings = settings.addTagSettings.toBuilder();
+      addLabelSettings = settings.addLabelSettings.toBuilder();
+      getBigBookSettings = settings.getBigBookSettings.toBuilder();
+      getBigBookOperationSettings = settings.getBigBookOperationSettings.toBuilder();
+      getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
+      getBigNothingOperationSettings = settings.getBigNothingOperationSettings.toBuilder();
+      testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
+
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+          createShelfSettings,
+          getShelfSettings,
+          listShelvesSettings,
+          deleteShelfSettings,
+          mergeShelvesSettings,
+          createBookSettings,
+          publishSeriesSettings,
+          getBookSettings,
+          listBooksSettings,
+          deleteBookSettings,
+          updateBookSettings,
+          moveBookSettings,
+          listStringsSettings,
+          addCommentsSettings,
+          getBookFromArchiveSettings,
+          getBookFromAnywhereSettings,
+          getBookFromAbsolutelyAnywhereSettings,
+          updateBookIndexSettings,
+          findRelatedBooksSettings,
+          addTagSettings,
+          addLabelSettings,
+          getBigBookSettings,
+          getBigNothingSettings,
+          testOptionalRequiredFlatteningParamsSettings
+      );
+    }
+
+    // NEXT_MAJOR_VER: remove 'throws Exception'
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) throws Exception {
+      super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, settingsUpdater);
+      return this;
+    }
+
+    public ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders() {
+      return unaryMethodSettingsBuilders;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to createShelf.
+     */
+    public UnaryCallSettings.Builder<CreateShelfRequest, Shelf> createShelfSettings() {
+      return createShelfSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getShelf.
+     */
+    public UnaryCallSettings.Builder<GetShelfRequest, Shelf> getShelfSettings() {
+      return getShelfSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to listShelves.
+     */
+    public PagedCallSettings.Builder<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings() {
+      return listShelvesSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to deleteShelf.
+     */
+    public UnaryCallSettings.Builder<DeleteShelfRequest, Empty> deleteShelfSettings() {
+      return deleteShelfSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to mergeShelves.
+     */
+    public UnaryCallSettings.Builder<MergeShelvesRequest, Shelf> mergeShelvesSettings() {
+      return mergeShelvesSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to createBook.
+     */
+    public UnaryCallSettings.Builder<CreateBookRequest, Book> createBookSettings() {
+      return createBookSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to publishSeries.
+     */
+    public BatchingCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
+      return publishSeriesSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBook.
+     */
+    public UnaryCallSettings.Builder<GetBookRequest, Book> getBookSettings() {
+      return getBookSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to listBooks.
+     */
+    public PagedCallSettings.Builder<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings() {
+      return listBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to deleteBook.
+     */
+    public UnaryCallSettings.Builder<DeleteBookRequest, Empty> deleteBookSettings() {
+      return deleteBookSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to updateBook.
+     */
+    public UnaryCallSettings.Builder<UpdateBookRequest, Book> updateBookSettings() {
+      return updateBookSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBook.
+     */
+    public UnaryCallSettings.Builder<MoveBookRequest, Book> moveBookSettings() {
+      return moveBookSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to listStrings.
+     */
+    public PagedCallSettings.Builder<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings() {
+      return listStringsSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to addComments.
+     */
+    public BatchingCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings() {
+      return addCommentsSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBookFromArchive.
+     */
+    public UnaryCallSettings.Builder<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveSettings() {
+      return getBookFromArchiveSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBookFromAnywhere.
+     */
+    public UnaryCallSettings.Builder<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings() {
+      return getBookFromAnywhereSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBookFromAbsolutelyAnywhere.
+     */
+    public UnaryCallSettings.Builder<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereSettings() {
+      return getBookFromAbsolutelyAnywhereSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to updateBookIndex.
+     */
+    public UnaryCallSettings.Builder<UpdateBookIndexRequest, Empty> updateBookIndexSettings() {
+      return updateBookIndexSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamShelves.
+     */
+    public ServerStreamingCallSettings.Builder<StreamShelvesRequest, StreamShelvesResponse> streamShelvesSettings() {
+      return streamShelvesSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamBooks.
+     */
+    public ServerStreamingCallSettings.Builder<StreamBooksRequest, Book> streamBooksSettings() {
+      return streamBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to discussBook.
+     */
+    public StreamingCallSettings.Builder<DiscussBookRequest, Comment> discussBookSettings() {
+      return discussBookSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to monologAboutBook.
+     */
+    public StreamingCallSettings.Builder<DiscussBookRequest, Comment> monologAboutBookSettings() {
+      return monologAboutBookSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to findRelatedBooks.
+     */
+    public PagedCallSettings.Builder<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings() {
+      return findRelatedBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to addTag.
+     */
+    public UnaryCallSettings.Builder<AddTagRequest, AddTagResponse> addTagSettings() {
+      return addTagSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to addLabel.
+     */
+    public UnaryCallSettings.Builder<AddLabelRequest, AddLabelResponse> addLabelSettings() {
+      return addLabelSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBigBook.
+     */
+    public UnaryCallSettings.Builder<GetBookRequest, Operation> getBigBookSettings() {
+      return getBigBookSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBigBook.
+     */
+    @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+    public OperationCallSettings.Builder<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationSettings() {
+      return getBigBookOperationSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBigNothing.
+     */
+    public UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings() {
+      return getBigNothingSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBigNothing.
+     */
+    @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+    public OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings() {
+      return getBigNothingOperationSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to testOptionalRequiredFlatteningParams.
+     */
+    public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
+      return testOptionalRequiredFlatteningParamsSettings;
+    }
+
+    @Override
+    public LibraryServiceStubSettings build() throws IOException {
+      return new LibraryServiceStubSettings(this);
+    }
+  }
+}
+============== file: src/main/java/samples/com/google/example/library/v1/discussbookcallable/DiscussBookCallableCallableStreamingBidiProg.java ==============
+// DO NOT EDIT! This is a generated sample ("CallableStreamingBidi",  "prog")
+package com.google.example.examples.library.v1.snippets;
+
+// [START turing_prog_callable_streaming_bidi]
+import com.google.example.library.v1.Comment;
+import com.google.example.library.v1.DiscussBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.protobuf.ByteString;
+
+public class DiscussBookCallableCallableStreamingBidiProg {
+  public static void sampleDiscussBook() {
+    // [START turing_prog_callable_streaming_bidi_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      BidiStream<DiscussBookRequest, Comment> bidiStream =
+          libraryClient.discussBookCallable().call();
+
+      String name = "BASIC";
+      String fileName = "comment_file";
+      Path path = Paths.get(fileName);
+      byte[] data = Files.readAllBytes(path);
+      ByteString comment = ByteString.copyFrom(data);
+      Comment comment2 = Comment.newBuilder()
+        .setComment(comment)
+        .build();
+      DiscussBookRequest request = DiscussBookRequest.newBuilder()
+        .setName(name)
+        .setComment(comment2)
+        .build();
+      bidiStream.send(request);
+      for (Comment responseItem : bidiStream) {
+        System.out.println(responseItem);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END turing_prog_callable_streaming_bidi_core]
+  }
+
+  public static void main(String[] args) {
+    sampleDiscussBook();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END turing_prog_callable_streaming_bidi]
+============== file: src/main/java/samples/com/google/example/library/v1/findrelatedbooks/FindRelatedBooksFlattenedPagedOdyssey.java ==============
+// DO NOT EDIT! This is a generated sample ("FlattenedPaged",  "odyssey")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.LibraryClient;
+
+public class FindRelatedBooksFlattenedPagedOdyssey {
+  public static void sampleFindRelatedBooks() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      String namesElement = "Odyssey";
+      List<String> names = Arrays.asList(namesElement);
+      String shelvesElement = "Classics";
+      List<String> shelves = Arrays.asList(shelvesElement);
+      ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooks().futureCall(names, shelves);
+
+      // Do something
+
+      for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
+        ShelfBookName book = responseItem;
+        System.out.printf("Here's a related book: %s\n", book);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: src/main/java/samples/com/google/example/library/v1/findrelatedbooks/FindRelatedBooksRequestPagedOdyssey.java ==============
+// DO NOT EDIT! This is a generated sample ("RequestPaged",  "odyssey")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+
+public class FindRelatedBooksRequestPagedOdyssey {
+  public static void sampleFindRelatedBooks() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      List<ShelfBookName> names = Arrays.asList(namesElement);
+      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      List<ShelfName> shelves = Arrays.asList(shelvesElement);
+      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+        .addAllNames(ShelfBookName.toStringList(names))
+        .addAllShelves(ShelfName.toStringList(shelves))
+        .build();
+      for (ShelfBookName responseItem : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
+        ShelfBookName book = responseItem;
+        System.out.printf("Here's a related book: %s\n", book);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: src/main/java/samples/com/google/example/library/v1/findrelatedbookscallable/FindRelatedBooksCallableCallableListOdyssey.java ==============
+// DO NOT EDIT! This is a generated sample ("CallableList",  "odyssey")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+
+public class FindRelatedBooksCallableCallableListOdyssey {
+  public static void sampleFindRelatedBooks() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      List<ShelfBookName> names = Arrays.asList(namesElement);
+      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      List<ShelfName> shelves = Arrays.asList(shelvesElement);
+      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+        .addAllNames(ShelfBookName.toStringList(names))
+        .addAllShelves(ShelfName.toStringList(shelves))
+        .build();
+      while (true) {
+        FindRelatedBooksResponse response = libraryClient.findRelatedBooksCallable().call(request);
+        for (ShelfBookName responseItem : ShelfBookName.parseList(response.getNamesList())) {
+          ShelfBookName book = responseItem;
+          System.out.printf("Here's a related book: %s\n", book);
+        }
+        String nextPageToken = response.getNextPageToken();
+        if (!Strings.isNullOrEmpty(nextPageToken)) {
+          request = request.toBuilder().setPageToken(nextPageToken).build();
+        } else {
+          break;
+        }
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: src/main/java/samples/com/google/example/library/v1/findrelatedbookspagedcallable/FindRelatedBooksPagedCallableCallablePagedOdyssey.java ==============
+// DO NOT EDIT! This is a generated sample ("CallablePaged",  "odyssey")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+
+public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
+  public static void sampleFindRelatedBooks() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      List<ShelfBookName> names = Arrays.asList(namesElement);
+      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      List<ShelfName> shelves = Arrays.asList(shelvesElement);
+      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+        .addAllNames(ShelfBookName.toStringList(names))
+        .addAllShelves(ShelfName.toStringList(shelves))
+        .build();
+      ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooksPagedCallable().futureCall(request);
+
+      // Do something
+
+      for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
+        ShelfBookName book = responseItem;
+        System.out.printf("Here's a related book: %s\n", book);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: src/main/java/samples/com/google/example/library/v1/getbigbookasync/GetBigBookAsyncLongRunningFlattenedAsyncWap.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningFlattenedAsync",  "wap")
+package com.google.example.examples.library.v1.snippets;
+
+// [START hopper]
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
+  public static void sampleGetBigBook() {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      Book response = libraryClient.getBigBookAsync(name.toString()).get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    sampleGetBigBook();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: src/main/java/samples/com/google/example/library/v1/getbigbookasync/GetBigBookAsyncLongRunningRequestAsyncWap.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
+package com.google.example.examples.library.v1.snippets;
+
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookAsyncLongRunningRequestAsyncWap {
+  public static void sampleGetBigBook() {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      Book response = libraryClient.getBigBookAsync(request).get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    sampleGetBigBook();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: src/main/java/samples/com/google/example/library/v1/getbigbookcallable/GetBigBookCallableCallableWap.java ==============
+// DO NOT EDIT! This is a generated sample ("Callable",  "wap")
+package com.google.example.examples.library.v1.snippets;
+
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookCallableCallableWap {
+  public static void sampleGetBigBook() {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      ApiFuture<Operation> future = libraryClient.getBigBookCallable().futureCall(request);
+
+      // Do something
+
+      Operation response = future.get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    sampleGetBigBook();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: src/main/java/samples/com/google/example/library/v1/getbigbookoperationcallable/GetBigBookOperationCallableLongRunningCallableWap.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningCallable",  "wap")
+package com.google.example.examples.library.v1.snippets;
+
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookOperationCallableLongRunningCallableWap {
+  public static void sampleGetBigBook() {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      OperationFuture<Operation> future = libraryClient.getBigBookOperationCallable().futureCall(request);
+
+      // Do something
+
+      Book response = future.get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    sampleGetBigBook();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: src/main/java/samples/com/google/example/library/v1/monologaboutbookcallable/MonologAboutBookCallableCallableStreamingClientProg.java ==============
+// DO NOT EDIT! This is a generated sample ("CallableStreamingClient",  "prog")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.DiscussBookRequest;
+import com.google.example.library.v1.LibraryClient;
+
+public class MonologAboutBookCallableCallableStreamingClientProg {
+  public static void sampleMonologAboutBook() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ApiStreamObserver<Comment> responseObserver =
+          new ApiStreamObserver<Comment>() {
+            @Override
+            public void onNext(Comment response) {
+              System.out.printf("The stage of the comment is: %s\n", response.getStage());
+            }
+
+            @Override
+            public void onError(Throwable t) {
+              // Add error-handling
+            }
+
+            @Override
+            public void onCompleted() {
+              // Do something when complete.
+            }
+          };
+      ApiStreamObserver<DiscussBookRequest> requestObserver =
+          libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
+
+      String name = "BASIC";
+      DiscussBookRequest request = DiscussBookRequest.newBuilder()
+        .setName(name)
+        .build();
+      requestObserver.onNext(request);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleMonologAboutBook();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: src/main/java/samples/com/google/example/library/v1/publishseries/PublishSeriesFlattenedPiVersion.java ==============
+// DO NOT EDIT! This is a generated sample ("Flattened",  "pi_version")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesFlattenedPiVersion {
+  public static void samplePublishSeries(String shelfName, int edition) {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelfName = "Math";
+      // int edition = 123;
+      Shelf shelf = Shelf.newBuilder()
+        .setName(shelfName)
+        .build();
+      List<Book> books = new ArrayList<>();
+      String seriesString = "xyz3141592654";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
+      for (String title : response.getBookNamesList()) {
+        System.out.printf("Title: %s\n", title);
+      }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.println("That's all!");
+      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelfName")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("edition")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelfName = cl.getOptionValue("shelfName", "Math");
+    int edition =
+        cl.getOptionValue("edition") != null
+            ? Integer.parseInt(cl.getOptionValue("edition"))
+            : 123;
+
+    samplePublishSeries(shelfName, edition);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: src/main/java/samples/com/google/example/library/v1/publishseries/PublishSeriesFlattenedSecondEdition.java ==============
+// DO NOT EDIT! This is a generated sample ("Flattened",  "second_edition")
+package com.google.example.examples.library.v1.snippets;
+
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesFlattenedSecondEdition {
+  public static void samplePublishSeries() {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      int edition = 2;
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
+      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: src/main/java/samples/com/google/example/library/v1/publishseries/PublishSeriesRequestPiVersion.java ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesRequestPiVersion {
+  public static void samplePublishSeries(String shelfName, int edition) {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelfName = "Math";
+      // int edition = 123;
+      Shelf shelf = Shelf.newBuilder()
+        .setName(shelfName)
+        .build();
+      List<Book> books = new ArrayList<>();
+      String seriesString = "xyz3141592654";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(request);
+      for (String title : response.getBookNamesList()) {
+        System.out.printf("Title: %s\n", title);
+      }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.println("That's all!");
+      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelfName")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("edition")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelfName = cl.getOptionValue("shelfName", "Math");
+    int edition =
+        cl.getOptionValue("edition") != null
+            ? Integer.parseInt(cl.getOptionValue("edition"))
+            : 123;
+
+    samplePublishSeries(shelfName, edition);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: src/main/java/samples/com/google/example/library/v1/publishseries/PublishSeriesRequestSecondEdition.java ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
+package com.google.example.examples.library.v1.snippets;
+
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesRequestSecondEdition {
+  public static void samplePublishSeries() {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
+      int edition = 2;
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(request);
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: src/main/java/samples/com/google/example/library/v1/publishseriescallable/PublishSeriesCallableCallablePiVersion.java ==============
+// DO NOT EDIT! This is a generated sample ("Callable",  "pi_version")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesCallableCallablePiVersion {
+  public static void samplePublishSeries(String shelfName, int edition) {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelfName = "Math";
+      // int edition = 123;
+      Shelf shelf = Shelf.newBuilder()
+        .setName(shelfName)
+        .build();
+      List<Book> books = new ArrayList<>();
+      String seriesString = "xyz3141592654";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
+
+      // Do something
+
+      PublishSeriesResponse response = future.get();
+      for (String title : response.getBookNamesList()) {
+        System.out.printf("Title: %s\n", title);
+      }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.println("That's all!");
+      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelfName")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("edition")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelfName = cl.getOptionValue("shelfName", "Math");
+    int edition =
+        cl.getOptionValue("edition") != null
+            ? Integer.parseInt(cl.getOptionValue("edition"))
+            : 123;
+
+    samplePublishSeries(shelfName, edition);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: src/main/java/samples/com/google/example/library/v1/publishseriescallable/PublishSeriesCallableCallableSecondEdition.java ==============
+// DO NOT EDIT! This is a generated sample ("Callable",  "second_edition")
+package com.google.example.examples.library.v1.snippets;
+
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesCallableCallableSecondEdition {
+  public static void samplePublishSeries() {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
+      int edition = 2;
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
+
+      // Do something
+
+      PublishSeriesResponse response = future.get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: src/main/java/samples/com/google/example/library/v1/streambookscallable/StreamBooksCallableCallableStreamingServerProg.java ==============
+// DO NOT EDIT! This is a generated sample ("CallableStreamingServer",  "prog")
+package com.google.example.examples.library.v1.snippets;
+
+// [START babbage]
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.StreamBooksRequest;
+
+public class StreamBooksCallableCallableStreamingServerProg {
+  public static void sampleStreamBooks() {
+    // [START babbage_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      String name = "BASIC";
+      StreamBooksRequest request = StreamBooksRequest.newBuilder()
+        .setName(name)
+        .build();
+
+      ServerStream<Book> stream = libraryClient.streamBooksCallable().call(request);
+      for (Book responseItem : stream) {
+        System.out.println(responseItem);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END babbage_core]
+  }
+
+  public static void main(String[] args) {
+    sampleStreamBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END babbage]
+============== file: src/main/java/samples/com/google/example/library/v1/streamshelvescallable/StreamShelvesCallableCallableStreamingServerEmpty.java ==============
+// DO NOT EDIT! This is a generated sample ("CallableStreamingServer",  "empty")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.StreamShelvesRequest;
+
+public class StreamShelvesCallableCallableStreamingServerEmpty {
+  public static void sampleStreamShelves() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+
+      ServerStream<StreamShelvesResponse> stream = libraryClient.streamShelvesCallable().call(request);
+      for (StreamShelvesResponse responseItem : stream) {
+        System.out.println(responseItem);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleStreamShelves();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: src/test/java/com/google/example/library/v1/LibraryClientTest.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
+import com.google.api.gax.grpc.testing.MockGrpcService;
+import com.google.api.gax.grpc.testing.MockServiceHelper;
+import com.google.api.gax.grpc.testing.MockStreamObserver;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.resourcenames.ResourceName;
+import com.google.cloud.ProjectName;
+import com.google.common.collect.Lists;
+import com.google.example.library.v1.Comment;
+import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
+import static com.google.example.library.v1.LibraryClient.ListStringsPagedResponse;
+import com.google.example.library.v1.SomeMessage2;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Empty;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
+import com.google.tagger.v1.TaggerProto.AddLabelRequest;
+import com.google.tagger.v1.TaggerProto.AddLabelResponse;
+import com.google.tagger.v1.TaggerProto.AddTagRequest;
+import com.google.tagger.v1.TaggerProto.AddTagResponse;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@javax.annotation.Generated("by GAPIC")
+public class LibraryClientTest {
+  private static MockLibraryService mockLibraryService;
+  private static MockLabeler mockLabeler;
+  private static MockServiceHelper serviceHelper;
+  private LibraryClient client;
+  private LocalChannelProvider channelProvider;
+
+  @BeforeClass
+  public static void startStaticServer() {
+    mockLibraryService = new MockLibraryService();
+    mockLabeler = new MockLabeler();
+    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler));
+    serviceHelper.start();
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    serviceHelper.stop();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    serviceHelper.reset();
+    channelProvider = serviceHelper.createChannelProvider();
+    LibrarySettings settings = LibrarySettings.newBuilder()
+        .setTransportChannelProvider(channelProvider)
+        .setCredentialsProvider(NoCredentialsProvider.create())
+        .build();
+    client = LibraryClient.create(settings);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    client.close();
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createShelfTest() {
+    ShelfName name = ShelfName.of("[SHELF_ID]");
+    String theme = "theme110327241";
+    String internalTheme = "internalTheme792518087";
+    Shelf expectedResponse = Shelf.newBuilder()
+      .setName(name.toString())
+      .setTheme(theme)
+      .setInternalTheme(internalTheme)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    Shelf shelf = Shelf.newBuilder().build();
+
+    Shelf actualResponse =
+        client.createShelf(shelf);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CreateShelfRequest actualRequest = (CreateShelfRequest)actualRequests.get(0);
+
+    Assert.assertEquals(shelf, actualRequest.getShelf());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createShelfExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      Shelf shelf = Shelf.newBuilder().build();
+
+      client.createShelf(shelf);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getShelfTest() {
+    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    String theme = "theme110327241";
+    String internalTheme = "internalTheme792518087";
+    Shelf expectedResponse = Shelf.newBuilder()
+      .setName(name2.toString())
+      .setTheme(theme)
+      .setInternalTheme(internalTheme)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ShelfName name = ShelfName.of("[SHELF_ID]");
+
+    Shelf actualResponse =
+        client.getShelf(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetShelfRequest actualRequest = (GetShelfRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfName.parse(actualRequest.getName()));
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getShelfExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfName name = ShelfName.of("[SHELF_ID]");
+
+      client.getShelf(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getShelfTest2() {
+    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    String theme = "theme110327241";
+    String internalTheme = "internalTheme792518087";
+    Shelf expectedResponse = Shelf.newBuilder()
+      .setName(name2.toString())
+      .setTheme(theme)
+      .setInternalTheme(internalTheme)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String formattedName = ShelfName.format("[SHELF_ID]");
+    SomeMessage message = SomeMessage.newBuilder().build();
+
+    Shelf actualResponse =
+        client.getShelf(formattedName, message);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetShelfRequest actualRequest = (GetShelfRequest)actualRequests.get(0);
+
+    Assert.assertEquals(formattedName, actualRequest.getName());
+    Assert.assertEquals(message, actualRequest.getMessage());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getShelfExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String formattedName = ShelfName.format("[SHELF_ID]");
+      SomeMessage message = SomeMessage.newBuilder().build();
+
+      client.getShelf(formattedName, message);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getShelfTest3() {
+    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    String theme = "theme110327241";
+    String internalTheme = "internalTheme792518087";
+    Shelf expectedResponse = Shelf.newBuilder()
+      .setName(name2.toString())
+      .setTheme(theme)
+      .setInternalTheme(internalTheme)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String formattedName = ShelfName.format("[SHELF_ID]");
+    SomeMessage message = SomeMessage.newBuilder().build();
+    com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
+
+    Shelf actualResponse =
+        client.getShelf(formattedName, message, stringBuilder);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetShelfRequest actualRequest = (GetShelfRequest)actualRequests.get(0);
+
+    Assert.assertEquals(formattedName, actualRequest.getName());
+    Assert.assertEquals(message, actualRequest.getMessage());
+    Assert.assertEquals(stringBuilder, actualRequest.getStringBuilder());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getShelfExceptionTest3() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String formattedName = ShelfName.format("[SHELF_ID]");
+      SomeMessage message = SomeMessage.newBuilder().build();
+      com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
+
+      client.getShelf(formattedName, message, stringBuilder);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listShelvesTest() {
+    String nextPageToken = "";
+    Shelf shelvesElement = Shelf.newBuilder().build();
+    List<Shelf> shelves = Arrays.asList(shelvesElement);
+    ListShelvesResponse expectedResponse = ListShelvesResponse.newBuilder()
+      .setNextPageToken(nextPageToken)
+      .addAllShelves(shelves)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+
+
+    ListShelvesPagedResponse pagedListResponse = client.listShelves();
+
+    List<Shelf> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getShelvesList().get(0), resources.get(0));
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListShelvesRequest actualRequest = (ListShelvesRequest)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listShelvesExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+
+
+      client.listShelves();
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void deleteShelfTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ShelfName name = ShelfName.of("[SHELF_ID]");
+
+    client.deleteShelf(name);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    DeleteShelfRequest actualRequest = (DeleteShelfRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfName.parse(actualRequest.getName()));
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void deleteShelfExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfName name = ShelfName.of("[SHELF_ID]");
+
+      client.deleteShelf(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void mergeShelvesTest() {
+    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    String theme = "theme110327241";
+    String internalTheme = "internalTheme792518087";
+    Shelf expectedResponse = Shelf.newBuilder()
+      .setName(name2.toString())
+      .setTheme(theme)
+      .setInternalTheme(internalTheme)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+
+    Shelf actualResponse =
+        client.mergeShelves(name, otherShelfName);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MergeShelvesRequest actualRequest = (MergeShelvesRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfName.parse(actualRequest.getName()));
+    Assert.assertEquals(otherShelfName, ShelfName.parse(actualRequest.getOtherShelfName()));
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void mergeShelvesExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+
+      client.mergeShelves(name, otherShelfName);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createBookTest() {
+    ShelfBookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    Book expectedResponse = Book.newBuilder()
+      .setName(name2.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String formattedName = ShelfName.format("[SHELF_ID]");
+    Book book = Book.newBuilder().build();
+
+    Book actualResponse =
+        client.createBook(formattedName, book);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CreateBookRequest actualRequest = (CreateBookRequest)actualRequests.get(0);
+
+    Assert.assertEquals(formattedName, actualRequest.getName());
+    Assert.assertEquals(book, actualRequest.getBook());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String formattedName = ShelfName.format("[SHELF_ID]");
+      Book book = Book.newBuilder().build();
+
+      client.createBook(formattedName, book);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void publishSeriesTest() {
+    String bookNamesElement = "bookNamesElement1491670575";
+    List<String> bookNames = Arrays.asList(bookNamesElement);
+    PublishSeriesResponse expectedResponse = PublishSeriesResponse.newBuilder()
+      .addAllBookNames(bookNames)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    Shelf shelf = Shelf.newBuilder().build();
+    List<Book> books = new ArrayList<>();
+    int edition = 1887963714;
+    String seriesString = "foobar";
+    SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+      .setSeriesString(seriesString)
+      .build();
+
+    PublishSeriesResponse actualResponse =
+        client.publishSeries(shelf, books, edition, seriesUuid);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    PublishSeriesRequest actualRequest = (PublishSeriesRequest)actualRequests.get(0);
+
+    Assert.assertEquals(shelf, actualRequest.getShelf());
+    Assert.assertEquals(books, actualRequest.getBooksList());
+    Assert.assertEquals(edition, actualRequest.getEdition());
+    Assert.assertEquals(seriesUuid, actualRequest.getSeriesUuid());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void publishSeriesExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      int edition = 1887963714;
+      String seriesString = "foobar";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+
+      client.publishSeries(shelf, books, edition, seriesUuid);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBookTest() {
+    ShelfBookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    Book expectedResponse = Book.newBuilder()
+      .setName(name2.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+    Book actualResponse =
+        client.getBook(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfBookName.parse(actualRequest.getName()));
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+      client.getBook(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listBooksTest() {
+    String nextPageToken = "";
+    Book booksElement = Book.newBuilder().build();
+    List<Book> books = Arrays.asList(booksElement);
+    ListBooksResponse expectedResponse = ListBooksResponse.newBuilder()
+      .setNextPageToken(nextPageToken)
+      .addAllBooks(books)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ShelfName name = ShelfName.of("[SHELF_ID]");
+    String filter = "book-filter-string";
+
+    ListBooksPagedResponse pagedListResponse = client.listBooks(name, filter);
+
+    List<Book> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getBooksList().get(0), resources.get(0));
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListBooksRequest actualRequest = (ListBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfName.parse(actualRequest.getName()));
+    Assert.assertEquals(filter, actualRequest.getFilter());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfName name = ShelfName.of("[SHELF_ID]");
+      String filter = "book-filter-string";
+
+      client.listBooks(name, filter);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void deleteBookTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+    client.deleteBook(name);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    DeleteBookRequest actualRequest = (DeleteBookRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfBookName.parse(actualRequest.getName()));
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void deleteBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+      client.deleteBook(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void updateBookTest() {
+    ShelfBookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    Book expectedResponse = Book.newBuilder()
+      .setName(name2.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    Book book = Book.newBuilder().build();
+
+    Book actualResponse =
+        client.updateBook(name, book);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    UpdateBookRequest actualRequest = (UpdateBookRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfBookName.parse(actualRequest.getName()));
+    Assert.assertEquals(book, actualRequest.getBook());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void updateBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      Book book = Book.newBuilder().build();
+
+      client.updateBook(name, book);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void updateBookTest2() {
+    ShelfBookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    Book expectedResponse = Book.newBuilder()
+      .setName(name2.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    String optionalFoo = "optionalFoo1822578535";
+    Book book = Book.newBuilder().build();
+    FieldMask updateMask = FieldMask.newBuilder().build();
+    com.google.example.library.v1.FieldMask physicalMask = com.google.example.library.v1.FieldMask.newBuilder().build();
+
+    Book actualResponse =
+        client.updateBook(name, optionalFoo, book, updateMask, physicalMask);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    UpdateBookRequest actualRequest = (UpdateBookRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfBookName.parse(actualRequest.getName()));
+    Assert.assertEquals(optionalFoo, actualRequest.getOptionalFoo());
+    Assert.assertEquals(book, actualRequest.getBook());
+    Assert.assertEquals(updateMask, actualRequest.getUpdateMask());
+    Assert.assertEquals(physicalMask, actualRequest.getPhysicalMask());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void updateBookExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      String optionalFoo = "optionalFoo1822578535";
+      Book book = Book.newBuilder().build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
+      com.google.example.library.v1.FieldMask physicalMask = com.google.example.library.v1.FieldMask.newBuilder().build();
+
+      client.updateBook(name, optionalFoo, book, updateMask, physicalMask);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void moveBookTest() {
+    ShelfBookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    Book expectedResponse = Book.newBuilder()
+      .setName(name2.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+
+    Book actualResponse =
+        client.moveBook(name, otherShelfName);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MoveBookRequest actualRequest = (MoveBookRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfBookName.parse(actualRequest.getName()));
+    Assert.assertEquals(otherShelfName, ShelfName.parse(actualRequest.getOtherShelfName()));
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void moveBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+
+      client.moveBook(name, otherShelfName);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listStringsTest() {
+    String nextPageToken = "";
+    ResourceName stringsElement = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    List<ResourceName> strings = Arrays.asList(stringsElement);
+    ListStringsResponse expectedResponse = ListStringsResponse.newBuilder()
+      .setNextPageToken(nextPageToken)
+      .addAllStrings(UntypedResourceName.toStringList(strings))
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+
+
+    ListStringsPagedResponse pagedListResponse = client.listStrings();
+
+    List<String> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getStringsList().get(0), resources.get(0));
+    List<ResourceName> resourceNames = Lists.newArrayList(pagedListResponse.iterateAllAsResourceName());
+    Assert.assertEquals(1, resourceNames.size());
+    Assert.assertEquals(UntypedResourceName.parse(expectedResponse.getStringsList().get(0)),
+        resourceNames.get(0));
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListStringsRequest actualRequest = (ListStringsRequest)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listStringsExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+
+
+      client.listStrings();
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listStringsTest2() {
+    String nextPageToken = "";
+    ResourceName stringsElement = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    List<ResourceName> strings = Arrays.asList(stringsElement);
+    ListStringsResponse expectedResponse = ListStringsResponse.newBuilder()
+      .setNextPageToken(nextPageToken)
+      .addAllStrings(UntypedResourceName.toStringList(strings))
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+
+    ListStringsPagedResponse pagedListResponse = client.listStrings(name);
+
+    List<String> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getStringsList().get(0), resources.get(0));
+    List<ResourceName> resourceNames = Lists.newArrayList(pagedListResponse.iterateAllAsResourceName());
+    Assert.assertEquals(1, resourceNames.size());
+    Assert.assertEquals(UntypedResourceName.parse(expectedResponse.getStringsList().get(0)),
+        resourceNames.get(0));
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListStringsRequest actualRequest = (ListStringsRequest)actualRequests.get(0);
+
+    Assert.assertEquals(Objects.toString(name), Objects.toString(actualRequest.getName()));
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listStringsExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+
+      client.listStrings(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addCommentsTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String formattedName = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+    ByteString comment = ByteString.copyFromUtf8("95");
+    Comment.Stage stage = Comment.Stage.UNSET;
+    SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
+    Comment commentsElement = Comment.newBuilder()
+      .setComment(comment)
+      .setStage(stage)
+      .setAlignment(alignment)
+      .build();
+    List<Comment> comments = Arrays.asList(commentsElement);
+
+    client.addComments(formattedName, comments);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    AddCommentsRequest actualRequest = (AddCommentsRequest)actualRequests.get(0);
+
+    Assert.assertEquals(formattedName, actualRequest.getName());
+    Assert.assertEquals(comments, actualRequest.getCommentsList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addCommentsExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String formattedName = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+      ByteString comment = ByteString.copyFromUtf8("95");
+      Comment.Stage stage = Comment.Stage.UNSET;
+      SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
+      Comment commentsElement = Comment.newBuilder()
+        .setComment(comment)
+        .setStage(stage)
+        .setAlignment(alignment)
+        .build();
+      List<Comment> comments = Arrays.asList(commentsElement);
+
+      client.addComments(formattedName, comments);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBookFromArchiveTest() {
+    ArchivedBookName name2 = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    BookFromArchive expectedResponse = BookFromArchive.newBuilder()
+      .setName(name2.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+
+    BookFromArchive actualResponse =
+        client.getBookFromArchive(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetBookFromArchiveRequest actualRequest = (GetBookFromArchiveRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ArchivedBookName.parse(actualRequest.getName()));
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBookFromArchiveExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+
+      client.getBookFromArchive(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBookFromAnywhereTest() {
+    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    BookFromAnywhere expectedResponse = BookFromAnywhere.newBuilder()
+      .setName(name2.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+    BookFromAnywhere actualResponse =
+        client.getBookFromAnywhere(name, altBookName);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetBookFromAnywhereRequest actualRequest = (GetBookFromAnywhereRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(Objects.toString(altBookName), actualRequest.getAltBookName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBookFromAnywhereExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+      client.getBookFromAnywhere(name, altBookName);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBookFromAbsolutelyAnywhereTest() {
+    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    BookFromAnywhere expectedResponse = BookFromAnywhere.newBuilder()
+      .setName(name2.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+    BookFromAnywhere actualResponse =
+        client.getBookFromAbsolutelyAnywhere(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetBookFromAbsolutelyAnywhereRequest actualRequest = (GetBookFromAbsolutelyAnywhereRequest)actualRequests.get(0);
+
+    Assert.assertEquals(Objects.toString(name), Objects.toString(actualRequest.getName()));
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBookFromAbsolutelyAnywhereExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+      client.getBookFromAbsolutelyAnywhere(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void updateBookIndexTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    String indexName = "default index";
+    String indexMapItem = "indexMapItem1918721251";
+    Map<String, String> indexMap = new HashMap<>();
+    indexMap.put("default_key", indexMapItem);
+
+    client.updateBookIndex(name, indexName, indexMap);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    UpdateBookIndexRequest actualRequest = (UpdateBookIndexRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfBookName.parse(actualRequest.getName()));
+    Assert.assertEquals(indexName, actualRequest.getIndexName());
+    Assert.assertEquals(indexMap, actualRequest.getIndexMapMap());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void updateBookIndexExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      String indexName = "default index";
+      String indexMapItem = "indexMapItem1918721251";
+      Map<String, String> indexMap = new HashMap<>();
+      indexMap.put("default_key", indexMapItem);
+
+      client.updateBookIndex(name, indexName, indexMap);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamShelvesTest() throws Exception {
+    Shelf shelvesElement = Shelf.newBuilder().build();
+    List<Shelf> shelves = Arrays.asList(shelvesElement);
+    StreamShelvesResponse expectedResponse = StreamShelvesResponse.newBuilder()
+      .addAllShelves(shelves)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+    StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+
+    MockStreamObserver<StreamShelvesResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> callable =
+        client.streamShelvesCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    List<StreamShelvesResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamShelvesExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+    StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+
+    MockStreamObserver<StreamShelvesResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> callable =
+        client.streamShelvesCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    try {
+      List<StreamShelvesResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamBooksTest() throws Exception {
+    ShelfBookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    Book expectedResponse = Book.newBuilder()
+      .setName(name2.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+    String name = "name3373707";
+    StreamBooksRequest request = StreamBooksRequest.newBuilder()
+      .setName(name)
+      .build();
+
+    MockStreamObserver<Book> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<StreamBooksRequest, Book> callable =
+        client.streamBooksCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    List<Book> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+    String name = "name3373707";
+    StreamBooksRequest request = StreamBooksRequest.newBuilder()
+      .setName(name)
+      .build();
+
+    MockStreamObserver<Book> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<StreamBooksRequest, Book> callable =
+        client.streamBooksCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    try {
+      List<Book> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void discussBookTest() throws Exception {
+    String userName = "userName339340927";
+    ByteString comment = ByteString.copyFromUtf8("95");
+    Comment expectedResponse = Comment.newBuilder()
+      .setUserName(userName)
+      .setComment(comment)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+    String name = "name3373707";
+    DiscussBookRequest request = DiscussBookRequest.newBuilder()
+      .setName(name)
+      .build();
+
+    MockStreamObserver<Comment> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<DiscussBookRequest, Comment> callable =
+        client.discussBookCallable();
+    ApiStreamObserver<DiscussBookRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+    requestObserver.onCompleted();
+
+    List<Comment> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void discussBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+    String name = "name3373707";
+    DiscussBookRequest request = DiscussBookRequest.newBuilder()
+      .setName(name)
+      .build();
+
+    MockStreamObserver<Comment> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<DiscussBookRequest, Comment> callable =
+        client.discussBookCallable();
+    ApiStreamObserver<DiscussBookRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+
+    try {
+      List<Comment> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void findRelatedBooksTest() {
+    String nextPageToken = "";
+    ShelfBookName namesElement2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    List<ShelfBookName> names2 = Arrays.asList(namesElement2);
+    FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
+      .setNextPageToken(nextPageToken)
+      .addAllNames(ShelfBookName.toStringList(names2))
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String namesElement = "namesElement-249113339";
+    List<String> names = Arrays.asList(namesElement);
+    List<String> shelves = new ArrayList<>();
+
+    FindRelatedBooksPagedResponse pagedListResponse = client.findRelatedBooks(names, shelves);
+
+    List<String> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getNamesList().get(0), resources.get(0));
+    List<ShelfBookName> resourceNames = Lists.newArrayList(pagedListResponse.iterateAllAsShelfBookName());
+    Assert.assertEquals(1, resourceNames.size());
+    Assert.assertEquals(ShelfBookName.parse(expectedResponse.getNamesList().get(0)),
+        resourceNames.get(0));
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    FindRelatedBooksRequest actualRequest = (FindRelatedBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(names, actualRequest.getNamesList());
+    Assert.assertEquals(shelves, actualRequest.getShelvesList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void findRelatedBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String namesElement = "namesElement-249113339";
+      List<String> names = Arrays.asList(namesElement);
+      List<String> shelves = new ArrayList<>();
+
+      client.findRelatedBooks(names, shelves);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addTagTest() {
+    AddTagResponse expectedResponse = AddTagResponse.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String formattedResource = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+    String tag = "tag114586";
+
+    AddTagResponse actualResponse =
+        client.addTag(formattedResource, tag);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    AddTagRequest actualRequest = (AddTagRequest)actualRequests.get(0);
+
+    Assert.assertEquals(formattedResource, actualRequest.getResource());
+    Assert.assertEquals(tag, actualRequest.getTag());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addTagExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String formattedResource = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+      String tag = "tag114586";
+
+      client.addTag(formattedResource, tag);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addLabelTest() {
+    AddLabelResponse expectedResponse = AddLabelResponse.newBuilder().build();
+    mockLabeler.addResponse(expectedResponse);
+
+    String formattedResource = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+    String label = "label102727412";
+
+    AddLabelResponse actualResponse =
+        client.addLabel(formattedResource, label);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLabeler.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    AddLabelRequest actualRequest = (AddLabelRequest)actualRequests.get(0);
+
+    Assert.assertEquals(formattedResource, actualRequest.getResource());
+    Assert.assertEquals(label, actualRequest.getLabel());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addLabelExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLabeler.addException(exception);
+
+    try {
+      String formattedResource = ShelfBookName.format("[SHELF_ID]", "[BOOK_ID]");
+      String label = "label102727412";
+
+      client.addLabel(formattedResource, label);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBigBookTest() throws Exception {
+    ShelfBookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    Book expectedResponse = Book.newBuilder()
+      .setName(name2.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("getBigBookTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockLibraryService.addResponse(resultOperation);
+
+    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+    Book actualResponse =
+        client.getBigBookAsync(name).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfBookName.parse(actualRequest.getName()));
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBigBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+      client.getBigBookAsync(name).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBigNothingTest() throws Exception {
+    Empty expectedResponse = Empty.newBuilder().build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("getBigNothingTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockLibraryService.addResponse(resultOperation);
+
+    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+    Empty actualResponse =
+        client.getBigNothingAsync(name).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, ShelfBookName.parse(actualRequest.getName()));
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBigNothingExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+
+      client.getBigNothingAsync(name).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+
+  @Test
+  @SuppressWarnings("all")
+  public void testOptionalRequiredFlatteningParamsTest() {
+    TestOptionalRequiredFlatteningParamsResponse expectedResponse = TestOptionalRequiredFlatteningParamsResponse.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+
+
+    TestOptionalRequiredFlatteningParamsResponse actualResponse =
+        client.testOptionalRequiredFlatteningParams();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    TestOptionalRequiredFlatteningParamsRequest actualRequest = (TestOptionalRequiredFlatteningParamsRequest)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void testOptionalRequiredFlatteningParamsExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+
+
+      client.testOptionalRequiredFlatteningParams();
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void testOptionalRequiredFlatteningParamsTest2() {
+    TestOptionalRequiredFlatteningParamsResponse expectedResponse = TestOptionalRequiredFlatteningParamsResponse.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    int requiredSingularInt32 = 72313594;
+    long requiredSingularInt64 = 72313499L;
+    float requiredSingularFloat = -7514705.0F;
+    double requiredSingularDouble = 1.9111005E8;
+    boolean requiredSingularBool = true;
+    TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+    String requiredSingularString = "requiredSingularString-1949894503";
+    ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
+    TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+    ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+    int requiredSingularFixed32 = 720656715;
+    long requiredSingularFixed64 = 720656810;
+    List<Integer> requiredRepeatedInt32 = new ArrayList<>();
+    List<Long> requiredRepeatedInt64 = new ArrayList<>();
+    List<Float> requiredRepeatedFloat = new ArrayList<>();
+    List<Double> requiredRepeatedDouble = new ArrayList<>();
+    List<Boolean> requiredRepeatedBool = new ArrayList<>();
+    List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum = new ArrayList<>();
+    List<String> requiredRepeatedString = new ArrayList<>();
+    List<ByteString> requiredRepeatedBytes = new ArrayList<>();
+    List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage = new ArrayList<>();
+    List<String> formattedRequiredRepeatedResourceName = new ArrayList<>();
+    List<String> formattedRequiredRepeatedResourceNameOneof = new ArrayList<>();
+    List<String> requiredRepeatedResourceNameCommon = new ArrayList<>();
+    List<Integer> requiredRepeatedFixed32 = new ArrayList<>();
+    List<Long> requiredRepeatedFixed64 = new ArrayList<>();
+    Map<Integer, String> requiredMap = new HashMap<>();
+    int optionalSingularInt32 = 1196565723;
+    long optionalSingularInt64 = 1196565628L;
+    float optionalSingularFloat = -1.19939918E8F;
+    double optionalSingularDouble = 1.41902287E8;
+    boolean optionalSingularBool = false;
+    TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+    String optionalSingularString = "optionalSingularString1852995162";
+    ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
+    TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+    ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+    int optionalSingularFixed32 = 1648847958;
+    long optionalSingularFixed64 = 1648847863;
+    List<Integer> optionalRepeatedInt32 = new ArrayList<>();
+    List<Long> optionalRepeatedInt64 = new ArrayList<>();
+    List<Float> optionalRepeatedFloat = new ArrayList<>();
+    List<Double> optionalRepeatedDouble = new ArrayList<>();
+    List<Boolean> optionalRepeatedBool = new ArrayList<>();
+    List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum = new ArrayList<>();
+    List<String> optionalRepeatedString = new ArrayList<>();
+    List<ByteString> optionalRepeatedBytes = new ArrayList<>();
+    List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage = new ArrayList<>();
+    List<String> formattedOptionalRepeatedResourceName = new ArrayList<>();
+    List<String> formattedOptionalRepeatedResourceNameOneof = new ArrayList<>();
+    List<String> optionalRepeatedResourceNameCommon = new ArrayList<>();
+    List<Integer> optionalRepeatedFixed32 = new ArrayList<>();
+    List<Long> optionalRepeatedFixed64 = new ArrayList<>();
+    Map<Integer, String> optionalMap = new HashMap<>();
+    Any anyValue = Any.newBuilder().build();
+    Struct structValue = Struct.newBuilder().build();
+    Value valueValue = Value.newBuilder().build();
+    ListValue listValueValue = ListValue.newBuilder().build();
+    Timestamp timeValue = Timestamp.newBuilder().build();
+    Duration durationValue = Duration.newBuilder().build();
+    FieldMask fieldMaskValue = FieldMask.newBuilder().build();
+    Int32Value int32Value = Int32Value.newBuilder().build();
+    UInt32Value uint32Value = UInt32Value.newBuilder().build();
+    Int64Value int64Value = Int64Value.newBuilder().build();
+    UInt64Value uint64Value = UInt64Value.newBuilder().build();
+    FloatValue floatValue = FloatValue.newBuilder().build();
+    DoubleValue doubleValue = DoubleValue.newBuilder().build();
+    StringValue stringValue = StringValue.newBuilder().build();
+    BoolValue boolValue = BoolValue.newBuilder().build();
+    BytesValue bytesValue = BytesValue.newBuilder().build();
+    List<Any> repeatedAnyValue = new ArrayList<>();
+    List<Struct> repeatedStructValue = new ArrayList<>();
+    List<Value> repeatedValueValue = new ArrayList<>();
+    List<ListValue> repeatedListValueValue = new ArrayList<>();
+    List<Timestamp> repeatedTimeValue = new ArrayList<>();
+    List<Duration> repeatedDurationValue = new ArrayList<>();
+    List<FieldMask> repeatedFieldMaskValue = new ArrayList<>();
+    List<Int32Value> repeatedInt32Value = new ArrayList<>();
+    List<UInt32Value> repeatedUint32Value = new ArrayList<>();
+    List<Int64Value> repeatedInt64Value = new ArrayList<>();
+    List<UInt64Value> repeatedUint64Value = new ArrayList<>();
+    List<FloatValue> repeatedFloatValue = new ArrayList<>();
+    List<DoubleValue> repeatedDoubleValue = new ArrayList<>();
+    List<StringValue> repeatedStringValue = new ArrayList<>();
+    List<BoolValue> repeatedBoolValue = new ArrayList<>();
+    List<BytesValue> repeatedBytesValue = new ArrayList<>();
+
+    TestOptionalRequiredFlatteningParamsResponse actualResponse =
+        client.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, formattedRequiredRepeatedResourceName, formattedRequiredRepeatedResourceNameOneof, requiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, formattedOptionalRepeatedResourceName, formattedOptionalRepeatedResourceNameOneof, optionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap, anyValue, structValue, valueValue, listValueValue, timeValue, durationValue, fieldMaskValue, int32Value, uint32Value, int64Value, uint64Value, floatValue, doubleValue, stringValue, boolValue, bytesValue, repeatedAnyValue, repeatedStructValue, repeatedValueValue, repeatedListValueValue, repeatedTimeValue, repeatedDurationValue, repeatedFieldMaskValue, repeatedInt32Value, repeatedUint32Value, repeatedInt64Value, repeatedUint64Value, repeatedFloatValue, repeatedDoubleValue, repeatedStringValue, repeatedBoolValue, repeatedBytesValue);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    TestOptionalRequiredFlatteningParamsRequest actualRequest = (TestOptionalRequiredFlatteningParamsRequest)actualRequests.get(0);
+
+    Assert.assertEquals(requiredSingularInt32, actualRequest.getRequiredSingularInt32());
+    Assert.assertEquals(requiredSingularInt64, actualRequest.getRequiredSingularInt64());
+    Assert.assertEquals(requiredSingularFloat, actualRequest.getRequiredSingularFloat());
+    Assert.assertEquals(requiredSingularDouble, actualRequest.getRequiredSingularDouble());
+    Assert.assertEquals(requiredSingularBool, actualRequest.getRequiredSingularBool());
+    Assert.assertEquals(requiredSingularEnum, actualRequest.getRequiredSingularEnum());
+    Assert.assertEquals(requiredSingularString, actualRequest.getRequiredSingularString());
+    Assert.assertEquals(requiredSingularBytes, actualRequest.getRequiredSingularBytes());
+    Assert.assertEquals(requiredSingularMessage, actualRequest.getRequiredSingularMessage());
+    Assert.assertEquals(requiredSingularResourceName, actualRequest.getRequiredSingularResourceName());
+    Assert.assertEquals(requiredSingularResourceNameOneof, actualRequest.getRequiredSingularResourceNameOneof());
+    Assert.assertEquals(requiredSingularResourceNameCommon, actualRequest.getRequiredSingularResourceNameCommon());
+    Assert.assertEquals(requiredSingularFixed32, actualRequest.getRequiredSingularFixed32());
+    Assert.assertEquals(requiredSingularFixed64, actualRequest.getRequiredSingularFixed64());
+    Assert.assertEquals(requiredRepeatedInt32, actualRequest.getRequiredRepeatedInt32List());
+    Assert.assertEquals(requiredRepeatedInt64, actualRequest.getRequiredRepeatedInt64List());
+    Assert.assertEquals(requiredRepeatedFloat, actualRequest.getRequiredRepeatedFloatList());
+    Assert.assertEquals(requiredRepeatedDouble, actualRequest.getRequiredRepeatedDoubleList());
+    Assert.assertEquals(requiredRepeatedBool, actualRequest.getRequiredRepeatedBoolList());
+    Assert.assertEquals(requiredRepeatedEnum, actualRequest.getRequiredRepeatedEnumList());
+    Assert.assertEquals(requiredRepeatedString, actualRequest.getRequiredRepeatedStringList());
+    Assert.assertEquals(requiredRepeatedBytes, actualRequest.getRequiredRepeatedBytesList());
+    Assert.assertEquals(requiredRepeatedMessage, actualRequest.getRequiredRepeatedMessageList());
+    Assert.assertEquals(formattedRequiredRepeatedResourceName, actualRequest.getRequiredRepeatedResourceNameList());
+    Assert.assertEquals(formattedRequiredRepeatedResourceNameOneof, actualRequest.getRequiredRepeatedResourceNameOneofList());
+    Assert.assertEquals(requiredRepeatedResourceNameCommon, actualRequest.getRequiredRepeatedResourceNameCommonList());
+    Assert.assertEquals(requiredRepeatedFixed32, actualRequest.getRequiredRepeatedFixed32List());
+    Assert.assertEquals(requiredRepeatedFixed64, actualRequest.getRequiredRepeatedFixed64List());
+    Assert.assertEquals(requiredMap, actualRequest.getRequiredMapMap());
+    Assert.assertEquals(optionalSingularInt32, actualRequest.getOptionalSingularInt32());
+    Assert.assertEquals(optionalSingularInt64, actualRequest.getOptionalSingularInt64());
+    Assert.assertEquals(optionalSingularFloat, actualRequest.getOptionalSingularFloat());
+    Assert.assertEquals(optionalSingularDouble, actualRequest.getOptionalSingularDouble());
+    Assert.assertEquals(optionalSingularBool, actualRequest.getOptionalSingularBool());
+    Assert.assertEquals(optionalSingularEnum, actualRequest.getOptionalSingularEnum());
+    Assert.assertEquals(optionalSingularString, actualRequest.getOptionalSingularString());
+    Assert.assertEquals(optionalSingularBytes, actualRequest.getOptionalSingularBytes());
+    Assert.assertEquals(optionalSingularMessage, actualRequest.getOptionalSingularMessage());
+    Assert.assertEquals(optionalSingularResourceName, actualRequest.getOptionalSingularResourceName());
+    Assert.assertEquals(optionalSingularResourceNameOneof, actualRequest.getOptionalSingularResourceNameOneof());
+    Assert.assertEquals(optionalSingularResourceNameCommon, actualRequest.getOptionalSingularResourceNameCommon());
+    Assert.assertEquals(optionalSingularFixed32, actualRequest.getOptionalSingularFixed32());
+    Assert.assertEquals(optionalSingularFixed64, actualRequest.getOptionalSingularFixed64());
+    Assert.assertEquals(optionalRepeatedInt32, actualRequest.getOptionalRepeatedInt32List());
+    Assert.assertEquals(optionalRepeatedInt64, actualRequest.getOptionalRepeatedInt64List());
+    Assert.assertEquals(optionalRepeatedFloat, actualRequest.getOptionalRepeatedFloatList());
+    Assert.assertEquals(optionalRepeatedDouble, actualRequest.getOptionalRepeatedDoubleList());
+    Assert.assertEquals(optionalRepeatedBool, actualRequest.getOptionalRepeatedBoolList());
+    Assert.assertEquals(optionalRepeatedEnum, actualRequest.getOptionalRepeatedEnumList());
+    Assert.assertEquals(optionalRepeatedString, actualRequest.getOptionalRepeatedStringList());
+    Assert.assertEquals(optionalRepeatedBytes, actualRequest.getOptionalRepeatedBytesList());
+    Assert.assertEquals(optionalRepeatedMessage, actualRequest.getOptionalRepeatedMessageList());
+    Assert.assertEquals(formattedOptionalRepeatedResourceName, actualRequest.getOptionalRepeatedResourceNameList());
+    Assert.assertEquals(formattedOptionalRepeatedResourceNameOneof, actualRequest.getOptionalRepeatedResourceNameOneofList());
+    Assert.assertEquals(optionalRepeatedResourceNameCommon, actualRequest.getOptionalRepeatedResourceNameCommonList());
+    Assert.assertEquals(optionalRepeatedFixed32, actualRequest.getOptionalRepeatedFixed32List());
+    Assert.assertEquals(optionalRepeatedFixed64, actualRequest.getOptionalRepeatedFixed64List());
+    Assert.assertEquals(optionalMap, actualRequest.getOptionalMapMap());
+    Assert.assertEquals(anyValue, actualRequest.getAnyValue());
+    Assert.assertEquals(structValue, actualRequest.getStructValue());
+    Assert.assertEquals(valueValue, actualRequest.getValueValue());
+    Assert.assertEquals(listValueValue, actualRequest.getListValueValue());
+    Assert.assertEquals(timeValue, actualRequest.getTimeValue());
+    Assert.assertEquals(durationValue, actualRequest.getDurationValue());
+    Assert.assertEquals(fieldMaskValue, actualRequest.getFieldMaskValue());
+    Assert.assertEquals(int32Value, actualRequest.getInt32Value());
+    Assert.assertEquals(uint32Value, actualRequest.getUint32Value());
+    Assert.assertEquals(int64Value, actualRequest.getInt64Value());
+    Assert.assertEquals(uint64Value, actualRequest.getUint64Value());
+    Assert.assertEquals(floatValue, actualRequest.getFloatValue());
+    Assert.assertEquals(doubleValue, actualRequest.getDoubleValue());
+    Assert.assertEquals(stringValue, actualRequest.getStringValue());
+    Assert.assertEquals(boolValue, actualRequest.getBoolValue());
+    Assert.assertEquals(bytesValue, actualRequest.getBytesValue());
+    Assert.assertEquals(repeatedAnyValue, actualRequest.getRepeatedAnyValueList());
+    Assert.assertEquals(repeatedStructValue, actualRequest.getRepeatedStructValueList());
+    Assert.assertEquals(repeatedValueValue, actualRequest.getRepeatedValueValueList());
+    Assert.assertEquals(repeatedListValueValue, actualRequest.getRepeatedListValueValueList());
+    Assert.assertEquals(repeatedTimeValue, actualRequest.getRepeatedTimeValueList());
+    Assert.assertEquals(repeatedDurationValue, actualRequest.getRepeatedDurationValueList());
+    Assert.assertEquals(repeatedFieldMaskValue, actualRequest.getRepeatedFieldMaskValueList());
+    Assert.assertEquals(repeatedInt32Value, actualRequest.getRepeatedInt32ValueList());
+    Assert.assertEquals(repeatedUint32Value, actualRequest.getRepeatedUint32ValueList());
+    Assert.assertEquals(repeatedInt64Value, actualRequest.getRepeatedInt64ValueList());
+    Assert.assertEquals(repeatedUint64Value, actualRequest.getRepeatedUint64ValueList());
+    Assert.assertEquals(repeatedFloatValue, actualRequest.getRepeatedFloatValueList());
+    Assert.assertEquals(repeatedDoubleValue, actualRequest.getRepeatedDoubleValueList());
+    Assert.assertEquals(repeatedStringValue, actualRequest.getRepeatedStringValueList());
+    Assert.assertEquals(repeatedBoolValue, actualRequest.getRepeatedBoolValueList());
+    Assert.assertEquals(repeatedBytesValue, actualRequest.getRepeatedBytesValueList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void testOptionalRequiredFlatteningParamsExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      int requiredSingularInt32 = 72313594;
+      long requiredSingularInt64 = 72313499L;
+      float requiredSingularFloat = -7514705.0F;
+      double requiredSingularDouble = 1.9111005E8;
+      boolean requiredSingularBool = true;
+      TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+      String requiredSingularString = "requiredSingularString-1949894503";
+      ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
+      TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+      ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+      int requiredSingularFixed32 = 720656715;
+      long requiredSingularFixed64 = 720656810;
+      List<Integer> requiredRepeatedInt32 = new ArrayList<>();
+      List<Long> requiredRepeatedInt64 = new ArrayList<>();
+      List<Float> requiredRepeatedFloat = new ArrayList<>();
+      List<Double> requiredRepeatedDouble = new ArrayList<>();
+      List<Boolean> requiredRepeatedBool = new ArrayList<>();
+      List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum = new ArrayList<>();
+      List<String> requiredRepeatedString = new ArrayList<>();
+      List<ByteString> requiredRepeatedBytes = new ArrayList<>();
+      List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage = new ArrayList<>();
+      List<String> formattedRequiredRepeatedResourceName = new ArrayList<>();
+      List<String> formattedRequiredRepeatedResourceNameOneof = new ArrayList<>();
+      List<String> requiredRepeatedResourceNameCommon = new ArrayList<>();
+      List<Integer> requiredRepeatedFixed32 = new ArrayList<>();
+      List<Long> requiredRepeatedFixed64 = new ArrayList<>();
+      Map<Integer, String> requiredMap = new HashMap<>();
+      int optionalSingularInt32 = 1196565723;
+      long optionalSingularInt64 = 1196565628L;
+      float optionalSingularFloat = -1.19939918E8F;
+      double optionalSingularDouble = 1.41902287E8;
+      boolean optionalSingularBool = false;
+      TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+      String optionalSingularString = "optionalSingularString1852995162";
+      ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
+      TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+      ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+      int optionalSingularFixed32 = 1648847958;
+      long optionalSingularFixed64 = 1648847863;
+      List<Integer> optionalRepeatedInt32 = new ArrayList<>();
+      List<Long> optionalRepeatedInt64 = new ArrayList<>();
+      List<Float> optionalRepeatedFloat = new ArrayList<>();
+      List<Double> optionalRepeatedDouble = new ArrayList<>();
+      List<Boolean> optionalRepeatedBool = new ArrayList<>();
+      List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum = new ArrayList<>();
+      List<String> optionalRepeatedString = new ArrayList<>();
+      List<ByteString> optionalRepeatedBytes = new ArrayList<>();
+      List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage = new ArrayList<>();
+      List<String> formattedOptionalRepeatedResourceName = new ArrayList<>();
+      List<String> formattedOptionalRepeatedResourceNameOneof = new ArrayList<>();
+      List<String> optionalRepeatedResourceNameCommon = new ArrayList<>();
+      List<Integer> optionalRepeatedFixed32 = new ArrayList<>();
+      List<Long> optionalRepeatedFixed64 = new ArrayList<>();
+      Map<Integer, String> optionalMap = new HashMap<>();
+      Any anyValue = Any.newBuilder().build();
+      Struct structValue = Struct.newBuilder().build();
+      Value valueValue = Value.newBuilder().build();
+      ListValue listValueValue = ListValue.newBuilder().build();
+      Timestamp timeValue = Timestamp.newBuilder().build();
+      Duration durationValue = Duration.newBuilder().build();
+      FieldMask fieldMaskValue = FieldMask.newBuilder().build();
+      Int32Value int32Value = Int32Value.newBuilder().build();
+      UInt32Value uint32Value = UInt32Value.newBuilder().build();
+      Int64Value int64Value = Int64Value.newBuilder().build();
+      UInt64Value uint64Value = UInt64Value.newBuilder().build();
+      FloatValue floatValue = FloatValue.newBuilder().build();
+      DoubleValue doubleValue = DoubleValue.newBuilder().build();
+      StringValue stringValue = StringValue.newBuilder().build();
+      BoolValue boolValue = BoolValue.newBuilder().build();
+      BytesValue bytesValue = BytesValue.newBuilder().build();
+      List<Any> repeatedAnyValue = new ArrayList<>();
+      List<Struct> repeatedStructValue = new ArrayList<>();
+      List<Value> repeatedValueValue = new ArrayList<>();
+      List<ListValue> repeatedListValueValue = new ArrayList<>();
+      List<Timestamp> repeatedTimeValue = new ArrayList<>();
+      List<Duration> repeatedDurationValue = new ArrayList<>();
+      List<FieldMask> repeatedFieldMaskValue = new ArrayList<>();
+      List<Int32Value> repeatedInt32Value = new ArrayList<>();
+      List<UInt32Value> repeatedUint32Value = new ArrayList<>();
+      List<Int64Value> repeatedInt64Value = new ArrayList<>();
+      List<UInt64Value> repeatedUint64Value = new ArrayList<>();
+      List<FloatValue> repeatedFloatValue = new ArrayList<>();
+      List<DoubleValue> repeatedDoubleValue = new ArrayList<>();
+      List<StringValue> repeatedStringValue = new ArrayList<>();
+      List<BoolValue> repeatedBoolValue = new ArrayList<>();
+      List<BytesValue> repeatedBytesValue = new ArrayList<>();
+
+      client.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, formattedRequiredRepeatedResourceName, formattedRequiredRepeatedResourceNameOneof, requiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, formattedOptionalRepeatedResourceName, formattedOptionalRepeatedResourceNameOneof, optionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap, anyValue, structValue, valueValue, listValueValue, timeValue, durationValue, fieldMaskValue, int32Value, uint32Value, int64Value, uint64Value, floatValue, doubleValue, stringValue, boolValue, bytesValue, repeatedAnyValue, repeatedStructValue, repeatedValueValue, repeatedListValueValue, repeatedTimeValue, repeatedDurationValue, repeatedFieldMaskValue, repeatedInt32Value, repeatedUint32Value, repeatedInt64Value, repeatedUint64Value, repeatedFloatValue, repeatedDoubleValue, repeatedStringValue, repeatedBoolValue, repeatedBytesValue);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+}
+============== file: src/test/java/com/google/example/library/v1/LibrarySmokeTest.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.example.library.v1.Book;
+import com.google.protobuf.FieldMask;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Test;
+
+@javax.annotation.Generated("by GAPIC")
+public class LibrarySmokeTest {
+  private static final String PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
+  private static final String LEGACY_PROJECT_ENV_NAME = "GCLOUD_PROJECT";
+
+  @Test
+  public void run() {
+    main(null);
+  }
+
+  public static void main(String args[]) {
+    Logger.getLogger("").setLevel(Level.WARNING);
+    try {
+      executeNoCatch(getProjectId());
+      System.out.println("OK");
+    } catch (Exception e) {
+      System.err.println("Failed with exception:");
+      e.printStackTrace(System.err);
+      System.exit(1);
+    }
+  }
+
+  public static void executeNoCatch(String projectId) throws Exception {
+    try (LibraryClient client = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("testShelf-" + System.currentTimeMillis(), projectId);
+      String optionalFoo = "";
+      Book.Rating rating = Book.Rating.GOOD;
+      Book book = Book.newBuilder()
+        .setRating(rating)
+        .build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
+      com.google.example.library.v1.FieldMask physicalMask = com.google.example.library.v1.FieldMask.newBuilder().build();
+
+      Book response = client.updateBook(name, optionalFoo, book, updateMask, physicalMask);
+    }
+  }
+
+  private static String getProjectId() {
+    String projectId = System.getProperty(PROJECT_ENV_NAME, System.getenv(PROJECT_ENV_NAME));
+    if (projectId == null) {
+      projectId = System.getProperty(LEGACY_PROJECT_ENV_NAME, System.getenv(LEGACY_PROJECT_ENV_NAME));
+    }
+    Preconditions.checkArgument(projectId != null, "A project ID is required.");
+    return projectId;
+  }
+}
+============== file: src/test/java/com/google/example/library/v1/MockLabeler.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.grpc.testing.MockGrpcService;
+import com.google.protobuf.GeneratedMessageV3;
+import io.grpc.ServerServiceDefinition;
+import java.util.List;
+
+@javax.annotation.Generated("by GAPIC")
+@BetaApi
+public class MockLabeler implements MockGrpcService  {
+  private final MockLabelerImpl serviceImpl;
+
+  public MockLabeler() {
+    serviceImpl = new MockLabelerImpl();
+  }
+
+  @Override
+  public List<GeneratedMessageV3> getRequests() {
+    return serviceImpl.getRequests();
+  }
+
+  @Override
+  public void addResponse(GeneratedMessageV3 response) {
+    serviceImpl.addResponse(response);
+  }
+
+  @Override
+  public void addException(Exception exception) {
+    serviceImpl.addException(exception);
+  }
+
+  @Override
+  public ServerServiceDefinition getServiceDefinition() {
+    return serviceImpl.bindService();
+  }
+
+  @Override
+  public void reset() {
+    serviceImpl.reset();
+  }
+}
+============== file: src/test/java/com/google/example/library/v1/MockLabelerImpl.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.common.collect.Lists;
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.tagger.v1.LabelerGrpc.LabelerImplBase;
+import com.google.tagger.v1.TaggerProto.AddLabelRequest;
+import com.google.tagger.v1.TaggerProto.AddLabelResponse;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+@javax.annotation.Generated("by GAPIC")
+@BetaApi
+public class MockLabelerImpl extends LabelerImplBase {
+  private ArrayList<GeneratedMessageV3> requests;
+  private Queue<Object> responses;
+
+  public MockLabelerImpl() {
+    requests = new ArrayList<>();
+    responses = new LinkedList<>();
+  }
+
+  public List<GeneratedMessageV3> getRequests() {
+    return requests;
+  }
+
+  public void addResponse(GeneratedMessageV3 response) {
+    responses.add(response);
+  }
+
+  public void setResponses(List<GeneratedMessageV3> responses) {
+    this.responses = new LinkedList<Object>(responses);
+  }
+
+  public void addException(Exception exception) {
+    responses.add(exception);
+  }
+
+  public void reset() {
+    requests = new ArrayList<>();
+    responses = new LinkedList<>();
+  }
+
+  @Override
+  public void addLabel(AddLabelRequest request,
+    StreamObserver<AddLabelResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof AddLabelResponse) {
+      requests.add(request);
+      responseObserver.onNext((AddLabelResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+}
+============== file: src/test/java/com/google/example/library/v1/MockLibraryService.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.grpc.testing.MockGrpcService;
+import com.google.protobuf.GeneratedMessageV3;
+import io.grpc.ServerServiceDefinition;
+import java.util.List;
+
+@javax.annotation.Generated("by GAPIC")
+@BetaApi
+public class MockLibraryService implements MockGrpcService  {
+  private final MockLibraryServiceImpl serviceImpl;
+
+  public MockLibraryService() {
+    serviceImpl = new MockLibraryServiceImpl();
+  }
+
+  @Override
+  public List<GeneratedMessageV3> getRequests() {
+    return serviceImpl.getRequests();
+  }
+
+  @Override
+  public void addResponse(GeneratedMessageV3 response) {
+    serviceImpl.addResponse(response);
+  }
+
+  @Override
+  public void addException(Exception exception) {
+    serviceImpl.addException(exception);
+  }
+
+  @Override
+  public ServerServiceDefinition getServiceDefinition() {
+    return serviceImpl.bindService();
+  }
+
+  @Override
+  public void reset() {
+    serviceImpl.reset();
+  }
+}
+============== file: src/test/java/com/google/example/library/v1/MockLibraryServiceImpl.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.example.library.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.common.collect.Lists;
+import com.google.example.library.v1.LibraryServiceGrpc.LibraryServiceImplBase;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Empty;
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.tagger.v1.TaggerProto.AddTagRequest;
+import com.google.tagger.v1.TaggerProto.AddTagResponse;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+@javax.annotation.Generated("by GAPIC")
+@BetaApi
+public class MockLibraryServiceImpl extends LibraryServiceImplBase {
+  private ArrayList<GeneratedMessageV3> requests;
+  private Queue<Object> responses;
+
+  public MockLibraryServiceImpl() {
+    requests = new ArrayList<>();
+    responses = new LinkedList<>();
+  }
+
+  public List<GeneratedMessageV3> getRequests() {
+    return requests;
+  }
+
+  public void addResponse(GeneratedMessageV3 response) {
+    responses.add(response);
+  }
+
+  public void setResponses(List<GeneratedMessageV3> responses) {
+    this.responses = new LinkedList<Object>(responses);
+  }
+
+  public void addException(Exception exception) {
+    responses.add(exception);
+  }
+
+  public void reset() {
+    requests = new ArrayList<>();
+    responses = new LinkedList<>();
+  }
+
+  @Override
+  public void createShelf(CreateShelfRequest request,
+    StreamObserver<Shelf> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Shelf) {
+      requests.add(request);
+      responseObserver.onNext((Shelf) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void getShelf(GetShelfRequest request,
+    StreamObserver<Shelf> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Shelf) {
+      requests.add(request);
+      responseObserver.onNext((Shelf) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void listShelves(ListShelvesRequest request,
+    StreamObserver<ListShelvesResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof ListShelvesResponse) {
+      requests.add(request);
+      responseObserver.onNext((ListShelvesResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void deleteShelf(DeleteShelfRequest request,
+    StreamObserver<Empty> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void mergeShelves(MergeShelvesRequest request,
+    StreamObserver<Shelf> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Shelf) {
+      requests.add(request);
+      responseObserver.onNext((Shelf) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void createBook(CreateBookRequest request,
+    StreamObserver<Book> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Book) {
+      requests.add(request);
+      responseObserver.onNext((Book) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void publishSeries(PublishSeriesRequest request,
+    StreamObserver<PublishSeriesResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof PublishSeriesResponse) {
+      requests.add(request);
+      responseObserver.onNext((PublishSeriesResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void getBook(GetBookRequest request,
+    StreamObserver<Book> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Book) {
+      requests.add(request);
+      responseObserver.onNext((Book) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void listBooks(ListBooksRequest request,
+    StreamObserver<ListBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof ListBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((ListBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void deleteBook(DeleteBookRequest request,
+    StreamObserver<Empty> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void updateBook(UpdateBookRequest request,
+    StreamObserver<Book> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Book) {
+      requests.add(request);
+      responseObserver.onNext((Book) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void moveBook(MoveBookRequest request,
+    StreamObserver<Book> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Book) {
+      requests.add(request);
+      responseObserver.onNext((Book) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void listStrings(ListStringsRequest request,
+    StreamObserver<ListStringsResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof ListStringsResponse) {
+      requests.add(request);
+      responseObserver.onNext((ListStringsResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void addComments(AddCommentsRequest request,
+    StreamObserver<Empty> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void getBookFromArchive(GetBookFromArchiveRequest request,
+    StreamObserver<BookFromArchive> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof BookFromArchive) {
+      requests.add(request);
+      responseObserver.onNext((BookFromArchive) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void getBookFromAnywhere(GetBookFromAnywhereRequest request,
+    StreamObserver<BookFromAnywhere> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof BookFromAnywhere) {
+      requests.add(request);
+      responseObserver.onNext((BookFromAnywhere) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void getBookFromAbsolutelyAnywhere(GetBookFromAbsolutelyAnywhereRequest request,
+    StreamObserver<BookFromAnywhere> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof BookFromAnywhere) {
+      requests.add(request);
+      responseObserver.onNext((BookFromAnywhere) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void updateBookIndex(UpdateBookIndexRequest request,
+    StreamObserver<Empty> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void streamShelves(StreamShelvesRequest request,
+    StreamObserver<StreamShelvesResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof StreamShelvesResponse) {
+      requests.add(request);
+      responseObserver.onNext((StreamShelvesResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void streamBooks(StreamBooksRequest request,
+    StreamObserver<Book> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Book) {
+      requests.add(request);
+      responseObserver.onNext((Book) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public StreamObserver<DiscussBookRequest> discussBook(
+      final StreamObserver<Comment> responseObserver) {
+    final Object response = responses.remove();
+    StreamObserver<DiscussBookRequest> requestObserver =
+        new StreamObserver<DiscussBookRequest>() {
+      @Override
+      public void onNext(DiscussBookRequest value) {
+        if (response instanceof Comment) {
+          responseObserver.onNext((Comment) response);
+        } else if (response instanceof Exception) {
+          responseObserver.onError((Exception) response);
+        } else {
+          responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+        }
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        responseObserver.onError(t);
+      }
+
+      @Override
+      public void onCompleted() {
+        responseObserver.onCompleted();
+      }
+    };
+    return requestObserver;
+  }
+
+  @Override
+  public StreamObserver<DiscussBookRequest> monologAboutBook(
+      final StreamObserver<Comment> responseObserver) {
+    final Object response = responses.remove();
+    StreamObserver<DiscussBookRequest> requestObserver =
+        new StreamObserver<DiscussBookRequest>() {
+      @Override
+      public void onNext(DiscussBookRequest value) {
+        if (response instanceof Comment) {
+          responseObserver.onNext((Comment) response);
+        } else if (response instanceof Exception) {
+          responseObserver.onError((Exception) response);
+        } else {
+          responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+        }
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        responseObserver.onError(t);
+      }
+
+      @Override
+      public void onCompleted() {
+        responseObserver.onCompleted();
+      }
+    };
+    return requestObserver;
+  }
+
+  @Override
+  public void findRelatedBooks(FindRelatedBooksRequest request,
+    StreamObserver<FindRelatedBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof FindRelatedBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((FindRelatedBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void addTag(AddTagRequest request,
+    StreamObserver<AddTagResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof AddTagResponse) {
+      requests.add(request);
+      responseObserver.onNext((AddTagResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void getBigBook(GetBookRequest request,
+    StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void getBigNothing(GetBookRequest request,
+    StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void testOptionalRequiredFlatteningParams(TestOptionalRequiredFlatteningParamsRequest request,
+    StreamObserver<TestOptionalRequiredFlatteningParamsResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof TestOptionalRequiredFlatteningParamsResponse) {
+      requests.add(request);
+      responseObserver.onNext((TestOptionalRequiredFlatteningParamsResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+}

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
@@ -367,7 +367,39 @@ service LibraryService {
         "optional_repeated_resource_name_common",
         "optional_repeated_fixed32",
         "optional_repeated_fixed64",
-        "optional_map"]
+        "optional_map",
+        "any_value",
+        "struct_value",
+        "value_value",
+        "list_value_value",
+        "time_value",
+        "duration_value",
+        "field_mask_value",
+        "int32_value",
+        "uint32_value",
+        "int64_value",
+        "uint64_value",
+        "float_value",
+        "double_value",
+        "string_value",
+        "bool_value",
+        "bytes_value",
+        "repeated_any_value",
+        "repeated_struct_value",
+        "repeated_value_value",
+        "repeated_list_value_value",
+        "repeated_time_value",
+        "repeated_duration_value",
+        "repeated_field_mask_value",
+        "repeated_int32_value",
+        "repeated_uint32_value",
+        "repeated_int64_value",
+        "repeated_uint64_value",
+        "repeated_float_value",
+        "repeated_double_value",
+        "repeated_string_value",
+        "repeated_bool_value",
+        "repeated_bytes_value"]
     };
   }
 }
@@ -975,7 +1007,39 @@ message TestOptionalRequiredFlatteningParamsRequest {
 
   map<int32, string> optional_map = 91;
 
+    google.protobuf.Any any_value = 100;
+    google.protobuf.Struct struct_value = 101;
+    google.protobuf.Value value_value = 102;
+    google.protobuf.ListValue list_value_value = 103;
+    google.protobuf.Timestamp time_value = 104;
+    google.protobuf.Duration duration_value = 105;
+    google.protobuf.FieldMask field_mask_value = 106;
+    google.protobuf.Int32Value int32_value = 107;
+    google.protobuf.UInt32Value uint32_value = 108;
+    google.protobuf.Int64Value int64_value = 109;
+    google.protobuf.UInt64Value uint64_value = 110;
+    google.protobuf.FloatValue float_value = 111;
+    google.protobuf.DoubleValue double_value = 112;
+    google.protobuf.StringValue string_value = 113;
+    google.protobuf.BoolValue bool_value = 114;
+    google.protobuf.BytesValue bytes_value = 115;
 
+    repeated google.protobuf.Any repeated_any_value = 120;
+    repeated google.protobuf.Struct repeated_struct_value = 121;
+    repeated google.protobuf.Value repeated_value_value = 122;
+    repeated google.protobuf.ListValue repeated_list_value_value = 123;
+    repeated google.protobuf.Timestamp repeated_time_value = 124;
+    repeated google.protobuf.Duration repeated_duration_value = 125;
+    repeated google.protobuf.FieldMask repeated_field_mask_value = 126;
+    repeated google.protobuf.Int32Value repeated_int32_value = 127;
+    repeated google.protobuf.UInt32Value repeated_uint32_value = 128;
+    repeated google.protobuf.Int64Value repeated_int64_value = 129;
+    repeated google.protobuf.UInt64Value repeated_uint64_value = 130;
+    repeated google.protobuf.FloatValue repeated_float_value = 131;
+    repeated google.protobuf.DoubleValue repeated_double_value = 132;
+    repeated google.protobuf.StringValue repeated_string_value = 133;
+    repeated google.protobuf.BoolValue repeated_bool_value = 134;
+    repeated google.protobuf.BytesValue repeated_bytes_value = 135;
 }
 
 message TestOptionalRequiredFlatteningParamsResponse {


### PR DESCRIPTION
Copy over the existing java_library.baseline (baseline file for legacy GAPIC yaml only generation) into the java_library_no_gapic_config.baseline file that will be generated by https://github.com/googleapis/gapic-generator/pull/2451/.

Also update the annotated library.proto file to reflect the recent changes in the un-annotated library.proto.  (Note: We should stop needing to copy over changes from the un-annotated library.proto to the annotated.proto once there's a toggle for turning off parsing proto annotations.)