### PR TITLE
Remove most of LanguageTransformer

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -25,7 +25,7 @@ import com.google.api.codegen.LanguageSettingsProto;
 import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.ResourceNameTreatment;
 import com.google.api.codegen.common.TargetLanguage;
-import com.google.api.codegen.configgen.transformer.LanguageTransformer;
+import com.google.api.codegen.configgen.mergers.LanguageSettingsMerger;
 import com.google.api.codegen.util.LicenseHeaderUtil;
 import com.google.api.codegen.util.ProtoParser;
 import com.google.api.tools.framework.model.Diag;
@@ -218,8 +218,7 @@ public abstract class GapicProductConfig implements ProductConfig {
       settings = LanguageSettingsProto.getDefaultInstance();
       String basePackageName =
           Optional.ofNullable(protoPackage).orElse(protoParser.getPackageName(model));
-      clientPackageName =
-          LanguageTransformer.getFormattedPackageName(language.name(), basePackageName);
+      clientPackageName = LanguageSettingsMerger.getFormattedPackageName(language, basePackageName);
     } else {
       clientPackageName = settings.getPackageName();
     }

--- a/src/main/java/com/google/api/codegen/configgen/transformer/LanguageTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/LanguageTransformer.java
@@ -14,189 +14,28 @@
  */
 package com.google.api.codegen.configgen.transformer;
 
+import static com.google.api.codegen.configgen.mergers.LanguageSettingsMerger.LANGUAGE_FORMATTERS;
+
+import com.google.api.codegen.common.TargetLanguage;
+import com.google.api.codegen.configgen.mergers.LanguageSettingsMerger.LanguageFormatter;
 import com.google.api.codegen.configgen.viewmodel.LanguageSettingView;
-import com.google.api.codegen.util.VersionMatcher;
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /** Generates language setting view objects using a package name. */
 public class LanguageTransformer {
-  private static final String DEFAULT_PACKAGE_SEPARATOR = ".";
 
-  public static final Map<String, LanguageFormatter> LANGUAGE_FORMATTERS;
-
-  static {
-    List<RewriteRule> javaRewriteRules =
-        Arrays.asList(new RewriteRule("^google(\\.cloud)?", "com.google.cloud"));
-    List<RewriteRule> commonRewriteRules =
-        Arrays.asList(new RewriteRule("^google(?!\\.cloud)", "google.cloud"));
-    LANGUAGE_FORMATTERS =
-        ImmutableMap.<String, LanguageFormatter>builder()
-            .put("java", new SimpleLanguageFormatter(".", javaRewriteRules, false))
-            .put("python", new PythonLanguageFormatter(commonRewriteRules))
-            .put("go", new GoLanguageFormatter())
-            .put("csharp", new SimpleLanguageFormatter(".", null, true))
-            .put("ruby", new SimpleLanguageFormatter("::", commonRewriteRules, true))
-            .put("php", new SimpleLanguageFormatter("\\", commonRewriteRules, true))
-            .put("nodejs", new NodeJSLanguageFormatter())
-            .build();
-  }
-
-  public List<LanguageSettingView> generateLanguageSettings(String packageName) {
+  List<LanguageSettingView> generateLanguageSettings(String packageName) {
     ImmutableList.Builder<LanguageSettingView> languageSettings = ImmutableList.builder();
-    for (Map.Entry<String, LanguageFormatter> entry : LANGUAGE_FORMATTERS.entrySet()) {
+    for (Map.Entry<TargetLanguage, LanguageFormatter> entry : LANGUAGE_FORMATTERS.entrySet()) {
       LanguageFormatter languageFormatter = entry.getValue();
       languageSettings.add(
           LanguageSettingView.newBuilder()
-              .language(entry.getKey())
+              .language(entry.getKey().name().toLowerCase())
               .packageName(languageFormatter.getFormattedPackageName(packageName))
               .build());
     }
     return languageSettings.build();
-  }
-
-  @Nullable
-  public static String getFormattedPackageName(String language, String basePackageName) {
-    LanguageTransformer.LanguageFormatter formatter =
-        LANGUAGE_FORMATTERS.get(language.toLowerCase());
-    return formatter.getFormattedPackageName(basePackageName);
-  }
-
-  public interface LanguageFormatter {
-    String getFormattedPackageName(String packageName);
-  }
-
-  private static class SimpleLanguageFormatter implements LanguageFormatter {
-
-    private final String separator;
-    private final List<RewriteRule> rewriteRules;
-    private final boolean shouldCapitalize;
-
-    public SimpleLanguageFormatter(
-        String separator, List<RewriteRule> rewriteRules, boolean shouldCapitalize) {
-      this.separator = separator;
-      if (rewriteRules != null) {
-        this.rewriteRules = rewriteRules;
-      } else {
-        this.rewriteRules = new ArrayList<>();
-      }
-      this.shouldCapitalize = shouldCapitalize;
-    }
-
-    @Override
-    public String getFormattedPackageName(String packageName) {
-      for (RewriteRule rewriteRule : rewriteRules) {
-        packageName = rewriteRule.rewrite(packageName);
-      }
-      List<String> elements = new LinkedList<>();
-      for (String component : Splitter.on(DEFAULT_PACKAGE_SEPARATOR).split(packageName)) {
-        if (shouldCapitalize) {
-          elements.add(capitalize(component));
-        } else {
-          elements.add(component);
-        }
-      }
-      return Joiner.on(separator).join(elements);
-    }
-
-    private String capitalize(String string) {
-      return Character.toUpperCase(string.charAt(0)) + string.substring(1);
-    }
-  }
-
-  private static class GoLanguageFormatter implements LanguageFormatter {
-    public String getFormattedPackageName(String packageName) {
-      List<String> nameComponents =
-          Lists.newArrayList(Splitter.on(DEFAULT_PACKAGE_SEPARATOR).splitToList(packageName));
-
-      // If the name follows the pattern google.foo.bar.v1234,
-      // we reformat it into cloud.google.com.
-      // google.logging.v2 => cloud.google.com/go/logging/apiv2
-      // Otherwise, fall back to backup
-      if (!isApiGoogleCloud(nameComponents)) {
-        nameComponents.add(0, "google.golang.org");
-        return Joiner.on("/").join(nameComponents);
-      }
-      int size = nameComponents.size();
-      return "cloud.google.com/go/"
-          + Joiner.on("/").join(nameComponents.subList(1, size - 1))
-          + "/api"
-          + nameComponents.get(size - 1);
-    }
-
-    /** Returns true if it is a Google Cloud API. */
-    private boolean isApiGoogleCloud(List<String> nameComponents) {
-      int size = nameComponents.size();
-      return size >= 3
-          && nameComponents.get(0).equals("google")
-          && nameComponents.get(size - 1).startsWith("v");
-    }
-  }
-
-  private static class NodeJSLanguageFormatter implements LanguageFormatter {
-    @Override
-    public String getFormattedPackageName(String packageName) {
-      List<String> nameComponents = Splitter.on(DEFAULT_PACKAGE_SEPARATOR).splitToList(packageName);
-      return nameComponents.get(nameComponents.size() - 2)
-          + "."
-          + nameComponents.get(nameComponents.size() - 1);
-    }
-  }
-
-  private static class RewriteRule {
-    private final String pattern;
-    private final String replacement;
-
-    public RewriteRule(String pattern, String replacement) {
-      this.pattern = pattern;
-      this.replacement = replacement;
-    }
-
-    public String rewrite(String input) {
-      if (pattern == null) {
-        return input;
-      }
-      return input.replaceAll(pattern, replacement);
-    }
-  }
-
-  private static class PythonLanguageFormatter implements LanguageFormatter {
-    private List<RewriteRule> rewriteRules;
-
-    public PythonLanguageFormatter(List<RewriteRule> rewriteRules) {
-      this.rewriteRules = rewriteRules;
-    }
-
-    @Override
-    public String getFormattedPackageName(String packageName) {
-      for (RewriteRule rule : rewriteRules) {
-        packageName = rule.rewrite(packageName);
-      }
-      List<String> names = Splitter.on(DEFAULT_PACKAGE_SEPARATOR).splitToList(packageName);
-      LinkedList<String> collector = new LinkedList<>();
-      boolean found = false;
-      for (String n : names) {
-        if (VersionMatcher.isVersion(n)) {
-          collector.add(String.format("%s_%s", collector.removeLast(), n));
-          collector.add("gapic");
-          found = true;
-        } else {
-          collector.add(n);
-        }
-      }
-      if (!found) {
-        collector.add("gapic");
-      }
-      return Joiner.on('.').join(collector);
-    }
   }
 }

--- a/src/main/java/com/google/api/codegen/configgen/transformer/LanguageTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/LanguageTransformer.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 /** Generates language setting view objects using a package name. */
-public class LanguageTransformer {
+class LanguageTransformer {
 
   List<LanguageSettingView> generateLanguageSettings(String packageName) {
     ImmutableList.Builder<LanguageSettingView> languageSettings = ImmutableList.builder();

--- a/src/main/java/com/google/api/codegen/configgen/transformer/RetryTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/RetryTransformer.java
@@ -34,7 +34,7 @@ public class RetryTransformer {
   public static final int DEFAULT_MAX_RPC_TIMEOUT_MILLIS = 20000;
   public static final int DEFAULT_TOTAL_TIMEOUT_MILLIS = 600000;
 
-  public void generateRetryDefinitions(
+  void generateRetryDefinitions(
       InterfaceView.Builder interfaceView,
       List<String> idempotentRetryCodes,
       List<String> nonIdempotentRetryCodes) {


### PR DESCRIPTION
There's a lot of duplicate logic in LanguageTransformer and LanguageSettingsMerger. Rip out everything in LanguageTransformer that already exists in LanguageSettingsMerger.

Ideally we'd remove all duplicate logic between the old Transformers and the ConfigNodeMerger implementations, but this is an easy first step.