### PR TITLE
[Discogapic] Better configgen package names

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/transformer/DiscoConfigTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/DiscoConfigTransformer.java
@@ -27,13 +27,10 @@ import com.google.api.codegen.discovery.Document;
 import com.google.api.codegen.discovery.Method;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.viewmodel.ViewModel;
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,9 +88,10 @@ public class DiscoConfigTransformer {
   }
 
   private String getPackageName(Document model) {
-    String reverseDomain =
-        Joiner.on(".").join(Lists.reverse(Arrays.asList(model.ownerDomain().split("\\."))));
-    return String.format("%s.%s.%s", reverseDomain, model.name(), model.version());
+    int periodIndex = model.ownerDomain().indexOf(".");
+    if (periodIndex < 0) periodIndex = model.ownerDomain().length();
+    String org = model.ownerDomain().substring(0, periodIndex);
+    return String.format("%s.%s.%s", org, model.name(), model.version());
   }
 
   private LicenseView generateLicense() {

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
@@ -8,17 +8,17 @@ config_schema_version: 1.0.0
 # The settings of generated code in a specific language.
 language_settings:
   java:
-    package_name: com.google.simplecompute.v1
+    package_name: com.google.cloud.simplecompute.v1
   python:
-    package_name: com.google.simplecompute_v1.gapic
+    package_name: google.cloud.simplecompute_v1.gapic
   go:
-    package_name: google.golang.org/com/google/simplecompute/v1
+    package_name: cloud.google.com/go/simplecompute/apiv1
   csharp:
-    package_name: Com.Google.Simplecompute.V1
+    package_name: Google.Simplecompute.V1
   ruby:
-    package_name: Com::Google::Simplecompute::V1
+    package_name: Google::Cloud::Simplecompute::V1
   php:
-    package_name: Com\Google\Simplecompute\V1
+    package_name: Google\Cloud\Simplecompute\V1
   nodejs:
     package_name: simplecompute.v1
 # The configuration for the license header to put on generated files.


### PR DESCRIPTION
Make Discovery-based bootstrapped GAPIC config have better generated package names.

See https://github.com/googleapis/googleapis/blob/master/google/cloud/language/v1/language_gapic.yaml for an example of standard generated package names.

Impetus for this: whenever I regen compute_gapic.yaml with configgen ([example](https://github.com/googleapis/discovery-artifact-manager/pull/101/files)), the java package name always [needs to be manually-reverted](https://github.com/googleapis/discovery-artifact-manager/pull/101/files#diff-f707e72f8271e8454e8c6e9388f8bee5R11).