### PR TITLE
Samplegen: avoid incorrect resource name configuration collisions

### DIFF
--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -185,7 +185,7 @@ public class FieldStructureParser {
   public static String parseEntityName(String path) {
     Scanner scanner = new Scanner(path);
     Preconditions.checkArgument(
-        scanner.scan() == Scanner.IDENT, "expected root identifier: %s", scanner.input());
+        scanner.scan() == Scanner.IDENT, "expected identifier: %s", scanner.input());
     int token;
     String entityName = null;
     while (true) {

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -181,7 +181,7 @@ public class FieldStructureParser {
     }
   }
 
-  /** Parses the entity name specified by `path` or null if `path` does not contain `%`. */
+  /** Returns the entity name specified by `path` or null if `path` does not contain `%`. */
   public static String parseEntityName(String path) {
     Scanner scanner = new Scanner(path);
     Preconditions.checkArgument(

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -136,7 +136,7 @@ public class FieldStructureParser {
    */
   public static InitCodeNode parsePath(InitCodeNode root, Scanner scanner) {
     Preconditions.checkArgument(
-        scanner.scan() == Scanner.IDENT, "expected root identifier: %s", scanner.input());
+        scanner.scan() == Scanner.IDENT, "expected identifier: %s", scanner.input());
     InitCodeNode parent = root.mergeChild(InitCodeNode.create(scanner.tokenStr()));
     int token;
 

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -181,6 +181,52 @@ public class FieldStructureParser {
     }
   }
 
+  /** Parses the entity name specified by `path` or null if `path` does not contain `%`. */
+  public static String parseEntityName(String path) {
+    Scanner scanner = new Scanner(path);
+    Preconditions.checkArgument(
+        scanner.scan() == Scanner.IDENT, "expected root identifier: %s", scanner.input());
+    int token;
+    String entityName = null;
+    while (true) {
+      token = scanner.scan();
+      switch (token) {
+        case '%':
+          Preconditions.checkArgument(
+              entityName == null, "expected only one \"%%\" in path: %s", path);
+          Preconditions.checkArgument(
+              scanner.scan() == Scanner.IDENT,
+              "expected identifier after '%%': %s",
+              scanner.input());
+          entityName = scanner.tokenStr();
+          break;
+        case '=':
+        case Scanner.EOF:
+          return entityName;
+        case '.':
+          Preconditions.checkArgument(
+              scanner.scan() == Scanner.IDENT,
+              "expected identifier after '.': %s",
+              scanner.input());
+          break;
+        case '[':
+          Preconditions.checkArgument(
+              scanner.scan() == Scanner.INT, "expected number after '[': %s", scanner.input());
+          Preconditions.checkArgument(
+              scanner.scan() == ']', "expected closing ']': %s", scanner.input());
+          break;
+        case '{':
+          parseKey(scanner);
+          Preconditions.checkArgument(
+              scanner.scan() == '}', "expected closing '}': %s", scanner.input());
+          break;
+        default:
+          throw new IllegalArgumentException(
+              String.format("unexpected character '%c': %s", token, scanner.input()));
+      }
+    }
+  }
+
   private static String parseKey(Scanner scanner) {
     int token = scanner.scan();
     Preconditions.checkArgument(

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -309,9 +309,8 @@ public class InitCodeTransformer {
     HashMap<InitCodeNode, String> refFrom = new HashMap<>();
 
     // Keep track of the resource name entities. Configuring an entity twice or configuring an
-    // entity
-    // and the parent node at the same time will cause collision. Configuring two different entities
-    // will not.
+    // entity and the parent node at the same time will cause collision. Configuring two different
+    // entities will not.
     Multimap<InitCodeNode, String> nodeEntities = HashMultimap.create();
 
     // Below we'll perform depth-first search, keep a list of nodes we've seen but have not
@@ -326,12 +325,17 @@ public class InitCodeTransformer {
         InitCodeNode node = subNodes.pollLast();
         String oldPath = refFrom.put(node, path);
         if (oldPath == null) {
+          // The node has not been specified before, thus check if entity has been specified
           checkArgument(
               entity == null || nodeEntities.put(node, entity),
-              "SampleInitAttribute %s overlaps with %s",
-              path,
+              "Entity %s in path %s specified multiple types",
+              entity,
               path);
         } else {
+          // The node has been specified before. The will be no overlap if and only if:
+          // All previous paths are configuring entities
+          // This path is configuraing an entity
+          // The same entity is never specified before
           checkArgument(
               entity != null && nodeEntities.containsKey(node),
               "SampleInitAttribute %s overlaps with %s",
@@ -339,8 +343,8 @@ public class InitCodeTransformer {
               path);
           checkArgument(
               nodeEntities.put(node, entity),
-              "SampleInitAttribute %s overlaps with %s",
-              path,
+              "Entity %s in path %s specified multiple types",
+              entity,
               path);
         }
         subNodes.addAll(node.getChildren().values());

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.transformer;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.api.codegen.config.FieldConfig;
@@ -54,10 +55,12 @@ import com.google.api.codegen.viewmodel.testing.ClientTestAssertView;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -305,6 +308,12 @@ public class InitCodeTransformer {
     // that reference the same nodes.
     HashMap<InitCodeNode, String> refFrom = new HashMap<>();
 
+    // Keep track of the resource name entities. Configuring an entity twice or configuring an
+    // entity
+    // and the parent node at the same time will cause collision. Configuring two different entities
+    // will not.
+    Multimap<InitCodeNode, String> nodeEntities = HashMultimap.create();
+
     // Below we'll perform depth-first search, keep a list of nodes we've seen but have not
     // descended into. It doesn't really matter if we search breath- or depth-first; DFS is a little
     // more efficient on average.
@@ -312,12 +321,27 @@ public class InitCodeTransformer {
 
     for (String path : paths) {
       subNodes.add(root.subTree(path));
+      String entity = FieldStructureParser.parseEntityName(path);
       while (!subNodes.isEmpty()) {
         InitCodeNode node = subNodes.pollLast();
         String oldPath = refFrom.put(node, path);
-        if (oldPath != null) {
-          throw new IllegalArgumentException(
-              String.format("SampleInitAttribute %s overlaps with %s", oldPath, path));
+        if (oldPath == null) {
+          checkArgument(
+              entity == null || nodeEntities.put(node, entity),
+              "SampleInitAttribute %s overlaps with %s",
+              path,
+              path);
+        } else {
+          checkArgument(
+              entity != null && nodeEntities.containsKey(node),
+              "SampleInitAttribute %s overlaps with %s",
+              oldPath,
+              path);
+          checkArgument(
+              nodeEntities.put(node, entity),
+              "SampleInitAttribute %s overlaps with %s",
+              path,
+              path);
         }
         subNodes.addAll(node.getChildren().values());
       }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -7698,6 +7698,58 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
+============== file: src/main/java/samples/com/google/example/library/v1/getbigbookasync/GetBigBookAsyncLongRunningFlattenedAsyncWap2.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningFlattenedAsync",  "wap2")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
+  public static void sampleGetBigBook(String shelf, String bigBookName) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      // String bigBookName = "War and Peace";
+      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
+      Book response = libraryClient.getBigBookAsync(name.toString()).get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("bigBookName")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
+
+    sampleGetBigBook(shelf, bigBookName);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
 ============== file: src/main/java/samples/com/google/example/library/v1/getbigbookasync/GetBigBookAsyncLongRunningRequestAsyncWap.java ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
 package com.google.example.examples.library.v1.snippets;
@@ -7742,6 +7794,62 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
     String shelf = cl.getOptionValue("shelf", "Novel");
 
     sampleGetBigBook(shelf);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: src/main/java/samples/com/google/example/library/v1/getbigbookasync/GetBigBookAsyncLongRunningRequestAsyncWap2.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap2")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
+  public static void sampleGetBigBook(String shelf, String bigBookName) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      // String bigBookName = "War and Peace";
+      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      Book response = libraryClient.getBigBookAsync(request).get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("bigBookName")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
+
+    sampleGetBigBook(shelf, bigBookName);
   }
 }
 // FIXME: Insert here clean-up code.
@@ -7800,6 +7908,66 @@ public class GetBigBookCallableCallableWap {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
+============== file: src/main/java/samples/com/google/example/library/v1/getbigbookcallable/GetBigBookCallableCallableWap2.java ==============
+// DO NOT EDIT! This is a generated sample ("Callable",  "wap2")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookCallableCallableWap2 {
+  public static void sampleGetBigBook(String shelf, String bigBookName) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      // String bigBookName = "War and Peace";
+      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      ApiFuture<Operation> future = libraryClient.getBigBookCallable().futureCall(request);
+
+      // Do something
+
+      Operation response = future.get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("bigBookName")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
+
+    sampleGetBigBook(shelf, bigBookName);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
 ============== file: src/main/java/samples/com/google/example/library/v1/getbigbookoperationcallable/GetBigBookOperationCallableLongRunningCallableWap.java ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningCallable",  "wap")
 package com.google.example.examples.library.v1.snippets;
@@ -7848,6 +8016,66 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
     String shelf = cl.getOptionValue("shelf", "Novel");
 
     sampleGetBigBook(shelf);
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END hopper]
+============== file: src/main/java/samples/com/google/example/library/v1/getbigbookoperationcallable/GetBigBookOperationCallableLongRunningCallableWap2.java ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningCallable",  "wap2")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class GetBigBookOperationCallableLongRunningCallableWap2 {
+  public static void sampleGetBigBook(String shelf, String bigBookName) {
+    // [START hopper_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // String shelf = "Novel";
+      // String bigBookName = "War and Peace";
+      ShelfBookName name = ShelfBookName.of(shelf, bigBookName);
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      OperationFuture<Operation> future = libraryClient.getBigBookOperationCallable().futureCall(request);
+
+      // Do something
+
+      Book response = future.get();
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END hopper_core]
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("shelf")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("bigBookName")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    String shelf = cl.getOptionValue("shelf", "Novel");
+    String bigBookName = cl.getOptionValue("bigBookName", "War and Peace");
+
+    sampleGetBigBook(shelf, bigBookName);
   }
 }
 // FIXME: Insert here clean-up code.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -463,6 +463,65 @@ client.getBigBook({name: formattedName})
 // FIXME: Insert here clean-up code.
 // tslint:disable-next-line:no-any
 // [END hopper]
+============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap2.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningEventEmitterWap2" ]
+//// STUB standalone sample "GetBigBookLongRunningEventEmitterWap2" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START hopper]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//      calling form: "LongRunningEventEmitter"
+//        region tag: "hopper"
+//         className: "GetBigBookLongRunningEventEmitterWap2"
+//          valueSet: "wap2" ("GetBigBook: 'War and Peace'")
+//       description: "Testing resource name overlap"
+//        [name%shelf_id=Novel, name%book_id="War and Peace"]
+//      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
+
+// [START hopper_core]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+// const shelf = 'Novel';
+// const bigBookName = 'War and Peace';
+const formattedName = client.bookPath(shelf, bigBookName);
+
+// Handle the operation using the event emitter pattern.
+client.getBigBook({name: formattedName})
+  .then(responses => {
+    const operation = responses[0];
+    const initialApiResponse = responses[1];
+
+    // Adding a listener for the "complete" event starts polling for the
+    // completion of the operation.
+    operation.on('complete', (result, metadata, finalApiResponse) => {
+      // doSomethingWith(result);
+    });
+
+    // Adding a listener for the "progress" event causes the callback to be
+    // called on any change in metadata when the operation is polled.
+    operation.on('progress', (metadata, apiResponse) => {
+      // doSomethingWith(metadata)
+    });
+
+    // Adding a listener for the "error" event handles any errors found during polling.
+    operation.on('error', err => {
+      // throw(err);
+    });
+  })
+  .catch(err => {
+    console.error(err);
+  });
+*/
+// [END hopper_core]
+
+// FIXME: Insert here clean-up code.
+// tslint:disable-next-line:no-any
+// [END hopper]
 ============== file: src/samples/v1/get_big_book_long_running_promise_wap.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningPromiseWap" ]
 //// STUB standalone sample "GetBigBookLongRunningPromiseWap" /////
@@ -488,6 +547,61 @@ client.getBigBook({name: formattedName})
 /*
 // const shelf = 'Novel';
 const formattedName = client.bookPath(shelf, 'War and Peace');
+
+// Handle the operation using the promise pattern.
+client.getBigBook({name: formattedName})
+  .then(responses => {
+    const operation = responses[0];
+    const initialApiResponse = responses[1];
+
+    // Operation#promise starts polling for the completion of the LRO.
+    return operation.promise();
+  })
+  .then(responses => {
+    // The final result of the operation.
+    const result = responses[0];
+
+    // The metadata value of the completed operation.
+    const metadata = responses[1];
+
+    // The response of the api call returning the complete operation.
+    const finalApiResponse = responses[2];
+  })
+  .catch(err => {
+    console.error(err);
+  });
+*/
+// [END hopper_core]
+
+// FIXME: Insert here clean-up code.
+// tslint:disable-next-line:no-any
+// [END hopper]
+============== file: src/samples/v1/get_big_book_long_running_promise_wap2.js ==============
+//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningPromiseWap2" ]
+//// STUB standalone sample "GetBigBookLongRunningPromiseWap2" /////
+
+// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
+
+// [START hopper]
+
+// FIXME: Insert here boilerplate code not directly related to the method call itself.
+
+//      calling form: "LongRunningPromise"
+//        region tag: "hopper"
+//         className: "GetBigBookLongRunningPromiseWap2"
+//          valueSet: "wap2" ("GetBigBook: 'War and Peace'")
+//       description: "Testing resource name overlap"
+//        [name%shelf_id=Novel, name%book_id="War and Peace"]
+//      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
+
+// [START hopper_core]
+
+// FIXME: Insert here code to prepare the request fields, make the call, process the response.
+
+/*
+// const shelf = 'Novel';
+// const bigBookName = 'War and Peace';
+const formattedName = client.bookPath(shelf, bigBookName);
 
 // Handle the operation using the promise pattern.
 client.getBigBook({name: formattedName})

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -3227,6 +3227,85 @@ $options += $defaultOptions;
 $shelf = $options['shelf'];
 
 sampleGetBigBook($shelf);
+============== file: src/V1/samples/getBigBook/GetBigBookLongRunningRequestAsyncWap2.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap2")
+ */
+
+// [START hopper]
+require __DIR__ . '/../../../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+function sampleGetBigBook($shelf, $bigBookName)
+{
+    // [START hopper_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    // $bigBookName = 'War and Peace';
+    $formattedName = $libraryServiceClient->bookName($shelf, $bigBookName);
+
+    try {
+        // start the operation, keep the operation name, and resume later
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationName = $operationResponse->getName();
+        // ... do other work
+        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigBook');
+        while (!$newOperationResponse->isDone()) {
+            // ... do other work
+            $newOperationResponse->reload();
+        }
+        if ($newOperationResponse->operationSucceeded()) {
+          $response = $newOperationResponse->getResult();
+          printf("%s" . PHP_EOL, print_r($response, true));
+        } else {
+          $error = $newOperationResponse->getError();
+          // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END hopper_core]
+}
+// [END hopper]
+
+$opts = [
+    'shelf::',
+    'bigBookName::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+    'bigBookName' => 'War and Peace',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+$bigBookName = $options['bigBookName'];
+
+sampleGetBigBook($shelf, $bigBookName);
 ============== file: src/V1/samples/getBigBook/GetBigBookLongRunningRequestWap.php ==============
 <?php
 /*
@@ -3296,6 +3375,78 @@ $options += $defaultOptions;
 $shelf = $options['shelf'];
 
 sampleGetBigBook($shelf);
+============== file: src/V1/samples/getBigBook/GetBigBookLongRunningRequestWap2.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap2")
+ */
+
+// [START hopper]
+require __DIR__ . '/../../../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+function sampleGetBigBook($shelf, $bigBookName)
+{
+    // [START hopper_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    // $bigBookName = 'War and Peace';
+    $formattedName = $libraryServiceClient->bookName($shelf, $bigBookName);
+
+    try {
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            $response = $operationResponse->getResult();
+            printf("%s" . PHP_EOL, print_r($response, true));
+        } else {
+            $error = $operationResponse->getError();
+            // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END hopper_core]
+}
+// [END hopper]
+
+$opts = [
+    'shelf::',
+    'bigBookName::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+    'bigBookName' => 'War and Peace',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+$bigBookName = $options['bigBookName'];
+
+sampleGetBigBook($shelf, $bigBookName);
 ============== file: src/V1/samples/monologAboutBook/MonologAboutBookRequestStreamingClientAsyncProg.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4538,6 +4538,73 @@ def main():
 
 if __name__ == '__main__':
   main()
+============== file: samples/google/cloud/example/library_v1/gapic/get_big_book/get_big_book_long_running_promise_wap2.py ==============
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "wap2")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-library
+
+import sys
+
+# [START hopper]
+
+from google.cloud.example import library_v1
+import six
+
+def sample_get_big_book(shelf, big_book_name):
+  """Testing resource name overlap"""
+
+  # [START hopper_core]
+
+  client = library_v1.LibraryServiceClient()
+
+  # shelf = 'Novel'
+  # big_book_name = 'War and Peace'
+
+  if isinstance(shelf, six.binary_type):
+    shelf = shelf.decode('utf-8')
+  if isinstance(big_book_name, six.binary_type):
+    big_book_name = big_book_name.decode('utf-8')
+  name = client.book_path(shelf, big_book_name)
+
+  operation = client.get_big_book(name)
+
+  print('Waiting for operation to complete...')
+  response = operation.result()
+
+  print(response)
+
+  # [END hopper_core]
+# [END hopper]
+
+def main():
+  import argparse
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--shelf', type=str, default='Novel')
+  parser.add_argument('--big_book_name', type=str, default='War and Peace')
+  args = parser.parse_args()
+
+  sample_get_big_book(args.shelf, args.big_book_name)
+
+if __name__ == '__main__':
+  main()
 ============== file: samples/google/cloud/example/library_v1/gapic/monolog_about_book/monolog_about_book_request_streaming_client_prog.py ==============
 # -*- coding: utf-8 -*-
 #

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -761,6 +761,18 @@ interfaces:
       - print:
         - "author: %s"
         - $resp.author
+    - id: wap2
+      title: "GetBigBook: 'War and Peace'"
+      description: "Testing resource name overlap"
+      parameters:
+        defaults:
+        - name%shelf_id=Novel
+        - name%book_id="War and Peace"
+        attributes:
+        - parameter: name%shelf_id
+          sample_argument_name: shelf
+        - parameter: name%book_id
+          sample_argument_name: big_book_name
     samples:
       standalone:
       - calling_forms: ".*"

--- a/src/test/java/com/google/api/codegen/transformer/InitCodeTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/InitCodeTransformerTest.java
@@ -35,12 +35,17 @@ public class InitCodeTransformerTest {
 
     InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a", "b"));
     InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a.x", "a.y"));
+    InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a%x", "a%y"));
 
     assertThrows(() -> InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a", "a.x")));
     assertThrows(() -> InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a", "a.y")));
     assertThrows(() -> InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a", "a")));
     assertThrows(() -> InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a.x", "a.x")));
     assertThrows(() -> InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a.y", "a.y")));
+    assertThrows(() -> InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a", "a%x")));
+    assertThrows(() -> InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a%x", "a")));
+    assertThrows(() -> InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a.x%y", "a")));
+    assertThrows(() -> InitCodeTransformer.assertNoOverlap(root, ImmutableList.of("a%x", "a%x")));
   }
 
   private static void assertThrows(Runnable runnable) {


### PR DESCRIPTION
This PR fixes the incorrect collision between `resource%a` and `resource%b`.