### PR TITLE
Qualify LRO type if not qualified

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -238,11 +238,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
 
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            defaultPackageName,
-            method,
-            diagCollector,
-            methodConfigProto.getLongRunning(),
-            protoParser);
+            method, diagCollector, methodConfigProto.getLongRunning(), protoParser);
     if (diagCollector.getErrorCount() > 0) {
       error = true;
     }

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -238,7 +238,11 @@ public abstract class GapicMethodConfig extends MethodConfig {
 
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            method, diagCollector, methodConfigProto.getLongRunning(), protoParser);
+            defaultPackageName,
+            method,
+            diagCollector,
+            methodConfigProto.getLongRunning(),
+            protoParser);
     if (diagCollector.getErrorCount() > 0) {
       error = true;
     }

--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -68,14 +68,13 @@ public abstract class LongRunningConfig {
 
   @Nullable
   static LongRunningConfig createLongRunningConfig(
-      String packageName,
       Method method,
       DiagCollector diagCollector,
       LongRunningConfigProto longRunningConfigProto,
       ProtoParser protoParser) {
     LongRunningConfig longRunningConfig =
         createLongRunningConfigFromProtoFile(
-            packageName, method, diagCollector, longRunningConfigProto, protoParser);
+            method, diagCollector, longRunningConfigProto, protoParser);
     if (longRunningConfig != null) {
       return longRunningConfig;
     }
@@ -101,7 +100,6 @@ public abstract class LongRunningConfig {
    */
   @Nullable
   private static LongRunningConfig createLongRunningConfigFromProtoFile(
-      String packageName,
       Method method,
       DiagCollector diagCollector,
       LongRunningConfigProto longRunningConfigProto,

--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -87,6 +87,14 @@ public abstract class LongRunningConfig {
     return null;
   }
 
+  private static String qualifyLroTypeName(
+      String typeName, Method method, ProtoParser protoParser) {
+    if (!typeName.contains(".")) {
+      typeName = String.format("%s.%s", protoParser.getProtoPackage(method), typeName);
+    }
+    return typeName;
+  }
+
   /**
    * Creates an instance of LongRunningConfig based on protofile annotations. If there is matching
    * long running config from GAPIC config, use the GAPIC config's timeout values.
@@ -107,15 +115,10 @@ public abstract class LongRunningConfig {
       return null;
     }
 
-    String responseTypeName = operationTypes.getResponseType();
-    String metadataTypeName = operationTypes.getMetadataType();
-
-    if (!responseTypeName.contains(".")) {
-      responseTypeName = String.format("%s.%s", packageName, responseTypeName);
-    }
-    if (!metadataTypeName.contains(".")) {
-      metadataTypeName = String.format("%s.%s", packageName, metadataTypeName);
-    }
+    String responseTypeName =
+        qualifyLroTypeName(operationTypes.getResponseType(), method, protoParser);
+    String metadataTypeName =
+        qualifyLroTypeName(operationTypes.getMetadataType(), method, protoParser);
 
     if (responseTypeName.equals(longRunningConfigProto.getReturnType())
         && metadataTypeName.equals(longRunningConfigProto.getMetadataType())) {

--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -68,13 +68,14 @@ public abstract class LongRunningConfig {
 
   @Nullable
   static LongRunningConfig createLongRunningConfig(
+      String packageName,
       Method method,
       DiagCollector diagCollector,
       LongRunningConfigProto longRunningConfigProto,
       ProtoParser protoParser) {
     LongRunningConfig longRunningConfig =
         createLongRunningConfigFromProtoFile(
-            method, diagCollector, longRunningConfigProto, protoParser);
+            packageName, method, diagCollector, longRunningConfigProto, protoParser);
     if (longRunningConfig != null) {
       return longRunningConfig;
     }
@@ -92,6 +93,7 @@ public abstract class LongRunningConfig {
    */
   @Nullable
   private static LongRunningConfig createLongRunningConfigFromProtoFile(
+      String packageName,
       Method method,
       DiagCollector diagCollector,
       LongRunningConfigProto longRunningConfigProto,
@@ -107,6 +109,13 @@ public abstract class LongRunningConfig {
 
     String responseTypeName = operationTypes.getResponseType();
     String metadataTypeName = operationTypes.getMetadataType();
+
+    if (!responseTypeName.contains(".")) {
+      responseTypeName = String.format("%s.%s", packageName, responseTypeName);
+    }
+    if (!metadataTypeName.contains(".")) {
+      metadataTypeName = String.format("%s.%s", packageName, metadataTypeName);
+    }
 
     if (responseTypeName.equals(longRunningConfigProto.getReturnType())
         && metadataTypeName.equals(longRunningConfigProto.getMetadataType())) {

--- a/src/main/java/com/google/api/codegen/util/ProtoParser.java
+++ b/src/main/java/com/google/api/codegen/util/ProtoParser.java
@@ -33,6 +33,7 @@ import com.google.api.tools.framework.model.ProtoElement;
 import com.google.api.tools.framework.model.ProtoFile;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.api.tools.framework.model.TypeRef;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -342,6 +343,12 @@ public class ProtoParser {
 
   public String getProtoPackage(ProtoFile file) {
     return file.getProto().getPackage();
+  }
+
+  @VisibleForTesting
+  // Exposed for test mocking.
+  public String getProtoPackage(Method method) {
+    return getProtoPackage(method.getFile());
   }
 
   private String getResourceFullName(Resource resource, ProtoFile file) {

--- a/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
@@ -28,14 +28,15 @@ import com.google.api.tools.framework.model.SymbolTable;
 import com.google.api.tools.framework.model.TypeRef;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 public class LongRunningConfigTest {
+  private static final String PROTO_PACKAGE_NAME = "google.example.library.v1";
   private static final String GAPIC_CONFIG_RETURN_TYPE_NAME = "MethodResponse";
   private static final String GAPIC_CONFIG_METADATA_TYPE = "HeaderType";
   private static final String ANNOTATIONS_RETURN_TYPE_NAME = "BookType";
   private static final String ANNOTATIONS_METADATA_TYPE = "FooterType";
-  private static final String CLIENT_PACKAGE_NAME = "com.google.library.v1";
   private static final boolean TEST_IMPLEMENTS_DELETE = false;
   private static final boolean TEST_IMPLEMENTS_CANCEL = false;
   private static final int TEST_INITIAL_POLL_DELAY = 5;
@@ -63,8 +64,8 @@ public class LongRunningConfigTest {
 
   private static final LongRunningConfigProto baseLroConfigProto =
       LongRunningConfigProto.newBuilder()
-          .setMetadataType(GAPIC_CONFIG_METADATA_TYPE)
-          .setReturnType(GAPIC_CONFIG_RETURN_TYPE_NAME)
+          .setMetadataType(PROTO_PACKAGE_NAME + "." + GAPIC_CONFIG_METADATA_TYPE)
+          .setReturnType(PROTO_PACKAGE_NAME + "." + GAPIC_CONFIG_RETURN_TYPE_NAME)
           .build();
   private static final LongRunningConfigProto lroConfigProtoWithPollSettings =
       baseLroConfigProto
@@ -83,6 +84,9 @@ public class LongRunningConfigTest {
     Mockito.when(lroAnnotatedMethod.getModel()).thenReturn(model);
     Mockito.when(model.getSymbolTable()).thenReturn(symbolTable);
 
+    Mockito.when(protoParser.getProtoPackage(ArgumentMatchers.any(Method.class)))
+        .thenReturn(PROTO_PACKAGE_NAME);
+
     Mockito.when(protoParser.getLongRunningOperation(lroAnnotatedMethod))
         .thenReturn(
             OperationData.newBuilder()
@@ -90,13 +94,13 @@ public class LongRunningConfigTest {
                 .setResponseType(ANNOTATIONS_RETURN_TYPE_NAME)
                 .build());
 
-    Mockito.when(symbolTable.lookupType(GAPIC_CONFIG_METADATA_TYPE))
+    Mockito.when(symbolTable.lookupType(PROTO_PACKAGE_NAME + "." + GAPIC_CONFIG_METADATA_TYPE))
         .thenReturn(gapicConfigMetadataType);
-    Mockito.when(symbolTable.lookupType(GAPIC_CONFIG_RETURN_TYPE_NAME))
+    Mockito.when(symbolTable.lookupType(PROTO_PACKAGE_NAME + "." + GAPIC_CONFIG_RETURN_TYPE_NAME))
         .thenReturn(gapicConfigReturnType);
-    Mockito.when(symbolTable.lookupType(ANNOTATIONS_METADATA_TYPE))
+    Mockito.when(symbolTable.lookupType(PROTO_PACKAGE_NAME + "." + ANNOTATIONS_METADATA_TYPE))
         .thenReturn(annotationsMetadataType);
-    Mockito.when(symbolTable.lookupType(ANNOTATIONS_RETURN_TYPE_NAME))
+    Mockito.when(symbolTable.lookupType(PROTO_PACKAGE_NAME + "." + ANNOTATIONS_RETURN_TYPE_NAME))
         .thenReturn(annotationsReturnType);
   }
 
@@ -105,7 +109,7 @@ public class LongRunningConfigTest {
     DiagCollector diagCollector = new BoundedDiagCollector();
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            CLIENT_PACKAGE_NAME,
+            PROTO_PACKAGE_NAME,
             lroAnnotatedMethod,
             diagCollector,
             LongRunningConfigProto.getDefaultInstance(),
@@ -141,7 +145,7 @@ public class LongRunningConfigTest {
     // lroConfigProtoWithPollSettings contains LRO settings.
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            CLIENT_PACKAGE_NAME,
+            PROTO_PACKAGE_NAME,
             simpleMethod,
             diagCollector,
             lroConfigProtoWithPollSettings,
@@ -173,7 +177,7 @@ public class LongRunningConfigTest {
     // lroAnnotatedMethod contains different settings than that in lroConfigProtoWithPollSettings.
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            CLIENT_PACKAGE_NAME,
+            PROTO_PACKAGE_NAME,
             lroAnnotatedMethod,
             diagCollector,
             lroConfigProtoWithPollSettings,
@@ -212,12 +216,12 @@ public class LongRunningConfigTest {
     LongRunningConfigProto longRunningConfigProto =
         lroConfigProtoWithPollSettings
             .toBuilder()
-            .setMetadataType(ANNOTATIONS_METADATA_TYPE)
-            .setReturnType(ANNOTATIONS_RETURN_TYPE_NAME)
+            .setMetadataType(PROTO_PACKAGE_NAME + "." + ANNOTATIONS_METADATA_TYPE)
+            .setReturnType(PROTO_PACKAGE_NAME + "." + ANNOTATIONS_RETURN_TYPE_NAME)
             .build();
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            CLIENT_PACKAGE_NAME,
+            PROTO_PACKAGE_NAME,
             lroAnnotatedMethod,
             diagCollector,
             longRunningConfigProto,
@@ -248,7 +252,7 @@ public class LongRunningConfigTest {
 
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            CLIENT_PACKAGE_NAME,
+            PROTO_PACKAGE_NAME,
             simpleMethod,
             diagCollector,
             LongRunningConfigProto.getDefaultInstance(),

--- a/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
@@ -35,6 +35,7 @@ public class LongRunningConfigTest {
   private static final String GAPIC_CONFIG_METADATA_TYPE = "HeaderType";
   private static final String ANNOTATIONS_RETURN_TYPE_NAME = "BookType";
   private static final String ANNOTATIONS_METADATA_TYPE = "FooterType";
+  private static final String CLIENT_PACKAGE_NAME = "com.google.library.v1";
   private static final boolean TEST_IMPLEMENTS_DELETE = false;
   private static final boolean TEST_IMPLEMENTS_CANCEL = false;
   private static final int TEST_INITIAL_POLL_DELAY = 5;
@@ -104,6 +105,7 @@ public class LongRunningConfigTest {
     DiagCollector diagCollector = new BoundedDiagCollector();
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
+            CLIENT_PACKAGE_NAME,
             lroAnnotatedMethod,
             diagCollector,
             LongRunningConfigProto.getDefaultInstance(),
@@ -139,7 +141,11 @@ public class LongRunningConfigTest {
     // lroConfigProtoWithPollSettings contains LRO settings.
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            simpleMethod, diagCollector, lroConfigProtoWithPollSettings, protoParser);
+            CLIENT_PACKAGE_NAME,
+            simpleMethod,
+            diagCollector,
+            lroConfigProtoWithPollSettings,
+            protoParser);
 
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
     assertThat(longRunningConfig).isNotNull();
@@ -167,7 +173,11 @@ public class LongRunningConfigTest {
     // lroAnnotatedMethod contains different settings than that in lroConfigProtoWithPollSettings.
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            lroAnnotatedMethod, diagCollector, lroConfigProtoWithPollSettings, protoParser);
+            CLIENT_PACKAGE_NAME,
+            lroAnnotatedMethod,
+            diagCollector,
+            lroConfigProtoWithPollSettings,
+            protoParser);
 
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
     assertThat(longRunningConfig).isNotNull();
@@ -207,7 +217,11 @@ public class LongRunningConfigTest {
             .build();
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            lroAnnotatedMethod, diagCollector, longRunningConfigProto, protoParser);
+            CLIENT_PACKAGE_NAME,
+            lroAnnotatedMethod,
+            diagCollector,
+            longRunningConfigProto,
+            protoParser);
 
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
     assertThat(longRunningConfig).isNotNull();
@@ -234,7 +248,11 @@ public class LongRunningConfigTest {
 
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            simpleMethod, diagCollector, LongRunningConfigProto.getDefaultInstance(), protoParser);
+            CLIENT_PACKAGE_NAME,
+            simpleMethod,
+            diagCollector,
+            LongRunningConfigProto.getDefaultInstance(),
+            protoParser);
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
     assertThat(longRunningConfig).isNull();
   }

--- a/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
@@ -109,7 +109,6 @@ public class LongRunningConfigTest {
     DiagCollector diagCollector = new BoundedDiagCollector();
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            PROTO_PACKAGE_NAME,
             lroAnnotatedMethod,
             diagCollector,
             LongRunningConfigProto.getDefaultInstance(),
@@ -145,11 +144,7 @@ public class LongRunningConfigTest {
     // lroConfigProtoWithPollSettings contains LRO settings.
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            PROTO_PACKAGE_NAME,
-            simpleMethod,
-            diagCollector,
-            lroConfigProtoWithPollSettings,
-            protoParser);
+            simpleMethod, diagCollector, lroConfigProtoWithPollSettings, protoParser);
 
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
     assertThat(longRunningConfig).isNotNull();
@@ -177,11 +172,7 @@ public class LongRunningConfigTest {
     // lroAnnotatedMethod contains different settings than that in lroConfigProtoWithPollSettings.
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            PROTO_PACKAGE_NAME,
-            lroAnnotatedMethod,
-            diagCollector,
-            lroConfigProtoWithPollSettings,
-            protoParser);
+            lroAnnotatedMethod, diagCollector, lroConfigProtoWithPollSettings, protoParser);
 
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
     assertThat(longRunningConfig).isNotNull();
@@ -221,11 +212,7 @@ public class LongRunningConfigTest {
             .build();
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            PROTO_PACKAGE_NAME,
-            lroAnnotatedMethod,
-            diagCollector,
-            longRunningConfigProto,
-            protoParser);
+            lroAnnotatedMethod, diagCollector, longRunningConfigProto, protoParser);
 
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
     assertThat(longRunningConfig).isNotNull();
@@ -252,11 +239,7 @@ public class LongRunningConfigTest {
 
     LongRunningConfig longRunningConfig =
         LongRunningConfig.createLongRunningConfig(
-            PROTO_PACKAGE_NAME,
-            simpleMethod,
-            diagCollector,
-            LongRunningConfigProto.getDefaultInstance(),
-            protoParser);
+            simpleMethod, diagCollector, LongRunningConfigProto.getDefaultInstance(), protoParser);
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
     assertThat(longRunningConfig).isNull();
   }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library.proto
@@ -297,7 +297,7 @@ service LibraryService {
       fields: ["name"]
     };
     option (google.api.operation) = {
-      metadata_type: "google.example.library.v1.GetBigBookMetadata"
+      metadata_type: "GetBigBookMetadata" // Test unqualified type.
       response_type: "google.protobuf.Empty"
     };
   }


### PR DESCRIPTION
Per API config specification, we should assume that LRO types of the proto package they are used in if the LRO type is not fully qualified.