### PR TITLE
Preserve JSON field names

### DIFF
--- a/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
@@ -154,7 +154,6 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
       return null;
     } else {
       return new AutoValue_DiscoGapicInterfaceConfig(
-          methodConfigs,
           retryCodesConfig,
           retrySettingsDefinition,
           requiredConstructorParams,
@@ -163,10 +162,14 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
           new DiscoInterfaceModel(interfaceName, model),
           smokeTestConfig,
           methodToSingleResourceNameMap.build(),
+          methodConfigs,
           methodConfigMap,
           singleResourceNames);
     }
   }
+
+  @Override
+  public abstract List<DiscoGapicMethodConfig> getMethodConfigs();
 
   private static Method lookupMethod(Document source, String lookupMethod) {
     for (com.google.api.codegen.discovery.Method method : source.methods()) {

--- a/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
@@ -49,6 +49,9 @@ import org.threeten.bp.Duration;
 public abstract class DiscoGapicMethodConfig extends MethodConfig {
 
   @Override
+  public abstract DiscoveryMethodModel getMethodModel();
+
+  @Override
   public boolean isGrpcStreaming() {
     return false;
   }
@@ -194,7 +197,6 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
       return null;
     } else {
       return new AutoValue_DiscoGapicMethodConfig(
-          methodModel,
           pageStreaming,
           flattening,
           retryCodesName,
@@ -209,7 +211,8 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
           sampleSpec,
           visibility,
           releaseLevel,
-          longRunningConfig);
+          longRunningConfig,
+          methodModel);
     }
   }
 

--- a/src/main/java/com/google/api/codegen/config/DiscoveryField.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryField.java
@@ -111,6 +111,10 @@ public class DiscoveryField implements FieldModel, TypeModel {
     return new DiscoveryField(schema, rootApiModel);
   }
 
+  public String getRawName() {
+    return originalSchema.getIdentifier();
+  }
+
   /** @return the underlying dereferenced Discovery Schema. */
   public Schema getDiscoveryField() {
     return schema;

--- a/src/main/java/com/google/api/codegen/config/DiscoveryField.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryField.java
@@ -111,6 +111,7 @@ public class DiscoveryField implements FieldModel, TypeModel {
     return new DiscoveryField(schema, rootApiModel);
   }
 
+  /** @return the JSON identifier for this field, unchanged from the Discovery doc. */
   public String getRawName() {
     return originalSchema.getIdentifier();
   }

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicRequestToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicRequestToViewTransformer.java
@@ -125,7 +125,7 @@ public class JavaDiscoGapicRequestToViewTransformer
               surfaceNamer,
               createTypeTable(productConfig.getPackageName()));
 
-      for (MethodModel method : context.getSupportedMethods()) {
+      for (DiscoveryMethodModel method : context.getSupportedMethods()) {
         RequestObjectParamView params = getRequestObjectParams(context, method);
 
         SchemaTransformationContext requestContext =
@@ -185,7 +185,7 @@ public class JavaDiscoGapicRequestToViewTransformer
 
   private StaticLangApiMessageView generateRequestClass(
       SchemaTransformationContext context,
-      MethodModel method,
+      DiscoveryMethodModel method,
       RequestObjectParamView resourceNameView) {
     StaticLangApiMessageView.Builder requestView = StaticLangApiMessageView.newBuilder();
 
@@ -194,8 +194,7 @@ public class JavaDiscoGapicRequestToViewTransformer
     String requestClassId =
         context
             .getNamer()
-            .privateFieldName(
-                DiscoGapicParser.getRequestName(((DiscoveryMethodModel) method).getDiscoMethod()));
+            .privateFieldName(DiscoGapicParser.getRequestName(method.getDiscoMethod()));
     String requestName =
         nameFormatter.privateFieldName(Name.anyCamel(symbolTable.getNewSymbol(requestClassId)));
 
@@ -215,6 +214,7 @@ public class JavaDiscoGapicRequestToViewTransformer
       }
       StaticLangApiMessageView.Builder paramView = StaticLangApiMessageView.newBuilder();
       paramView.description(STANDARD_QUERY_PARAMS.get(param));
+      paramView.rawName(param);
       paramView.name(symbolTable.getNewSymbol(param));
       paramView.typeName("String");
       paramView.innerTypeName("String");
@@ -236,7 +236,7 @@ public class JavaDiscoGapicRequestToViewTransformer
       properties.add(paramView.build());
     }
 
-    for (FieldModel entry : method.getInputFields()) {
+    for (DiscoveryField entry : method.getInputFields()) {
       if (entry.mayBeInResourceName()) {
         requestView.hasRequiredProperties(true);
         continue;
@@ -250,7 +250,7 @@ public class JavaDiscoGapicRequestToViewTransformer
     }
 
     StaticLangApiMessageView.Builder paramView = StaticLangApiMessageView.newBuilder();
-    Method discoMethod = ((DiscoveryMethodModel) method).getDiscoMethod();
+    Method discoMethod = method.getDiscoMethod();
     String resourceName = DiscoGapicParser.getResourceIdentifier(discoMethod.path()).toLowerCamel();
     StringBuilder description =
         new StringBuilder(discoMethod.parameters().get(resourceName).description());
@@ -262,6 +262,7 @@ public class JavaDiscoGapicRequestToViewTransformer
             + "     * signs (\\`%\\`). It must be between 3 and 255 characters in length, and it\n"
             + "     * must not start with \\`\"goog\"\\`.");
     paramView.description(description.toString());
+    paramView.rawName(resourceNameView.name());
     paramView.name(symbolTable.getNewSymbol(resourceNameView.name()));
     paramView.typeName("String");
     paramView.innerTypeName("String");
@@ -282,7 +283,7 @@ public class JavaDiscoGapicRequestToViewTransformer
 
     Schema requestBodyDef = discoMethod.request();
     if (requestBodyDef != null && !Strings.isNullOrEmpty(requestBodyDef.reference())) {
-      FieldModel requestBody =
+      DiscoveryField requestBody =
           DiscoveryField.create(requestBodyDef, context.getDocContext().getApiModel());
       requestView.requestBodyType(
           schemaToParamView(
@@ -300,19 +301,21 @@ public class JavaDiscoGapicRequestToViewTransformer
   // Transforms a request/response Schema object into a StaticLangApiMessageView.
   private StaticLangApiMessageView schemaToParamView(
       SchemaTransformationContext context,
-      FieldModel schema,
+      DiscoveryField schema,
       String preferredName,
       SymbolTable symbolTable,
       EscapeName escapeName) {
     StaticLangApiMessageView.Builder paramView = StaticLangApiMessageView.newBuilder();
     String typeName = context.getSchemaTypeTable().getAndSaveNicknameFor(schema);
-    String innerTypeName = context.getSchemaTypeTable().getAndSaveNicknameForElementType(schema);
+    String innerTypeName =
+        context.getSchemaTypeTable().getAndSaveNicknameForElementType((FieldModel) schema);
     paramView.description(schema.getScopedDocumentation());
     String name = context.getNamer().privateFieldName(Name.anyCamel(preferredName));
     String fieldName = name;
     if (escapeName.equals(EscapeName.ESCAPE_NAME)) {
       fieldName = symbolTable.getNewSymbol(name);
     }
+    paramView.rawName(fieldName); // rawName doesn't matter for request objects.
     paramView.name(fieldName);
     paramView.typeName(typeName);
     paramView.innerTypeName(innerTypeName);
@@ -337,6 +340,7 @@ public class JavaDiscoGapicRequestToViewTransformer
     typeTable.getAndSaveNicknameFor("com.google.common.collect.ImmutableList");
     typeTable.getAndSaveNicknameFor("com.google.common.collect.ImmutableMap");
     typeTable.getAndSaveNicknameFor("com.google.api.gax.httpjson.ApiMessage");
+    typeTable.getAndSaveNicknameFor("com.google.gson.annotations.SerializedName");
     typeTable.getAndSaveNicknameFor("java.util.Collections");
     typeTable.getAndSaveNicknameFor("java.util.LinkedList");
     typeTable.getAndSaveNicknameFor("java.util.List");

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicRequestToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicRequestToViewTransformer.java
@@ -198,6 +198,7 @@ public class JavaDiscoGapicRequestToViewTransformer
     String requestName =
         nameFormatter.privateFieldName(Name.anyCamel(symbolTable.getNewSymbol(requestClassId)));
 
+    requestView.rawName(requestName); // Serialized name doesn't matter here.
     requestView.name(requestName);
     requestView.description(method.getDescription());
 

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSchemaToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSchemaToViewTransformer.java
@@ -156,6 +156,7 @@ public class JavaDiscoGapicSchemaToViewTransformer
     String schemaName =
         nameFormatter.privateFieldName(Name.anyCamel(symbolTableCopy.getNewSymbol(schemaId)));
 
+    schemaView.rawName(schema.getIdentifier());
     schemaView.name(schemaName);
     schemaView.defaultValue(schema.defaultValue());
     schemaView.description(schema.description());
@@ -209,6 +210,7 @@ public class JavaDiscoGapicSchemaToViewTransformer
   private void addApiImports(ImportTypeTable typeTable) {
     typeTable.getAndSaveNicknameFor("com.google.api.core.BetaApi");
     typeTable.getAndSaveNicknameFor("com.google.api.gax.httpjson.ApiMessage");
+    typeTable.getAndSaveNicknameFor("com.google.gson.annotations.SerializedName");
     typeTable.getAndSaveNicknameFor("com.google.common.collect.ImmutableList");
     typeTable.getAndSaveNicknameFor("com.google.common.collect.ImmutableMap");
     typeTable.getAndSaveNicknameFor("java.util.Collections");

--- a/src/main/java/com/google/api/codegen/transformer/DiscoGapicInterfaceContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/DiscoGapicInterfaceContext.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  */
 @AutoValue
 public abstract class DiscoGapicInterfaceContext implements InterfaceContext {
-  private ImmutableList<MethodModel> interfaceMethods;
+  private ImmutableList<DiscoveryMethodModel> interfaceMethods;
 
   public static DiscoGapicInterfaceContext createWithoutInterface(
       DiscoApiModel model,
@@ -121,14 +121,14 @@ public abstract class DiscoGapicInterfaceContext implements InterfaceContext {
 
   /** Returns a list of methods for this interface. Memoize the result. */
   @Override
-  public List<MethodModel> getInterfaceConfigMethods() {
+  public List<DiscoveryMethodModel> getInterfaceConfigMethods() {
     if (interfaceMethods != null) {
       return interfaceMethods;
     }
 
-    ImmutableList.Builder<MethodModel> methodBuilder = ImmutableList.builder();
-    for (MethodConfig methodConfig : getInterfaceConfig().getMethodConfigs()) {
-      MethodModel method = methodConfig.getMethodModel();
+    ImmutableList.Builder<DiscoveryMethodModel> methodBuilder = ImmutableList.builder();
+    for (DiscoGapicMethodConfig methodConfig : getInterfaceConfig().getMethodConfigs()) {
+      DiscoveryMethodModel method = methodConfig.getMethodModel();
       if (isSupported(method)) {
         methodBuilder.add(method);
       }
@@ -139,7 +139,7 @@ public abstract class DiscoGapicInterfaceContext implements InterfaceContext {
 
   /** Returns a list of methods for this interface. Memoize the result. */
   @Override
-  public List<MethodModel> getInterfaceMethods() {
+  public List<DiscoveryMethodModel> getInterfaceMethods() {
     return getInterfaceConfigMethods();
   }
 
@@ -185,7 +185,7 @@ public abstract class DiscoGapicInterfaceContext implements InterfaceContext {
 
   @Override
   /* Returns a list of public methods, configured by FeatureConfig. Memoize the result. */
-  public Iterable<MethodModel> getPublicMethods() {
+  public Iterable<DiscoveryMethodModel> getPublicMethods() {
     return getInterfaceConfigMethods()
         .stream()
         .filter(m -> isSupported(m))
@@ -194,7 +194,7 @@ public abstract class DiscoGapicInterfaceContext implements InterfaceContext {
 
   @Override
   /* Returns a list of supported methods, configured by FeatureConfig. Memoize the result. */
-  public Iterable<MethodModel> getSupportedMethods() {
+  public Iterable<DiscoveryMethodModel> getSupportedMethods() {
     return getPublicMethods();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/InterfaceContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/InterfaceContext.java
@@ -37,9 +37,9 @@ public interface InterfaceContext extends TransformationContext {
 
   FeatureConfig getFeatureConfig();
 
-  Iterable<MethodModel> getSupportedMethods();
+  Iterable<? extends MethodModel> getSupportedMethods();
 
-  Iterable<MethodModel> getPublicMethods();
+  Iterable<? extends MethodModel> getPublicMethods();
 
   Iterable<MethodModel> getPageStreamingMethods();
 
@@ -62,10 +62,10 @@ public interface InterfaceContext extends TransformationContext {
   MethodContext asFlattenedMethodContext(MethodModel method, FlatteningConfig flatteningConfig);
 
   /* @return the methods in the interface. */
-  List<MethodModel> getInterfaceMethods();
+  List<? extends MethodModel> getInterfaceMethods();
 
   /* @return the methods in the interface that have method configs. */
-  List<MethodModel> getInterfaceConfigMethods();
+  List<? extends MethodModel> getInterfaceConfigMethods();
 
   Iterable<MethodModel> getLongRunningMethods();
 

--- a/src/main/java/com/google/api/codegen/transformer/MockServiceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/MockServiceTransformer.java
@@ -74,7 +74,7 @@ public class MockServiceTransformer {
     if (!context.getProductConfig().getTransportProtocol().equals(TransportProtocol.GRPC)) {
       return ImmutableList.of();
     }
-    List<MethodModel> methods = context.getInterfaceMethods();
+    List<? extends MethodModel> methods = context.getInterfaceMethods();
     ArrayList<MockGrpcMethodView> mocks = new ArrayList<>(methods.size());
     for (MethodModel method : methods) {
       if (context.getMethodConfig(method) == null) {

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -255,7 +255,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer<ProtoAp
 
   @VisibleForTesting
   List<StaticLangApiMethodView> generateApiMethods(
-      InterfaceContext context, Iterable<MethodModel> methods) {
+      InterfaceContext context, Iterable<? extends MethodModel> methods) {
     List<StaticLangApiMethodView> apiMethods = new ArrayList<>();
     for (MethodModel method : methods) {
       MethodConfig methodConfig = context.getMethodConfig(method);
@@ -331,7 +331,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer<ProtoAp
   }
 
   @VisibleForTesting
-  void addXExampleImports(InterfaceContext context, Iterable<MethodModel> methods) {
+  void addXExampleImports(InterfaceContext context, Iterable<? extends MethodModel> methods) {
     ImportTypeTable typeTable = context.getImportTypeTable();
     typeTable.saveNicknameFor("context;;;");
     typeTable.saveNicknameFor(context.getProductConfig().getPackageName() + ";;;");
@@ -343,7 +343,9 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer<ProtoAp
   }
 
   private void addContextImports(
-      InterfaceContext context, ImportContext importContext, Iterable<MethodModel> methods) {
+      InterfaceContext context,
+      ImportContext importContext,
+      Iterable<? extends MethodModel> methods) {
     for (ImportKind kind : getImportKinds(context.getInterfaceConfig(), methods)) {
       ImmutableList<String> imps = CONTEXTUAL_IMPORTS.get(importContext, kind);
       if (imps != null) {
@@ -355,7 +357,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer<ProtoAp
   }
 
   private Set<ImportKind> getImportKinds(
-      InterfaceConfig interfaceConfig, Iterable<MethodModel> methods) {
+      InterfaceConfig interfaceConfig, Iterable<? extends MethodModel> methods) {
     EnumSet<ImportKind> kinds = EnumSet.noneOf(ImportKind.class);
     for (MethodModel method : methods) {
       if (method.getResponseStreaming()) {

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiMessageView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiMessageView.java
@@ -37,8 +37,16 @@ public abstract class StaticLangApiMessageView implements Comparable<StaticLangA
   // TODO(andrealin) Populate and render this field.
   public abstract String defaultValue();
 
+  // The untransformed ID of the schema from the Discovery Doc, to be used in the JSON http body.
+  public abstract String rawName();
+
   // The possibly-transformed ID of the schema from the Discovery Doc
   public abstract String name();
+
+  // Returns if there is a non-null serialized name and if it is different from the rendered name.
+  public boolean serializedNameDifferent() {
+    return !name().equals(rawName());
+  }
 
   // The type name for this Schema when rendered as a field in its parent Schema, e.g.
   // "List<Operation>".
@@ -90,6 +98,8 @@ public abstract class StaticLangApiMessageView implements Comparable<StaticLangA
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder typeName(String val);
+
+    public abstract Builder rawName(String val);
 
     public abstract Builder name(String val);
 

--- a/src/main/resources/com/google/api/codegen/java/message.snip
+++ b/src/main/resources/com/google/api/codegen/java/message.snip
@@ -68,6 +68,10 @@
 @private members(schema)
   @join property : schema.properties
     @if schema.isSerializable
+      @if property.serializedNameDifferent
+        @@SerializedName("{@property.rawName}")
+        {@""}
+      @end
       private final {@property.typeName} {@property.name};
     @else
       private final transient {@property.typeName} {@property.name};

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -1214,6 +1214,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -1278,34 +1279,34 @@ public final class Address implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("address".equals(fieldName)) {
+    if (fieldName.equals("address")) {
       return address;
     }
-    if ("creationTimestamp".equals(fieldName)) {
+    if (fieldName.equals("creationTimestamp")) {
       return creationTimestamp;
     }
-    if ("description".equals(fieldName)) {
+    if (fieldName.equals("description")) {
       return description;
     }
-    if ("id".equals(fieldName)) {
+    if (fieldName.equals("id")) {
       return id;
     }
-    if ("kind".equals(fieldName)) {
+    if (fieldName.equals("kind")) {
       return kind;
     }
-    if ("name".equals(fieldName)) {
+    if (fieldName.equals("name")) {
       return name;
     }
-    if ("region".equals(fieldName)) {
+    if (fieldName.equals("region")) {
       return region;
     }
-    if ("selfLink".equals(fieldName)) {
+    if (fieldName.equals("selfLink")) {
       return selfLink;
     }
-    if ("status".equals(fieldName)) {
+    if (fieldName.equals("status")) {
       return status;
     }
-    if ("users".equals(fieldName)) {
+    if (fieldName.equals("users")) {
       return users;
     }
     return null;
@@ -1665,6 +1666,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -1713,22 +1715,22 @@ public final class AddressAggregatedList implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("id".equals(fieldName)) {
+    if (fieldName.equals("id")) {
       return id;
     }
-    if ("items".equals(fieldName)) {
+    if (fieldName.equals("items")) {
       return items;
     }
-    if ("kind".equals(fieldName)) {
+    if (fieldName.equals("kind")) {
       return kind;
     }
-    if ("nextPageToken".equals(fieldName)) {
+    if (fieldName.equals("nextPageToken")) {
       return nextPageToken;
     }
-    if ("selfLink".equals(fieldName)) {
+    if (fieldName.equals("selfLink")) {
       return selfLink;
     }
-    if ("warning".equals(fieldName)) {
+    if (fieldName.equals("warning")) {
       return warning;
     }
     return null;
@@ -1981,6 +1983,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -2013,10 +2016,10 @@ public final class AddressesScopedList implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("addresses".equals(fieldName)) {
+    if (fieldName.equals("addresses")) {
       return addresses;
     }
-    if ("warning".equals(fieldName)) {
+    if (fieldName.equals("warning")) {
       return warning;
     }
     return null;
@@ -2184,6 +2187,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -2228,19 +2232,19 @@ public final class AddressList implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("id".equals(fieldName)) {
+    if (fieldName.equals("id")) {
       return id;
     }
-    if ("items".equals(fieldName)) {
+    if (fieldName.equals("items")) {
       return items;
     }
-    if ("kind".equals(fieldName)) {
+    if (fieldName.equals("kind")) {
       return kind;
     }
-    if ("nextPageToken".equals(fieldName)) {
+    if (fieldName.equals("nextPageToken")) {
       return nextPageToken;
     }
-    if ("selfLink".equals(fieldName)) {
+    if (fieldName.equals("selfLink")) {
       return selfLink;
     }
     return null;
@@ -2480,6 +2484,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -2512,10 +2517,10 @@ public final class Data implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("key".equals(fieldName)) {
+    if (fieldName.equals("key")) {
       return key;
     }
-    if ("value".equals(fieldName)) {
+    if (fieldName.equals("value")) {
       return value;
     }
     return null;
@@ -2672,6 +2677,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -2700,7 +2706,7 @@ public final class DUMMYObject implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("name".equals(fieldName)) {
+    if (fieldName.equals("name")) {
       return name;
     }
     return null;
@@ -2833,6 +2839,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -2847,6 +2854,8 @@ import javax.annotation.Nullable;
 @BetaApi
 public final class DummyObject2 implements ApiMessage {
   private final Float floatie;
+  @SerializedName("IPProtocol")
+  private final String iPProtocol;
   private final String name;
   private final Double precisionFloatie;
   private final Address primaryAddress;
@@ -2854,6 +2863,7 @@ public final class DummyObject2 implements ApiMessage {
 
   private DummyObject2() {
     this.floatie = null;
+    this.iPProtocol = null;
     this.name = null;
     this.precisionFloatie = null;
     this.primaryAddress = null;
@@ -2863,12 +2873,14 @@ public final class DummyObject2 implements ApiMessage {
 
   private DummyObject2(
       Float floatie,
+      String iPProtocol,
       String name,
       Double precisionFloatie,
       Address primaryAddress,
       Address secondaryAddress
       ) {
     this.floatie = floatie;
+    this.iPProtocol = iPProtocol;
     this.name = name;
     this.precisionFloatie = precisionFloatie;
     this.primaryAddress = primaryAddress;
@@ -2877,19 +2889,22 @@ public final class DummyObject2 implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("floatie".equals(fieldName)) {
+    if (fieldName.equals("floatie")) {
       return floatie;
     }
-    if ("name".equals(fieldName)) {
+    if (fieldName.equals("iPProtocol")) {
+      return iPProtocol;
+    }
+    if (fieldName.equals("name")) {
       return name;
     }
-    if ("precisionFloatie".equals(fieldName)) {
+    if (fieldName.equals("precisionFloatie")) {
       return precisionFloatie;
     }
-    if ("primaryAddress".equals(fieldName)) {
+    if (fieldName.equals("primaryAddress")) {
       return primaryAddress;
     }
-    if ("secondaryAddress".equals(fieldName)) {
+    if (fieldName.equals("secondaryAddress")) {
       return secondaryAddress;
     }
     return null;
@@ -2909,6 +2924,10 @@ public final class DummyObject2 implements ApiMessage {
 
   public Float getFloatie() {
     return floatie;
+  }
+
+  public String getIPProtocol() {
+    return iPProtocol;
   }
 
   public String getName() {
@@ -2949,6 +2968,7 @@ public final class DummyObject2 implements ApiMessage {
 
   public static class Builder {
     private Float floatie;
+    private String iPProtocol;
     private String name;
     private Double precisionFloatie;
     private Address primaryAddress;
@@ -2960,6 +2980,9 @@ public final class DummyObject2 implements ApiMessage {
       if (other == DummyObject2.getDefaultInstance()) return this;
       if (other.getFloatie() != null) {
         this.floatie = other.floatie;
+      }
+      if (other.getIPProtocol() != null) {
+        this.iPProtocol = other.iPProtocol;
       }
       if (other.getName() != null) {
         this.name = other.name;
@@ -2978,6 +3001,7 @@ public final class DummyObject2 implements ApiMessage {
 
     Builder(DummyObject2 source) {
       this.floatie = source.floatie;
+      this.iPProtocol = source.iPProtocol;
       this.name = source.name;
       this.precisionFloatie = source.precisionFloatie;
       this.primaryAddress = source.primaryAddress;
@@ -2990,6 +3014,15 @@ public final class DummyObject2 implements ApiMessage {
 
     public Builder setFloatie(Float floatie) {
       this.floatie = floatie;
+      return this;
+    }
+
+    public String getIPProtocol() {
+      return iPProtocol;
+    }
+
+    public Builder setIPProtocol(String iPProtocol) {
+      this.iPProtocol = iPProtocol;
       return this;
     }
 
@@ -3035,8 +3068,10 @@ public final class DummyObject2 implements ApiMessage {
 
 
 
+
       return new DummyObject2(
         floatie,
+        iPProtocol,
         name,
         precisionFloatie,
         primaryAddress,
@@ -3047,6 +3082,7 @@ public final class DummyObject2 implements ApiMessage {
     public Builder clone() {
       Builder newBuilder = new Builder();
       newBuilder.setFloatie(this.floatie);
+      newBuilder.setIPProtocol(this.iPProtocol);
       newBuilder.setName(this.name);
       newBuilder.setPrecisionFloatie(this.precisionFloatie);
       newBuilder.setPrimaryAddress(this.primaryAddress);
@@ -3059,6 +3095,7 @@ public final class DummyObject2 implements ApiMessage {
   public String toString() {
     return "DummyObject2{"
         + "floatie=" + floatie + ", "
+        + "iPProtocol=" + iPProtocol + ", "
         + "name=" + name + ", "
         + "precisionFloatie=" + precisionFloatie + ", "
         + "primaryAddress=" + primaryAddress + ", "
@@ -3075,6 +3112,7 @@ public final class DummyObject2 implements ApiMessage {
       DummyObject2 that = (DummyObject2) o;
       return
           Objects.equals(this.floatie, that.getFloatie()) &&
+          Objects.equals(this.iPProtocol, that.getIPProtocol()) &&
           Objects.equals(this.name, that.getName()) &&
           Objects.equals(this.precisionFloatie, that.getPrecisionFloatie()) &&
           Objects.equals(this.primaryAddress, that.getPrimaryAddress()) &&
@@ -3088,6 +3126,7 @@ public final class DummyObject2 implements ApiMessage {
   public int hashCode() {
     return Objects.hash(
       floatie,
+      iPProtocol,
       name,
       precisionFloatie,
       primaryAddress,
@@ -3118,6 +3157,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -3146,7 +3186,7 @@ public final class Error implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("errors".equals(fieldName)) {
+    if (fieldName.equals("errors")) {
       return errors;
     }
     return null;
@@ -3290,6 +3330,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -3326,13 +3367,13 @@ public final class Errors implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("code".equals(fieldName)) {
+    if (fieldName.equals("code")) {
       return code;
     }
-    if ("location".equals(fieldName)) {
+    if (fieldName.equals("location")) {
       return location;
     }
-    if ("message".equals(fieldName)) {
+    if (fieldName.equals("message")) {
       return message;
     }
     return null;
@@ -3513,6 +3554,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -3629,73 +3671,73 @@ public final class Operation implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("clientOperationId".equals(fieldName)) {
+    if (fieldName.equals("clientOperationId")) {
       return clientOperationId;
     }
-    if ("creationTimestamp".equals(fieldName)) {
+    if (fieldName.equals("creationTimestamp")) {
       return creationTimestamp;
     }
-    if ("description".equals(fieldName)) {
+    if (fieldName.equals("description")) {
       return description;
     }
-    if ("endTime".equals(fieldName)) {
+    if (fieldName.equals("endTime")) {
       return endTime;
     }
-    if ("error".equals(fieldName)) {
+    if (fieldName.equals("error")) {
       return error;
     }
-    if ("httpErrorMessage".equals(fieldName)) {
+    if (fieldName.equals("httpErrorMessage")) {
       return httpErrorMessage;
     }
-    if ("httpErrorStatusCode".equals(fieldName)) {
+    if (fieldName.equals("httpErrorStatusCode")) {
       return httpErrorStatusCode;
     }
-    if ("id".equals(fieldName)) {
+    if (fieldName.equals("id")) {
       return id;
     }
-    if ("insertTime".equals(fieldName)) {
+    if (fieldName.equals("insertTime")) {
       return insertTime;
     }
-    if ("kind".equals(fieldName)) {
+    if (fieldName.equals("kind")) {
       return kind;
     }
-    if ("name".equals(fieldName)) {
+    if (fieldName.equals("name")) {
       return name;
     }
-    if ("operationType".equals(fieldName)) {
+    if (fieldName.equals("operationType")) {
       return operationType;
     }
-    if ("progress".equals(fieldName)) {
+    if (fieldName.equals("progress")) {
       return progress;
     }
-    if ("region".equals(fieldName)) {
+    if (fieldName.equals("region")) {
       return region;
     }
-    if ("selfLink".equals(fieldName)) {
+    if (fieldName.equals("selfLink")) {
       return selfLink;
     }
-    if ("startTime".equals(fieldName)) {
+    if (fieldName.equals("startTime")) {
       return startTime;
     }
-    if ("status".equals(fieldName)) {
+    if (fieldName.equals("status")) {
       return status;
     }
-    if ("statusMessage".equals(fieldName)) {
+    if (fieldName.equals("statusMessage")) {
       return statusMessage;
     }
-    if ("targetId".equals(fieldName)) {
+    if (fieldName.equals("targetId")) {
       return targetId;
     }
-    if ("targetLink".equals(fieldName)) {
+    if (fieldName.equals("targetLink")) {
       return targetLink;
     }
-    if ("user".equals(fieldName)) {
+    if (fieldName.equals("user")) {
       return user;
     }
-    if ("warnings".equals(fieldName)) {
+    if (fieldName.equals("warnings")) {
       return warnings;
     }
-    if ("zone".equals(fieldName)) {
+    if (fieldName.equals("zone")) {
       return zone;
     }
     return null;
@@ -4367,6 +4409,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -4403,13 +4446,13 @@ public final class ProjectsGetDummyObjectResources implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("kind".equals(fieldName)) {
+    if (fieldName.equals("kind")) {
       return kind;
     }
-    if ("nextPageToken".equals(fieldName)) {
+    if (fieldName.equals("nextPageToken")) {
       return nextPageToken;
     }
-    if ("resources".equals(fieldName)) {
+    if (fieldName.equals("resources")) {
       return resources;
     }
     return null;
@@ -4601,6 +4644,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -4637,13 +4681,13 @@ public final class Warning implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("code".equals(fieldName)) {
+    if (fieldName.equals("code")) {
       return code;
     }
-    if ("data".equals(fieldName)) {
+    if (fieldName.equals("data")) {
       return data;
     }
-    if ("message".equals(fieldName)) {
+    if (fieldName.equals("message")) {
       return message;
     }
     return null;
@@ -4835,6 +4879,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -4871,13 +4916,13 @@ public final class Warnings implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("code".equals(fieldName)) {
+    if (fieldName.equals("code")) {
       return code;
     }
-    if ("data".equals(fieldName)) {
+    if (fieldName.equals("data")) {
       return data;
     }
-    if ("message".equals(fieldName)) {
+    if (fieldName.equals("message")) {
       return message;
     }
     return null;
@@ -5069,6 +5114,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -5141,40 +5187,40 @@ public final class AggregatedListAddressesHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("access_token".equals(fieldName)) {
+    if (fieldName.equals("access_token")) {
       return access_token;
     }
-    if ("callback".equals(fieldName)) {
+    if (fieldName.equals("callback")) {
       return callback;
     }
-    if ("fields".equals(fieldName)) {
+    if (fieldName.equals("fields")) {
       return fields;
     }
-    if ("filter".equals(fieldName)) {
+    if (fieldName.equals("filter")) {
       return filter;
     }
-    if ("key".equals(fieldName)) {
+    if (fieldName.equals("key")) {
       return key;
     }
-    if ("maxResults".equals(fieldName)) {
+    if (fieldName.equals("maxResults")) {
       return maxResults;
     }
-    if ("orderBy".equals(fieldName)) {
+    if (fieldName.equals("orderBy")) {
       return orderBy;
     }
-    if ("pageToken".equals(fieldName)) {
+    if (fieldName.equals("pageToken")) {
       return pageToken;
     }
-    if ("prettyPrint".equals(fieldName)) {
+    if (fieldName.equals("prettyPrint")) {
       return prettyPrint;
     }
-    if ("project".equals(fieldName)) {
+    if (fieldName.equals("project")) {
       return project;
     }
-    if ("quotaUser".equals(fieldName)) {
+    if (fieldName.equals("quotaUser")) {
       return quotaUser;
     }
-    if ("userIp".equals(fieldName)) {
+    if (fieldName.equals("userIp")) {
       return userIp;
     }
     return null;
@@ -5578,6 +5624,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -5634,28 +5681,28 @@ public final class DeleteAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("access_token".equals(fieldName)) {
+    if (fieldName.equals("access_token")) {
       return access_token;
     }
-    if ("address".equals(fieldName)) {
+    if (fieldName.equals("address")) {
       return address;
     }
-    if ("callback".equals(fieldName)) {
+    if (fieldName.equals("callback")) {
       return callback;
     }
-    if ("fields".equals(fieldName)) {
+    if (fieldName.equals("fields")) {
       return fields;
     }
-    if ("key".equals(fieldName)) {
+    if (fieldName.equals("key")) {
       return key;
     }
-    if ("prettyPrint".equals(fieldName)) {
+    if (fieldName.equals("prettyPrint")) {
       return prettyPrint;
     }
-    if ("quotaUser".equals(fieldName)) {
+    if (fieldName.equals("quotaUser")) {
       return quotaUser;
     }
-    if ("userIp".equals(fieldName)) {
+    if (fieldName.equals("userIp")) {
       return userIp;
     }
     return null;
@@ -5963,6 +6010,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -6019,28 +6067,28 @@ public final class DeleteDummyObjectHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("access_token".equals(fieldName)) {
+    if (fieldName.equals("access_token")) {
       return access_token;
     }
-    if ("callback".equals(fieldName)) {
+    if (fieldName.equals("callback")) {
       return callback;
     }
-    if ("dummyObject".equals(fieldName)) {
+    if (fieldName.equals("dummyObject")) {
       return dummyObject;
     }
-    if ("fields".equals(fieldName)) {
+    if (fieldName.equals("fields")) {
       return fields;
     }
-    if ("key".equals(fieldName)) {
+    if (fieldName.equals("key")) {
       return key;
     }
-    if ("prettyPrint".equals(fieldName)) {
+    if (fieldName.equals("prettyPrint")) {
       return prettyPrint;
     }
-    if ("quotaUser".equals(fieldName)) {
+    if (fieldName.equals("quotaUser")) {
       return quotaUser;
     }
-    if ("userIp".equals(fieldName)) {
+    if (fieldName.equals("userIp")) {
       return userIp;
     }
     return null;
@@ -6348,6 +6396,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -6404,28 +6453,28 @@ public final class GetAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("access_token".equals(fieldName)) {
+    if (fieldName.equals("access_token")) {
       return access_token;
     }
-    if ("address".equals(fieldName)) {
+    if (fieldName.equals("address")) {
       return address;
     }
-    if ("callback".equals(fieldName)) {
+    if (fieldName.equals("callback")) {
       return callback;
     }
-    if ("fields".equals(fieldName)) {
+    if (fieldName.equals("fields")) {
       return fields;
     }
-    if ("key".equals(fieldName)) {
+    if (fieldName.equals("key")) {
       return key;
     }
-    if ("prettyPrint".equals(fieldName)) {
+    if (fieldName.equals("prettyPrint")) {
       return prettyPrint;
     }
-    if ("quotaUser".equals(fieldName)) {
+    if (fieldName.equals("quotaUser")) {
       return quotaUser;
     }
-    if ("userIp".equals(fieldName)) {
+    if (fieldName.equals("userIp")) {
       return userIp;
     }
     return null;
@@ -6733,6 +6782,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -6789,28 +6839,28 @@ public final class GetResourceDummyObjectHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("access_token".equals(fieldName)) {
+    if (fieldName.equals("access_token")) {
       return access_token;
     }
-    if ("callback".equals(fieldName)) {
+    if (fieldName.equals("callback")) {
       return callback;
     }
-    if ("fields".equals(fieldName)) {
+    if (fieldName.equals("fields")) {
       return fields;
     }
-    if ("key".equals(fieldName)) {
+    if (fieldName.equals("key")) {
       return key;
     }
-    if ("prettyPrint".equals(fieldName)) {
+    if (fieldName.equals("prettyPrint")) {
       return prettyPrint;
     }
-    if ("quotaUser".equals(fieldName)) {
+    if (fieldName.equals("quotaUser")) {
       return quotaUser;
     }
-    if ("resource".equals(fieldName)) {
+    if (fieldName.equals("resource")) {
       return resource;
     }
-    if ("userIp".equals(fieldName)) {
+    if (fieldName.equals("userIp")) {
       return userIp;
     }
     return null;
@@ -7118,6 +7168,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -7178,31 +7229,31 @@ public final class InsertAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("access_token".equals(fieldName)) {
+    if (fieldName.equals("access_token")) {
       return access_token;
     }
-    if ("addressResource".equals(fieldName)) {
+    if (fieldName.equals("addressResource")) {
       return addressResource;
     }
-    if ("callback".equals(fieldName)) {
+    if (fieldName.equals("callback")) {
       return callback;
     }
-    if ("fields".equals(fieldName)) {
+    if (fieldName.equals("fields")) {
       return fields;
     }
-    if ("key".equals(fieldName)) {
+    if (fieldName.equals("key")) {
       return key;
     }
-    if ("prettyPrint".equals(fieldName)) {
+    if (fieldName.equals("prettyPrint")) {
       return prettyPrint;
     }
-    if ("quotaUser".equals(fieldName)) {
+    if (fieldName.equals("quotaUser")) {
       return quotaUser;
     }
-    if ("region".equals(fieldName)) {
+    if (fieldName.equals("region")) {
       return region;
     }
-    if ("userIp".equals(fieldName)) {
+    if (fieldName.equals("userIp")) {
       return userIp;
     }
     return null;
@@ -7534,6 +7585,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -7606,40 +7658,40 @@ public final class ListAddressesHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("access_token".equals(fieldName)) {
+    if (fieldName.equals("access_token")) {
       return access_token;
     }
-    if ("callback".equals(fieldName)) {
+    if (fieldName.equals("callback")) {
       return callback;
     }
-    if ("fields".equals(fieldName)) {
+    if (fieldName.equals("fields")) {
       return fields;
     }
-    if ("filter".equals(fieldName)) {
+    if (fieldName.equals("filter")) {
       return filter;
     }
-    if ("key".equals(fieldName)) {
+    if (fieldName.equals("key")) {
       return key;
     }
-    if ("maxResults".equals(fieldName)) {
+    if (fieldName.equals("maxResults")) {
       return maxResults;
     }
-    if ("orderBy".equals(fieldName)) {
+    if (fieldName.equals("orderBy")) {
       return orderBy;
     }
-    if ("pageToken".equals(fieldName)) {
+    if (fieldName.equals("pageToken")) {
       return pageToken;
     }
-    if ("prettyPrint".equals(fieldName)) {
+    if (fieldName.equals("prettyPrint")) {
       return prettyPrint;
     }
-    if ("quotaUser".equals(fieldName)) {
+    if (fieldName.equals("quotaUser")) {
       return quotaUser;
     }
-    if ("region".equals(fieldName)) {
+    if (fieldName.equals("region")) {
       return region;
     }
-    if ("userIp".equals(fieldName)) {
+    if (fieldName.equals("userIp")) {
       return userIp;
     }
     return null;
@@ -8043,6 +8095,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -8111,37 +8164,37 @@ public final class ListResourcesDummyObjectsHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("access_token".equals(fieldName)) {
+    if (fieldName.equals("access_token")) {
       return access_token;
     }
-    if ("callback".equals(fieldName)) {
+    if (fieldName.equals("callback")) {
       return callback;
     }
-    if ("fields".equals(fieldName)) {
+    if (fieldName.equals("fields")) {
       return fields;
     }
-    if ("key".equals(fieldName)) {
+    if (fieldName.equals("key")) {
       return key;
     }
-    if ("maxResults".equals(fieldName)) {
+    if (fieldName.equals("maxResults")) {
       return maxResults;
     }
-    if ("orderBy".equals(fieldName)) {
+    if (fieldName.equals("orderBy")) {
       return orderBy;
     }
-    if ("pageToken".equals(fieldName)) {
+    if (fieldName.equals("pageToken")) {
       return pageToken;
     }
-    if ("prettyPrint".equals(fieldName)) {
+    if (fieldName.equals("prettyPrint")) {
       return prettyPrint;
     }
-    if ("project".equals(fieldName)) {
+    if (fieldName.equals("project")) {
       return project;
     }
-    if ("quotaUser".equals(fieldName)) {
+    if (fieldName.equals("quotaUser")) {
       return quotaUser;
     }
-    if ("userIp".equals(fieldName)) {
+    if (fieldName.equals("userIp")) {
       return userIp;
     }
     return null;
@@ -8521,6 +8574,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -8593,40 +8647,40 @@ public final class PatchAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("access_token".equals(fieldName)) {
+    if (fieldName.equals("access_token")) {
       return access_token;
     }
-    if ("address".equals(fieldName)) {
+    if (fieldName.equals("address")) {
       return address;
     }
-    if ("addressResource".equals(fieldName)) {
+    if (fieldName.equals("addressResource")) {
       return addressResource;
     }
-    if ("callback".equals(fieldName)) {
+    if (fieldName.equals("callback")) {
       return callback;
     }
-    if ("fieldMask".equals(fieldName)) {
+    if (fieldName.equals("fieldMask")) {
       return fieldMask;
     }
-    if ("fields".equals(fieldName)) {
+    if (fieldName.equals("fields")) {
       return fields;
     }
-    if ("key".equals(fieldName)) {
+    if (fieldName.equals("key")) {
       return key;
     }
-    if ("prettyPrint".equals(fieldName)) {
+    if (fieldName.equals("prettyPrint")) {
       return prettyPrint;
     }
-    if ("quotaUser".equals(fieldName)) {
+    if (fieldName.equals("quotaUser")) {
       return quotaUser;
     }
-    if ("region".equals(fieldName)) {
+    if (fieldName.equals("region")) {
       return region;
     }
-    if ("requestId".equals(fieldName)) {
+    if (fieldName.equals("requestId")) {
       return requestId;
     }
-    if ("userIp".equals(fieldName)) {
+    if (fieldName.equals("userIp")) {
       return userIp;
     }
     return null;
@@ -9038,6 +9092,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -9106,37 +9161,37 @@ public final class UpdateAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if ("access_token".equals(fieldName)) {
+    if (fieldName.equals("access_token")) {
       return access_token;
     }
-    if ("address".equals(fieldName)) {
+    if (fieldName.equals("address")) {
       return address;
     }
-    if ("addressResource".equals(fieldName)) {
+    if (fieldName.equals("addressResource")) {
       return addressResource;
     }
-    if ("callback".equals(fieldName)) {
+    if (fieldName.equals("callback")) {
       return callback;
     }
-    if ("fieldMask".equals(fieldName)) {
+    if (fieldName.equals("fieldMask")) {
       return fieldMask;
     }
-    if ("fields".equals(fieldName)) {
+    if (fieldName.equals("fields")) {
       return fields;
     }
-    if ("key".equals(fieldName)) {
+    if (fieldName.equals("key")) {
       return key;
     }
-    if ("prettyPrint".equals(fieldName)) {
+    if (fieldName.equals("prettyPrint")) {
       return prettyPrint;
     }
-    if ("quotaUser".equals(fieldName)) {
+    if (fieldName.equals("quotaUser")) {
       return quotaUser;
     }
-    if ("requestId".equals(fieldName)) {
+    if (fieldName.equals("requestId")) {
       return requestId;
     }
-    if ("userIp".equals(fieldName)) {
+    if (fieldName.equals("userIp")) {
       return userIp;
     }
     return null;

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -1279,34 +1279,34 @@ public final class Address implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("address")) {
+    if ("address".equals(fieldName)) {
       return address;
     }
-    if (fieldName.equals("creationTimestamp")) {
+    if ("creationTimestamp".equals(fieldName)) {
       return creationTimestamp;
     }
-    if (fieldName.equals("description")) {
+    if ("description".equals(fieldName)) {
       return description;
     }
-    if (fieldName.equals("id")) {
+    if ("id".equals(fieldName)) {
       return id;
     }
-    if (fieldName.equals("kind")) {
+    if ("kind".equals(fieldName)) {
       return kind;
     }
-    if (fieldName.equals("name")) {
+    if ("name".equals(fieldName)) {
       return name;
     }
-    if (fieldName.equals("region")) {
+    if ("region".equals(fieldName)) {
       return region;
     }
-    if (fieldName.equals("selfLink")) {
+    if ("selfLink".equals(fieldName)) {
       return selfLink;
     }
-    if (fieldName.equals("status")) {
+    if ("status".equals(fieldName)) {
       return status;
     }
-    if (fieldName.equals("users")) {
+    if ("users".equals(fieldName)) {
       return users;
     }
     return null;
@@ -1715,22 +1715,22 @@ public final class AddressAggregatedList implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("id")) {
+    if ("id".equals(fieldName)) {
       return id;
     }
-    if (fieldName.equals("items")) {
+    if ("items".equals(fieldName)) {
       return items;
     }
-    if (fieldName.equals("kind")) {
+    if ("kind".equals(fieldName)) {
       return kind;
     }
-    if (fieldName.equals("nextPageToken")) {
+    if ("nextPageToken".equals(fieldName)) {
       return nextPageToken;
     }
-    if (fieldName.equals("selfLink")) {
+    if ("selfLink".equals(fieldName)) {
       return selfLink;
     }
-    if (fieldName.equals("warning")) {
+    if ("warning".equals(fieldName)) {
       return warning;
     }
     return null;
@@ -2016,10 +2016,10 @@ public final class AddressesScopedList implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("addresses")) {
+    if ("addresses".equals(fieldName)) {
       return addresses;
     }
-    if (fieldName.equals("warning")) {
+    if ("warning".equals(fieldName)) {
       return warning;
     }
     return null;
@@ -2232,19 +2232,19 @@ public final class AddressList implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("id")) {
+    if ("id".equals(fieldName)) {
       return id;
     }
-    if (fieldName.equals("items")) {
+    if ("items".equals(fieldName)) {
       return items;
     }
-    if (fieldName.equals("kind")) {
+    if ("kind".equals(fieldName)) {
       return kind;
     }
-    if (fieldName.equals("nextPageToken")) {
+    if ("nextPageToken".equals(fieldName)) {
       return nextPageToken;
     }
-    if (fieldName.equals("selfLink")) {
+    if ("selfLink".equals(fieldName)) {
       return selfLink;
     }
     return null;
@@ -2517,10 +2517,10 @@ public final class Data implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("value")) {
+    if ("value".equals(fieldName)) {
       return value;
     }
     return null;
@@ -2706,7 +2706,7 @@ public final class DUMMYObject implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("name")) {
+    if ("name".equals(fieldName)) {
       return name;
     }
     return null;
@@ -2889,22 +2889,22 @@ public final class DummyObject2 implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("floatie")) {
+    if ("floatie".equals(fieldName)) {
       return floatie;
     }
-    if (fieldName.equals("iPProtocol")) {
+    if ("iPProtocol".equals(fieldName)) {
       return iPProtocol;
     }
-    if (fieldName.equals("name")) {
+    if ("name".equals(fieldName)) {
       return name;
     }
-    if (fieldName.equals("precisionFloatie")) {
+    if ("precisionFloatie".equals(fieldName)) {
       return precisionFloatie;
     }
-    if (fieldName.equals("primaryAddress")) {
+    if ("primaryAddress".equals(fieldName)) {
       return primaryAddress;
     }
-    if (fieldName.equals("secondaryAddress")) {
+    if ("secondaryAddress".equals(fieldName)) {
       return secondaryAddress;
     }
     return null;
@@ -3186,7 +3186,7 @@ public final class Error implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("errors")) {
+    if ("errors".equals(fieldName)) {
       return errors;
     }
     return null;
@@ -3367,13 +3367,13 @@ public final class Errors implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("code")) {
+    if ("code".equals(fieldName)) {
       return code;
     }
-    if (fieldName.equals("location")) {
+    if ("location".equals(fieldName)) {
       return location;
     }
-    if (fieldName.equals("message")) {
+    if ("message".equals(fieldName)) {
       return message;
     }
     return null;
@@ -3671,73 +3671,73 @@ public final class Operation implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("clientOperationId")) {
+    if ("clientOperationId".equals(fieldName)) {
       return clientOperationId;
     }
-    if (fieldName.equals("creationTimestamp")) {
+    if ("creationTimestamp".equals(fieldName)) {
       return creationTimestamp;
     }
-    if (fieldName.equals("description")) {
+    if ("description".equals(fieldName)) {
       return description;
     }
-    if (fieldName.equals("endTime")) {
+    if ("endTime".equals(fieldName)) {
       return endTime;
     }
-    if (fieldName.equals("error")) {
+    if ("error".equals(fieldName)) {
       return error;
     }
-    if (fieldName.equals("httpErrorMessage")) {
+    if ("httpErrorMessage".equals(fieldName)) {
       return httpErrorMessage;
     }
-    if (fieldName.equals("httpErrorStatusCode")) {
+    if ("httpErrorStatusCode".equals(fieldName)) {
       return httpErrorStatusCode;
     }
-    if (fieldName.equals("id")) {
+    if ("id".equals(fieldName)) {
       return id;
     }
-    if (fieldName.equals("insertTime")) {
+    if ("insertTime".equals(fieldName)) {
       return insertTime;
     }
-    if (fieldName.equals("kind")) {
+    if ("kind".equals(fieldName)) {
       return kind;
     }
-    if (fieldName.equals("name")) {
+    if ("name".equals(fieldName)) {
       return name;
     }
-    if (fieldName.equals("operationType")) {
+    if ("operationType".equals(fieldName)) {
       return operationType;
     }
-    if (fieldName.equals("progress")) {
+    if ("progress".equals(fieldName)) {
       return progress;
     }
-    if (fieldName.equals("region")) {
+    if ("region".equals(fieldName)) {
       return region;
     }
-    if (fieldName.equals("selfLink")) {
+    if ("selfLink".equals(fieldName)) {
       return selfLink;
     }
-    if (fieldName.equals("startTime")) {
+    if ("startTime".equals(fieldName)) {
       return startTime;
     }
-    if (fieldName.equals("status")) {
+    if ("status".equals(fieldName)) {
       return status;
     }
-    if (fieldName.equals("statusMessage")) {
+    if ("statusMessage".equals(fieldName)) {
       return statusMessage;
     }
-    if (fieldName.equals("targetId")) {
+    if ("targetId".equals(fieldName)) {
       return targetId;
     }
-    if (fieldName.equals("targetLink")) {
+    if ("targetLink".equals(fieldName)) {
       return targetLink;
     }
-    if (fieldName.equals("user")) {
+    if ("user".equals(fieldName)) {
       return user;
     }
-    if (fieldName.equals("warnings")) {
+    if ("warnings".equals(fieldName)) {
       return warnings;
     }
-    if (fieldName.equals("zone")) {
+    if ("zone".equals(fieldName)) {
       return zone;
     }
     return null;
@@ -4446,13 +4446,13 @@ public final class ProjectsGetDummyObjectResources implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("kind")) {
+    if ("kind".equals(fieldName)) {
       return kind;
     }
-    if (fieldName.equals("nextPageToken")) {
+    if ("nextPageToken".equals(fieldName)) {
       return nextPageToken;
     }
-    if (fieldName.equals("resources")) {
+    if ("resources".equals(fieldName)) {
       return resources;
     }
     return null;
@@ -4681,13 +4681,13 @@ public final class Warning implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("code")) {
+    if ("code".equals(fieldName)) {
       return code;
     }
-    if (fieldName.equals("data")) {
+    if ("data".equals(fieldName)) {
       return data;
     }
-    if (fieldName.equals("message")) {
+    if ("message".equals(fieldName)) {
       return message;
     }
     return null;
@@ -4916,13 +4916,13 @@ public final class Warnings implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("code")) {
+    if ("code".equals(fieldName)) {
       return code;
     }
-    if (fieldName.equals("data")) {
+    if ("data".equals(fieldName)) {
       return data;
     }
-    if (fieldName.equals("message")) {
+    if ("message".equals(fieldName)) {
       return message;
     }
     return null;
@@ -5187,40 +5187,40 @@ public final class AggregatedListAddressesHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("filter")) {
+    if ("filter".equals(fieldName)) {
       return filter;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("maxResults")) {
+    if ("maxResults".equals(fieldName)) {
       return maxResults;
     }
-    if (fieldName.equals("orderBy")) {
+    if ("orderBy".equals(fieldName)) {
       return orderBy;
     }
-    if (fieldName.equals("pageToken")) {
+    if ("pageToken".equals(fieldName)) {
       return pageToken;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("project")) {
+    if ("project".equals(fieldName)) {
       return project;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -5681,28 +5681,28 @@ public final class DeleteAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("address")) {
+    if ("address".equals(fieldName)) {
       return address;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -6067,28 +6067,28 @@ public final class DeleteDummyObjectHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("dummyObject")) {
+    if ("dummyObject".equals(fieldName)) {
       return dummyObject;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -6453,28 +6453,28 @@ public final class GetAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("address")) {
+    if ("address".equals(fieldName)) {
       return address;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -6839,28 +6839,28 @@ public final class GetResourceDummyObjectHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("resource")) {
+    if ("resource".equals(fieldName)) {
       return resource;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -7229,31 +7229,31 @@ public final class InsertAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("addressResource")) {
+    if ("addressResource".equals(fieldName)) {
       return addressResource;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("region")) {
+    if ("region".equals(fieldName)) {
       return region;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -7658,40 +7658,40 @@ public final class ListAddressesHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("filter")) {
+    if ("filter".equals(fieldName)) {
       return filter;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("maxResults")) {
+    if ("maxResults".equals(fieldName)) {
       return maxResults;
     }
-    if (fieldName.equals("orderBy")) {
+    if ("orderBy".equals(fieldName)) {
       return orderBy;
     }
-    if (fieldName.equals("pageToken")) {
+    if ("pageToken".equals(fieldName)) {
       return pageToken;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("region")) {
+    if ("region".equals(fieldName)) {
       return region;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -8164,37 +8164,37 @@ public final class ListResourcesDummyObjectsHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("maxResults")) {
+    if ("maxResults".equals(fieldName)) {
       return maxResults;
     }
-    if (fieldName.equals("orderBy")) {
+    if ("orderBy".equals(fieldName)) {
       return orderBy;
     }
-    if (fieldName.equals("pageToken")) {
+    if ("pageToken".equals(fieldName)) {
       return pageToken;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("project")) {
+    if ("project".equals(fieldName)) {
       return project;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -8647,40 +8647,40 @@ public final class PatchAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("address")) {
+    if ("address".equals(fieldName)) {
       return address;
     }
-    if (fieldName.equals("addressResource")) {
+    if ("addressResource".equals(fieldName)) {
       return addressResource;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fieldMask")) {
+    if ("fieldMask".equals(fieldName)) {
       return fieldMask;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("region")) {
+    if ("region".equals(fieldName)) {
       return region;
     }
-    if (fieldName.equals("requestId")) {
+    if ("requestId".equals(fieldName)) {
       return requestId;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;
@@ -9161,37 +9161,37 @@ public final class UpdateAddressHttpRequest implements ApiMessage {
 
   @Override
   public Object getFieldValue(String fieldName) {
-    if (fieldName.equals("access_token")) {
+    if ("access_token".equals(fieldName)) {
       return access_token;
     }
-    if (fieldName.equals("address")) {
+    if ("address".equals(fieldName)) {
       return address;
     }
-    if (fieldName.equals("addressResource")) {
+    if ("addressResource".equals(fieldName)) {
       return addressResource;
     }
-    if (fieldName.equals("callback")) {
+    if ("callback".equals(fieldName)) {
       return callback;
     }
-    if (fieldName.equals("fieldMask")) {
+    if ("fieldMask".equals(fieldName)) {
       return fieldMask;
     }
-    if (fieldName.equals("fields")) {
+    if ("fields".equals(fieldName)) {
       return fields;
     }
-    if (fieldName.equals("key")) {
+    if ("key".equals(fieldName)) {
       return key;
     }
-    if (fieldName.equals("prettyPrint")) {
+    if ("prettyPrint".equals(fieldName)) {
       return prettyPrint;
     }
-    if (fieldName.equals("quotaUser")) {
+    if ("quotaUser".equals(fieldName)) {
       return quotaUser;
     }
-    if (fieldName.equals("requestId")) {
+    if ("requestId".equals(fieldName)) {
       return requestId;
     }
-    if (fieldName.equals("userIp")) {
+    if ("userIp".equals(fieldName)) {
       return userIp;
     }
     return null;

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute.v1.json
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute.v1.json
@@ -623,6 +623,10 @@
     "secondaryAddress": {
      "$ref": "Address",
      "description": "Address two."
+    },
+    "IPProtocol": {
+     "type": "string",
+     "description": "The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp), or the IP protocol number."
     }
    }
   },


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-java/issues/4292.

The Gson util serializes a class by mapping the class's field names to the field's values. However, the class field names are not always the names used in the Discovery doc (names are sometimes escaped or in lowerCamelCase), and this makes Gson render the wrong field name.

This PR annotates fields that have a different name from the Discovery doc field with `@SerializedName`, which Gson will use to override the class's field name.