### PR TITLE
[Proto Annotations] Expose generator option for client package name

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -135,7 +135,7 @@ public abstract class GapicProductConfig implements ProductConfig {
   @Nullable
   public static GapicProductConfig create(
       Model model, ConfigProto configProto, TargetLanguage language) {
-    return create(model, configProto, null, language);
+    return create(model, configProto, null, null, language);
   }
 
   /**
@@ -147,6 +147,7 @@ public abstract class GapicProductConfig implements ProductConfig {
    * @param configProto The parsed set of config files from input
    * @param protoPackage The source proto package, as opposed to imported protos, that we will
    *     generate clients for.
+   * @param clientPackage The desired package name for the generated client.
    * @param language The language that this config will be used to generate a client in.
    */
   @Nullable
@@ -154,6 +155,7 @@ public abstract class GapicProductConfig implements ProductConfig {
       Model model,
       @Nullable ConfigProto configProto,
       @Nullable String protoPackage,
+      @Nullable String clientPackage,
       TargetLanguage language) {
 
     final String defaultPackage;
@@ -236,9 +238,15 @@ public abstract class GapicProductConfig implements ProductConfig {
         configProto.getLanguageSettingsMap().get(language.toString().toLowerCase());
     if (settings == null) {
       settings = LanguageSettingsProto.getDefaultInstance();
-      String basePackageName = Optional.ofNullable(protoPackage).orElse(getPackageName(model));
-      clientPackageName =
-          LanguageTransformer.getFormattedPackageName(language.name(), basePackageName);
+
+      if (!Strings.isNullOrEmpty(clientPackage)) {
+        clientPackageName = clientPackage;
+      } else {
+        String basePackageName = Optional.ofNullable(protoPackage).orElse(getPackageName(model));
+        clientPackageName =
+            LanguageTransformer.getFormattedPackageName(
+                language.name().toLowerCase(), basePackageName);
+      }
     } else {
       clientPackageName = settings.getPackageName();
     }

--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
@@ -66,6 +66,12 @@ public class GapicGeneratorApp extends ToolDriverBase {
           "The proto package designating the files actually intended for output.\n"
               + "This option is required if the GAPIC generator config files are not given.",
           "");
+  public static final Option<String> CLIENT_PACKAGE =
+      ToolOptions.createOption(
+          String.class,
+          "client_package",
+          "The desired package name for the generated Java client. \n",
+          "");
 
   public static final Option<List<String>> GENERATOR_CONFIG_FILES =
       ToolOptions.createOption(
@@ -157,8 +163,10 @@ public class GapicGeneratorApp extends ToolDriverBase {
       language = TargetLanguage.fromString(configProto.getLanguage().toUpperCase());
     }
 
+    String clientPackage = Strings.emptyToNull(options.get(CLIENT_PACKAGE));
+
     GapicProductConfig productConfig =
-        GapicProductConfig.create(model, configProto, protoPackage, language);
+        GapicProductConfig.create(model, configProto, protoPackage, clientPackage, language);
     if (productConfig == null) {
       return;
     }

--- a/src/test/java/com/google/api/codegen/config/GapicConfigProducerTest.java
+++ b/src/test/java/com/google/api/codegen/config/GapicConfigProducerTest.java
@@ -48,7 +48,7 @@ public class GapicConfigProducerTest {
             model.getDiagReporter().getDiagCollector(),
             locator,
             new String[] {"missing_config_schema_version.yaml"});
-    productConfig = GapicProductConfig.create(model, configProto, null, TargetLanguage.JAVA);
+    productConfig = GapicProductConfig.create(model, configProto, null, null, TargetLanguage.JAVA);
     Diag expectedError =
         Diag.error(
             SimpleLocation.TOPLEVEL, "config_schema_version field is required in GAPIC yaml.");

--- a/src/test/java/com/google/api/codegen/gapic/GapicCodeGeneratorTest.java
+++ b/src/test/java/com/google/api/codegen/gapic/GapicCodeGeneratorTest.java
@@ -36,9 +36,9 @@ public class GapicCodeGeneratorTest extends GapicTestBase2 {
       List<String> snippetName,
       String apiName,
       String baseline,
-      String protoPackage) {
-    super(
-        language, gapicConfigFileNames, packageConfigFileName, snippetName, baseline, protoPackage);
+      String protoPackage,
+      String clientPackage) {
+    super(language, gapicConfigFileNames, packageConfigFileName, snippetName, baseline, null, null);
     this.apiName = apiName;
     getTestDataLocator().addTestDataSource(CodegenTestUtil.class, "testsrc/libraryproto");
   }
@@ -47,101 +47,82 @@ public class GapicCodeGeneratorTest extends GapicTestBase2 {
   public static List<Object[]> testedConfigs() {
     return Arrays.asList(
         GapicTestBase2.createTestConfig(
-            TargetLanguage.GO,
-            new String[] {"library_gapic.yaml"},
-            null,
-            "library",
-            "google.example.library.v1"),
+            TargetLanguage.GO, new String[] {"library_gapic.yaml"}, null, "library"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.PHP,
             new String[] {"library_gapic.yaml"},
             "library_pkg2.yaml",
-            "library",
-            "google.example.library.v1"), // Test passing in a proto_package flag.
+            "library"), // Test passing in a proto_package flag.
         GapicTestBase2.createTestConfig(
             TargetLanguage.PHP,
             new String[] {"longrunning_gapic.yaml"},
             "longrunning_pkg2.yaml",
-            "longrunning",
-            "google.longrunning"), // Test passing in a proto_package flag.
+            "longrunning"), // Test passing in a proto_package flag.
         GapicTestBase2.createTestConfig(
             TargetLanguage.PHP,
             new String[] {"no_path_templates_gapic.yaml"},
             "no_path_templates_pkg2.yaml",
-            "no_path_templates",
-            "google.cloud.example.v1"),
+            "no_path_templates"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.JAVA,
             new String[] {"library_gapic.yaml"},
             "library_pkg2.yaml",
-            "library",
-            null),
+            "library"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.JAVA,
             new String[] {"no_path_templates_gapic.yaml"},
             "no_path_templates_pkg2.yaml",
-            "no_path_templates",
-            null),
+            "no_path_templates"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.RUBY,
             new String[] {"library_gapic.yaml"},
             "library_pkg2.yaml",
-            "library",
-            null),
+            "library"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.RUBY,
             new String[] {"multiple_services_gapic.yaml"},
             "multiple_services_pkg2.yaml",
-            "multiple_services",
-            null),
+            "multiple_services"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.RUBY,
             new String[] {"longrunning_gapic.yaml"},
             "longrunning_pkg2.yaml",
-            "longrunning",
-            null),
+            "longrunning"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.PYTHON,
             new String[] {"library_gapic.yaml"},
             "library_pkg2.yaml",
-            "library",
-            null),
+            "library"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.PYTHON,
             new String[] {"no_path_templates_gapic.yaml"},
             "no_path_templates_pkg2.yaml",
-            "no_path_templates",
-            null),
+            "no_path_templates"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.PYTHON,
             new String[] {"multiple_services_gapic.yaml"},
             "multiple_services_pkg2.yaml",
-            "multiple_services",
-            null),
+            "multiple_services"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.NODEJS,
             new String[] {"library_gapic.yaml"},
             "library_pkg2.yaml",
-            "library",
-            null),
+            "library"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.NODEJS,
             new String[] {"no_path_templates_gapic.yaml"},
             "library_pkg2.yaml",
-            "no_path_templates",
-            null),
+            "no_path_templates"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.NODEJS,
             new String[] {"multiple_services_gapic.yaml"},
             "multiple_services_pkg2.yaml",
-            "multiple_services",
-            null),
+            "multiple_services"),
         GapicTestBase2.createTestConfig(
             TargetLanguage.CSHARP,
             new String[] {"library_gapic.yaml"},
             "library_pkg2.yaml",
-            "library",
-            null));
+            "library"));
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/gapic/GapicTestBase2.java
+++ b/src/test/java/com/google/api/codegen/gapic/GapicTestBase2.java
@@ -54,6 +54,7 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
   protected PackageMetadataConfig packageConfig;
   private final String baselineFile;
   private final String protoPackage;
+  private final String clientPackage;
 
   public GapicTestBase2(
       TargetLanguage language,
@@ -61,12 +62,14 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
       String packageConfigFileName,
       List<String> snippetNames,
       String baselineFile,
-      String protoPackage) {
+      String protoPackage,
+      String clientPackage) {
     this.language = language;
     this.gapicConfigFileNames = gapicConfigFileNames;
     this.packageConfigFileName = packageConfigFileName;
     this.snippetNames = ImmutableList.copyOf(snippetNames);
     this.baselineFile = baselineFile;
+    this.clientPackage = clientPackage;
 
     // Represents the test value for the --package flag.
     this.protoPackage = protoPackage;
@@ -132,12 +135,29 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
    * set of arguments is created for each combination of CodeGenerator x snippet that
    * GapicGeneratorFactory returns.
    */
+  static Object[] createTestConfig(
+      TargetLanguage language,
+      String[] gapicConfigFileNames,
+      String packageConfigFileName,
+      String apiName) {
+    return createTestConfig(
+        language, gapicConfigFileNames, packageConfigFileName, apiName, null, null);
+  }
+
+  /**
+   * Creates the constructor arguments to be passed onto this class (GapicTestBase2) to create test
+   * methods. The idForFactory String is passed to GapicGeneratorFactory to get the GapicGenerators
+   * provided by that id, and then the snippet file names are scraped from those generators, and a
+   * set of arguments is created for each combination of CodeGenerator x snippet that
+   * GapicGeneratorFactory returns.
+   */
   public static Object[] createTestConfig(
       TargetLanguage language,
       String[] gapicConfigFileNames,
       String packageConfigFileName,
       String apiName,
-      String protoPackage) {
+      String protoPackage,
+      String clientPackage) {
     Model model = Model.create(Service.getDefaultInstance());
     GapicProductConfig productConfig = GapicProductConfig.createDummyInstance();
     PackageMetadataConfig packageConfig = PackageMetadataConfig.createDummyPackageMetadataConfig();
@@ -169,7 +189,8 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
       snippetNames,
       apiName,
       baseline,
-      protoPackage
+      protoPackage,
+      clientPackage
     };
   }
 
@@ -189,7 +210,7 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
     }
 
     GapicProductConfig productConfig =
-        GapicProductConfig.create(model, gapicConfig, protoPackage, language);
+        GapicProductConfig.create(model, gapicConfig, protoPackage, clientPackage, language);
     if (productConfig == null) {
       for (Diag diag : model.getDiagReporter().getDiagCollector().getDiags()) {
         System.err.println(diag.toString());

--- a/src/test/java/com/google/api/codegen/protoannotations/GapicCodeGeneratorAnnotationsTest.java
+++ b/src/test/java/com/google/api/codegen/protoannotations/GapicCodeGeneratorAnnotationsTest.java
@@ -40,9 +40,16 @@ public class GapicCodeGeneratorAnnotationsTest extends GapicTestBase2 {
       List<String> snippetName,
       String apiName,
       String baseline,
-      String protoPackage) {
+      String protoPackage,
+      String clientPackage) {
     super(
-        language, gapicConfigFileNames, packageConfigFileName, snippetName, baseline, protoPackage);
+        language,
+        gapicConfigFileNames,
+        packageConfigFileName,
+        snippetName,
+        baseline,
+        protoPackage,
+        clientPackage);
 
     this.apiName = apiName;
 
@@ -70,8 +77,8 @@ public class GapicCodeGeneratorAnnotationsTest extends GapicTestBase2 {
             null,
             "library_pkg2.yaml",
             "library",
-            "google.example.library.v1"));
-    // TODO(andrealin): More tests.
+            "google.example.library.v1",
+            "com.google.example.library.v1"));
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -76,7 +76,7 @@ task allJars(type: Copy) {
   // Replace with `from configurations.testRuntime, jar` to include test dependencies
   from configurations.runtime, jar
 }
-============== file: src/main/java/com/google/cloud/example/library/v1/LibraryServiceClient.java ==============
+============== file: src/main/java/com/google/example/library/v1/LibraryServiceClient.java ==============
 /*
  * Copyright 2018 Google LLC
  *
@@ -92,7 +92,7 @@ task allJars(type: Copy) {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.example.library.v1;
+package com.google.example.library.v1;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
@@ -113,46 +113,10 @@ import com.google.api.gax.rpc.PageContext;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.pathtemplate.PathTemplate;
-import com.google.cloud.example.library.v1.stub.LibraryServiceStub;
-import com.google.cloud.example.library.v1.stub.LibraryServiceStubSettings;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import com.google.example.library.v1.AddCommentsRequest;
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromAnywhere;
-import com.google.example.library.v1.BookFromArchive;
-import com.google.example.library.v1.Comment;
-import com.google.example.library.v1.CreateBookRequest;
-import com.google.example.library.v1.CreateShelfRequest;
-import com.google.example.library.v1.DeleteBookRequest;
-import com.google.example.library.v1.DeleteShelfRequest;
-import com.google.example.library.v1.DiscussBookRequest;
-import com.google.example.library.v1.FindRelatedBooksRequest;
-import com.google.example.library.v1.FindRelatedBooksResponse;
-import com.google.example.library.v1.GetBigBookMetadata;
-import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
-import com.google.example.library.v1.GetBookFromAnywhereRequest;
-import com.google.example.library.v1.GetBookFromArchiveRequest;
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.GetShelfRequest;
-import com.google.example.library.v1.ListBooksRequest;
-import com.google.example.library.v1.ListBooksResponse;
-import com.google.example.library.v1.ListShelvesRequest;
-import com.google.example.library.v1.ListShelvesResponse;
-import com.google.example.library.v1.ListStringsRequest;
-import com.google.example.library.v1.ListStringsResponse;
-import com.google.example.library.v1.MergeShelvesRequest;
-import com.google.example.library.v1.MoveBookRequest;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.PublishSeriesResponse;
-import com.google.example.library.v1.Shelf;
-import com.google.example.library.v1.StreamBooksRequest;
-import com.google.example.library.v1.StreamShelvesRequest;
-import com.google.example.library.v1.StreamShelvesResponse;
-import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
-import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
-import com.google.example.library.v1.UpdateBookIndexRequest;
-import com.google.example.library.v1.UpdateBookRequest;
+import com.google.example.library.v1.stub.LibraryServiceStub;
+import com.google.example.library.v1.stub.LibraryServiceStubSettings;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsClient;
 import com.google.protobuf.Empty;
@@ -1697,7 +1661,7 @@ public class LibraryServiceClient implements BackgroundResource {
 
 
 }
-============== file: src/main/java/com/google/cloud/example/library/v1/LibraryServiceSettings.java ==============
+============== file: src/main/java/com/google/example/library/v1/LibraryServiceSettings.java ==============
 /*
  * Copyright 2018 Google LLC
  *
@@ -1713,7 +1677,7 @@ public class LibraryServiceClient implements BackgroundResource {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.example.library.v1;
+package com.google.example.library.v1;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.BetaApi;
@@ -1742,49 +1706,12 @@ import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.auth.Credentials;
-import com.google.cloud.example.library.v1.stub.LibraryServiceStubSettings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.google.example.library.v1.AddCommentsRequest;
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromAnywhere;
-import com.google.example.library.v1.BookFromArchive;
-import com.google.example.library.v1.Comment;
-import com.google.example.library.v1.CreateBookRequest;
-import com.google.example.library.v1.CreateShelfRequest;
-import com.google.example.library.v1.DeleteBookRequest;
-import com.google.example.library.v1.DeleteShelfRequest;
-import com.google.example.library.v1.DiscussBookRequest;
-import com.google.example.library.v1.FindRelatedBooksRequest;
-import com.google.example.library.v1.FindRelatedBooksResponse;
-import com.google.example.library.v1.GetBigBookMetadata;
-import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
-import com.google.example.library.v1.GetBookFromAnywhereRequest;
-import com.google.example.library.v1.GetBookFromArchiveRequest;
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.GetShelfRequest;
-import com.google.example.library.v1.LibraryServiceGrpc;
-import com.google.example.library.v1.ListBooksRequest;
-import com.google.example.library.v1.ListBooksResponse;
-import com.google.example.library.v1.ListShelvesRequest;
-import com.google.example.library.v1.ListShelvesResponse;
-import com.google.example.library.v1.ListStringsRequest;
-import com.google.example.library.v1.ListStringsResponse;
-import com.google.example.library.v1.MergeShelvesRequest;
-import com.google.example.library.v1.MoveBookRequest;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.PublishSeriesResponse;
-import com.google.example.library.v1.Shelf;
-import com.google.example.library.v1.StreamBooksRequest;
-import com.google.example.library.v1.StreamShelvesRequest;
-import com.google.example.library.v1.StreamShelvesResponse;
-import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
-import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
-import com.google.example.library.v1.UpdateBookIndexRequest;
-import com.google.example.library.v1.UpdateBookRequest;
+import com.google.example.library.v1.stub.LibraryServiceStubSettings;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import com.google.tagger.v1.TaggerProto.AddTagRequest;
@@ -2369,7 +2296,7 @@ public class LibraryServiceSettings extends ClientSettings<LibraryServiceSetting
     }
   }
 }
-============== file: src/main/java/com/google/cloud/example/library/v1/package-info.java ==============
+============== file: src/main/java/com/google/example/library/v1/package-info.java ==============
 /*
  * Copyright 2018 Google LLC
  *
@@ -2425,8 +2352,8 @@ public class LibraryServiceSettings extends ClientSettings<LibraryServiceSetting
  *
  */
 
-package com.google.cloud.example.library.v1;
-============== file: src/main/java/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceCallableFactory.java ==============
+package com.google.example.library.v1;
+============== file: src/main/java/com/google/example/library/v1/stub/GrpcLibraryServiceCallableFactory.java ==============
 /*
  * Copyright 2018 Google LLC
  *
@@ -2442,7 +2369,7 @@ package com.google.cloud.example.library.v1;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.example.library.v1.stub;
+package com.google.example.library.v1.stub;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
@@ -2465,7 +2392,6 @@ import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.StreamingCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.example.library.v1.LibraryServiceSettings;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
 import com.google.example.library.v1.Book;
@@ -2485,6 +2411,7 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.LibraryServiceSettings;
 import com.google.example.library.v1.ListBooksRequest;
 import com.google.example.library.v1.ListBooksResponse;
 import com.google.example.library.v1.ListShelvesRequest;
@@ -2582,7 +2509,7 @@ public class GrpcLibraryServiceCallableFactory implements GrpcStubCallableFactor
     return GrpcCallableFactory.createClientStreamingCallable(grpcCallSettings, streamingCallSettings, clientContext);
   }
 }
-============== file: src/main/java/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceStub.java ==============
+============== file: src/main/java/com/google/example/library/v1/stub/GrpcLibraryServiceStub.java ==============
 /*
  * Copyright 2018 Google LLC
  *
@@ -2598,7 +2525,7 @@ public class GrpcLibraryServiceCallableFactory implements GrpcStubCallableFactor
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.example.library.v1.stub;
+package com.google.example.library.v1.stub;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
@@ -2615,7 +2542,6 @@ import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.RequestParamsExtractor;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.example.library.v1.LibraryServiceSettings;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
 import com.google.example.library.v1.Book;
@@ -2635,6 +2561,7 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.LibraryServiceSettings;
 import com.google.example.library.v1.ListBooksRequest;
 import com.google.example.library.v1.ListBooksResponse;
 import com.google.example.library.v1.ListShelvesRequest;
@@ -3247,7 +3174,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   }
 
 }
-============== file: src/main/java/com/google/cloud/example/library/v1/stub/LibraryServiceStub.java ==============
+============== file: src/main/java/com/google/example/library/v1/stub/LibraryServiceStub.java ==============
 /*
  * Copyright 2018 Google LLC
  *
@@ -3263,7 +3190,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.example.library.v1.stub;
+package com.google.example.library.v1.stub;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
@@ -3458,7 +3385,7 @@ public abstract class LibraryServiceStub implements BackgroundResource {
   @Override
   public abstract void close();
 }
-============== file: src/main/java/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java ==============
+============== file: src/main/java/com/google/example/library/v1/stub/LibraryServiceStubSettings.java ==============
 /*
  * Copyright 2018 Google LLC
  *
@@ -3474,7 +3401,7 @@ public abstract class LibraryServiceStub implements BackgroundResource {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.example.library.v1.stub;
+package com.google.example.library.v1.stub;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.BetaApi;
@@ -4574,7 +4501,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     }
   }
 }
-============== file: src/test/java/com/google/cloud/example/library/v1/LibraryServiceClientTest.java ==============
+============== file: src/test/java/com/google/example/library/v1/LibraryServiceClientTest.java ==============
 /*
  * Copyright 2018 Google LLC
  *
@@ -4590,7 +4517,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.example.library.v1;
+package com.google.example.library.v1;
 
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GaxGrpcProperties;
@@ -4606,14 +4533,6 @@ import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.collect.Lists;
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookOneOfName;
-import com.google.example.library.v1.Comment;
-import com.google.example.library.v1.DeletedBookName;
-import com.google.example.library.v1.DiscussBookRequest;
-import com.google.example.library.v1.StreamBooksRequest;
-import com.google.example.library.v1.StreamShelvesRequest;
-import com.google.example.library.v1.StreamShelvesResponse;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.GeneratedMessageV3;
@@ -4824,7 +4743,7 @@ public class LibraryServiceClientTest {
   }
 
 }
-============== file: src/test/java/com/google/cloud/example/library/v1/MockLibraryService.java ==============
+============== file: src/test/java/com/google/example/library/v1/MockLibraryService.java ==============
 /*
  * Copyright 2018 Google LLC
  *
@@ -4840,7 +4759,7 @@ public class LibraryServiceClientTest {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.example.library.v1;
+package com.google.example.library.v1;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.grpc.testing.MockGrpcService;
@@ -4882,7 +4801,7 @@ public class MockLibraryService implements MockGrpcService  {
     serviceImpl.reset();
   }
 }
-============== file: src/test/java/com/google/cloud/example/library/v1/MockLibraryServiceImpl.java ==============
+============== file: src/test/java/com/google/example/library/v1/MockLibraryServiceImpl.java ==============
 /*
  * Copyright 2018 Google LLC
  *
@@ -4898,46 +4817,11 @@ public class MockLibraryService implements MockGrpcService  {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.example.library.v1;
+package com.google.example.library.v1;
 
 import com.google.api.core.BetaApi;
 import com.google.common.collect.Lists;
-import com.google.example.library.v1.AddCommentsRequest;
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromAnywhere;
-import com.google.example.library.v1.BookFromArchive;
-import com.google.example.library.v1.Comment;
-import com.google.example.library.v1.CreateBookRequest;
-import com.google.example.library.v1.CreateShelfRequest;
-import com.google.example.library.v1.DeleteBookRequest;
-import com.google.example.library.v1.DeleteShelfRequest;
-import com.google.example.library.v1.DiscussBookRequest;
-import com.google.example.library.v1.FindRelatedBooksRequest;
-import com.google.example.library.v1.FindRelatedBooksResponse;
-import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
-import com.google.example.library.v1.GetBookFromAnywhereRequest;
-import com.google.example.library.v1.GetBookFromArchiveRequest;
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.GetShelfRequest;
 import com.google.example.library.v1.LibraryServiceGrpc.LibraryServiceImplBase;
-import com.google.example.library.v1.ListBooksRequest;
-import com.google.example.library.v1.ListBooksResponse;
-import com.google.example.library.v1.ListShelvesRequest;
-import com.google.example.library.v1.ListShelvesResponse;
-import com.google.example.library.v1.ListStringsRequest;
-import com.google.example.library.v1.ListStringsResponse;
-import com.google.example.library.v1.MergeShelvesRequest;
-import com.google.example.library.v1.MoveBookRequest;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.PublishSeriesResponse;
-import com.google.example.library.v1.Shelf;
-import com.google.example.library.v1.StreamBooksRequest;
-import com.google.example.library.v1.StreamShelvesRequest;
-import com.google.example.library.v1.StreamShelvesResponse;
-import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
-import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
-import com.google.example.library.v1.UpdateBookIndexRequest;
-import com.google.example.library.v1.UpdateBookRequest;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import com.google.protobuf.GeneratedMessageV3;


### PR DESCRIPTION
Allow client package names to be customizable through a command-line option.

Custom package names were previously only definable in the [language-specific settings](https://github.com/googleapis/gapic-generator/blob/49c2677021a2447cf3a68ad1dcdfce8adbb134d5/src/main/proto/com/google/api/codegen/config.proto#L103) of the GAPIC config. When we don't have a GAPIC config, we have to be able to override generated package names some other way.

The baseline file `java_library_no_gapic_config.baseline`, generated _without_ a GAPIC config, now uses the `com.google.example.library.v1` package as given in the [test method call](https://github.com/googleapis/gapic-generator/pull/2468/files#diff-8eb27f70b7cf7e6151268a56b248ba1dR81), parallel to the library_gapic.yaml's [java package override](https://github.com/googleapis/gapic-generator/blob/49c2677021a2447cf3a68ad1dcdfce8adbb134d5/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml#L5).