### PR TITLE
Remove request_object_method

### DIFF
--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -253,9 +253,7 @@ message MethodConfigProto {
   // Specifies the configuration for batching.
   BatchingConfigProto batching = 6;
 
-  // Turns on or off the generation of a method whose sole parameter is
-  // a request object. Not all languages will generate this method.
-  bool request_object_method = 7; // UNSUPPORTED.
+  reserved 7;
 
   // Fields that are always required for a request to be valid.
   repeated string required_fields = 8;

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -59,7 +59,6 @@ option java_package = "com.google.api.codegen";
 //             subresponse_field: pic_id
 //         retry_codes_name: idempotent
 //         retry_params_name: default
-//         request_object_method: true
 //         field_name_patterns:
 //           name: book
 //         header_request_params:

--- a/src/test/java/com/google/api/codegen/testsrc/common/longrunning_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/longrunning_gapic.yaml
@@ -69,7 +69,6 @@ interfaces:
     required_fields:
     - name
     - filter
-    request_object_method: true
     page_streaming:
       request:
         page_size_field: page_size
@@ -97,7 +96,6 @@ interfaces:
         - name
     required_fields:
     - name
-    request_object_method: false
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 60000


### PR DESCRIPTION
There shall be no trace left of `request_object_method`.

All existing uses of that config param have been removed in googleapis and googleapis_private.