### PR TITLE
Samplegen: Make accessing fields of indexed fields work in output

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
@@ -367,6 +367,7 @@ public class OutputTransformer {
             valueSet.getId(),
             config.input());
 
+        type = type.makeOptional();
         accessors.add(AccessorView.IndexView.newBuilder().index(config.tokenStr()).build());
 
         Preconditions.checkArgument(

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -7937,6 +7937,7 @@ public class PublishSeriesFlattenedPiVersion {
       for (String title : response.getBookNamesList()) {
         System.out.printf("Title: %s\n", title);
       }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
       System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
       System.out.println("That's all!");
       System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
@@ -8050,6 +8051,7 @@ public class PublishSeriesRequestPiVersion {
       for (String title : response.getBookNamesList()) {
         System.out.printf("Title: %s\n", title);
       }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
       System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
       System.out.println("That's all!");
       System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
@@ -8174,6 +8176,7 @@ public class PublishSeriesCallableCallablePiVersion {
       for (String title : response.getBookNamesList()) {
         System.out.printf("Title: %s\n", title);
       }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
       System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
       System.out.println("That's all!");
       System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -7937,7 +7937,7 @@ public class PublishSeriesFlattenedPiVersion {
       for (String title : response.getBookNamesList()) {
         System.out.printf("Title: %s\n", title);
       }
-      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
       System.out.println("That's all!");
       System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     } catch (Exception exception) {
@@ -8050,7 +8050,7 @@ public class PublishSeriesRequestPiVersion {
       for (String title : response.getBookNamesList()) {
         System.out.printf("Title: %s\n", title);
       }
-      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
       System.out.println("That's all!");
       System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     } catch (Exception exception) {
@@ -8174,7 +8174,7 @@ public class PublishSeriesCallableCallablePiVersion {
       for (String title : response.getBookNamesList()) {
         System.out.printf("Title: %s\n", title);
       }
-      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
       System.out.println("That's all!");
       System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
     } catch (Exception exception) {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -1302,6 +1302,9 @@ const SeriesUuid = {
  * @property {string[]} bookNames
  *   The names of the books in the series that were published
  *
+ * @property {Object[]} books
+ *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
+ *
  * @property {Object} seriesUuid
  *   Uniquely identifies the series published
  *

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -3455,7 +3455,7 @@ function samplePublishSeries($shelfName, $edition)
         foreach ($response->getBookNames() as $title) {
             printf("Title: %s" . PHP_EOL, $title);
         }
-        printf("The first book is: %s" . PHP_EOL, $response->getBookNames()[0]);
+        printf("The author of the first book is: %s" . PHP_EOL, $response->getBooks()[0]->getAuthor());
         printf("That's all!" . PHP_EOL);
         printf("series_uuid: %s" . PHP_EOL, $response->getSeriesUuid()->getSeriesBytes());
     } finally {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -3455,6 +3455,7 @@ function samplePublishSeries($shelfName, $edition)
         foreach ($response->getBookNames() as $title) {
             printf("Title: %s" . PHP_EOL, $title);
         }
+        printf("The first book is: %s" . PHP_EOL, $response->getBookNames()[0]);
         printf("The author of the first book is: %s" . PHP_EOL, $response->getBooks()[0]->getAuthor());
         printf("That's all!" . PHP_EOL);
         printf("series_uuid: %s" . PHP_EOL, $response->getSeriesUuid()->getSeriesBytes());

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4646,6 +4646,7 @@ def sample_publish_series(shelf_name, edition):
   response = client.publish_series(shelf, books, series_uuid, edition=edition)
   for title in response.book_names:
     print('Title: {}'.format(title))
+  print('The first book is: {}'.format(response.book_names[0]))
   print('The author of the first book is: {}'.format(response.books[0].author))
   print('That\'s all!')
   print('series_uuid: {}'.format(response.series_uuid.series_bytes))

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4646,7 +4646,7 @@ def sample_publish_series(shelf_name, edition):
   response = client.publish_series(shelf, books, series_uuid, edition=edition)
   for title in response.book_names:
     print('Title: {}'.format(title))
-  print('The first book is: {}'.format(response.book_names[0]))
+  print('The author of the first book is: {}'.format(response.books[0].author))
   print('That\'s all!')
   print('series_uuid: {}'.format(response.series_uuid.series_bytes))
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -2199,6 +2199,8 @@ module Google
         # @!attribute [rw] book_names
         #   @return [Array<String>]
         #     The names of the books in the series that were published
+        # @!attribute [rw] books
+        #   @return [Array<Google::Example::Library::V1::Book>]
         # @!attribute [rw] series_uuid
         #   @return [Google::Example::Library::V1::SeriesUuid]
         #     Uniquely identifies the series published

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
@@ -443,8 +443,10 @@ message PublishSeriesResponse {
   // The names of the books in the series that were published
   repeated string book_names = 1;
 
+  repeated Book books = 2;
+
   // Uniquely identifies the series published
-  SeriesUuid series_uuid = 2;
+  SeriesUuid series_uuid = 3;
 }
 
 // Request message for LibraryService.GetBook.

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -252,8 +252,8 @@ interfaces:
               - "Title: %s"
               - title
       - print:
-        - "The first book is: %s"
-        - $resp.book_names[0]
+        - "The author of the first book is: %s"
+        - $resp.books[0].author
       - print:
         - "That's all!"
       - print:

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -252,6 +252,9 @@ interfaces:
               - "Title: %s"
               - title
       - print:
+        - "The first book is: %s"
+        - $resp.book_names[0]
+      - print:
         - "The author of the first book is: %s"
         - $resp.books[0].author
       - print:

--- a/src/test/java/com/google/api/codegen/transformer/OutputTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/OutputTransformerTest.java
@@ -244,7 +244,11 @@ public class OutputTransformerTest {
     TypeModel propertyTypeModel = mock(TypeModel.class);
     when(namer.getFieldGetFunctionName(propertyFieldModel)).thenReturn("getProperty");
     when(propertyTypeModel.isRepeated()).thenReturn(true);
-    when(namer.getAndSaveTypeName(typeTable, propertyTypeModel)).thenReturn("PropertyTypeName");
+    TypeModel optionalPropertyTypeModel = mock(TypeModel.class);
+    when(propertyTypeModel.makeOptional()).thenReturn(optionalPropertyTypeModel);
+
+    when(namer.getAndSaveTypeName(typeTable, optionalPropertyTypeModel))
+        .thenReturn("OptionalPropertyTypeName");
     when(propertyFieldModel.getType()).thenReturn(propertyTypeModel);
 
     OutputView.VariableView variableView =
@@ -256,8 +260,8 @@ public class OutputTransformerTest {
             AccessorView.FieldView.newBuilder().field("getProperty").build(),
             AccessorView.IndexView.newBuilder().index("0").build())
         .inOrder();
-    assertThat(parent.getTypeName("newVar")).isEqualTo("PropertyTypeName");
-    assertThat(parent.getTypeModel("newVar")).isEqualTo(propertyTypeModel);
+    assertThat(parent.getTypeName("newVar")).isEqualTo("OptionalPropertyTypeName");
+    assertThat(parent.getTypeModel("newVar")).isEqualTo(optionalPropertyTypeModel);
   }
 
   @Test


### PR DESCRIPTION
Before this PR, accessing fields like `var.repeated_field[0].whatever` in the `on_success` section does not work. This PR fixes it.