### PR TITLE
Fix string .equals() to avoid NPE

### DIFF
--- a/src/main/resources/com/google/api/codegen/java/message.snip
+++ b/src/main/resources/com/google/api/codegen/java/message.snip
@@ -36,7 +36,7 @@
   @@Override
   public Object getFieldValue(String fieldName) {
     @join param : schema.properties
-      if (fieldName.equals("{@param.name}")) {
+      if ("{@param.name}".equals(fieldName)) {
         return {@param.name};
       }
     @end

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -1278,34 +1278,34 @@ public final class Address implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("address")) {
+    if ("address".equals(fieldName)) {
       return address;
     }
-    if (fieldName.equals("creationTimestamp")) {
+    if ("creationTimestamp".equals(fieldName)) {
       return creationTimestamp;
     }
-    if (fieldName.equals("description")) {
+    if ("description".equals(fieldName)) {
       return description;
     }
-    if (fieldName.equals("id")) {
+    if ("id".equals(fieldName)) {
       return id;
     }
-    if (fieldName.equals("kind")) {
+    if ("kind".equals(fieldName)) {
       return kind;
     }
-    if (fieldName.equals("name")) {
+    if ("name".equals(fieldName)) {
       return name;
     }
-    if (fieldName.equals("region")) {
+    if ("region".equals(fieldName)) {
       return region;
     }
-    if (fieldName.equals("selfLink")) {
+    if ("selfLink".equals(fieldName)) {
       return selfLink;
     }
-    if (fieldName.equals("status")) {
+    if ("status".equals(fieldName)) {
       return status;
     }
-    if (fieldName.equals("users")) {
+    if ("users".equals(fieldName)) {
       return users;
     }
     return null;
@@ -1713,22 +1713,22 @@ public final class AddressAggregatedList implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("id")) {
+    if ("id".equals(fieldName)) {
       return id;
     }
-    if (fieldName.equals("items")) {
+    if ("items".equals(fieldName)) {
       return items;
     }
-    if (fieldName.equals("kind")) {
+    if ("kind".equals(fieldName)) {
       return kind;
     }
-    if (fieldName.equals("nextPageToken")) {
+    if ("nextPageToken".equals(fieldName)) {
       return nextPageToken;
     }
-    if (fieldName.equals("selfLink")) {
+    if ("selfLink".equals(fieldName)) {
       return selfLink;
     }
-    if (fieldName.equals("warning")) {
+    if ("warning".equals(fieldName)) {
       return warning;
     }
     return null;
@@ -2013,10 +2013,10 @@ public final class AddressesScopedList implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("addresses")) {
+    if ("addresses".equals(fieldName)) {
       return addresses;
     }
-    if (fieldName.equals("warning")) {
+    if ("warning".equals(fieldName)) {
       return warning;
     }
     return null;
@@ -2228,19 +2228,19 @@ public final class AddressList implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("id")) {
+    if ("id".equals(fieldName)) {
       return id;
     }
-    if (fieldName.equals("items")) {
+    if ("items".equals(fieldName)) {
       return items;
     }
-    if (fieldName.equals("kind")) {
+    if ("kind".equals(fieldName)) {
       return kind;
     }
-    if (fieldName.equals("nextPageToken")) {
+    if ("nextPageToken".equals(fieldName)) {
       return nextPageToken;
     }
-    if (fieldName.equals("selfLink")) {
+    if ("selfLink".equals(fieldName)) {
       return selfLink;
     }
     return null;
@@ -2512,10 +2512,10 @@ public final class Data implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("value")) {
+    if ("value".equals(fieldName)) {
       return value;
     }
     return null;
@@ -2700,7 +2700,7 @@ public final class DUMMYObject implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("name")) {
+    if ("name".equals(fieldName)) {
       return name;
     }
     return null;
@@ -2877,19 +2877,19 @@ public final class DummyObject2 implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("floatie")) {
+    if ("floatie".equals(fieldName)) {
       return floatie;
     }
-    if (fieldName.equals("name")) {
+    if ("name".equals(fieldName)) {
       return name;
     }
-    if (fieldName.equals("precisionFloatie")) {
+    if ("precisionFloatie".equals(fieldName)) {
       return precisionFloatie;
     }
-    if (fieldName.equals("primaryAddress")) {
+    if ("primaryAddress".equals(fieldName)) {
       return primaryAddress;
     }
-    if (fieldName.equals("secondaryAddress")) {
+    if ("secondaryAddress".equals(fieldName)) {
       return secondaryAddress;
     }
     return null;
@@ -3146,7 +3146,7 @@ public final class Error implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("errors")) {
+    if ("errors".equals(fieldName)) {
       return errors;
     }
     return null;
@@ -3326,13 +3326,13 @@ public final class Errors implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("code")) {
+    if ("code".equals(fieldName)) {
       return code;
     }
-    if (fieldName.equals("location")) {
+    if ("location".equals(fieldName)) {
       return location;
     }
-    if (fieldName.equals("message")) {
+    if ("message".equals(fieldName)) {
       return message;
     }
     return null;
@@ -3629,73 +3629,73 @@ public final class Operation implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("clientOperationId")) {
+    if ("clientOperationId".equals(fieldName)) {
       return clientOperationId;
     }
-    if (fieldName.equals("creationTimestamp")) {
+    if ("creationTimestamp".equals(fieldName)) {
       return creationTimestamp;
     }
-    if (fieldName.equals("description")) {
+    if ("description".equals(fieldName)) {
       return description;
     }
-    if (fieldName.equals("endTime")) {
+    if ("endTime".equals(fieldName)) {
       return endTime;
     }
-    if (fieldName.equals("error")) {
+    if ("error".equals(fieldName)) {
       return error;
     }
-    if (fieldName.equals("httpErrorMessage")) {
+    if ("httpErrorMessage".equals(fieldName)) {
       return httpErrorMessage;
     }
-    if (fieldName.equals("httpErrorStatusCode")) {
+    if ("httpErrorStatusCode".equals(fieldName)) {
       return httpErrorStatusCode;
     }
-    if (fieldName.equals("id")) {
+    if ("id".equals(fieldName)) {
       return id;
     }
-    if (fieldName.equals("insertTime")) {
+    if ("insertTime".equals(fieldName)) {
       return insertTime;
     }
-    if (fieldName.equals("kind")) {
+    if ("kind".equals(fieldName)) {
       return kind;
     }
-    if (fieldName.equals("name")) {
+    if ("name".equals(fieldName)) {
       return name;
     }
-    if (fieldName.equals("operationType")) {
+    if ("operationType".equals(fieldName)) {
       return operationType;
     }
-    if (fieldName.equals("progress")) {
+    if ("progress".equals(fieldName)) {
       return progress;
     }
-    if (fieldName.equals("region")) {
+    if ("region".equals(fieldName)) {
       return region;
     }
-    if (fieldName.equals("selfLink")) {
+    if ("selfLink".equals(fieldName)) {
       return selfLink;
     }
-    if (fieldName.equals("startTime")) {
+    if ("startTime".equals(fieldName)) {
       return startTime;
     }
-    if (fieldName.equals("status")) {
+    if ("status".equals(fieldName)) {
       return status;
     }
-    if (fieldName.equals("statusMessage")) {
+    if ("statusMessage".equals(fieldName)) {
       return statusMessage;
     }
-    if (fieldName.equals("targetId")) {
+    if ("targetId".equals(fieldName)) {
       return targetId;
     }
-    if (fieldName.equals("targetLink")) {
+    if ("targetLink".equals(fieldName)) {
       return targetLink;
     }
-    if (fieldName.equals("user")) {
+    if ("user".equals(fieldName)) {
       return user;
     }
-    if (fieldName.equals("warnings")) {
+    if ("warnings".equals(fieldName)) {
       return warnings;
     }
-    if (fieldName.equals("zone")) {
+    if ("zone".equals(fieldName)) {
       return zone;
     }
     return null;
@@ -4403,13 +4403,13 @@ public final class ProjectsGetDummyObjectResources implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("kind")) {
+    if ("kind".equals(fieldName)) {
       return kind;
     }
-    if (fieldName.equals("nextPageToken")) {
+    if ("nextPageToken".equals(fieldName)) {
       return nextPageToken;
     }
-    if (fieldName.equals("resources")) {
+    if ("resources".equals(fieldName)) {
       return resources;
     }
     return null;
@@ -4637,13 +4637,13 @@ public final class Warning implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("code")) {
+    if ("code".equals(fieldName)) {
       return code;
     }
-    if (fieldName.equals("data")) {
+    if ("data".equals(fieldName)) {
       return data;
     }
-    if (fieldName.equals("message")) {
+    if ("message".equals(fieldName)) {
       return message;
     }
     return null;
@@ -4871,13 +4871,13 @@ public final class Warnings implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("code")) {
+    if ("code".equals(fieldName)) {
       return code;
     }
-    if (fieldName.equals("data")) {
+    if ("data".equals(fieldName)) {
       return data;
     }
-    if (fieldName.equals("message")) {
+    if ("message".equals(fieldName)) {
       return message;
     }
     return null;
@@ -5141,40 +5141,40 @@ public final class AggregatedListAddressesHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("filter")) {
+    if ("filter".equals(fieldName)) {
       return filter;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("maxResults")) {
+    if ("maxResults".equals(fieldName)) {
       return maxResults;
     }
-    if (fieldName.equals("orderBy")) {
+    if ("orderBy".equals(fieldName)) {
       return orderBy;
     }
-    if (fieldName.equals("pageToken")) {
+    if ("pageToken".equals(fieldName)) {
       return pageToken;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("project")) {
+    if ("project".equals(fieldName)) {
       return project;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -5634,28 +5634,28 @@ public final class DeleteAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("address")) {
+    if ("address".equals(fieldName)) {
       return address;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -6019,28 +6019,28 @@ public final class DeleteDummyObjectHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("dummyObject")) {
+    if ("dummyObject".equals(fieldName)) {
       return dummyObject;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -6404,28 +6404,28 @@ public final class GetAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("address")) {
+    if ("address".equals(fieldName)) {
       return address;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -6789,28 +6789,28 @@ public final class GetResourceDummyObjectHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("resource")) {
+    if ("resource".equals(fieldName)) {
       return resource;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -7178,31 +7178,31 @@ public final class InsertAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("addressResource")) {
+    if ("addressResource".equals(fieldName)) {
       return addressResource;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("region")) {
+    if ("region".equals(fieldName)) {
       return region;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -7606,40 +7606,40 @@ public final class ListAddressesHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("filter")) {
+    if ("filter".equals(fieldName)) {
       return filter;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("maxResults")) {
+    if ("maxResults".equals(fieldName)) {
       return maxResults;
     }
-    if (fieldName.equals("orderBy")) {
+    if ("orderBy".equals(fieldName)) {
       return orderBy;
     }
-    if (fieldName.equals("pageToken")) {
+    if ("pageToken".equals(fieldName)) {
       return pageToken;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("region")) {
+    if ("region".equals(fieldName)) {
       return region;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -8111,37 +8111,37 @@ public final class ListResourcesDummyObjectsHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("maxResults")) {
+    if ("maxResults".equals(fieldName)) {
       return maxResults;
     }
-    if (fieldName.equals("orderBy")) {
+    if ("orderBy".equals(fieldName)) {
       return orderBy;
     }
-    if (fieldName.equals("pageToken")) {
+    if ("pageToken".equals(fieldName)) {
       return pageToken;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("project")) {
+    if ("project".equals(fieldName)) {
       return project;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -8593,40 +8593,40 @@ public final class PatchAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("address")) {
+    if ("address".equals(fieldName)) {
       return address;
     }
-    if (fieldName.equals("addressResource")) {
+    if ("addressResource".equals(fieldName)) {
       return addressResource;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fieldMask")) {
+    if ("fieldMask".equals(fieldName)) {
       return fieldMask;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("region")) {
+    if ("region".equals(fieldName)) {
       return region;
     }
-    if (fieldName.equals("requestId")) {
+    if ("requestId".equals(fieldName)) {
       return requestId;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -9106,37 +9106,37 @@ public final class UpdateAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("address")) {
+    if ("address".equals(fieldName)) {
       return address;
     }
-    if (fieldName.equals("addressResource")) {
+    if ("addressResource".equals(fieldName)) {
       return addressResource;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fieldMask")) {
+    if ("fieldMask".equals(fieldName)) {
       return fieldMask;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("requestId")) {
+    if ("requestId".equals(fieldName)) {
       return requestId;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-java/issues/4320.

Currently, we are calling `fieldName.equals("someResource")` which will throw a NPE when variable `fieldName` is null.
Avoid the NPE by calling `.equals()` on the constant string instead.