### PR TITLE
timeout_millis is unsupported

### DIFF
--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -248,7 +248,7 @@ message MethodConfigProto {
 
   // Specifies the default timeout for a non-retrying call. If the call is
   // retrying, refer to `retry_params_name` instead.
-  uint64 timeout_millis = 11;
+  uint64 timeout_millis = 11; // UNSUPPORTED.
 
   // Specifies the configuration for batching.
   BatchingConfigProto batching = 6;


### PR DESCRIPTION
We never actually process the `timeout_millis` config value. Note that in the comments.

See https://github.com/googleapis/gapic-generator/issues/2481.