### PR TITLE
[Discogapic] Parse ResourceName when it contains a service address

### DIFF
--- a/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicResourceNameToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicResourceNameToViewTransformer.java
@@ -167,6 +167,7 @@ public class JavaDiscoGapicResourceNameToViewTransformer
     resourceNameView.name(resourceName);
     resourceNameView.typeName(nameFormatter.publicClassName(Name.anyCamel(resourceName)));
     resourceNameView.pathTemplate(nameConfig.getNamePattern());
+    resourceNameView.serviceAddress(context.getDocContext().getServiceAddress());
 
     List<StaticLangMemberView> properties = new LinkedList<>();
     for (Map.Entry<String, Schema> entry : method.parameters().entrySet()) {

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiResourceNameView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiResourceNameView.java
@@ -32,6 +32,10 @@ public abstract class StaticLangApiResourceNameView
   // The template for the path, e.g. "projects/{projects}/topic/{topic}"
   public abstract String pathTemplate();
 
+  // The leading protocol+hostname string that qualifies a resource path.
+  // e.g. "https://www.googleapis.com/compute/v1/projects/"
+  public abstract String serviceAddress();
+
   // The list of path parameter views.
   public abstract List<StaticLangMemberView> pathParams();
 
@@ -46,6 +50,8 @@ public abstract class StaticLangApiResourceNameView
     public abstract Builder typeName(String val);
 
     public abstract Builder pathTemplate(String val);
+
+    public abstract Builder serviceAddress(String val);
 
     public abstract Builder pathParams(List<StaticLangMemberView> val);
 

--- a/src/main/resources/com/google/api/codegen/java/resource_name.snip
+++ b/src/main/resources/com/google/api/codegen/java/resource_name.snip
@@ -40,6 +40,8 @@
   private static final PathTemplate PATH_TEMPLATE =
         PathTemplate.createWithoutUrlEncoding("{@resourceName.pathTemplate}");
 
+  public static final String SERVICE_ADDRESS = "{@resourceName.serviceAddress}";
+
   private volatile Map<String, String> fieldValuesMap;
 @end
 
@@ -74,8 +76,12 @@
   }
 
   public static {@resourceName.typeName} parse(String formattedString) {
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
     Map<String, String> matchMap =
-        PATH_TEMPLATE.validatedMatch(formattedString, "{@resourceName.typeName}.parse: formattedString not in valid format");
+        PATH_TEMPLATE.validatedMatch(resourcePath, "{@resourceName.typeName}.parse: formattedString not in valid format");
     return of(
       @join param : resourceName.pathParams on ",".add(BREAK)
         matchMap.get("{@param.name}")
@@ -84,7 +90,11 @@
   }
 
   public static boolean isParsableFrom(String formattedString) {
-    return PATH_TEMPLATE.matches(formattedString);
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
+    return PATH_TEMPLATE.matches(resourcePath);
   }
 @end
 

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -39,6 +39,8 @@ public final class ProjectDummyObjectName implements ResourceName {
   private static final PathTemplate PATH_TEMPLATE =
         PathTemplate.createWithoutUrlEncoding("{project}/dummyObjects/{dummyObject}");
 
+  public static final String SERVICE_ADDRESS = "https://www.googleapis.com/compute/v1/projects/";
+
   private volatile Map<String, String> fieldValuesMap;
 
   public static Builder newBuilder() {
@@ -111,8 +113,12 @@ public final class ProjectDummyObjectName implements ResourceName {
   }
 
   public static ProjectDummyObjectName parse(String formattedString) {
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
     Map<String, String> matchMap =
-        PATH_TEMPLATE.validatedMatch(formattedString, "ProjectDummyObjectName.parse: formattedString not in valid format");
+        PATH_TEMPLATE.validatedMatch(resourcePath, "ProjectDummyObjectName.parse: formattedString not in valid format");
     return of(
       matchMap.get("dummyObject"),
       matchMap.get("project")
@@ -120,7 +126,11 @@ public final class ProjectDummyObjectName implements ResourceName {
   }
 
   public static boolean isParsableFrom(String formattedString) {
-    return PATH_TEMPLATE.matches(formattedString);
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
+    return PATH_TEMPLATE.matches(resourcePath);
   }
 
   public static class Builder {
@@ -228,6 +238,8 @@ public final class ProjectDummyObjectResourceName implements ResourceName {
   private static final PathTemplate PATH_TEMPLATE =
         PathTemplate.createWithoutUrlEncoding("{project}/dummyObjects/{resource}");
 
+  public static final String SERVICE_ADDRESS = "https://www.googleapis.com/compute/v1/projects/";
+
   private volatile Map<String, String> fieldValuesMap;
 
   public static Builder newBuilder() {
@@ -300,8 +312,12 @@ public final class ProjectDummyObjectResourceName implements ResourceName {
   }
 
   public static ProjectDummyObjectResourceName parse(String formattedString) {
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
     Map<String, String> matchMap =
-        PATH_TEMPLATE.validatedMatch(formattedString, "ProjectDummyObjectResourceName.parse: formattedString not in valid format");
+        PATH_TEMPLATE.validatedMatch(resourcePath, "ProjectDummyObjectResourceName.parse: formattedString not in valid format");
     return of(
       matchMap.get("project"),
       matchMap.get("resource")
@@ -309,7 +325,11 @@ public final class ProjectDummyObjectResourceName implements ResourceName {
   }
 
   public static boolean isParsableFrom(String formattedString) {
-    return PATH_TEMPLATE.matches(formattedString);
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
+    return PATH_TEMPLATE.matches(resourcePath);
   }
 
   public static class Builder {
@@ -417,6 +437,8 @@ public final class ProjectGlobalAddressName implements ResourceName {
   private static final PathTemplate PATH_TEMPLATE =
         PathTemplate.createWithoutUrlEncoding("{project}/global/addresses/{address}");
 
+  public static final String SERVICE_ADDRESS = "https://www.googleapis.com/compute/v1/projects/";
+
   private volatile Map<String, String> fieldValuesMap;
 
   public static Builder newBuilder() {
@@ -489,8 +511,12 @@ public final class ProjectGlobalAddressName implements ResourceName {
   }
 
   public static ProjectGlobalAddressName parse(String formattedString) {
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
     Map<String, String> matchMap =
-        PATH_TEMPLATE.validatedMatch(formattedString, "ProjectGlobalAddressName.parse: formattedString not in valid format");
+        PATH_TEMPLATE.validatedMatch(resourcePath, "ProjectGlobalAddressName.parse: formattedString not in valid format");
     return of(
       matchMap.get("address"),
       matchMap.get("project")
@@ -498,7 +524,11 @@ public final class ProjectGlobalAddressName implements ResourceName {
   }
 
   public static boolean isParsableFrom(String formattedString) {
-    return PATH_TEMPLATE.matches(formattedString);
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
+    return PATH_TEMPLATE.matches(resourcePath);
   }
 
   public static class Builder {
@@ -605,6 +635,8 @@ public final class ProjectName implements ResourceName {
   private static final PathTemplate PATH_TEMPLATE =
         PathTemplate.createWithoutUrlEncoding("{project}");
 
+  public static final String SERVICE_ADDRESS = "https://www.googleapis.com/compute/v1/projects/";
+
   private volatile Map<String, String> fieldValuesMap;
 
   public static Builder newBuilder() {
@@ -667,15 +699,23 @@ public final class ProjectName implements ResourceName {
   }
 
   public static ProjectName parse(String formattedString) {
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
     Map<String, String> matchMap =
-        PATH_TEMPLATE.validatedMatch(formattedString, "ProjectName.parse: formattedString not in valid format");
+        PATH_TEMPLATE.validatedMatch(resourcePath, "ProjectName.parse: formattedString not in valid format");
     return of(
       matchMap.get("project")
     );
   }
 
   public static boolean isParsableFrom(String formattedString) {
-    return PATH_TEMPLATE.matches(formattedString);
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
+    return PATH_TEMPLATE.matches(resourcePath);
   }
 
   public static class Builder {
@@ -772,6 +812,8 @@ public final class ProjectRegionAddressName implements ResourceName {
   private static final PathTemplate PATH_TEMPLATE =
         PathTemplate.createWithoutUrlEncoding("{project}/regions/{region}/addresses/{address}");
 
+  public static final String SERVICE_ADDRESS = "https://www.googleapis.com/compute/v1/projects/";
+
   private volatile Map<String, String> fieldValuesMap;
 
   public static Builder newBuilder() {
@@ -854,8 +896,12 @@ public final class ProjectRegionAddressName implements ResourceName {
   }
 
   public static ProjectRegionAddressName parse(String formattedString) {
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
     Map<String, String> matchMap =
-        PATH_TEMPLATE.validatedMatch(formattedString, "ProjectRegionAddressName.parse: formattedString not in valid format");
+        PATH_TEMPLATE.validatedMatch(resourcePath, "ProjectRegionAddressName.parse: formattedString not in valid format");
     return of(
       matchMap.get("address"),
       matchMap.get("project"),
@@ -864,7 +910,11 @@ public final class ProjectRegionAddressName implements ResourceName {
   }
 
   public static boolean isParsableFrom(String formattedString) {
-    return PATH_TEMPLATE.matches(formattedString);
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
+    return PATH_TEMPLATE.matches(resourcePath);
   }
 
   public static class Builder {
@@ -984,6 +1034,8 @@ public final class ProjectRegionName implements ResourceName {
   private static final PathTemplate PATH_TEMPLATE =
         PathTemplate.createWithoutUrlEncoding("{project}/regions/{region}");
 
+  public static final String SERVICE_ADDRESS = "https://www.googleapis.com/compute/v1/projects/";
+
   private volatile Map<String, String> fieldValuesMap;
 
   public static Builder newBuilder() {
@@ -1056,8 +1108,12 @@ public final class ProjectRegionName implements ResourceName {
   }
 
   public static ProjectRegionName parse(String formattedString) {
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
     Map<String, String> matchMap =
-        PATH_TEMPLATE.validatedMatch(formattedString, "ProjectRegionName.parse: formattedString not in valid format");
+        PATH_TEMPLATE.validatedMatch(resourcePath, "ProjectRegionName.parse: formattedString not in valid format");
     return of(
       matchMap.get("project"),
       matchMap.get("region")
@@ -1065,7 +1121,11 @@ public final class ProjectRegionName implements ResourceName {
   }
 
   public static boolean isParsableFrom(String formattedString) {
-    return PATH_TEMPLATE.matches(formattedString);
+    String resourcePath = formattedString;
+    if (formattedString.startsWith(SERVICE_ADDRESS)) {
+      resourcePath = formattedString.substring(SERVICE_ADDRESS.length());
+    }
+    return PATH_TEMPLATE.matches(resourcePath);
   }
 
   public static class Builder {


### PR DESCRIPTION
This would fix googleapis/google-cloud-java#3604.

_Problem_: When a resource comes back from the server, its resource path is something like 
```
instance.zone = https://www.googleapis.com/compute/v1/projects/project-123/zones/europe-west3-c
```
And that string won't be parseable against a PathTemplate of form `{project}/zones/{zone}`.

_Proposed solution_: Optionally ignore the leading [service address](https://github.com/googleapis/google-cloud-java/blob/969bbeef18f004fd51fd46c5def1ae5c644cae3c/google-cloud-clients/google-cloud-compute/src/main/java/com/google/cloud/compute/v1/stub/ProjectStubSettings.java#L237), which for Compute is `https://www.googleapis.com/compute/v1/projects/`.

See https://github.com/googleapis/google-cloud-java/pull/4208 for resulting changes.