### PR TITLE
Samplegen: Restructure Java sample files

### DIFF
--- a/src/main/java/com/google/api/codegen/gapic/CommonGapicCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/gapic/CommonGapicCodePathMapper.java
@@ -54,12 +54,12 @@ public class CommonGapicCodePathMapper implements GapicCodePathMapper {
     ArrayList<String> dirs = new ArrayList<>();
     boolean haveSample = !Strings.isNullOrEmpty(methodSample);
 
-    if (haveSample) {
-      dirs.add(SAMPLES_DIRECTORY);
-    }
-
     if (!Strings.isNullOrEmpty(prefix)) {
       dirs.add(prefix);
+    }
+
+    if (haveSample) {
+      dirs.add(SAMPLES_DIRECTORY);
     }
 
     if (shouldAppendPackage && !Strings.isNullOrEmpty(config.getPackageName())) {

--- a/src/main/java/com/google/api/codegen/gapic/CommonGapicCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/gapic/CommonGapicCodePathMapper.java
@@ -54,12 +54,12 @@ public class CommonGapicCodePathMapper implements GapicCodePathMapper {
     ArrayList<String> dirs = new ArrayList<>();
     boolean haveSample = !Strings.isNullOrEmpty(methodSample);
 
-    if (!Strings.isNullOrEmpty(prefix)) {
-      dirs.add(prefix);
-    }
-
     if (haveSample) {
       dirs.add(SAMPLES_DIRECTORY);
+    }
+
+    if (!Strings.isNullOrEmpty(prefix)) {
+      dirs.add(prefix);
     }
 
     if (shouldAppendPackage && !Strings.isNullOrEmpty(config.getPackageName())) {

--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorFactory.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorFactory.java
@@ -31,6 +31,7 @@ import com.google.api.codegen.common.TargetLanguage;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.ProtoApiModel;
+import com.google.api.codegen.java.JavaGapicCodePathMapper;
 import com.google.api.codegen.nodejs.NodeJSCodePathMapper;
 import com.google.api.codegen.php.PhpGapicCodePathMapper;
 import com.google.api.codegen.rendering.CommonSnippetSetRunner;
@@ -218,10 +219,7 @@ public class GapicGeneratorFactory {
 
       if (artifactFlags.surfaceGeneratorEnabled()) {
         GapicCodePathMapper javaPathMapper =
-            CommonGapicCodePathMapper.newBuilder()
-                .setPrefix("src/main/java")
-                .setShouldAppendPackage(true)
-                .build();
+            JavaGapicCodePathMapper.newBuilder().prefix("src/main/java").build();
 
         if (artifactFlags.codeFilesEnabled()) {
           generators.add(newJavaGenerator.apply(new JavaGapicSurfaceTransformer(javaPathMapper)));
@@ -255,10 +253,7 @@ public class GapicGeneratorFactory {
       if (artifactFlags.testGeneratorEnabled()) {
         if (artifactFlags.codeFilesEnabled()) {
           GapicCodePathMapper javaTestPathMapper =
-              CommonGapicCodePathMapper.newBuilder()
-                  .setPrefix("src/test/java")
-                  .setShouldAppendPackage(true)
-                  .build();
+              JavaGapicCodePathMapper.newBuilder().prefix("src/test/java").build();
           generators.add(
               newJavaGenerator.apply(
                   new JavaSurfaceTestTransformer<>(

--- a/src/main/java/com/google/api/codegen/java/JavaGapicCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/java/JavaGapicCodePathMapper.java
@@ -43,7 +43,10 @@ public abstract class JavaGapicCodePathMapper implements GapicCodePathMapper {
     return getOutputPath(config, method);
   }
 
-  /* If the methodName is not null, returns the path for generated samples for this method. */
+  /*
+   * If the methodName is not null, returns the path for generated samples for this method.
+   * Otherwise, returns the path for the client library classes.
+   */
   private String getOutputPath(ProductConfig config, String methodName) {
     ArrayList<String> dirs = new ArrayList<>();
     boolean hasSample = !Strings.isNullOrEmpty(methodName);
@@ -55,7 +58,7 @@ public abstract class JavaGapicCodePathMapper implements GapicCodePathMapper {
         dirs.add(seg.toLowerCase());
       }
 
-      // The Java package name a the top of each sample file must match the output path for
+      // The Java package name at the top of each sample file must match the output path for
       // that file. This means that since we want the output path to eventually be of the form
       // `samples/src/main/java/com/google/cloud/examples/API_NAME/VER/METHOD_NAME/SAMPLE_NAME.java`,
       // we need to make `methodName` be the last element of the Java package name at the top of the

--- a/src/main/java/com/google/api/codegen/java/JavaGapicCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/java/JavaGapicCodePathMapper.java
@@ -43,9 +43,10 @@ public abstract class JavaGapicCodePathMapper implements GapicCodePathMapper {
     return getOutputPath(config, method);
   }
 
-  private String getOutputPath(ProductConfig config, String methodSample) {
+  /* If the methodName is not null, returns the path for generated samples for this method. */
+  private String getOutputPath(ProductConfig config, String methodName) {
     ArrayList<String> dirs = new ArrayList<>();
-    boolean hasSample = !Strings.isNullOrEmpty(methodSample);
+    boolean hasSample = !Strings.isNullOrEmpty(methodName);
     if (hasSample) {
       dirs.add(SAMPLES_DIRECTORY);
       dirs.add(prefix());
@@ -54,10 +55,13 @@ public abstract class JavaGapicCodePathMapper implements GapicCodePathMapper {
         dirs.add(seg.toLowerCase());
       }
 
-      // TODO(hzyi): it requires non-trivial work to append the method name to package name. Thus
-      // removing it from the output path for now to make Java samples in a structure that compiles.
-      // After we figure out how to append the method name to package name, we need to call
-      // `dirs.add(methodSample)` here.
+      // The Java package name a the top of each sample file must match the output path for
+      // that file. This means that since we want the output path to eventually be of the form
+      // `samples/src/main/java/com/google/cloud/examples/API_NAME/VER/METHOD_NAME/SAMPLE_NAME.java`,
+      // we need to make `methodName` be the last element of the Java package name at the top of the
+      // sample file. This is non-trivial to do, so we'll do it separately. Once we do it, we can
+      // then make `methodName` be the final path element for this output path so that they continue
+      // to match by calling `dirs.add(methodName)` here.
     } else {
       dirs.add(prefix());
       for (String seg : config.getPackageName().split(PACKAGE_SPLITTER)) {

--- a/src/main/java/com/google/api/codegen/java/JavaGapicCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/java/JavaGapicCodePathMapper.java
@@ -58,7 +58,6 @@ public abstract class JavaGapicCodePathMapper implements GapicCodePathMapper {
       // removing it from the output path for now to make Java samples in a structure that compiles.
       // After we figure out how to append the method name to package name, we need to call
       // `dirs.add(methodSample)` here.
-      dirs.add(methodSample.toLowerCase());
     } else {
       dirs.add(prefix());
       for (String seg : config.getPackageName().split(PACKAGE_SPLITTER)) {

--- a/src/main/java/com/google/api/codegen/java/JavaGapicCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/java/JavaGapicCodePathMapper.java
@@ -1,0 +1,82 @@
+/* Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.java;
+
+import com.google.api.codegen.config.ProductConfig;
+import com.google.api.codegen.gapic.GapicCodePathMapper;
+import com.google.api.codegen.transformer.java.JavaSurfaceNamer;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import java.util.ArrayList;
+
+/**
+ * An implementation of GapicCodePathMapper that generates the output path from a prefix, and/or
+ * package name.
+ */
+@AutoValue
+public abstract class JavaGapicCodePathMapper implements GapicCodePathMapper {
+
+  private final String PACKAGE_SPLITTER = "\\.";
+
+  public abstract String prefix();
+
+  @Override
+  public String getOutputPath(String elementFullName, ProductConfig config) {
+    return getOutputPath(config, null);
+  }
+
+  @Override
+  public String getSamplesOutputPath(String elementFullName, ProductConfig config, String method) {
+    return getOutputPath(config, method);
+  }
+
+  private String getOutputPath(ProductConfig config, String methodSample) {
+    ArrayList<String> dirs = new ArrayList<>();
+    boolean hasSample = !Strings.isNullOrEmpty(methodSample);
+    if (hasSample) {
+      dirs.add(SAMPLES_DIRECTORY);
+      dirs.add(prefix());
+      for (String seg :
+          JavaSurfaceNamer.getExamplePackageName(config.getPackageName()).split(PACKAGE_SPLITTER)) {
+        dirs.add(seg.toLowerCase());
+      }
+
+      // TODO(hzyi): it requires non-trivial work to append the method name to package name. Thus
+      // removing it from the output path for now to make Java samples in a structure that compiles.
+      // After we figure out how to append the method name to package name, we need to call
+      // `dirs.add(methodSample)` here.
+      dirs.add(methodSample.toLowerCase());
+    } else {
+      dirs.add(prefix());
+      for (String seg : config.getPackageName().split(PACKAGE_SPLITTER)) {
+        dirs.add(seg.toLowerCase());
+      }
+    }
+    return Joiner.on("/").join(dirs);
+  }
+
+  public static Builder newBuilder() {
+    return new AutoValue_JavaGapicCodePathMapper.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder prefix(String prefix);
+
+    public abstract JavaGapicCodePathMapper build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -328,7 +328,7 @@ public class InitCodeTransformer {
           // The node has not been specified before, thus check if entity has been specified
           checkArgument(
               entity == null || nodeEntities.put(node, entity),
-              "Entity %s in path %s specified multiple types",
+              "Entity %s in path %s specified multiple times",
               entity,
               path);
         } else {
@@ -343,7 +343,7 @@ public class InitCodeTransformer {
               path);
           checkArgument(
               nodeEntities.put(node, entity),
-              "Entity %s in path %s specified multiple types",
+              "Entity %s in path %s specified multiple times",
               entity,
               path);
         }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -429,7 +429,10 @@ public class JavaSurfaceNamer extends SurfaceNamer {
    */
   @Override
   public String getExamplePackageName() {
-    String packageName = getPackageName();
+    return getExamplePackageName(getPackageName());
+  }
+
+  public static String getExamplePackageName(String packageName) {
     checkArgument(
         packageName.startsWith("com.google."),
         "We currently only support packages beginning with 'com.google'");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -443,6 +443,6 @@ public class JavaSurfaceNamer extends SurfaceNamer {
     int index = packageName.indexOf('.');
     String firstComponent = index < 0 ? packageName : packageName.substring(0, index);
     String remainingComponents = packageName.replaceFirst(firstComponent, "");
-    return "com.google." + firstComponent + ".examples" + remainingComponents + ".snippets";
+    return "com.google." + firstComponent + ".examples" + remainingComponents;
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -443,6 +443,9 @@ public class JavaSurfaceNamer extends SurfaceNamer {
     int index = packageName.indexOf('.');
     String firstComponent = index < 0 ? packageName : packageName.substring(0, index);
     String remainingComponents = packageName.replaceFirst(firstComponent, "");
+    // Ideally we want to change `.examples` to `.samples`. We call it `examples` for
+    // now to be consistent with manual samples. Consider change it to `samples` to
+    // be consistent across languages once the sample publish infrastructure in set.
     return "com.google." + firstComponent + ".examples" + remainingComponents;
   }
 }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -119,9 +119,9 @@ clean {
   delete 'all-jars'
 }
 
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/DiscussBookCallableCallableStreamingBidiProg.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/DiscussBookCallableCallableStreamingBidiProg.java ==============
 // DO NOT EDIT! This is a generated sample ("CallableStreamingBidi",  "prog")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -189,9 +189,9 @@ public class DiscussBookCallableCallableStreamingBidiProg {
 // FIXME: Insert here clean-up code.
 
 // [END turing_prog_callable_streaming_bidi]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/FindRelatedBooksCallableCallableListOdyssey.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/FindRelatedBooksCallableCallableListOdyssey.java ==============
 // DO NOT EDIT! This is a generated sample ("CallableList",  "odyssey")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 // [START sample]
 import com.google.example.library.v1.FindRelatedBooksRequest;
@@ -237,9 +237,9 @@ public class FindRelatedBooksCallableCallableListOdyssey {
 // FIXME: Insert here clean-up code.
 
 // [END sample]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/FindRelatedBooksFlattenedPagedOdyssey.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/FindRelatedBooksFlattenedPagedOdyssey.java ==============
 // DO NOT EDIT! This is a generated sample ("FlattenedPaged",  "odyssey")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 // [START sample]
 import com.google.example.library.v1.LibraryClient;
@@ -273,9 +273,9 @@ public class FindRelatedBooksFlattenedPagedOdyssey {
 // FIXME: Insert here clean-up code.
 
 // [END sample]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/FindRelatedBooksPagedCallableCallablePagedOdyssey.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/FindRelatedBooksPagedCallableCallablePagedOdyssey.java ==============
 // DO NOT EDIT! This is a generated sample ("CallablePaged",  "odyssey")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 // [START sample]
 import com.google.example.library.v1.FindRelatedBooksRequest;
@@ -316,9 +316,9 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
 // FIXME: Insert here clean-up code.
 
 // [END sample]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/FindRelatedBooksRequestPagedOdyssey.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/FindRelatedBooksRequestPagedOdyssey.java ==============
 // DO NOT EDIT! This is a generated sample ("RequestPaged",  "odyssey")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 // [START sample]
 import com.google.example.library.v1.FindRelatedBooksRequest;
@@ -355,9 +355,9 @@ public class FindRelatedBooksRequestPagedOdyssey {
 // FIXME: Insert here clean-up code.
 
 // [END sample]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/GetBigBookAsyncLongRunningFlattenedAsyncWap.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBigBookAsyncLongRunningFlattenedAsyncWap.java ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningFlattenedAsync",  "wap")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -400,9 +400,9 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/GetBigBookAsyncLongRunningRequestAsyncWap.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBigBookAsyncLongRunningRequestAsyncWap.java ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -449,9 +449,9 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/GetBigBookCallableCallableWap.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBigBookCallableCallableWap.java ==============
 // DO NOT EDIT! This is a generated sample ("Callable",  "wap")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -502,9 +502,9 @@ public class GetBigBookCallableCallableWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/GetBigBookOperationCallableLongRunningCallableWap.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBigBookOperationCallableLongRunningCallableWap.java ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningCallable",  "wap")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -555,9 +555,9 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/MonologAboutBookCallableCallableStreamingClientProg.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/MonologAboutBookCallableCallableStreamingClientProg.java ==============
 // DO NOT EDIT! This is a generated sample ("CallableStreamingClient",  "prog")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 // [START sample]
 import com.google.example.library.v1.DiscussBookRequest;
@@ -605,9 +605,9 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
 // FIXME: Insert here clean-up code.
 
 // [END sample]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesCallableCallablePiVersion.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/PublishSeriesCallableCallablePiVersion.java ==============
 // DO NOT EDIT! This is a generated sample ("Callable",  "pi_version")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -688,9 +688,9 @@ public class PublishSeriesCallableCallablePiVersion {
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesCallableCallableSecondEdition.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/PublishSeriesCallableCallableSecondEdition.java ==============
 // DO NOT EDIT! This is a generated sample ("Callable",  "second_edition")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 // [START canonical]
 import com.google.example.library.v1.Book;
@@ -734,9 +734,9 @@ public class PublishSeriesCallableCallableSecondEdition {
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesFlattenedPiVersion.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/PublishSeriesFlattenedPiVersion.java ==============
 // DO NOT EDIT! This is a generated sample ("Flattened",  "pi_version")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -806,9 +806,9 @@ public class PublishSeriesFlattenedPiVersion {
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesFlattenedSecondEdition.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/PublishSeriesFlattenedSecondEdition.java ==============
 // DO NOT EDIT! This is a generated sample ("Flattened",  "second_edition")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 // [START canonical]
 import com.google.example.library.v1.Book;
@@ -841,9 +841,9 @@ public class PublishSeriesFlattenedSecondEdition {
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesRequestPiVersion.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/PublishSeriesRequestPiVersion.java ==============
 // DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -920,9 +920,9 @@ public class PublishSeriesRequestPiVersion {
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesRequestSecondEdition.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/PublishSeriesRequestSecondEdition.java ==============
 // DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 // [START canonical]
 import com.google.example.library.v1.Book;
@@ -962,9 +962,9 @@ public class PublishSeriesRequestSecondEdition {
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/StreamBooksCallableCallableStreamingServerProg.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/StreamBooksCallableCallableStreamingServerProg.java ==============
 // DO NOT EDIT! This is a generated sample ("CallableStreamingServer",  "prog")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 // [START babbage]
 import com.google.example.library.v1.LibraryClient;
@@ -996,9 +996,9 @@ public class StreamBooksCallableCallableStreamingServerProg {
 // FIXME: Insert here clean-up code.
 
 // [END babbage]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/StreamShelvesCallableCallableStreamingServerEmpty.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/StreamShelvesCallableCallableStreamingServerEmpty.java ==============
 // DO NOT EDIT! This is a generated sample ("CallableStreamingServer",  "empty")
-package com.google.example.examples.library.v1.snippets;
+package com.google.example.examples.library.v1;
 
 // [START sample]
 import com.google.example.library.v1.LibraryClient;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -76,6 +76,914 @@ task allJars(type: Copy) {
   // Replace with `from configurations.testRuntime, jar` to include test dependencies
   from configurations.runtime, jar
 }
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/discussbookcallable/DiscussBookCallableCallableStreamingBidiProg.java ==============
+// DO NOT EDIT! This is a generated sample ("CallableStreamingBidi",  "prog")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START turing_prog_callable_streaming_bidi]
+import com.google.example.library.v1.Comment;
+import com.google.example.library.v1.DiscussBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.protobuf.ByteString;
+import java.nio.File;
+import java.nio.Files;
+import java.nio.Path;
+import java.nio.Paths;
+
+public class DiscussBookCallableCallableStreamingBidiProg {
+  public static void sampleDiscussBook(String imageFileName) {
+    // [START turing_prog_callable_streaming_bidi_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      BidiStream<DiscussBookRequest, Comment> bidiStream =
+          libraryClient.discussBookCallable().call();
+
+      // String imageFileName = "image_file.jpg";
+      String name = "BASIC";
+      String fileName = "comment_file";
+      Path path = Paths.get(fileName);
+      byte[] data = Files.readAllBytes(path);
+      ByteString comment = ByteString.copyFrom(data);
+      Comment comment2 = Comment.newBuilder()
+        .setComment(comment)
+        .build();
+      path = Paths.get(imageFileName);
+      data = Files.readAllBytes(path);
+      ByteString image = ByteString.copyFrom(data);
+      DiscussBookRequest request = DiscussBookRequest.newBuilder()
+        .setName(name)
+        .setComment(comment2)
+        .setImage(image)
+        .build();
+      bidiStream.send(request);
+      for (Comment responseItem : bidiStream) {
+        System.out.println(responseItem);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END turing_prog_callable_streaming_bidi_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("imageFileName")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String imageFileName = cl.getOptionValue("imageFileName", "image_file.jpg");
+
+    sampleDiscussBook(imageFileName);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END turing_prog_callable_streaming_bidi]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/findrelatedbooks/FindRelatedBooksFlattenedPagedOdyssey.java ==============
+// DO NOT EDIT! This is a generated sample ("FlattenedPaged",  "odyssey")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.LibraryClient;
+
+public class FindRelatedBooksFlattenedPagedOdyssey {
+  public static void sampleFindRelatedBooks() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      String namesElement = "Odyssey";
+      List<String> names = Arrays.asList(namesElement);
+      String shelvesElement = "Classics";
+      List<String> shelves = Arrays.asList(shelvesElement);
+      ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooks().futureCall(names, shelves);
+
+      // Do something
+
+      for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
+        ShelfBookName book = responseItem;
+        System.out.printf("Here's a related book: %s\n", book);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/findrelatedbooks/FindRelatedBooksRequestPagedOdyssey.java ==============
+// DO NOT EDIT! This is a generated sample ("RequestPaged",  "odyssey")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+
+public class FindRelatedBooksRequestPagedOdyssey {
+  public static void sampleFindRelatedBooks() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      List<ShelfBookName> names = Arrays.asList(namesElement);
+      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      List<ShelfName> shelves = Arrays.asList(shelvesElement);
+      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+        .addAllNames(ShelfBookName.toStringList(names))
+        .addAllShelves(ShelfName.toStringList(shelves))
+        .build();
+      for (ShelfBookName responseItem : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
+        ShelfBookName book = responseItem;
+        System.out.printf("Here's a related book: %s\n", book);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/findrelatedbookscallable/FindRelatedBooksCallableCallableListOdyssey.java ==============
+// DO NOT EDIT! This is a generated sample ("CallableList",  "odyssey")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+
+public class FindRelatedBooksCallableCallableListOdyssey {
+  public static void sampleFindRelatedBooks() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      List<ShelfBookName> names = Arrays.asList(namesElement);
+      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      List<ShelfName> shelves = Arrays.asList(shelvesElement);
+      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+        .addAllNames(ShelfBookName.toStringList(names))
+        .addAllShelves(ShelfName.toStringList(shelves))
+        .build();
+      while (true) {
+        FindRelatedBooksResponse response = libraryClient.findRelatedBooksCallable().call(request);
+        for (ShelfBookName responseItem : ShelfBookName.parseList(response.getNamesList())) {
+          ShelfBookName book = responseItem;
+          System.out.printf("Here's a related book: %s\n", book);
+        }
+        String nextPageToken = response.getNextPageToken();
+        if (!Strings.isNullOrEmpty(nextPageToken)) {
+          request = request.toBuilder().setPageToken(nextPageToken).build();
+        } else {
+          break;
+        }
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/findrelatedbookspagedcallable/FindRelatedBooksPagedCallableCallablePagedOdyssey.java ==============
+// DO NOT EDIT! This is a generated sample ("CallablePaged",  "odyssey")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+
+public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
+  public static void sampleFindRelatedBooks() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      List<ShelfBookName> names = Arrays.asList(namesElement);
+      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      List<ShelfName> shelves = Arrays.asList(shelvesElement);
+      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+        .addAllNames(ShelfBookName.toStringList(names))
+        .addAllShelves(ShelfName.toStringList(shelves))
+        .build();
+      ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooksPagedCallable().futureCall(request);
+
+      // Do something
+
+      for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
+        ShelfBookName book = responseItem;
+        System.out.printf("Here's a related book: %s\n", book);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/getbigbookasync/GetBigBookAsyncLongRunningFlattenedAsyncWap.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningFlattenedAsync",  "wap")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
+  public static void sampleGetBigBook(String shelf) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      ShelfBookName name = ShelfBookName.of(shelf, "War and Peace");
+      Book response = libraryClient.getBigBookAsync(name.toString()).get();
+      System.out.printf("name: %s\n", response.getName());
+      System.out.printf("author: %s\n", response.getAuthor());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+
+    sampleGetBigBook(shelf);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/getbigbookasync/GetBigBookAsyncLongRunningRequestAsyncWap.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookAsyncLongRunningRequestAsyncWap {
+  public static void sampleGetBigBook(String shelf) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      ShelfBookName name = ShelfBookName.of(shelf, "War and Peace");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      Book response = libraryClient.getBigBookAsync(request).get();
+      System.out.printf("name: %s\n", response.getName());
+      System.out.printf("author: %s\n", response.getAuthor());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+
+    sampleGetBigBook(shelf);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/getbigbookcallable/GetBigBookCallableCallableWap.java ==============
+// DO NOT EDIT! This is a generated sample ("Callable",  "wap")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookCallableCallableWap {
+  public static void sampleGetBigBook(String shelf) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      ShelfBookName name = ShelfBookName.of(shelf, "War and Peace");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      ApiFuture<Operation> future = libraryClient.getBigBookCallable().futureCall(request);
+
+      // Do something
+
+      Operation response = future.get();
+      System.out.printf("name: %s\n", response.getName());
+      System.out.printf("author: %s\n", response.getAuthor());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+
+    sampleGetBigBook(shelf);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/getbigbookoperationcallable/GetBigBookOperationCallableLongRunningCallableWap.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningCallable",  "wap")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookOperationCallableLongRunningCallableWap {
+  public static void sampleGetBigBook(String shelf) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      ShelfBookName name = ShelfBookName.of(shelf, "War and Peace");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      OperationFuture<Operation> future = libraryClient.getBigBookOperationCallable().futureCall(request);
+
+      // Do something
+
+      Book response = future.get();
+      System.out.printf("name: %s\n", response.getName());
+      System.out.printf("author: %s\n", response.getAuthor());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+
+    sampleGetBigBook(shelf);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/monologaboutbookcallable/MonologAboutBookCallableCallableStreamingClientProg.java ==============
+// DO NOT EDIT! This is a generated sample ("CallableStreamingClient",  "prog")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.DiscussBookRequest;
+import com.google.example.library.v1.LibraryClient;
+
+public class MonologAboutBookCallableCallableStreamingClientProg {
+  public static void sampleMonologAboutBook() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ApiStreamObserver<Comment> responseObserver =
+          new ApiStreamObserver<Comment>() {
+            @Override
+            public void onNext(Comment response) {
+              System.out.printf("The stage of the comment is: %s\n", response.getStage());
+            }
+
+            @Override
+            public void onError(Throwable t) {
+              // Add error-handling
+            }
+
+            @Override
+            public void onCompleted() {
+              // Do something when complete.
+            }
+          };
+      ApiStreamObserver<DiscussBookRequest> requestObserver =
+          libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
+
+      String name = "BASIC";
+      DiscussBookRequest request = DiscussBookRequest.newBuilder()
+        .setName(name)
+        .build();
+      requestObserver.onNext(request);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleMonologAboutBook();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseries/PublishSeriesFlattenedPiVersion.java ==============
+// DO NOT EDIT! This is a generated sample ("Flattened",  "pi_version")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesFlattenedPiVersion {
+  public static void samplePublishSeries(String shelfName, int edition) {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelfName = "Math";
+      // int edition = 123;
+      Shelf shelf = Shelf.newBuilder()
+        .setName(shelfName)
+        .build();
+      List<Book> books = new ArrayList<>();
+      String seriesString = "xyz3141592654";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
+      for (String title : response.getBookNamesList()) {
+        System.out.printf("Title: %s\n", title);
+      }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
+      System.out.println("That's all!");
+      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelfName")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("edition")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelfName = cl.getOptionValue("shelfName", "Math");
+    int edition =
+        cl.getOptionValue("edition") != null
+            ? Integer.parseInt(cl.getOptionValue("edition"))
+            : 123;
+
+    samplePublishSeries(shelfName, edition);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseries/PublishSeriesFlattenedSecondEdition.java ==============
+// DO NOT EDIT! This is a generated sample ("Flattened",  "second_edition")
+package com.google.example.examples.library.v1.snippets;
+
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesFlattenedSecondEdition {
+  public static void samplePublishSeries() {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      int edition = 2;
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
+      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseries/PublishSeriesRequestPiVersion.java ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesRequestPiVersion {
+  public static void samplePublishSeries(String shelfName, int edition) {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelfName = "Math";
+      // int edition = 123;
+      Shelf shelf = Shelf.newBuilder()
+        .setName(shelfName)
+        .build();
+      List<Book> books = new ArrayList<>();
+      String seriesString = "xyz3141592654";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(request);
+      for (String title : response.getBookNamesList()) {
+        System.out.printf("Title: %s\n", title);
+      }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
+      System.out.println("That's all!");
+      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelfName")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("edition")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelfName = cl.getOptionValue("shelfName", "Math");
+    int edition =
+        cl.getOptionValue("edition") != null
+            ? Integer.parseInt(cl.getOptionValue("edition"))
+            : 123;
+
+    samplePublishSeries(shelfName, edition);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseries/PublishSeriesRequestSecondEdition.java ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
+package com.google.example.examples.library.v1.snippets;
+
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesRequestSecondEdition {
+  public static void samplePublishSeries() {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
+      int edition = 2;
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(request);
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseriescallable/PublishSeriesCallableCallablePiVersion.java ==============
+// DO NOT EDIT! This is a generated sample ("Callable",  "pi_version")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesCallableCallablePiVersion {
+  public static void samplePublishSeries(String shelfName, int edition) {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelfName = "Math";
+      // int edition = 123;
+      Shelf shelf = Shelf.newBuilder()
+        .setName(shelfName)
+        .build();
+      List<Book> books = new ArrayList<>();
+      String seriesString = "xyz3141592654";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
+
+      // Do something
+
+      PublishSeriesResponse response = future.get();
+      for (String title : response.getBookNamesList()) {
+        System.out.printf("Title: %s\n", title);
+      }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
+      System.out.println("That's all!");
+      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelfName")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("edition")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelfName = cl.getOptionValue("shelfName", "Math");
+    int edition =
+        cl.getOptionValue("edition") != null
+            ? Integer.parseInt(cl.getOptionValue("edition"))
+            : 123;
+
+    samplePublishSeries(shelfName, edition);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseriescallable/PublishSeriesCallableCallableSecondEdition.java ==============
+// DO NOT EDIT! This is a generated sample ("Callable",  "second_edition")
+package com.google.example.examples.library.v1.snippets;
+
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesCallableCallableSecondEdition {
+  public static void samplePublishSeries() {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
+      int edition = 2;
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
+
+      // Do something
+
+      PublishSeriesResponse response = future.get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/streambookscallable/StreamBooksCallableCallableStreamingServerProg.java ==============
+// DO NOT EDIT! This is a generated sample ("CallableStreamingServer",  "prog")
+package com.google.example.examples.library.v1.snippets;
+
+// [START babbage]
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.StreamBooksRequest;
+
+public class StreamBooksCallableCallableStreamingServerProg {
+  public static void sampleStreamBooks() {
+    // [START babbage_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      String name = "BASIC";
+      StreamBooksRequest request = StreamBooksRequest.newBuilder()
+        .setName(name)
+        .build();
+
+      ServerStream<Book> stream = libraryClient.streamBooksCallable().call(request);
+      for (Book responseItem : stream) {
+        System.out.println(responseItem);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END babbage_core]
+  }
+
+  public static void main(String[] args) {
+    sampleStreamBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END babbage]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/streamshelvescallable/StreamShelvesCallableCallableStreamingServerEmpty.java ==============
+// DO NOT EDIT! This is a generated sample ("CallableStreamingServer",  "empty")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.StreamShelvesRequest;
+
+public class StreamShelvesCallableCallableStreamingServerEmpty {
+  public static void sampleStreamShelves() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+
+      ServerStream<StreamShelvesResponse> stream = libraryClient.streamShelvesCallable().call(request);
+      for (StreamShelvesResponse responseItem : stream) {
+        System.out.println(responseItem);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleStreamShelves();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
 ============== file: src/main/java/com/google/example/library/v1/LibraryClient.java ==============
 /*
  * Copyright 2019 Google LLC
@@ -7417,914 +8325,6 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     }
   }
 }
-============== file: src/main/java/samples/com/google/example/library/v1/discussbookcallable/DiscussBookCallableCallableStreamingBidiProg.java ==============
-// DO NOT EDIT! This is a generated sample ("CallableStreamingBidi",  "prog")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START turing_prog_callable_streaming_bidi]
-import com.google.example.library.v1.Comment;
-import com.google.example.library.v1.DiscussBookRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.protobuf.ByteString;
-import java.nio.File;
-import java.nio.Files;
-import java.nio.Path;
-import java.nio.Paths;
-
-public class DiscussBookCallableCallableStreamingBidiProg {
-  public static void sampleDiscussBook(String imageFileName) {
-    // [START turing_prog_callable_streaming_bidi_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      BidiStream<DiscussBookRequest, Comment> bidiStream =
-          libraryClient.discussBookCallable().call();
-
-      // String imageFileName = "image_file.jpg";
-      String name = "BASIC";
-      String fileName = "comment_file";
-      Path path = Paths.get(fileName);
-      byte[] data = Files.readAllBytes(path);
-      ByteString comment = ByteString.copyFrom(data);
-      Comment comment2 = Comment.newBuilder()
-        .setComment(comment)
-        .build();
-      path = Paths.get(imageFileName);
-      data = Files.readAllBytes(path);
-      ByteString image = ByteString.copyFrom(data);
-      DiscussBookRequest request = DiscussBookRequest.newBuilder()
-        .setName(name)
-        .setComment(comment2)
-        .setImage(image)
-        .build();
-      bidiStream.send(request);
-      for (Comment responseItem : bidiStream) {
-        System.out.println(responseItem);
-      }
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END turing_prog_callable_streaming_bidi_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("imageFileName")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String imageFileName = cl.getOptionValue("imageFileName", "image_file.jpg");
-
-    sampleDiscussBook(imageFileName);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END turing_prog_callable_streaming_bidi]
-============== file: src/main/java/samples/com/google/example/library/v1/findrelatedbooks/FindRelatedBooksFlattenedPagedOdyssey.java ==============
-// DO NOT EDIT! This is a generated sample ("FlattenedPaged",  "odyssey")
-package com.google.example.examples.library.v1.snippets;
-
-// [START sample]
-import com.google.example.library.v1.LibraryClient;
-
-public class FindRelatedBooksFlattenedPagedOdyssey {
-  public static void sampleFindRelatedBooks() {
-    // [START sample_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      String namesElement = "Odyssey";
-      List<String> names = Arrays.asList(namesElement);
-      String shelvesElement = "Classics";
-      List<String> shelves = Arrays.asList(shelvesElement);
-      ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooks().futureCall(names, shelves);
-
-      // Do something
-
-      for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
-        ShelfBookName book = responseItem;
-        System.out.printf("Here's a related book: %s\n", book);
-      }
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END sample_core]
-  }
-
-  public static void main(String[] args) {
-    sampleFindRelatedBooks();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END sample]
-============== file: src/main/java/samples/com/google/example/library/v1/findrelatedbooks/FindRelatedBooksRequestPagedOdyssey.java ==============
-// DO NOT EDIT! This is a generated sample ("RequestPaged",  "odyssey")
-package com.google.example.examples.library.v1.snippets;
-
-// [START sample]
-import com.google.example.library.v1.FindRelatedBooksRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-import com.google.example.library.v1.ShelfName;
-
-public class FindRelatedBooksRequestPagedOdyssey {
-  public static void sampleFindRelatedBooks() {
-    // [START sample_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      List<ShelfBookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
-      List<ShelfName> shelves = Arrays.asList(shelvesElement);
-      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
-        .addAllNames(ShelfBookName.toStringList(names))
-        .addAllShelves(ShelfName.toStringList(shelves))
-        .build();
-      for (ShelfBookName responseItem : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
-        ShelfBookName book = responseItem;
-        System.out.printf("Here's a related book: %s\n", book);
-      }
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END sample_core]
-  }
-
-  public static void main(String[] args) {
-    sampleFindRelatedBooks();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END sample]
-============== file: src/main/java/samples/com/google/example/library/v1/findrelatedbookscallable/FindRelatedBooksCallableCallableListOdyssey.java ==============
-// DO NOT EDIT! This is a generated sample ("CallableList",  "odyssey")
-package com.google.example.examples.library.v1.snippets;
-
-// [START sample]
-import com.google.example.library.v1.FindRelatedBooksRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-import com.google.example.library.v1.ShelfName;
-
-public class FindRelatedBooksCallableCallableListOdyssey {
-  public static void sampleFindRelatedBooks() {
-    // [START sample_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      List<ShelfBookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
-      List<ShelfName> shelves = Arrays.asList(shelvesElement);
-      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
-        .addAllNames(ShelfBookName.toStringList(names))
-        .addAllShelves(ShelfName.toStringList(shelves))
-        .build();
-      while (true) {
-        FindRelatedBooksResponse response = libraryClient.findRelatedBooksCallable().call(request);
-        for (ShelfBookName responseItem : ShelfBookName.parseList(response.getNamesList())) {
-          ShelfBookName book = responseItem;
-          System.out.printf("Here's a related book: %s\n", book);
-        }
-        String nextPageToken = response.getNextPageToken();
-        if (!Strings.isNullOrEmpty(nextPageToken)) {
-          request = request.toBuilder().setPageToken(nextPageToken).build();
-        } else {
-          break;
-        }
-      }
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END sample_core]
-  }
-
-  public static void main(String[] args) {
-    sampleFindRelatedBooks();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END sample]
-============== file: src/main/java/samples/com/google/example/library/v1/findrelatedbookspagedcallable/FindRelatedBooksPagedCallableCallablePagedOdyssey.java ==============
-// DO NOT EDIT! This is a generated sample ("CallablePaged",  "odyssey")
-package com.google.example.examples.library.v1.snippets;
-
-// [START sample]
-import com.google.example.library.v1.FindRelatedBooksRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-import com.google.example.library.v1.ShelfName;
-
-public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
-  public static void sampleFindRelatedBooks() {
-    // [START sample_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      List<ShelfBookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
-      List<ShelfName> shelves = Arrays.asList(shelvesElement);
-      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
-        .addAllNames(ShelfBookName.toStringList(names))
-        .addAllShelves(ShelfName.toStringList(shelves))
-        .build();
-      ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooksPagedCallable().futureCall(request);
-
-      // Do something
-
-      for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
-        ShelfBookName book = responseItem;
-        System.out.printf("Here's a related book: %s\n", book);
-      }
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END sample_core]
-  }
-
-  public static void main(String[] args) {
-    sampleFindRelatedBooks();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END sample]
-============== file: src/main/java/samples/com/google/example/library/v1/getbigbookasync/GetBigBookAsyncLongRunningFlattenedAsyncWap.java ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningFlattenedAsync",  "wap")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-
-public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
-  public static void sampleGetBigBook(String shelf) {
-    // [START hopper_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelf = "Novel";
-      ShelfBookName name = ShelfBookName.of(shelf, "War and Peace");
-      Book response = libraryClient.getBigBookAsync(name.toString()).get();
-      System.out.printf("name: %s\n", response.getName());
-      System.out.printf("author: %s\n", response.getAuthor());
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END hopper_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelf")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelf = cl.getOptionValue("shelf", "Novel");
-
-    sampleGetBigBook(shelf);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/getbigbookasync/GetBigBookAsyncLongRunningRequestAsyncWap.java ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-
-public class GetBigBookAsyncLongRunningRequestAsyncWap {
-  public static void sampleGetBigBook(String shelf) {
-    // [START hopper_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelf = "Novel";
-      ShelfBookName name = ShelfBookName.of(shelf, "War and Peace");
-      GetBookRequest request = GetBookRequest.newBuilder()
-        .setName(name.toString())
-        .build();
-      Book response = libraryClient.getBigBookAsync(request).get();
-      System.out.printf("name: %s\n", response.getName());
-      System.out.printf("author: %s\n", response.getAuthor());
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END hopper_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelf")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelf = cl.getOptionValue("shelf", "Novel");
-
-    sampleGetBigBook(shelf);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/getbigbookcallable/GetBigBookCallableCallableWap.java ==============
-// DO NOT EDIT! This is a generated sample ("Callable",  "wap")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-
-public class GetBigBookCallableCallableWap {
-  public static void sampleGetBigBook(String shelf) {
-    // [START hopper_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelf = "Novel";
-      ShelfBookName name = ShelfBookName.of(shelf, "War and Peace");
-      GetBookRequest request = GetBookRequest.newBuilder()
-        .setName(name.toString())
-        .build();
-      ApiFuture<Operation> future = libraryClient.getBigBookCallable().futureCall(request);
-
-      // Do something
-
-      Operation response = future.get();
-      System.out.printf("name: %s\n", response.getName());
-      System.out.printf("author: %s\n", response.getAuthor());
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END hopper_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelf")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelf = cl.getOptionValue("shelf", "Novel");
-
-    sampleGetBigBook(shelf);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/getbigbookoperationcallable/GetBigBookOperationCallableLongRunningCallableWap.java ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningCallable",  "wap")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-
-public class GetBigBookOperationCallableLongRunningCallableWap {
-  public static void sampleGetBigBook(String shelf) {
-    // [START hopper_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelf = "Novel";
-      ShelfBookName name = ShelfBookName.of(shelf, "War and Peace");
-      GetBookRequest request = GetBookRequest.newBuilder()
-        .setName(name.toString())
-        .build();
-      OperationFuture<Operation> future = libraryClient.getBigBookOperationCallable().futureCall(request);
-
-      // Do something
-
-      Book response = future.get();
-      System.out.printf("name: %s\n", response.getName());
-      System.out.printf("author: %s\n", response.getAuthor());
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END hopper_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelf")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelf = cl.getOptionValue("shelf", "Novel");
-
-    sampleGetBigBook(shelf);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/monologaboutbookcallable/MonologAboutBookCallableCallableStreamingClientProg.java ==============
-// DO NOT EDIT! This is a generated sample ("CallableStreamingClient",  "prog")
-package com.google.example.examples.library.v1.snippets;
-
-// [START sample]
-import com.google.example.library.v1.DiscussBookRequest;
-import com.google.example.library.v1.LibraryClient;
-
-public class MonologAboutBookCallableCallableStreamingClientProg {
-  public static void sampleMonologAboutBook() {
-    // [START sample_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      ApiStreamObserver<Comment> responseObserver =
-          new ApiStreamObserver<Comment>() {
-            @Override
-            public void onNext(Comment response) {
-              System.out.printf("The stage of the comment is: %s\n", response.getStage());
-            }
-
-            @Override
-            public void onError(Throwable t) {
-              // Add error-handling
-            }
-
-            @Override
-            public void onCompleted() {
-              // Do something when complete.
-            }
-          };
-      ApiStreamObserver<DiscussBookRequest> requestObserver =
-          libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
-
-      String name = "BASIC";
-      DiscussBookRequest request = DiscussBookRequest.newBuilder()
-        .setName(name)
-        .build();
-      requestObserver.onNext(request);
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END sample_core]
-  }
-
-  public static void main(String[] args) {
-    sampleMonologAboutBook();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END sample]
-============== file: src/main/java/samples/com/google/example/library/v1/publishseries/PublishSeriesFlattenedPiVersion.java ==============
-// DO NOT EDIT! This is a generated sample ("Flattened",  "pi_version")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
-public class PublishSeriesFlattenedPiVersion {
-  public static void samplePublishSeries(String shelfName, int edition) {
-    // [START canonical_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelfName = "Math";
-      // int edition = 123;
-      Shelf shelf = Shelf.newBuilder()
-        .setName(shelfName)
-        .build();
-      List<Book> books = new ArrayList<>();
-      String seriesString = "xyz3141592654";
-      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
-        .setSeriesString(seriesString)
-        .build();
-      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
-      for (String title : response.getBookNamesList()) {
-        System.out.printf("Title: %s\n", title);
-      }
-      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
-      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
-      System.out.println("That's all!");
-      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END canonical_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelfName")
-          .build());
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("edition")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelfName = cl.getOptionValue("shelfName", "Math");
-    int edition =
-        cl.getOptionValue("edition") != null
-            ? Integer.parseInt(cl.getOptionValue("edition"))
-            : 123;
-
-    samplePublishSeries(shelfName, edition);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END canonical]
-============== file: src/main/java/samples/com/google/example/library/v1/publishseries/PublishSeriesFlattenedSecondEdition.java ==============
-// DO NOT EDIT! This is a generated sample ("Flattened",  "second_edition")
-package com.google.example.examples.library.v1.snippets;
-
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
-public class PublishSeriesFlattenedSecondEdition {
-  public static void samplePublishSeries() {
-    // [START canonical_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      Shelf shelf = Shelf.newBuilder().build();
-      List<Book> books = new ArrayList<>();
-      int edition = 2;
-      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
-      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
-      System.out.println(response);
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END canonical_core]
-  }
-
-  public static void main(String[] args) {
-    samplePublishSeries();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END canonical]
-============== file: src/main/java/samples/com/google/example/library/v1/publishseries/PublishSeriesRequestPiVersion.java ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
-public class PublishSeriesRequestPiVersion {
-  public static void samplePublishSeries(String shelfName, int edition) {
-    // [START canonical_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelfName = "Math";
-      // int edition = 123;
-      Shelf shelf = Shelf.newBuilder()
-        .setName(shelfName)
-        .build();
-      List<Book> books = new ArrayList<>();
-      String seriesString = "xyz3141592654";
-      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
-        .setSeriesString(seriesString)
-        .build();
-      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-        .setShelf(shelf)
-        .addAllBooks(books)
-        .setSeriesUuid(seriesUuid)
-        .setEdition(edition)
-        .build();
-      PublishSeriesResponse response = libraryClient.publishSeries(request);
-      for (String title : response.getBookNamesList()) {
-        System.out.printf("Title: %s\n", title);
-      }
-      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
-      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
-      System.out.println("That's all!");
-      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END canonical_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelfName")
-          .build());
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("edition")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelfName = cl.getOptionValue("shelfName", "Math");
-    int edition =
-        cl.getOptionValue("edition") != null
-            ? Integer.parseInt(cl.getOptionValue("edition"))
-            : 123;
-
-    samplePublishSeries(shelfName, edition);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END canonical]
-============== file: src/main/java/samples/com/google/example/library/v1/publishseries/PublishSeriesRequestSecondEdition.java ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
-package com.google.example.examples.library.v1.snippets;
-
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
-public class PublishSeriesRequestSecondEdition {
-  public static void samplePublishSeries() {
-    // [START canonical_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      Shelf shelf = Shelf.newBuilder().build();
-      List<Book> books = new ArrayList<>();
-      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
-      int edition = 2;
-      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-        .setShelf(shelf)
-        .addAllBooks(books)
-        .setSeriesUuid(seriesUuid)
-        .setEdition(edition)
-        .build();
-      PublishSeriesResponse response = libraryClient.publishSeries(request);
-      System.out.println(response);
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END canonical_core]
-  }
-
-  public static void main(String[] args) {
-    samplePublishSeries();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END canonical]
-============== file: src/main/java/samples/com/google/example/library/v1/publishseriescallable/PublishSeriesCallableCallablePiVersion.java ==============
-// DO NOT EDIT! This is a generated sample ("Callable",  "pi_version")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
-public class PublishSeriesCallableCallablePiVersion {
-  public static void samplePublishSeries(String shelfName, int edition) {
-    // [START canonical_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelfName = "Math";
-      // int edition = 123;
-      Shelf shelf = Shelf.newBuilder()
-        .setName(shelfName)
-        .build();
-      List<Book> books = new ArrayList<>();
-      String seriesString = "xyz3141592654";
-      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
-        .setSeriesString(seriesString)
-        .build();
-      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-        .setShelf(shelf)
-        .addAllBooks(books)
-        .setSeriesUuid(seriesUuid)
-        .setEdition(edition)
-        .build();
-      ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
-
-      // Do something
-
-      PublishSeriesResponse response = future.get();
-      for (String title : response.getBookNamesList()) {
-        System.out.printf("Title: %s\n", title);
-      }
-      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
-      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
-      System.out.println("That's all!");
-      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END canonical_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelfName")
-          .build());
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("edition")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelfName = cl.getOptionValue("shelfName", "Math");
-    int edition =
-        cl.getOptionValue("edition") != null
-            ? Integer.parseInt(cl.getOptionValue("edition"))
-            : 123;
-
-    samplePublishSeries(shelfName, edition);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END canonical]
-============== file: src/main/java/samples/com/google/example/library/v1/publishseriescallable/PublishSeriesCallableCallableSecondEdition.java ==============
-// DO NOT EDIT! This is a generated sample ("Callable",  "second_edition")
-package com.google.example.examples.library.v1.snippets;
-
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
-public class PublishSeriesCallableCallableSecondEdition {
-  public static void samplePublishSeries() {
-    // [START canonical_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      Shelf shelf = Shelf.newBuilder().build();
-      List<Book> books = new ArrayList<>();
-      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
-      int edition = 2;
-      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-        .setShelf(shelf)
-        .addAllBooks(books)
-        .setSeriesUuid(seriesUuid)
-        .setEdition(edition)
-        .build();
-      ApiFuture<PublishSeriesResponse> future = libraryClient.publishSeriesCallable().futureCall(request);
-
-      // Do something
-
-      PublishSeriesResponse response = future.get();
-      System.out.println(response);
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END canonical_core]
-  }
-
-  public static void main(String[] args) {
-    samplePublishSeries();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END canonical]
-============== file: src/main/java/samples/com/google/example/library/v1/streambookscallable/StreamBooksCallableCallableStreamingServerProg.java ==============
-// DO NOT EDIT! This is a generated sample ("CallableStreamingServer",  "prog")
-package com.google.example.examples.library.v1.snippets;
-
-// [START babbage]
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.StreamBooksRequest;
-
-public class StreamBooksCallableCallableStreamingServerProg {
-  public static void sampleStreamBooks() {
-    // [START babbage_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      String name = "BASIC";
-      StreamBooksRequest request = StreamBooksRequest.newBuilder()
-        .setName(name)
-        .build();
-
-      ServerStream<Book> stream = libraryClient.streamBooksCallable().call(request);
-      for (Book responseItem : stream) {
-        System.out.println(responseItem);
-      }
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END babbage_core]
-  }
-
-  public static void main(String[] args) {
-    sampleStreamBooks();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END babbage]
-============== file: src/main/java/samples/com/google/example/library/v1/streamshelvescallable/StreamShelvesCallableCallableStreamingServerEmpty.java ==============
-// DO NOT EDIT! This is a generated sample ("CallableStreamingServer",  "empty")
-package com.google.example.examples.library.v1.snippets;
-
-// [START sample]
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.StreamShelvesRequest;
-
-public class StreamShelvesCallableCallableStreamingServerEmpty {
-  public static void sampleStreamShelves() {
-    // [START sample_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
-
-      ServerStream<StreamShelvesResponse> stream = libraryClient.streamShelvesCallable().call(request);
-      for (StreamShelvesResponse responseItem : stream) {
-        System.out.println(responseItem);
-      }
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END sample_core]
-  }
-
-  public static void main(String[] args) {
-    sampleStreamShelves();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END sample]
 ============== file: src/test/java/com/google/example/library/v1/LibraryClientTest.java ==============
 /*
  * Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -400,6 +400,58 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBigBookAsyncLongRunningFlattenedAsyncWap2.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningFlattenedAsync",  "wap2")
+package com.google.example.examples.library.v1;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
+  public static void sampleGetBigBook(String shelf, String bigBookName) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      // String bigBookName = "War and Peace";
+      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
+      Book response = libraryClient.getBigBookAsync(name.toString()).get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("bigBookName")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
+
+    sampleGetBigBook(shelf, bigBookName);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
 ============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBigBookAsyncLongRunningRequestAsyncWap.java ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
 package com.google.example.examples.library.v1;
@@ -444,6 +496,62 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
     String shelf = cl.getOptionValue("shelf", "Novel");
 
     sampleGetBigBook(shelf);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBigBookAsyncLongRunningRequestAsyncWap2.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap2")
+package com.google.example.examples.library.v1;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
+  public static void sampleGetBigBook(String shelf, String bigBookName) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      // String bigBookName = "War and Peace";
+      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      Book response = libraryClient.getBigBookAsync(request).get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("bigBookName")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
+
+    sampleGetBigBook(shelf, bigBookName);
   }
 }
 // FIXME: Insert here clean-up code.
@@ -502,6 +610,66 @@ public class GetBigBookCallableCallableWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBigBookCallableCallableWap2.java ==============
+// DO NOT EDIT! This is a generated sample ("Callable",  "wap2")
+package com.google.example.examples.library.v1;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookCallableCallableWap2 {
+  public static void sampleGetBigBook(String shelf, String bigBookName) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      // String bigBookName = "War and Peace";
+      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      ApiFuture<Operation> future = libraryClient.getBigBookCallable().futureCall(request);
+
+      // Do something
+
+      Operation response = future.get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("bigBookName")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
+
+    sampleGetBigBook(shelf, bigBookName);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
 ============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBigBookOperationCallableLongRunningCallableWap.java ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningCallable",  "wap")
 package com.google.example.examples.library.v1;
@@ -550,6 +718,66 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
     String shelf = cl.getOptionValue("shelf", "Novel");
 
     sampleGetBigBook(shelf);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBigBookOperationCallableLongRunningCallableWap2.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningCallable",  "wap2")
+package com.google.example.examples.library.v1;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookOperationCallableLongRunningCallableWap2 {
+  public static void sampleGetBigBook(String shelf, String bigBookName) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      // String bigBookName = "War and Peace";
+      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      OperationFuture<Operation> future = libraryClient.getBigBookOperationCallable().futureCall(request);
+
+      // Do something
+
+      Book response = future.get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("bigBookName")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
+
+    sampleGetBigBook(shelf, bigBookName);
   }
 }
 // FIXME: Insert here clean-up code.
@@ -7844,65 +8072,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       streamBooksSettings = ServerStreamingCallSettings.newBuilder();
 
-
       discussBookSettings = StreamingCallSettings.newBuilder();
-
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/getbigbookasync/GetBigBookAsyncLongRunningFlattenedAsyncWap2.java ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningFlattenedAsync",  "wap2")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-
-public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
-  public static void sampleGetBigBook(String shelf, String bigBookName) {
-    // [START hopper_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelf = "Novel";
-      // String bigBookName = "War and Peace";
-      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
-      Book response = libraryClient.getBigBookAsync(name.toString()).get();
-      System.out.println(response);
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END hopper_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelf")
-          .build());
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("bigBookName")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelf = cl.getOptionValue("shelf", "Novel");
-    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
-
-    sampleGetBigBook(shelf, bigBookName);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/getbigbookasync/GetBigBookAsyncLongRunningRequestAsyncWap.java ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
-package com.google.example.examples.library.v1.snippets;
 
       monologAboutBookSettings = StreamingCallSettings.newBuilder();
 
@@ -7915,70 +8085,7 @@ package com.google.example.examples.library.v1.snippets;
 
       getBigBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
-
       getBigBookOperationSettings = OperationCallSettings.newBuilder();
-=======
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/getbigbookasync/GetBigBookAsyncLongRunningRequestAsyncWap2.java ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap2")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-
-public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
-  public static void sampleGetBigBook(String shelf, String bigBookName) {
-    // [START hopper_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelf = "Novel";
-      // String bigBookName = "War and Peace";
-      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
-      GetBookRequest request = GetBookRequest.newBuilder()
-        .setName(name.toString())
-        .build();
-      Book response = libraryClient.getBigBookAsync(request).get();
-      System.out.println(response);
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END hopper_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelf")
-          .build());
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("bigBookName")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelf = cl.getOptionValue("shelf", "Novel");
-    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
-
-    sampleGetBigBook(shelf, bigBookName);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/getbigbookcallable/GetBigBookCallableCallableWap.java ==============
-// DO NOT EDIT! This is a generated sample ("Callable",  "wap")
-package com.google.example.examples.library.v1.snippets;
-
 
       getBigNothingSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
@@ -8031,76 +8138,9 @@ package com.google.example.examples.library.v1.snippets;
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
-
       builder.getShelfSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
-
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/getbigbookcallable/GetBigBookCallableCallableWap2.java ==============
-// DO NOT EDIT! This is a generated sample ("Callable",  "wap2")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-
-public class GetBigBookCallableCallableWap2 {
-  public static void sampleGetBigBook(String shelf, String bigBookName) {
-    // [START hopper_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelf = "Novel";
-      // String bigBookName = "War and Peace";
-      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
-      GetBookRequest request = GetBookRequest.newBuilder()
-        .setName(name.toString())
-        .build();
-      ApiFuture<Operation> future = libraryClient.getBigBookCallable().futureCall(request);
-
-      // Do something
-
-      Operation response = future.get();
-      System.out.println(response);
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END hopper_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelf")
-          .build());
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("bigBookName")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelf = cl.getOptionValue("shelf", "Novel");
-    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
-
-    sampleGetBigBook(shelf, bigBookName);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/getbigbookoperationcallable/GetBigBookOperationCallableLongRunningCallableWap.java ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningCallable",  "wap")
-package com.google.example.examples.library.v1.snippets;
-
 
       builder.listShelvesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
@@ -8152,76 +8192,9 @@ package com.google.example.examples.library.v1.snippets;
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
-
       builder.listStringsSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
-
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/getbigbookoperationcallable/GetBigBookOperationCallableLongRunningCallableWap2.java ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningCallable",  "wap2")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-
-public class GetBigBookOperationCallableLongRunningCallableWap2 {
-  public static void sampleGetBigBook(String shelf, String bigBookName) {
-    // [START hopper_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelf = "Novel";
-      // String bigBookName = "War and Peace";
-      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
-      GetBookRequest request = GetBookRequest.newBuilder()
-        .setName(name.toString())
-        .build();
-      OperationFuture<Operation> future = libraryClient.getBigBookOperationCallable().futureCall(request);
-
-      // Do something
-
-      Book response = future.get();
-      System.out.println(response);
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END hopper_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelf")
-          .build());
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("bigBookName")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelf = cl.getOptionValue("shelf", "Novel");
-    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
-
-    sampleGetBigBook(shelf, bigBookName);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END hopper]
-============== file: src/main/java/samples/com/google/example/library/v1/monologaboutbookcallable/MonologAboutBookCallableCallableStreamingClientProg.java ==============
-// DO NOT EDIT! This is a generated sample ("CallableStreamingClient",  "prog")
-package com.google.example.examples.library.v1.snippets;
-
 
       builder.addCommentsSettings().setBatchingSettings(
           BatchingSettings.newBuilder()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -76,7 +76,7 @@ task allJars(type: Copy) {
   // Replace with `from configurations.testRuntime, jar` to include test dependencies
   from configurations.runtime, jar
 }
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/discussbookcallable/DiscussBookCallableCallableStreamingBidiProg.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/DiscussBookCallableCallableStreamingBidiProg.java ==============
 // DO NOT EDIT! This is a generated sample ("CallableStreamingBidi",  "prog")
 package com.google.example.examples.library.v1.snippets;
 
@@ -146,82 +146,7 @@ public class DiscussBookCallableCallableStreamingBidiProg {
 // FIXME: Insert here clean-up code.
 
 // [END turing_prog_callable_streaming_bidi]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/findrelatedbooks/FindRelatedBooksFlattenedPagedOdyssey.java ==============
-// DO NOT EDIT! This is a generated sample ("FlattenedPaged",  "odyssey")
-package com.google.example.examples.library.v1.snippets;
-
-// [START sample]
-import com.google.example.library.v1.LibraryClient;
-
-public class FindRelatedBooksFlattenedPagedOdyssey {
-  public static void sampleFindRelatedBooks() {
-    // [START sample_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      String namesElement = "Odyssey";
-      List<String> names = Arrays.asList(namesElement);
-      String shelvesElement = "Classics";
-      List<String> shelves = Arrays.asList(shelvesElement);
-      ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooks().futureCall(names, shelves);
-
-      // Do something
-
-      for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
-        ShelfBookName book = responseItem;
-        System.out.printf("Here's a related book: %s\n", book);
-      }
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END sample_core]
-  }
-
-  public static void main(String[] args) {
-    sampleFindRelatedBooks();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END sample]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/findrelatedbooks/FindRelatedBooksRequestPagedOdyssey.java ==============
-// DO NOT EDIT! This is a generated sample ("RequestPaged",  "odyssey")
-package com.google.example.examples.library.v1.snippets;
-
-// [START sample]
-import com.google.example.library.v1.FindRelatedBooksRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-import com.google.example.library.v1.ShelfName;
-
-public class FindRelatedBooksRequestPagedOdyssey {
-  public static void sampleFindRelatedBooks() {
-    // [START sample_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      List<ShelfBookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
-      List<ShelfName> shelves = Arrays.asList(shelvesElement);
-      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
-        .addAllNames(ShelfBookName.toStringList(names))
-        .addAllShelves(ShelfName.toStringList(shelves))
-        .build();
-      for (ShelfBookName responseItem : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
-        ShelfBookName book = responseItem;
-        System.out.printf("Here's a related book: %s\n", book);
-      }
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END sample_core]
-  }
-
-  public static void main(String[] args) {
-    sampleFindRelatedBooks();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END sample]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/findrelatedbookscallable/FindRelatedBooksCallableCallableListOdyssey.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/FindRelatedBooksCallableCallableListOdyssey.java ==============
 // DO NOT EDIT! This is a generated sample ("CallableList",  "odyssey")
 package com.google.example.examples.library.v1.snippets;
 
@@ -269,7 +194,43 @@ public class FindRelatedBooksCallableCallableListOdyssey {
 // FIXME: Insert here clean-up code.
 
 // [END sample]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/findrelatedbookspagedcallable/FindRelatedBooksPagedCallableCallablePagedOdyssey.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/FindRelatedBooksFlattenedPagedOdyssey.java ==============
+// DO NOT EDIT! This is a generated sample ("FlattenedPaged",  "odyssey")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.LibraryClient;
+
+public class FindRelatedBooksFlattenedPagedOdyssey {
+  public static void sampleFindRelatedBooks() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      String namesElement = "Odyssey";
+      List<String> names = Arrays.asList(namesElement);
+      String shelvesElement = "Classics";
+      List<String> shelves = Arrays.asList(shelvesElement);
+      ApiFuture<FindRelatedBooksPagedResponse> future = libraryClient.findRelatedBooks().futureCall(names, shelves);
+
+      // Do something
+
+      for (ShelfBookName responseItem : future.get().iterateAllAsShelfBookName()) {
+        ShelfBookName book = responseItem;
+        System.out.printf("Here's a related book: %s\n", book);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/FindRelatedBooksPagedCallableCallablePagedOdyssey.java ==============
 // DO NOT EDIT! This is a generated sample ("CallablePaged",  "odyssey")
 package com.google.example.examples.library.v1.snippets;
 
@@ -312,7 +273,46 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
 // FIXME: Insert here clean-up code.
 
 // [END sample]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/getbigbookasync/GetBigBookAsyncLongRunningFlattenedAsyncWap.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/FindRelatedBooksRequestPagedOdyssey.java ==============
+// DO NOT EDIT! This is a generated sample ("RequestPaged",  "odyssey")
+package com.google.example.examples.library.v1.snippets;
+
+// [START sample]
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+
+public class FindRelatedBooksRequestPagedOdyssey {
+  public static void sampleFindRelatedBooks() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      List<ShelfBookName> names = Arrays.asList(namesElement);
+      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      List<ShelfName> shelves = Arrays.asList(shelvesElement);
+      FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
+        .addAllNames(ShelfBookName.toStringList(names))
+        .addAllShelves(ShelfName.toStringList(shelves))
+        .build();
+      for (ShelfBookName responseItem : libraryClient.findRelatedBooks(request).iterateAllAsShelfBookName()) {
+        ShelfBookName book = responseItem;
+        System.out.printf("Here's a related book: %s\n", book);
+      }
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleFindRelatedBooks();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/GetBigBookAsyncLongRunningFlattenedAsyncWap.java ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningFlattenedAsync",  "wap")
 package com.google.example.examples.library.v1.snippets;
 
@@ -357,7 +357,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/getbigbookasync/GetBigBookAsyncLongRunningRequestAsyncWap.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/GetBigBookAsyncLongRunningRequestAsyncWap.java ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
 package com.google.example.examples.library.v1.snippets;
 
@@ -406,7 +406,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/getbigbookcallable/GetBigBookCallableCallableWap.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/GetBigBookCallableCallableWap.java ==============
 // DO NOT EDIT! This is a generated sample ("Callable",  "wap")
 package com.google.example.examples.library.v1.snippets;
 
@@ -459,7 +459,7 @@ public class GetBigBookCallableCallableWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/getbigbookoperationcallable/GetBigBookOperationCallableLongRunningCallableWap.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/GetBigBookOperationCallableLongRunningCallableWap.java ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningCallable",  "wap")
 package com.google.example.examples.library.v1.snippets;
 
@@ -512,7 +512,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/monologaboutbookcallable/MonologAboutBookCallableCallableStreamingClientProg.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/MonologAboutBookCallableCallableStreamingClientProg.java ==============
 // DO NOT EDIT! This is a generated sample ("CallableStreamingClient",  "prog")
 package com.google.example.examples.library.v1.snippets;
 
@@ -562,235 +562,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
 // FIXME: Insert here clean-up code.
 
 // [END sample]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseries/PublishSeriesFlattenedPiVersion.java ==============
-// DO NOT EDIT! This is a generated sample ("Flattened",  "pi_version")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
-public class PublishSeriesFlattenedPiVersion {
-  public static void samplePublishSeries(String shelfName, int edition) {
-    // [START canonical_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelfName = "Math";
-      // int edition = 123;
-      Shelf shelf = Shelf.newBuilder()
-        .setName(shelfName)
-        .build();
-      List<Book> books = new ArrayList<>();
-      String seriesString = "xyz3141592654";
-      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
-        .setSeriesString(seriesString)
-        .build();
-      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
-      for (String title : response.getBookNamesList()) {
-        System.out.printf("Title: %s\n", title);
-      }
-      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
-      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
-      System.out.println("That's all!");
-      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END canonical_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelfName")
-          .build());
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("edition")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelfName = cl.getOptionValue("shelfName", "Math");
-    int edition =
-        cl.getOptionValue("edition") != null
-            ? Integer.parseInt(cl.getOptionValue("edition"))
-            : 123;
-
-    samplePublishSeries(shelfName, edition);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseries/PublishSeriesFlattenedSecondEdition.java ==============
-// DO NOT EDIT! This is a generated sample ("Flattened",  "second_edition")
-package com.google.example.examples.library.v1.snippets;
-
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
-public class PublishSeriesFlattenedSecondEdition {
-  public static void samplePublishSeries() {
-    // [START canonical_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      Shelf shelf = Shelf.newBuilder().build();
-      List<Book> books = new ArrayList<>();
-      int edition = 2;
-      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
-      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
-      System.out.println(response);
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END canonical_core]
-  }
-
-  public static void main(String[] args) {
-    samplePublishSeries();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseries/PublishSeriesRequestPiVersion.java ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
-public class PublishSeriesRequestPiVersion {
-  public static void samplePublishSeries(String shelfName, int edition) {
-    // [START canonical_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      // String shelfName = "Math";
-      // int edition = 123;
-      Shelf shelf = Shelf.newBuilder()
-        .setName(shelfName)
-        .build();
-      List<Book> books = new ArrayList<>();
-      String seriesString = "xyz3141592654";
-      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
-        .setSeriesString(seriesString)
-        .build();
-      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-        .setShelf(shelf)
-        .addAllBooks(books)
-        .setSeriesUuid(seriesUuid)
-        .setEdition(edition)
-        .build();
-      PublishSeriesResponse response = libraryClient.publishSeries(request);
-      for (String title : response.getBookNamesList()) {
-        System.out.printf("Title: %s\n", title);
-      }
-      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
-      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
-      System.out.println("That's all!");
-      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END canonical_core]
-  }
-
-  public static void main(String[] args) {
-    Options options = new Options();
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("shelfName")
-          .build());
-    options.addOption(
-        Option.builder("")
-          .required(false)
-          .hasArg(true)
-          .longOpt("edition")
-          .build());
-
-    CommandLine cl = (new DefaultParser()).parse(options, args);
-    String shelfName = cl.getOptionValue("shelfName", "Math");
-    int edition =
-        cl.getOptionValue("edition") != null
-            ? Integer.parseInt(cl.getOptionValue("edition"))
-            : 123;
-
-    samplePublishSeries(shelfName, edition);
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseries/PublishSeriesRequestSecondEdition.java ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
-package com.google.example.examples.library.v1.snippets;
-
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
-public class PublishSeriesRequestSecondEdition {
-  public static void samplePublishSeries() {
-    // [START canonical_core]
-    try (LibraryClient libraryClient = LibraryClient.create()) {
-      Shelf shelf = Shelf.newBuilder().build();
-      List<Book> books = new ArrayList<>();
-      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
-      int edition = 2;
-      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
-        .setShelf(shelf)
-        .addAllBooks(books)
-        .setSeriesUuid(seriesUuid)
-        .setEdition(edition)
-        .build();
-      PublishSeriesResponse response = libraryClient.publishSeries(request);
-      System.out.println(response);
-    } catch (Exception exception) {
-      System.err.println("Failed to create the client due to: " + exception);
-    }
-    // [END canonical_core]
-  }
-
-  public static void main(String[] args) {
-    samplePublishSeries();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseriescallable/PublishSeriesCallableCallablePiVersion.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesCallableCallablePiVersion.java ==============
 // DO NOT EDIT! This is a generated sample ("Callable",  "pi_version")
 package com.google.example.examples.library.v1.snippets;
 
@@ -873,7 +645,7 @@ public class PublishSeriesCallableCallablePiVersion {
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/publishseriescallable/PublishSeriesCallableCallableSecondEdition.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesCallableCallableSecondEdition.java ==============
 // DO NOT EDIT! This is a generated sample ("Callable",  "second_edition")
 package com.google.example.examples.library.v1.snippets;
 
@@ -919,7 +691,235 @@ public class PublishSeriesCallableCallableSecondEdition {
 // FIXME: Insert here clean-up code.
 
 // [END canonical]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/streambookscallable/StreamBooksCallableCallableStreamingServerProg.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesFlattenedPiVersion.java ==============
+// DO NOT EDIT! This is a generated sample ("Flattened",  "pi_version")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesFlattenedPiVersion {
+  public static void samplePublishSeries(String shelfName, int edition) {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelfName = "Math";
+      // int edition = 123;
+      Shelf shelf = Shelf.newBuilder()
+        .setName(shelfName)
+        .build();
+      List<Book> books = new ArrayList<>();
+      String seriesString = "xyz3141592654";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
+      for (String title : response.getBookNamesList()) {
+        System.out.printf("Title: %s\n", title);
+      }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
+      System.out.println("That's all!");
+      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelfName")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("edition")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelfName = cl.getOptionValue("shelfName", "Math");
+    int edition =
+        cl.getOptionValue("edition") != null
+            ? Integer.parseInt(cl.getOptionValue("edition"))
+            : 123;
+
+    samplePublishSeries(shelfName, edition);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesFlattenedSecondEdition.java ==============
+// DO NOT EDIT! This is a generated sample ("Flattened",  "second_edition")
+package com.google.example.examples.library.v1.snippets;
+
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesFlattenedSecondEdition {
+  public static void samplePublishSeries() {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      int edition = 2;
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
+      PublishSeriesResponse response = libraryClient.publishSeries(shelf, books, edition, seriesUuid);
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesRequestPiVersion.java ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesRequestPiVersion {
+  public static void samplePublishSeries(String shelfName, int edition) {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelfName = "Math";
+      // int edition = 123;
+      Shelf shelf = Shelf.newBuilder()
+        .setName(shelfName)
+        .build();
+      List<Book> books = new ArrayList<>();
+      String seriesString = "xyz3141592654";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(request);
+      for (String title : response.getBookNamesList()) {
+        System.out.printf("Title: %s\n", title);
+      }
+      System.out.printf("The first book is: %s\n", response.getBookNamesList().get(0));
+      System.out.printf("The author of the first book is: %s\n", response.getBooksList().get(0).getAuthor());
+      System.out.println("That's all!");
+      System.out.printf("series_uuid: %s\n", response.getSeriesUuid().getSeriesBytes());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelfName")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("edition")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelfName = cl.getOptionValue("shelfName", "Math");
+    int edition =
+        cl.getOptionValue("edition") != null
+            ? Integer.parseInt(cl.getOptionValue("edition"))
+            : 123;
+
+    samplePublishSeries(shelfName, edition);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/PublishSeriesRequestSecondEdition.java ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
+package com.google.example.examples.library.v1.snippets;
+
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishSeriesRequestSecondEdition {
+  public static void samplePublishSeries() {
+    // [START canonical_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+      List<Book> books = new ArrayList<>();
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder().build();
+      int edition = 2;
+      PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
+        .setShelf(shelf)
+        .addAllBooks(books)
+        .setSeriesUuid(seriesUuid)
+        .setEdition(edition)
+        .build();
+      PublishSeriesResponse response = libraryClient.publishSeries(request);
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/StreamBooksCallableCallableStreamingServerProg.java ==============
 // DO NOT EDIT! This is a generated sample ("CallableStreamingServer",  "prog")
 package com.google.example.examples.library.v1.snippets;
 
@@ -953,7 +953,7 @@ public class StreamBooksCallableCallableStreamingServerProg {
 // FIXME: Insert here clean-up code.
 
 // [END babbage]
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/streamshelvescallable/StreamShelvesCallableCallableStreamingServerEmpty.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/StreamShelvesCallableCallableStreamingServerEmpty.java ==============
 // DO NOT EDIT! This is a generated sample ("CallableStreamingServer",  "empty")
 package com.google.example.examples.library.v1.snippets;
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -76,9 +76,6 @@ task allJars(type: Copy) {
   // Replace with `from configurations.testRuntime, jar` to include test dependencies
   from configurations.runtime, jar
 }
-============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/DiscussBookCallableCallableStreamingBidiProg.java ==============
-// DO NOT EDIT! This is a generated sample ("CallableStreamingBidi",  "prog")
-package com.google.example.examples.library.v1.snippets;
 ============== file: samples/build.gradle ==============
 buildscript {
   repositories {
@@ -122,23 +119,9 @@ clean {
   delete 'all-jars'
 }
 
-============== file: src/main/java/com/google/example/library/v1/LibraryClient.java ==============
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package com.google.example.library.v1;
+============== file: samples/src/main/java/com/google/example/examples/library/v1/snippets/DiscussBookCallableCallableStreamingBidiProg.java ==============
+// DO NOT EDIT! This is a generated sample ("CallableStreamingBidi",  "prog")
+package com.google.example.examples.library.v1.snippets;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;


### PR DESCRIPTION
Restructures Java sample package:
- file paths are now in consistent with class paths (`com.google(.cloud/example).examples.apiname.versionname`)
- appending method name to package name contains more than trivial work. This PR removes the method name from sample paths. This unblocks generating `build.gradle` for the sample package and making the sample package compile
- sample package is temporarily placed at `gapic-google-cloud-x-v1/samples`. We will in the future put the samples in a separate package at the same level as the gapic package. However to achieve this we need to update both gapic-generator and artman. For now after this PR to make samples compile we need to manually run `cp -r gapic-google-cloud-x-v1/samples samples-google-cloud-x-v1` after artman generation from `artman-output/java` directory.