### PR TITLE
Remove methodModel from GapicMethodContext because redundant

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/GapicInterfaceContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/GapicInterfaceContext.java
@@ -179,7 +179,6 @@ public abstract class GapicInterfaceContext implements InterfaceContext {
         getProductConfig(),
         getImportTypeTable(),
         getNamer(),
-        (ProtoMethodModel) method,
         getMethodConfig(method),
         flatteningConfig,
         getFeatureConfig());
@@ -193,7 +192,6 @@ public abstract class GapicInterfaceContext implements InterfaceContext {
         getProductConfig(),
         getImportTypeTable(),
         getNamer(),
-        (ProtoMethodModel) method,
         getMethodConfig(method),
         null,
         getFeatureConfig());
@@ -207,7 +205,6 @@ public abstract class GapicInterfaceContext implements InterfaceContext {
         getProductConfig(),
         getImportTypeTable(),
         getNamer(),
-        (ProtoMethodModel) method,
         getMethodConfig(method),
         null,
         getFeatureConfig());

--- a/src/main/java/com/google/api/codegen/transformer/GapicMethodContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/GapicMethodContext.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
@@ -35,7 +36,6 @@ public abstract class GapicMethodContext implements MethodContext {
       GapicProductConfig productConfig,
       ModelTypeTable typeTable,
       SurfaceNamer namer,
-      ProtoMethodModel method,
       GapicMethodConfig methodConfig,
       FlatteningConfig flatteningConfig,
       FeatureConfig featureConfig) {
@@ -44,24 +44,25 @@ public abstract class GapicMethodContext implements MethodContext {
         namer,
         flatteningConfig,
         featureConfig,
-        method,
         methodConfig,
         surfaceTransformerContext,
         typeTable,
         new ProtoInterfaceModel(apiInterface));
   }
 
+  @Override
+  public MethodModel getMethodModel() {
+    return getMethodConfig().getMethodModel();
+  }
+
   /** The Method for which this object is a transformation context. */
   public Method getMethod() {
-    return getMethodModel().getProtoMethod();
+    return ((ProtoMethodModel) getMethodModel()).getProtoMethod();
   }
 
   public Interface getInterface() {
     return getInterfaceModel().getInterface();
   }
-
-  @Override
-  public abstract ProtoMethodModel getMethodModel();
 
   @Override
   public abstract GapicMethodConfig getMethodConfig();
@@ -105,7 +106,6 @@ public abstract class GapicMethodContext implements MethodContext {
         getProductConfig(),
         getTypeTable().cloneEmpty(),
         getNamer(),
-        getMethodModel(),
         getMethodConfig(),
         getFlatteningConfig(),
         getFeatureConfig());
@@ -124,7 +124,6 @@ public abstract class GapicMethodContext implements MethodContext {
         getProductConfig(),
         getTypeTable(),
         getNamer(),
-        getMethodModel(),
         getMethodConfig(),
         getFlatteningConfig() == null
             ? null


### PR DESCRIPTION
cleanup

GapicMethodContext already contains a GapicMethodConfig, from which we can fetch a MethodModel. We don't need to carry around an extra MethodModel, which is sometimes different from the GapicMethodConfig.getMethodModel (this is more accurate because it has the reroute_to_grpc_interface config applied).