### PR TITLE
Properly handle quoted strings in the sample default configuration values

### DIFF
--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -99,13 +99,12 @@ public class FieldStructureParser {
 
     InitValue initValue = null;
     if (token == '=') {
-      fieldNamePos = Math.min(fieldNamePos, scanner.pos() - 1);
-
+      // fieldNamePos = Math.min(fieldNamePos, scanner.pos() - 1);
       // TODO(pongad): Quote the RHS of existing configs, and once that's done use 'parseValue' here
       // (`String valueString = parseValue(scanner)`). For now we are preserving the previous
       // behavior, where everything on the right of the equal sign is a string.
-      String valueString = config.substring(scanner.pos());
-
+      // String valueString = config.substring(scanner.pos());
+      String valueString = parseValue(scanner);
       if (valueString.contains(InitFieldConfig.RANDOM_TOKEN)) {
         initValue = InitValue.createRandom(valueString);
       } else if (valueString.contains(PROJECT_ID_TOKEN)) {

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -191,9 +191,9 @@ public class FieldStructureParser {
   }
 
   /**
-   * Parses the value of configs. If the value is a double-quoted string literal we return it
-   * unquoted. Otherwise we strip leading spaces and return the rest of value as a string for
-   * backward compatibility.
+   * Parses the value of configs (i.e. the RHS of the '='). If the value is a double-quoted string
+   * literal we return it unquoted. Otherwise we strip leading spaces and return the rest of value
+   * as a string for backward compatibility.
    */
   private static String parseValue(Scanner scanner) {
     int token = scanner.scan();

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -99,11 +99,6 @@ public class FieldStructureParser {
 
     InitValue initValue = null;
     if (token == '=') {
-      // fieldNamePos = Math.min(fieldNamePos, scanner.pos() - 1);
-      // TODO(pongad): Quote the RHS of existing configs, and once that's done use 'parseValue' here
-      // (`String valueString = parseValue(scanner)`). For now we are preserving the previous
-      // behavior, where everything on the right of the equal sign is a string.
-      // String valueString = config.substring(scanner.pos());
       String valueString = parseValue(scanner);
       if (valueString.contains(InitFieldConfig.RANDOM_TOKEN)) {
         initValue = InitValue.createRandom(valueString);
@@ -118,9 +113,7 @@ public class FieldStructureParser {
         initValue = InitValue.createLiteral(valueString);
       }
     }
-
-    // TODO(pongad): When we can actually parse the RHS, we should expect EOF.
-    // Preconditions.checkArgument(scanner.scan() == Scanner.EOF, "expected EOF: %s", config);
+    Preconditions.checkArgument(scanner.scan() == Scanner.EOF, "expected EOF: %s", config);
 
     InitValueConfig valueConfig =
         createInitValueConfig(

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -113,7 +113,6 @@ public class FieldStructureParser {
         initValue = InitValue.createLiteral(valueString);
       }
     }
-    Preconditions.checkArgument(scanner.scan() == Scanner.EOF, "expected EOF: %s", config);
 
     InitValueConfig valueConfig =
         createInitValueConfig(

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -169,7 +169,7 @@ public class FieldStructureParser {
 
         case '{':
           parent.setLineType(InitCodeLineType.MapInitLine);
-          parent = parent.mergeChild(InitCodeNode.create(parseValue(scanner)));
+          parent = parent.mergeChild(InitCodeNode.create(parseKey(scanner)));
 
           Preconditions.checkArgument(
               scanner.scan() == '}', "expected closing '}': %s", scanner.input());
@@ -182,12 +182,27 @@ public class FieldStructureParser {
     }
   }
 
-  private static String parseValue(Scanner scanner) {
+  private static String parseKey(Scanner scanner) {
     int token = scanner.scan();
     Preconditions.checkArgument(
         token == Scanner.INT || token == Scanner.IDENT || token == Scanner.STRING,
         "invalid value: %s",
         scanner.input());
     return scanner.tokenStr();
+  }
+
+  /**
+   * Parses the RHS of configs. If the RHS is a string literal we return the unquote string.
+   * Otherwise we strip leading spaces and return the rest of RHS as a string.
+   */
+  private static String parseValue(Scanner scanner) {
+    int token = scanner.scan();
+    if (token == Scanner.STRING) {
+      String tokenStr = scanner.tokenStr();
+      if (scanner.scan() == Scanner.EOF) {
+        return tokenStr;
+      }
+    }
+    return scanner.tokenStr() + scanner.input().substring(scanner.pos());
   }
 }

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -192,8 +192,9 @@ public class FieldStructureParser {
   }
 
   /**
-   * Parses the RHS of configs. If the RHS is a string literal we return the unquote string.
-   * Otherwise we strip leading spaces and return the rest of RHS as a string.
+   * Parses the RHS of configs. If the RHS is a string literal we return the unquoted string.
+   * Otherwise we strip leading spaces and return the rest of RHS as a string for backward
+   * compatibility.
    */
   private static String parseValue(Scanner scanner) {
     int token = scanner.scan();

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -191,12 +191,14 @@ public class FieldStructureParser {
   }
 
   /**
-   * Parses the RHS of configs. If the RHS is a string literal we return the unquoted string.
-   * Otherwise we strip leading spaces and return the rest of RHS as a string for backward
-   * compatibility.
+   * Parses the value of configs. If the value is a double-quoted string literal we return it
+   * unquoted. Otherwise we strip leading spaces and return the rest of value as a string for
+   * backward compatibility.
    */
   private static String parseValue(Scanner scanner) {
     int token = scanner.scan();
+
+    // Scanner.STRING means a double-quoted string literal
     if (token == Scanner.STRING) {
       String tokenStr = scanner.tokenStr();
       if (scanner.scan() == Scanner.EOF) {

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -741,7 +741,12 @@ public class InitCodeTransformer {
             entityValue = context.getNamer().injectRandomStringGeneratorCode(initValue.getValue());
             break;
           case Literal:
-            entityValue = initValue.getValue();
+            entityValue =
+                context
+                    .getTypeTable()
+                    .renderPrimitiveValue(
+                        ProtoTypeRef.create(TypeRef.fromPrimitiveName("string")),
+                        initValue.getValue());
             break;
           default:
             throw new IllegalArgumentException("Unhandled init value type");

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -263,7 +263,7 @@ module.exports.default = Object.assign({}, module.exports);
 //         className: "DiscussBookRequestStreamingBidiProg"
 //          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//        [name=BASIC, comment.comment=comment_file, image="image_file.jpg"]
+//        [name=BASIC, comment.comment = comment_file, image="image_file.jpg"]
 //      apiMethod "discussBook" of type "OptionalArrayMethod"
 
 // [START turing_prog_request_streaming_bidi_core]

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -420,7 +420,7 @@ client.findRelatedBooks(request, options)
 //         className: "GetBigBookLongRunningEventEmitterWap"
 //          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//        [name%shelf_id="Novel", name%book_id="War and Peace"]
+//        [name%shelf_id=Novel, name%book_id="War and Peace"]
 //      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
 
 // [START hopper_core]
@@ -478,7 +478,7 @@ client.getBigBook({name: formattedName})
 //         className: "GetBigBookLongRunningPromiseWap"
 //          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//        [name%shelf_id="Novel", name%book_id="War and Peace"]
+//        [name%shelf_id=Novel, name%book_id="War and Peace"]
 //      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
 
 // [START hopper_core]

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -263,7 +263,7 @@ module.exports.default = Object.assign({}, module.exports);
 //         className: "DiscussBookRequestStreamingBidiProg"
 //          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//        [name=BASIC, comment.comment = comment_file, image="image_file.jpg"]
+//        [name=BASIC, comment.comment = comment_file, image= "image_file.jpg"]
 //      apiMethod "discussBook" of type "OptionalArrayMethod"
 
 // [START turing_prog_request_streaming_bidi_core]

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -263,7 +263,7 @@ module.exports.default = Object.assign({}, module.exports);
 //         className: "DiscussBookRequestStreamingBidiProg"
 //          valueSet: "prog" ("Programming Books")
 //       description: "Testing calling forms"
-//        [name=BASIC, comment.comment=comment_file, image=image_file.jpg]
+//        [name=BASIC, comment.comment=comment_file, image="image_file.jpg"]
 //      apiMethod "discussBook" of type "OptionalArrayMethod"
 
 // [START turing_prog_request_streaming_bidi_core]
@@ -420,7 +420,7 @@ client.findRelatedBooks(request, options)
 //         className: "GetBigBookLongRunningEventEmitterWap"
 //          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//        [name%shelf_id=Novel, name%book_id="War and Peace"]
+//        [name%shelf_id="Novel", name%book_id="War and Peace"]
 //      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
 
 // [START hopper_core]
@@ -429,7 +429,7 @@ client.findRelatedBooks(request, options)
 
 /*
 // const shelf = 'Novel';
-const formattedName = client.bookPath(shelf, "War and Peace");
+const formattedName = client.bookPath(shelf, 'War and Peace');
 
 // Handle the operation using the event emitter pattern.
 client.getBigBook({name: formattedName})
@@ -478,7 +478,7 @@ client.getBigBook({name: formattedName})
 //         className: "GetBigBookLongRunningPromiseWap"
 //          valueSet: "wap" ("GetBigBook: 'War and Peace'")
 //       description: "Testing calling forms"
-//        [name%shelf_id=Novel, name%book_id="War and Peace"]
+//        [name%shelf_id="Novel", name%book_id="War and Peace"]
 //      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
 
 // [START hopper_core]
@@ -487,7 +487,7 @@ client.getBigBook({name: formattedName})
 
 /*
 // const shelf = 'Novel';
-const formattedName = client.bookPath(shelf, "War and Peace");
+const formattedName = client.bookPath(shelf, 'War and Peace');
 
 // Handle the operation using the promise pattern.
 client.getBigBook({name: formattedName})

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -3185,7 +3185,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel';
-    $formattedName = $libraryServiceClient->bookName($shelf, "War and Peace");
+    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -3261,7 +3261,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel';
-    $formattedName = $libraryServiceClient->bookName($shelf, "War and Peace");
+    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4514,7 +4514,7 @@ def sample_get_big_book(shelf):
 
   if isinstance(shelf, six.binary_type):
     shelf = shelf.decode('utf-8')
-  name = client.book_path(shelf, "War and Peace")
+  name = client.book_path(shelf, 'War and Peace')
 
   operation = client.get_big_book(name)
 

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -577,7 +577,7 @@ interfaces:
       parameters:
         defaults:
         - name=BASIC
-        - comment.comment=comment_file
+        - comment.comment = comment_file
         - image="image_file.jpg"
         attributes:
         - parameter: comment.comment

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -578,7 +578,7 @@ interfaces:
         defaults:
         - name=BASIC
         - comment.comment=comment_file
-        - image=image_file.jpg
+        - image="image_file.jpg"
         attributes:
         - parameter: comment.comment
           read_file: true
@@ -749,7 +749,7 @@ interfaces:
       description: "Testing calling forms"
       parameters:
         defaults:
-        - name%shelf_id=Novel
+        - name%shelf_id="Novel"
         - name%book_id="War and Peace"
         attributes:
         - parameter: name%shelf_id

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -578,7 +578,7 @@ interfaces:
         defaults:
         - name=BASIC
         - comment.comment = comment_file
-        - image="image_file.jpg"
+        - image= "image_file.jpg"
         attributes:
         - parameter: comment.comment
           read_file: true

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -749,7 +749,7 @@ interfaces:
       description: "Testing calling forms"
       parameters:
         defaults:
-        - name%shelf_id="Novel"
+        - name%shelf_id=Novel
         - name%book_id="War and Peace"
         attributes:
         - parameter: name%shelf_id


### PR DESCRIPTION
If RHS is a string literal, return the unquoted string. Otherwise, return the RHS as it is for backward compatibility.