### PR TITLE
Reset default values for LRO config 

### DIFF
--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -34,7 +34,7 @@ public abstract class LongRunningConfig {
   // Default values for LongRunningConfig fields.
   static final boolean LRO_IMPLEMENTS_CANCEL = true;
   static final boolean LRO_IMPLEMENTS_DELETE = true;
-  static final int LRO_INITIAL_POLL_DELAY_MILLIS = 30000;
+  static final int LRO_INITIAL_POLL_DELAY_MILLIS = 500;
   static final double LRO_POLL_DELAY_MULTIPLIER = 1.5;
   static final int LRO_MAX_POLL_DELAY_MILLIS = 5000;
   static final int LRO_TOTAL_POLL_TIMEOUT_MILLS = 300000;

--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -34,10 +34,10 @@ public abstract class LongRunningConfig {
   // Default values for LongRunningConfig fields.
   static final boolean LRO_IMPLEMENTS_CANCEL = true;
   static final boolean LRO_IMPLEMENTS_DELETE = true;
-  static final int LRO_INITIAL_POLL_DELAY_MILLIS = 3000;
-  static final double LRO_POLL_DELAY_MULTIPLIER = 1.3;
-  static final int LRO_MAX_POLL_DELAY_MILLIS = 60000;
-  static final int LRO_TOTAL_POLL_TIMEOUT_MILLS = 600000;
+  static final int LRO_INITIAL_POLL_DELAY_MILLIS = 30000;
+  static final double LRO_POLL_DELAY_MULTIPLIER = 1.5;
+  static final int LRO_MAX_POLL_DELAY_MILLIS = 5000;
+  static final int LRO_TOTAL_POLL_TIMEOUT_MILLS = 300000;
 
   /** Returns the message type returned from a completed operation. */
   public abstract TypeModel getReturnType();

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -4247,7 +4247,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setPollingAlgorithm(
               OperationTimedPollAlgorithm.create(
                   RetrySettings.newBuilder()
-                     .setInitialRetryDelay(Duration.ofMillis(30000L))
+                     .setInitialRetryDelay(Duration.ofMillis(500L))
                      .setRetryDelayMultiplier(1.5)
                      .setMaxRetryDelay(Duration.ofMillis(5000L))
                      .setInitialRpcTimeout(Duration.ZERO) // ignored
@@ -4267,7 +4267,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setPollingAlgorithm(
               OperationTimedPollAlgorithm.create(
                   RetrySettings.newBuilder()
-                     .setInitialRetryDelay(Duration.ofMillis(30000L))
+                     .setInitialRetryDelay(Duration.ofMillis(500L))
                      .setRetryDelayMultiplier(1.5)
                      .setMaxRetryDelay(Duration.ofMillis(5000L))
                      .setInitialRpcTimeout(Duration.ZERO) // ignored

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -4247,13 +4247,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setPollingAlgorithm(
               OperationTimedPollAlgorithm.create(
                   RetrySettings.newBuilder()
-                     .setInitialRetryDelay(Duration.ofMillis(3000L))
-                     .setRetryDelayMultiplier(1.3)
-                     .setMaxRetryDelay(Duration.ofMillis(60000L))
+                     .setInitialRetryDelay(Duration.ofMillis(30000L))
+                     .setRetryDelayMultiplier(1.5)
+                     .setMaxRetryDelay(Duration.ofMillis(5000L))
                      .setInitialRpcTimeout(Duration.ZERO) // ignored
                      .setRpcTimeoutMultiplier(1.0) // ignored
                      .setMaxRpcTimeout(Duration.ZERO) // ignored
-                     .setTotalTimeout(Duration.ofMillis(600000L))
+                     .setTotalTimeout(Duration.ofMillis(300000L))
                      .build()));
       builder
           .getBigNothingOperationSettings()
@@ -4267,13 +4267,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setPollingAlgorithm(
               OperationTimedPollAlgorithm.create(
                   RetrySettings.newBuilder()
-                     .setInitialRetryDelay(Duration.ofMillis(3000L))
-                     .setRetryDelayMultiplier(1.3)
-                     .setMaxRetryDelay(Duration.ofMillis(60000L))
+                     .setInitialRetryDelay(Duration.ofMillis(30000L))
+                     .setRetryDelayMultiplier(1.5)
+                     .setMaxRetryDelay(Duration.ofMillis(5000L))
                      .setInitialRpcTimeout(Duration.ZERO) // ignored
                      .setRpcTimeoutMultiplier(1.0) // ignored
                      .setMaxRpcTimeout(Duration.ZERO) // ignored
-                     .setTotalTimeout(Duration.ofMillis(600000L))
+                     .setTotalTimeout(Duration.ofMillis(300000L))
                      .build()));
 
       return builder;


### PR DESCRIPTION
Use the most common values for each config field, according to googleapis/googleapis, to be our default settings.