### PR TITLE
Samplegen: Slightly refactor samplegen infrastructure and correctly import everything Java needs

### DIFF
--- a/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
@@ -82,6 +82,7 @@ public abstract class InitCodeContext {
         .collect(ImmutableList.toImmutableList());
   }
 
+  /** Returns a copy of this initCodeContext, but with an empty symbolTable. */
   public InitCodeContext cloneWithEmptySymbolTable() {
     return newBuilder()
         .initObjectType(initObjectType())

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
@@ -82,6 +82,22 @@ public abstract class InitCodeContext {
         .collect(ImmutableList.toImmutableList());
   }
 
+  public InitCodeContext cloneWithEmptySymbolTable() {
+    return newBuilder()
+        .initObjectType(initObjectType())
+        .suggestedName(suggestedName())
+        .symbolTable(new SymbolTable())
+        .initFields(initFields())
+        .initValueConfigMap(initValueConfigMap())
+        .fieldConfigMap(fieldConfigMap())
+        .outputType(outputType())
+        .additionalInitCodeNodes(additionalInitCodeNodes())
+        .initFieldConfigStrings(initFieldConfigStrings())
+        .sampleParamConfigMap(sampleParamConfigMap())
+        .valueGenerator(valueGenerator())
+        .build();
+  }
+
   /**
    * Allows additional InitCodeNode objects which will be placed into the generated subtrees. This
    * is currently used by smoke testing only.

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
@@ -84,19 +84,7 @@ public abstract class InitCodeContext {
 
   /** Returns a copy of this initCodeContext, but with an empty symbolTable. */
   public InitCodeContext cloneWithEmptySymbolTable() {
-    return newBuilder()
-        .initObjectType(initObjectType())
-        .suggestedName(suggestedName())
-        .symbolTable(new SymbolTable())
-        .initFields(initFields())
-        .initValueConfigMap(initValueConfigMap())
-        .fieldConfigMap(fieldConfigMap())
-        .outputType(outputType())
-        .additionalInitCodeNodes(additionalInitCodeNodes())
-        .initFieldConfigStrings(initFieldConfigStrings())
-        .sampleParamConfigMap(sampleParamConfigMap())
-        .valueGenerator(valueGenerator())
-        .build();
+    return toBuilder().symbolTable(new SymbolTable()).build();
   }
 
   /**
@@ -121,6 +109,8 @@ public abstract class InitCodeContext {
         .initFieldConfigStrings(ImmutableList.of())
         .sampleParamConfigMap(ImmutableMap.of());
   }
+
+  abstract Builder toBuilder();
 
   @AutoValue.Builder
   public abstract static class Builder {

--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -63,7 +63,11 @@ public class DynamicLangApiMethodTransformer {
       SampleType sampleType) {
     this.apiMethodParamTransformer = apiMethodParamTransformer;
     this.initCodeTransformer = initCodeTransformer;
-    this.sampleTransformer = new SampleTransformer(sampleType);
+    this.sampleTransformer =
+        SampleTransformer.newBuilder()
+            .sampleType(sampleType)
+            .initCodeTransformer(initCodeTransformer)
+            .build();
   }
 
   public DynamicLangApiMethodTransformer(
@@ -73,7 +77,12 @@ public class DynamicLangApiMethodTransformer {
       OutputTransformer outputTransformer) {
     this.apiMethodParamTransformer = apiMethodParamTransformer;
     this.initCodeTransformer = initCodeTransformer;
-    this.sampleTransformer = new SampleTransformer(sampleType, outputTransformer);
+    this.sampleTransformer =
+        SampleTransformer.newBuilder()
+            .sampleType(sampleType)
+            .outputTransformer(outputTransformer)
+            .initCodeTransformer(initCodeTransformer)
+            .build();
   }
 
   public OptionalArrayMethodView generateMethod(GapicMethodContext context) {
@@ -236,9 +245,6 @@ public class DynamicLangApiMethodTransformer {
         initContext,
         context.getMethodConfig().getRequiredFieldConfigs(),
         initCodeOutputType,
-        initCodeContext ->
-            initCodeTransformer.generateInitCode(
-                context.cloneWithEmptyTypeTable(), initCodeContext),
         callingForms);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -40,7 +40,6 @@ import java.util.List;
  */
 public class DynamicLangApiMethodTransformer {
   private final ApiMethodParamTransformer apiMethodParamTransformer;
-  private final InitCodeTransformer initCodeTransformer;
   private final LongRunningTransformer lroTransformer = new LongRunningTransformer();
   private final HeaderRequestParamTransformer headerRequestParamTransformer =
       new HeaderRequestParamTransformer();
@@ -48,45 +47,13 @@ public class DynamicLangApiMethodTransformer {
   private final SampleTransformer sampleTransformer;
 
   public DynamicLangApiMethodTransformer(ApiMethodParamTransformer apiMethodParamTransformer) {
-    this(apiMethodParamTransformer, new InitCodeTransformer());
+    this(apiMethodParamTransformer, SampleTransformer.create(SampleType.IN_CODE));
   }
 
   public DynamicLangApiMethodTransformer(
-      ApiMethodParamTransformer apiMethodParamTransformer,
-      InitCodeTransformer initCodeTransformer) {
-    this(apiMethodParamTransformer, initCodeTransformer, SampleType.IN_CODE);
-  }
-
-  public DynamicLangApiMethodTransformer(
-      ApiMethodParamTransformer apiMethodParamTransformer,
-      InitCodeTransformer initCodeTransformer,
-      SampleType sampleType) {
+      ApiMethodParamTransformer apiMethodParamTransformer, SampleTransformer sampleTransformer) {
     this.apiMethodParamTransformer = apiMethodParamTransformer;
-    this.initCodeTransformer = initCodeTransformer;
-    this.sampleTransformer =
-        SampleTransformer.newBuilder()
-            .sampleType(sampleType)
-            .initCodeTransformer(initCodeTransformer)
-            .sampleImportTransformer(
-                new SampleImportTransformer(initCodeTransformer.getImportSectionTransformer()))
-            .build();
-  }
-
-  public DynamicLangApiMethodTransformer(
-      ApiMethodParamTransformer apiMethodParamTransformer,
-      InitCodeTransformer initCodeTransformer,
-      SampleType sampleType,
-      OutputTransformer outputTransformer,
-      SampleImportTransformer sampleImportTransformer) {
-    this.apiMethodParamTransformer = apiMethodParamTransformer;
-    this.initCodeTransformer = initCodeTransformer;
-    this.sampleTransformer =
-        SampleTransformer.newBuilder()
-            .sampleType(sampleType)
-            .outputTransformer(outputTransformer)
-            .initCodeTransformer(initCodeTransformer)
-            .sampleImportTransformer(sampleImportTransformer)
-            .build();
+    this.sampleTransformer = sampleTransformer;
   }
 
   public OptionalArrayMethodView generateMethod(GapicMethodContext context) {

--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -67,6 +67,8 @@ public class DynamicLangApiMethodTransformer {
         SampleTransformer.newBuilder()
             .sampleType(sampleType)
             .initCodeTransformer(initCodeTransformer)
+            .sampleImportTransformer(
+                new SampleImportTransformer(initCodeTransformer.getImportSectionTransformer()))
             .build();
   }
 
@@ -74,7 +76,8 @@ public class DynamicLangApiMethodTransformer {
       ApiMethodParamTransformer apiMethodParamTransformer,
       InitCodeTransformer initCodeTransformer,
       SampleType sampleType,
-      OutputTransformer outputTransformer) {
+      OutputTransformer outputTransformer,
+      SampleImportTransformer sampleImportTransformer) {
     this.apiMethodParamTransformer = apiMethodParamTransformer;
     this.initCodeTransformer = initCodeTransformer;
     this.sampleTransformer =
@@ -82,6 +85,7 @@ public class DynamicLangApiMethodTransformer {
             .sampleType(sampleType)
             .outputTransformer(outputTransformer)
             .initCodeTransformer(initCodeTransformer)
+            .sampleImportTransformer(sampleImportTransformer)
             .build();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -105,6 +105,10 @@ public class InitCodeTransformer {
     this.generateUserFacingComments = generateUserFacingComments;
   }
 
+  public ImportSectionTransformer getImportSectionTransformer() {
+    return this.importSectionTransformer;
+  }
+
   /** Generates initialization code from the given MethodContext and InitCodeContext objects. */
   public InitCodeView generateInitCode(
       MethodContext methodContext, InitCodeContext initCodeContext) {
@@ -114,6 +118,24 @@ public class InitCodeTransformer {
     } else {
       return buildInitCodeViewRequestObject(methodContext, initCodeContext, rootNode);
     }
+  }
+
+  public Iterable<InitCodeNode> getInitCodeNodes(
+      MethodContext methodContext, InitCodeContext initCodeContext) {
+    initCodeContext = initCodeContext.cloneWithEmptySymbolTable();
+    InitCodeNode root = InitCodeNode.createTree(initCodeContext);
+    List<InitCodeNode> orderedItems;
+    if (initCodeContext.outputType() == InitCodeOutputType.FieldList) {
+      orderedItems = root.listInInitializationOrder();
+      orderedItems.remove(orderedItems.size() - 1);
+    } else {
+      orderedItems = root.listInInitializationOrder();
+    }
+    for (InitCodeNode param : sampleFuncParams(root, initCodeContext.sampleArgStrings())) {
+      List<InitCodeNode> paramInits = param.listInInitializationOrder();
+      orderedItems.removeAll(paramInits);
+    }
+    return orderedItems;
   }
 
   public InitCodeContext createRequestInitCodeContext(

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -120,16 +120,13 @@ public class InitCodeTransformer {
     }
   }
 
-  public Iterable<InitCodeNode> getInitCodeNodes(
+  public List<InitCodeNode> getInitCodeNodes(
       MethodContext methodContext, InitCodeContext initCodeContext) {
-    initCodeContext = initCodeContext.cloneWithEmptySymbolTable();
     InitCodeNode root = InitCodeNode.createTree(initCodeContext);
-    List<InitCodeNode> orderedItems;
+    List<InitCodeNode> orderedItems = root.listInInitializationOrder();
     if (initCodeContext.outputType() == InitCodeOutputType.FieldList) {
-      orderedItems = root.listInInitializationOrder();
+      // Remove the request object for flattened method
       orderedItems.remove(orderedItems.size() - 1);
-    } else {
-      orderedItems = root.listInInitializationOrder();
     }
     for (InitCodeNode param : sampleFuncParams(root, initCodeContext.sampleArgStrings())) {
       List<InitCodeNode> paramInits = param.listInInitializationOrder();

--- a/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
@@ -23,10 +23,21 @@ import java.util.List;
 /** Generates an ImportSection for standalone samples. */
 public interface SampleImportTransformer {
 
+  /** Adds all the types to import referenced in the rpc call part of a sample. */
   void addSampleBodyImports(MethodContext context, CallingForm form);
 
+  /**
+   * Adds all the types to import referenced in the output handling part of a sample. The output
+   * handling does something with the object returned by RPC call, and is usually right above the
+   * closed region tag.
+   */
   void addOutputImports(MethodContext context, List<OutputView> views);
 
+  /**
+   * Adds all the types to import referenced in the initCode part of sample. The initCode is
+   * responsible for setting up the rpc call request object and/or parameters, and is usually right
+   * below the open region tag.
+   */
   void addInitCodeImports(
       MethodContext context, ImportTypeTable initCodeTypeTable, Iterable<InitCodeNode> nodes);
 

--- a/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
@@ -28,12 +28,17 @@ public class SampleImportTransformer {
     this.importSectionTransformer = importSectionTransformer;
   }
 
-  protected void addSampleBodyImports(MethodContext context, CallingForm form) {}
+  protected void addSampleBodyImports(MethodContext context, CallingForm form) {
+    // default behavior: no types used in the sample body needs to be imported
+  }
 
-  protected void addOutputImports(MethodContext context, List<OutputView> views) {}
+  protected void addOutputImports(MethodContext context, List<OutputView> views) {
+    // default behavior: no types used in the output part of a sample needs to be imported
+  }
 
   protected void addInitCodeImports(
       MethodContext context, ImportTypeTable initCodeTypeTable, Iterable<InitCodeNode> nodes) {
+    // by default, copy over all types from initCodeTypeTable
     initCodeTypeTable
         .getImports()
         .values()

--- a/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
@@ -20,6 +20,7 @@ import com.google.api.codegen.viewmodel.ImportSectionView;
 import com.google.api.codegen.viewmodel.OutputView;
 import java.util.List;
 
+/** Generates an ImportSection for standalone samples. */
 public class SampleImportTransformer {
 
   private final ImportSectionTransformer importSectionTransformer;

--- a/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
@@ -21,40 +21,14 @@ import com.google.api.codegen.viewmodel.OutputView;
 import java.util.List;
 
 /** Generates an ImportSection for standalone samples. */
-public class SampleImportTransformer {
+public interface SampleImportTransformer {
 
-  private final ImportSectionTransformer importSectionTransformer;
+  void addSampleBodyImports(MethodContext context, CallingForm form);
 
-  public SampleImportTransformer(ImportSectionTransformer importSectionTransformer) {
-    this.importSectionTransformer = importSectionTransformer;
-  }
+  void addOutputImports(MethodContext context, List<OutputView> views);
 
-  protected void addSampleBodyImports(MethodContext context, CallingForm form) {
-    // default behavior: no types used in the sample body needs to be imported
-  }
+  void addInitCodeImports(
+      MethodContext context, ImportTypeTable initCodeTypeTable, Iterable<InitCodeNode> nodes);
 
-  protected void addOutputImports(MethodContext context, List<OutputView> views) {
-    // default behavior: no types used in the output part of a sample needs to be imported
-  }
-
-  protected void addInitCodeImports(
-      MethodContext context, ImportTypeTable initCodeTypeTable, Iterable<InitCodeNode> nodes) {
-    // by default, copy over all types from initCodeTypeTable
-    initCodeTypeTable
-        .getImports()
-        .values()
-        .forEach(t -> context.getTypeTable().getAndSaveNicknameFor(t));
-  }
-
-  public ImportSectionView toImportSectionView(
-      MethodContext context,
-      CallingForm form,
-      List<OutputView> views,
-      ImportTypeTable initCodeTypeTable,
-      Iterable<InitCodeNode> nodes) {
-    addSampleBodyImports(context, form);
-    addOutputImports(context, views);
-    addInitCodeImports(context, initCodeTypeTable, nodes);
-    return importSectionTransformer.generateImportSection(context, nodes);
-  }
+  ImportSectionView generateImportSection(MethodContext context);
 }

--- a/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
@@ -1,0 +1,54 @@
+/* Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer;
+
+import com.google.api.codegen.metacode.InitCodeNode;
+import com.google.api.codegen.viewmodel.CallingForm;
+import com.google.api.codegen.viewmodel.ImportSectionView;
+import com.google.api.codegen.viewmodel.OutputView;
+import java.util.List;
+
+public class SampleImportTransformer {
+
+  private final ImportSectionTransformer importSectionTransformer;
+
+  public SampleImportTransformer(ImportSectionTransformer importSectionTransformer) {
+    this.importSectionTransformer = importSectionTransformer;
+  }
+
+  protected void addSampleBodyImports(MethodContext context, CallingForm form) {}
+
+  protected void addOutputImports(MethodContext context, List<OutputView> views) {}
+
+  protected void addInitCodeImports(
+      MethodContext context, ImportTypeTable initCodeTypeTable, Iterable<InitCodeNode> nodes) {
+    initCodeTypeTable
+        .getImports()
+        .values()
+        .forEach(t -> context.getImportTypeTable().getAndSaveNicknameFor(t));
+  }
+
+  public ImportSectionView toImportSectionView(
+      MethodContext context,
+      CallingForm form,
+      List<OutputView> views,
+      ImportTypeTable initCodeTypeTable,
+      Iterable<InitCodeNode> nodes) {
+    addSampleBodyImports(methodContext, form);
+    addOutputImports(methodContext, views);
+    addInitCodeImports(methodContext, initCodeTypeTable, nodes);
+    return importSectionTransformer.generateImportSection(methodContext, nodes);
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleImportTransformer.java
@@ -37,7 +37,7 @@ public class SampleImportTransformer {
     initCodeTypeTable
         .getImports()
         .values()
-        .forEach(t -> context.getImportTypeTable().getAndSaveNicknameFor(t));
+        .forEach(t -> context.getTypeTable().getAndSaveNicknameFor(t));
   }
 
   public ImportSectionView toImportSectionView(
@@ -46,9 +46,9 @@ public class SampleImportTransformer {
       List<OutputView> views,
       ImportTypeTable initCodeTypeTable,
       Iterable<InitCodeNode> nodes) {
-    addSampleBodyImports(methodContext, form);
-    addOutputImports(methodContext, views);
-    addInitCodeImports(methodContext, initCodeTypeTable, nodes);
-    return importSectionTransformer.generateImportSection(methodContext, nodes);
+    addSampleBodyImports(context, form);
+    addOutputImports(context, views);
+    addInitCodeImports(context, initCodeTypeTable, nodes);
+    return importSectionTransformer.generateImportSection(context, nodes);
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -273,7 +273,7 @@ public abstract class SampleTransformer {
         .sampleInitCode(initCodeView)
         .outputs(outputViews)
         .outputImports( // TODO(hzyi): remove outputImports once we implement
-                        // PythonSampleImportTransformer
+            // PythonSampleImportTransformer
             outputTransformer()
                 .getOutputImportTransformer()
                 .generateOutputImports(methodContext, outputViews))

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -194,29 +194,7 @@ public abstract class SampleTransformer {
 
     List<MethodSampleView> methodSampleViews = new ArrayList<>();
     MethodConfig methodConfig = methodContext.getMethodConfig();
-
-    // For backwards compatibility in the configs, we need to use sample_code_init_fields instead
-    // to generate the samples in various scenarios. Once all the configs have been migrated to
-    // use the SampleSpec, we can delete the code below as well as sample_code_init_fields.
-    String defaultId =
-        (sampleType() == SampleType.IN_CODE) ? "sample_code_init_field" : INIT_CODE_SHIM;
-
-    ImmutableList<ValueSetAndTags> defaultValueSets =
-        ImmutableList.of(
-            ValueSetAndTags.newBuilder()
-                .values(
-                    SampleValueSet.newBuilder()
-                        .setParameters(
-                            SampleParameters.newBuilder()
-                                .addAllDefaults(methodConfig.getSampleCodeInitFields())
-                                .build())
-                        .setId(defaultId)
-                        .setDescription("value set imported from sample_code_init_fields")
-                        .setTitle("Sample Values")
-                        .build())
-                .regionTag("")
-                .build());
-
+    ImmutableList<ValueSetAndTags> defaultValueSets = defaultValueSets(methodConfig);
     for (CallingForm form : callingForms) {
       List<ValueSetAndTags> matchingValueSets =
           methodConfig.getSampleSpec().getMatchingValueSets(form, sampleType());
@@ -320,6 +298,30 @@ public abstract class SampleTransformer {
         .outputType(initCodeOutputType)
         .fieldConfigMap(FieldConfig.toFieldConfigMap(fieldConfigs))
         .build();
+  }
+
+  private ImmutableList<ValueSetAndTags> defaultValueSets(MethodConfig methodConfig) {
+    // For backwards compatibility in the configs, we need to use sample_code_init_fields instead
+    // to generate the samples in various scenarios. Once all the configs have been migrated to
+    // use the SampleSpec, we can delete the code below as well as sample_code_init_fields.
+    String defaultId =
+        (sampleType() == SampleType.IN_CODE) ? "sample_code_init_field" : INIT_CODE_SHIM;
+    ImmutableList<ValueSetAndTags> defaultValueSets =
+        ImmutableList.of(
+            ValueSetAndTags.newBuilder()
+                .values(
+                    SampleValueSet.newBuilder()
+                        .setParameters(
+                            SampleParameters.newBuilder()
+                                .addAllDefaults(methodConfig.getSampleCodeInitFields())
+                                .build())
+                        .setId(defaultId)
+                        .setDescription("value set imported from sample_code_init_fields")
+                        .setTitle("Sample Values")
+                        .build())
+                .regionTag("")
+                .build());
+    return defaultValueSets;
   }
 
   private ImmutableMap<String, SampleParameterConfig> sampleParamConfigMapFromValueSet(

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -64,7 +64,7 @@ public abstract class SampleTransformer {
         .initCodeTransformer(new InitCodeTransformer())
         .outputTransformer(new OutputTransformer())
         .sampleImportTransformer(
-            new SampleImportTransformer(new StandardImportSectionTransformer()));
+            new StandardSampleImportTransformer(new StandardImportSectionTransformer()));
   }
 
   @AutoValue.Builder
@@ -234,17 +234,18 @@ public abstract class SampleTransformer {
     }
     ImmutableList<OutputView> outputViews =
         outputTransformer().toViews(outputs, methodContext, valueSet);
+    sampleImportTransformer().addSampleBodyImports(methodContext, form);
+    sampleImportTransformer().addOutputImports(methodContext, outputViews);
+    sampleImportTransformer()
+        .addInitCodeImports(
+            methodContext,
+            methodContext.getTypeTable(),
+            initCodeTransformer()
+                .getInitCodeNodes(
+                    methodContext,
+                    initCodeContext.cloneWithEmptySymbolTable())); // to avoid symbol collision
     ImportSectionView sampleImportSectionView =
-        sampleImportTransformer()
-            .toImportSectionView(
-                methodContext,
-                form,
-                outputViews,
-                methodContext.getTypeTable(),
-                initCodeTransformer()
-                    .getInitCodeNodes(
-                        methodContext,
-                        initCodeContext.cloneWithEmptySymbolTable())); // to avoid symbol collision
+        sampleImportTransformer().generateImportSection(methodContext);
     return MethodSampleView.newBuilder()
         .callingForm(form)
         .valueSet(SampleValueSetView.of(valueSet))

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -50,6 +50,11 @@ import java.util.List;
 @AutoValue
 public abstract class SampleTransformer {
 
+  private static final InitCodeTransformer defaultInitCodeTransformer = new InitCodeTransformer();
+  private static final OutputTransformer defaultOutputTransformer = new OutputTransformer();
+  private static final SampleImportTransformer defaultSampleImportTransformer =
+      new StandardSampleImportTransformer(new StandardImportSectionTransformer());
+
   public abstract SampleType sampleType();
 
   public abstract InitCodeTransformer initCodeTransformer();
@@ -61,10 +66,9 @@ public abstract class SampleTransformer {
   public static Builder newBuilder() {
     return new AutoValue_SampleTransformer.Builder()
         .sampleType(SampleType.IN_CODE)
-        .initCodeTransformer(new InitCodeTransformer())
-        .outputTransformer(new OutputTransformer())
-        .sampleImportTransformer(
-            new StandardSampleImportTransformer(new StandardImportSectionTransformer()));
+        .initCodeTransformer(defaultInitCodeTransformer)
+        .outputTransformer(defaultOutputTransformer)
+        .sampleImportTransformer(defaultSampleImportTransformer);
   }
 
   @AutoValue.Builder

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -55,10 +55,14 @@ public abstract class SampleTransformer {
 
   public abstract OutputTransformer outputTransformer();
 
+  public abstract SampleImportTransformer sampleImportTransformer();
+
   public static Builder newBuilder() {
     return new AutoValue_SampleTransformer.Builder()
         .initCodeTransformer(new InitCodeTransformer())
-        .outputTransformer(new OutputTransformer());
+        .outputTransformer(new OutputTransformer())
+        .sampleImportTransformer(
+            new SampleImportTransformer(new StandardImportSectionTransformer()));
   }
 
   @AutoValue.Builder
@@ -69,6 +73,8 @@ public abstract class SampleTransformer {
     public abstract Builder initCodeTransformer(InitCodeTransformer val);
 
     public abstract Builder outputTransformer(OutputTransformer val);
+
+    public abstract Builder sampleImportTransformer(SampleImportTransformer val);
 
     public abstract SampleTransformer build();
   }
@@ -239,9 +245,6 @@ public abstract class SampleTransformer {
       MethodContext methodContext,
       InitCodeContext initCodeContext) {
     methodContext = methodContext.cloneWithEmptyTypeTable();
-    SampleImportTransformer importTransformer =
-        new SampleImportTransformer(
-            initCodeTransformer().getImportSectionTransformer(), methodContext);
     InitCodeView initCodeView =
         initCodeTransformer().generateInitCode(methodContext, initCodeContext);
     SampleValueSet valueSet = setAndTag.values();
@@ -252,11 +255,13 @@ public abstract class SampleTransformer {
     ImmutableList<OutputView> outputViews =
         outputTransformer().toViews(outputs, methodContext, valueSet);
     ImportSectionView sampleImportSectionView =
-        importTransformer.toImportSectionView(
-            form,
-            outputViews,
-            methodContext.getTypeTable(),
-            initCodeTransformer().getInitCodeNodes(methodContext, initCodeContext));
+        sampleImportTransformer()
+            .toImportSectionView(
+                methodContext,
+                form,
+                outputViews,
+                methodContext.getTypeTable(),
+                initCodeTransformer().getInitCodeNodes(methodContext, initCodeContext));
     return MethodSampleView.newBuilder()
         .callingForm(form)
         .valueSet(SampleValueSetView.of(valueSet))

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -264,16 +264,14 @@ public abstract class SampleTransformer {
                 initCodeTransformer()
                     .getInitCodeNodes(
                         methodContext,
-                        initCodeContext
-                            .cloneWithEmptySymbolTable())); // to avoid symbol collision, since we
-    // are only interested in types
+                        initCodeContext.cloneWithEmptySymbolTable())); // to avoid symbol collision
     return MethodSampleView.newBuilder()
         .callingForm(form)
         .valueSet(SampleValueSetView.of(valueSet))
         .sampleInitCode(initCodeView)
         .outputs(outputViews)
-        .outputImports( // TODO(hzyi): remove outputImports once we implement
-            // PythonSampleImportTransformer
+        .outputImports(
+            // TODO(hzyi): remove outputImports once we implement PythonSampleImportTransformer
             outputTransformer()
                 .getOutputImportTransformer()
                 .generateOutputImports(methodContext, outputViews))

--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -261,13 +261,19 @@ public abstract class SampleTransformer {
                 form,
                 outputViews,
                 methodContext.getTypeTable(),
-                initCodeTransformer().getInitCodeNodes(methodContext, initCodeContext));
+                initCodeTransformer()
+                    .getInitCodeNodes(
+                        methodContext,
+                        initCodeContext
+                            .cloneWithEmptySymbolTable())); // to avoid symbol collision, since we
+    // are only interested in types
     return MethodSampleView.newBuilder()
         .callingForm(form)
         .valueSet(SampleValueSetView.of(valueSet))
         .sampleInitCode(initCodeView)
         .outputs(outputViews)
-        .outputImports(
+        .outputImports( // TODO(hzyi): remove outputImports once we implement
+                        // PythonSampleImportTransformer
             outputTransformer()
                 .getOutputImportTransformer()
                 .generateOutputImports(methodContext, outputViews))

--- a/src/main/java/com/google/api/codegen/transformer/StandardSampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StandardSampleImportTransformer.java
@@ -1,0 +1,53 @@
+/* Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer;
+
+import com.google.api.codegen.metacode.InitCodeNode;
+import com.google.api.codegen.viewmodel.CallingForm;
+import com.google.api.codegen.viewmodel.ImportSectionView;
+import com.google.api.codegen.viewmodel.OutputView;
+import java.util.Collections;
+import java.util.List;
+
+public class StandardSampleImportTransformer implements SampleImportTransformer {
+
+  private final ImportSectionTransformer importSectionTransformer;
+
+  public StandardSampleImportTransformer(ImportSectionTransformer importSectionTransformer) {
+    this.importSectionTransformer = importSectionTransformer;
+  }
+
+  public void addSampleBodyImports(MethodContext context, CallingForm form) {
+    // default behavior: no types used in the sample body needs to be imported
+  }
+
+  public void addOutputImports(MethodContext context, List<OutputView> views) {
+    // default behavior: no types used in the output part of a sample needs to be imported
+  }
+
+  public void addInitCodeImports(
+      MethodContext context, ImportTypeTable initCodeTypeTable, Iterable<InitCodeNode> nodes) {
+    // by default, copy over all types from initCodeTypeTable
+    initCodeTypeTable
+        .getImports()
+        .values()
+        .forEach(t -> context.getTypeTable().getAndSaveNicknameFor(t));
+  }
+
+  public ImportSectionView generateImportSection(MethodContext context) {
+    return importSectionTransformer.generateImportSection(
+        context, Collections.<InitCodeNode>emptyList());
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/StandardSampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StandardSampleImportTransformer.java
@@ -30,11 +30,11 @@ public class StandardSampleImportTransformer implements SampleImportTransformer 
   }
 
   public void addSampleBodyImports(MethodContext context, CallingForm form) {
-    // default behavior: no types used in the sample body needs to be imported
+    // default behavior: no types used in the sample body need to be imported
   }
 
   public void addOutputImports(MethodContext context, List<OutputView> views) {
-    // default behavior: no types used in the output part of a sample needs to be imported
+    // default behavior: no types used in the output part of a sample need to be imported
   }
 
   public void addInitCodeImports(

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -52,7 +52,6 @@ import java.util.List;
  * languages.
  */
 public class StaticLangApiMethodTransformer {
-  private final InitCodeTransformer initCodeTransformer;
   private final LongRunningTransformer lroTransformer = new LongRunningTransformer();
   private final StaticLangResourceObjectTransformer resourceObjectTransformer =
       new StaticLangResourceObjectTransformer();
@@ -60,41 +59,12 @@ public class StaticLangApiMethodTransformer {
       new HeaderRequestParamTransformer();
   private final SampleTransformer sampleTransformer;
 
-  public StaticLangApiMethodTransformer(SampleType sampleType) {
-    this.initCodeTransformer = new InitCodeTransformer();
-    this.sampleTransformer = SampleTransformer.create(sampleType);
-  }
-
-  public StaticLangApiMethodTransformer(
-      SampleType sampleType,
-      InitCodeTransformer initCodeTransformer,
-      OutputTransformer outputTransformer) {
-    this.initCodeTransformer = initCodeTransformer;
-    this.sampleTransformer =
-        SampleTransformer.newBuilder()
-            .sampleType(sampleType)
-            .initCodeTransformer(initCodeTransformer)
-            .outputTransformer(outputTransformer)
-            .build();
-  }
-
-  public StaticLangApiMethodTransformer(
-      SampleType sampleType,
-      InitCodeTransformer initCodeTransformer,
-      OutputTransformer outputTransformer,
-      SampleImportTransformer sampleImportTransformer) {
-    this.initCodeTransformer = initCodeTransformer;
-    this.sampleTransformer =
-        SampleTransformer.newBuilder()
-            .sampleType(sampleType)
-            .initCodeTransformer(initCodeTransformer)
-            .outputTransformer(outputTransformer)
-            .sampleImportTransformer(sampleImportTransformer)
-            .build();
+  public StaticLangApiMethodTransformer(SampleTransformer sampleTransformer) {
+    this.sampleTransformer = sampleTransformer;
   }
 
   public StaticLangApiMethodTransformer() {
-    this(SampleType.IN_CODE);
+    this(SampleTransformer.create(SampleType.IN_CODE));
   }
 
   public StaticLangApiMethodView generatePagedFlattenedMethod(MethodContext context) {

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -78,6 +78,21 @@ public class StaticLangApiMethodTransformer {
             .build();
   }
 
+  public StaticLangApiMethodTransformer(
+      SampleType sampleType,
+      InitCodeTransformer initCodeTransformer,
+      OutputTransformer outputTransformer,
+      SampleImportTransformer sampleImportTransformer) {
+    this.initCodeTransformer = initCodeTransformer;
+    this.sampleTransformer =
+        SampleTransformer.newBuilder()
+            .sampleType(sampleType)
+            .initCodeTransformer(initCodeTransformer)
+            .outputTransformer(outputTransformer)
+            .sampleImportTransformer(sampleImportTransformer)
+            .build();
+  }
+
   public StaticLangApiMethodTransformer() {
     this(SampleType.IN_CODE);
   }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
@@ -64,7 +64,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer<Pr
   private final StaticLangApiMethodTransformer apiMethodTransformer =
       new CSharpApiMethodTransformer();
   private final CSharpCommonTransformer csharpCommonTransformer = new CSharpCommonTransformer();
-  private final SampleTransformer sampleTransformer = new SampleTransformer(SampleType.IN_CODE);
+  private final SampleTransformer sampleTransformer = SampleTransformer.create(SampleType.IN_CODE);
   private final InitCodeTransformer initCodeTransformer = new InitCodeTransformer();
 
   public CSharpGapicSnippetsTransformer(GapicCodePathMapper pathMapper) {
@@ -525,13 +525,12 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer<Pr
     // This is a bit hacky, but fixes the problem that initcode is generated using a different
     // context. Without this, the per-snippet imports don't get included in the snippet file.
     StaticLangApiMethodView.Builder builder = method.toBuilder();
-    sampleTransformer.generateSamples(
-        builder,
-        context,
-        fieldConfigs,
-        initCodeOutputType,
-        initCodeContext -> initCodeTransformer.generateInitCode(context, initCodeContext),
-        Arrays.asList(callingForm));
+    SampleTransformer.newBuilder()
+        .initCodeTransformer(initCodeTransformer)
+        .sampleType(SampleType.IN_CODE)
+        .build()
+        .generateSamples(
+            builder, context, fieldConfigs, initCodeOutputType, Arrays.asList(callingForm));
     return builder.build();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
@@ -22,7 +22,6 @@ import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PageStreamingConfig;
 import com.google.api.codegen.config.ProtoApiModel;
-import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
@@ -64,8 +63,9 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer<Pr
   private final StaticLangApiMethodTransformer apiMethodTransformer =
       new CSharpApiMethodTransformer();
   private final CSharpCommonTransformer csharpCommonTransformer = new CSharpCommonTransformer();
-  private final SampleTransformer sampleTransformer = SampleTransformer.create(SampleType.IN_CODE);
   private final InitCodeTransformer initCodeTransformer = new InitCodeTransformer();
+  private final SampleTransformer sampleTransformer =
+      SampleTransformer.newBuilder().initCodeTransformer(initCodeTransformer).build();
 
   public CSharpGapicSnippetsTransformer(GapicCodePathMapper pathMapper) {
     this.pathMapper = pathMapper;
@@ -525,12 +525,8 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer<Pr
     // This is a bit hacky, but fixes the problem that initcode is generated using a different
     // context. Without this, the per-snippet imports don't get included in the snippet file.
     StaticLangApiMethodView.Builder builder = method.toBuilder();
-    SampleTransformer.newBuilder()
-        .initCodeTransformer(initCodeTransformer)
-        .sampleType(SampleType.IN_CODE)
-        .build()
-        .generateSamples(
-            builder, context, fieldConfigs, initCodeOutputType, Arrays.asList(callingForm));
+    sampleTransformer.generateSamples(
+        builder, context, fieldConfigs, initCodeOutputType, Arrays.asList(callingForm));
     return builder.build();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
@@ -21,8 +21,10 @@ import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.InterfaceContext;
 import com.google.api.codegen.transformer.MethodContext;
+import com.google.api.codegen.transformer.OutputTransformer;
 import com.google.api.codegen.transformer.StaticLangApiMethodTransformer;
 import com.google.api.codegen.viewmodel.CallingForm;
 import com.google.api.codegen.viewmodel.StaticLangApiMethodView;
@@ -41,7 +43,12 @@ public class JavaMethodViewGenerator {
   final StaticLangApiMethodTransformer clientMethodTransformer;
 
   public JavaMethodViewGenerator(SampleType sampleType) {
-    clientMethodTransformer = new StaticLangApiMethodTransformer(sampleType);
+    clientMethodTransformer =
+        new StaticLangApiMethodTransformer(
+            sampleType,
+            new InitCodeTransformer(),
+            new OutputTransformer(),
+            new JavaSampleImportTransformer());
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
@@ -21,10 +21,8 @@ import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.transformer.ImportTypeTable;
-import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.InterfaceContext;
 import com.google.api.codegen.transformer.MethodContext;
-import com.google.api.codegen.transformer.OutputTransformer;
 import com.google.api.codegen.transformer.SampleTransformer;
 import com.google.api.codegen.transformer.StaticLangApiMethodTransformer;
 import com.google.api.codegen.viewmodel.CallingForm;
@@ -48,8 +46,6 @@ public class JavaMethodViewGenerator {
         new StaticLangApiMethodTransformer(
             SampleTransformer.newBuilder()
                 .sampleType(sampleType)
-                .initCodeTransformer(new InitCodeTransformer())
-                .outputTransformer(new OutputTransformer())
                 .sampleImportTransformer(new JavaSampleImportTransformer())
                 .build());
   }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
@@ -25,6 +25,7 @@ import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.InterfaceContext;
 import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.OutputTransformer;
+import com.google.api.codegen.transformer.SampleTransformer;
 import com.google.api.codegen.transformer.StaticLangApiMethodTransformer;
 import com.google.api.codegen.viewmodel.CallingForm;
 import com.google.api.codegen.viewmodel.StaticLangApiMethodView;
@@ -45,10 +46,12 @@ public class JavaMethodViewGenerator {
   public JavaMethodViewGenerator(SampleType sampleType) {
     clientMethodTransformer =
         new StaticLangApiMethodTransformer(
-            sampleType,
-            new InitCodeTransformer(),
-            new OutputTransformer(),
-            new JavaSampleImportTransformer());
+            SampleTransformer.newBuilder()
+                .sampleType(sampleType)
+                .initCodeTransformer(new InitCodeTransformer())
+                .outputTransformer(new OutputTransformer())
+                .sampleImportTransformer(new JavaSampleImportTransformer())
+                .build());
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
@@ -1,0 +1,88 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer.java;
+
+import com.google.api.codegen.config.FieldConfig;
+import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.MethodContext;
+import com.google.api.codegen.transformer.SampleImportTransformer;
+import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.viewmodel.CallingForm;
+
+public class JavaSampleImportTransformer extends SampleImportTransformer {
+
+  public JavaSampleImportTransformer() {
+    super(new StandardImportSectionTransformer());
+  }
+
+  @Override
+  public void addSampleBodyImports(MethodContext context, CallingForm form) {
+    ImportTypeTable typeTable = context.getTypeTable();
+    MethodModel method = context.getMethodModel();
+    SurfaceNamer namer = context.getNamer();
+    switch (form) {
+      case Request:
+      case Flattened:
+        saveResponseTypeName(context);
+        break;
+      case RequestPaged:
+        saveResourceTypeName(context);
+        break;
+      case FlattendPaged:
+      case CallablePaged:
+        typeTable.saveNicknameFor("com.google.api.common.ApiFuture");
+        context.getMethodModel().getAndSaveResponseTypeName(typeTable, namer);
+        saveResourceTypeName(context);
+        break;
+      case Callable:
+        typeTable.saveNicknameFor("com.google.api.common.ApiFuture");
+        type.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
+        saveResponseTypeName(context);
+        break;
+      case CallableList:
+      	saveResponseTypeName(context);
+      	saveResourceTypeName(context);
+      	break;
+      case CallableStreamingBidi:
+      	typeTable.saveNicknameFor("com.google.api.gax.rpc.BidiStreamingCallable");
+      	type.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
+      	break;
+      case CallableStreamingClient:
+      	
+      case CallableStreamingServer:
+      case LongrunningCallable:
+      case LongrunningFlattenedAsync:
+        LongrunningRequestAsync:
+        break;
+    }
+  }
+
+  private void saveResourceTypeName(MethodContext context) {
+    FieldConfig resourceFieldConfig =
+        context.getMethodConfig().getPageStreaming().getResourcesFieldConfig();
+    if (context.getFeatureConfig().useResourceNameFormatOption(resourceFieldConfig)) {
+      namer.getAndSaveElementResourceTypeName(typeTable, resourceFieldConfig);
+    } else {
+      typeTable.getAndSaveNicknameForElementType(resourceField);
+    }
+  }
+
+  private void saveResponseTypeName(MethodContext context) {
+    if (!method.isOutputTypeEmpty()) {
+      context.getMethodModel().getAndSaveResponseTypeName(typeTable, namer);
+    }
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
@@ -61,7 +61,6 @@ public class JavaSampleImportTransformer extends SampleImportTransformer {
       case Callable:
         typeTable.saveNicknameFor(API_FUTURE);
         typeTable.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
-        saveResponseTypeName(context);
         break;
       case CallableList:
         saveResponseTypeName(context);
@@ -81,7 +80,6 @@ public class JavaSampleImportTransformer extends SampleImportTransformer {
         break;
       case LongRunningCallable:
         typeTable.saveNicknameFor(OPERATION_FUTURE);
-        typeTable.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
         saveResponseTypeNameForLongRunningMethod(context);
         break;
       case LongRunningFlattenedAsync:

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
@@ -17,6 +17,7 @@ package com.google.api.codegen.transformer.java;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.TypeModel;
+import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.transformer.ImportTypeTable;
 import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.SampleImportTransformer;
@@ -29,8 +30,7 @@ import java.util.List;
 public class JavaSampleImportTransformer extends SampleImportTransformer {
 
   private static final String API_FUTURE = "com.google.api.common.ApiFuture";
-  private static final String BIDI_STEAMING_CALLABLE =
-      "com.google.api.gax.rpc.BidiStreamingCallable";
+  private static final String BIDI_STEAMING_CALLABLE = "com.google.api.gax.rpc.BidiStream";
   private static final String OPERATION_FUTURE = "com.google.api.gax.longrunning.OperationFuture";
   private static final String SERVER_STREAM = "com.google.api.gax.rpc.ServerStream";
   private static final String API_STREAM_OBSERVER = "com.google.api.gax.rpc.ApiStreamObserver";
@@ -119,6 +119,35 @@ public class JavaSampleImportTransformer extends SampleImportTransformer {
           break; // fall through
         default:
           throw new IllegalArgumentException("unrecognized output view kind: " + view.kind());
+      }
+    }
+  }
+
+  protected void addInitCodeImports(
+      MethodContext context, ImportTypeTable initCodeTypeTable, Iterable<InitCodeNode> nodes) {
+    super.addInitCodeImports(context, initCodeTypeTable, nodes);
+    ImportTypeTable typeTable = context.getTypeTable();
+    for (InitCodeNode node : nodes) {
+      switch (node.getLineType()) {
+        case ListInitLine:
+          typeTable.saveNicknameFor("java.util.List");
+          typeTable.saveNicknameFor("java.util.Arrays");
+          break;
+        case MapInitLine:
+          typeTable.saveNicknameFor("java.util.Map");
+          typeTable.saveNicknameFor("java.util.HashMap");
+          break;
+        case ReadFileInitLine:
+          typeTable.saveNicknameFor("java.nio.Files");
+          typeTable.saveNicknameFor("java.nio.File");
+          typeTable.saveNicknameFor("java.nio.Paths");
+          typeTable.saveNicknameFor("java.nio.Path");
+          break;
+        case SimpleInitLine:
+        case StructureInitLine:
+          break; // fall through
+        default:
+          throw new IllegalArgumentException("Unrecognized line type: " + node.getLineType());
       }
     }
   }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
@@ -16,20 +16,31 @@ package com.google.api.codegen.transformer.java;
 
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.TypeModel;
 import com.google.api.codegen.transformer.ImportTypeTable;
 import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.SampleImportTransformer;
+import com.google.api.codegen.transformer.StandardImportSectionTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.viewmodel.CallingForm;
+import com.google.api.codegen.viewmodel.OutputView;
+import java.util.List;
 
 public class JavaSampleImportTransformer extends SampleImportTransformer {
+
+  private static final String API_FUTURE = "com.google.api.common.ApiFuture";
+  private static final String BIDI_STEAMING_CALLABLE =
+      "com.google.api.gax.rpc.BidiStreamingCallable";
+  private static final String OPERATION_FUTURE = "com.google.api.gax.longrunning.OperationFuture";
+  private static final String SERVER_STREAM = "com.google.api.gax.rpc.ServerStream";
+  private static final String API_STREAM_OBSERVER = "com.google.api.gax.rpc.ApiStreamObserver";
 
   public JavaSampleImportTransformer() {
     super(new StandardImportSectionTransformer());
   }
 
   @Override
-  public void addSampleBodyImports(MethodContext context, CallingForm form) {
+  protected void addSampleBodyImports(MethodContext context, CallingForm form) {
     ImportTypeTable typeTable = context.getTypeTable();
     MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
@@ -41,32 +52,74 @@ public class JavaSampleImportTransformer extends SampleImportTransformer {
       case RequestPaged:
         saveResourceTypeName(context);
         break;
-      case FlattendPaged:
+      case FlattenedPaged:
       case CallablePaged:
-        typeTable.saveNicknameFor("com.google.api.common.ApiFuture");
-        context.getMethodModel().getAndSaveResponseTypeName(typeTable, namer);
+        typeTable.saveNicknameFor(API_FUTURE);
+        saveResponseTypeName(context);
         saveResourceTypeName(context);
         break;
       case Callable:
-        typeTable.saveNicknameFor("com.google.api.common.ApiFuture");
-        type.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
+        typeTable.saveNicknameFor(API_FUTURE);
+        typeTable.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
         saveResponseTypeName(context);
         break;
       case CallableList:
-      	saveResponseTypeName(context);
-      	saveResourceTypeName(context);
-      	break;
-      case CallableStreamingBidi:
-      	typeTable.saveNicknameFor("com.google.api.gax.rpc.BidiStreamingCallable");
-      	type.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
-      	break;
-      case CallableStreamingClient:
-      	
-      case CallableStreamingServer:
-      case LongrunningCallable:
-      case LongrunningFlattenedAsync:
-        LongrunningRequestAsync:
+        saveResponseTypeName(context);
+        saveResourceTypeName(context);
         break;
+      case CallableStreamingBidi:
+        typeTable.saveNicknameFor(BIDI_STEAMING_CALLABLE);
+        typeTable.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
+        break;
+      case CallableStreamingClient:
+        typeTable.saveNicknameFor(API_STREAM_OBSERVER);
+        typeTable.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
+        break;
+      case CallableStreamingServer:
+        typeTable.saveNicknameFor(SERVER_STREAM);
+        typeTable.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
+        break;
+      case LongRunningCallable:
+        typeTable.saveNicknameFor(OPERATION_FUTURE);
+        typeTable.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
+        saveResponseTypeNameForLongRunningMethod(context);
+        break;
+      case LongRunningFlattenedAsync:
+      case LongRunningRequestAsync:
+        saveResponseTypeNameForLongRunningMethod(context);
+        break;
+    }
+  }
+
+  @Override
+  protected void addOutputImports(MethodContext context, List<OutputView> views) {
+    ImportTypeTable typeTable = context.getTypeTable();
+    for (OutputView view : views) {
+      switch (view.kind()) {
+        case DEFINE:
+          TypeModel type = ((OutputView.DefineView) view).reference().type();
+          if (type != null) {
+            typeTable.getAndSaveNicknameFor(type);
+          } else {
+            saveResourceTypeName(context);
+          }
+          break;
+        case LOOP:
+          OutputView.LoopView loopView = (OutputView.LoopView) view;
+          type = loopView.collection().type();
+          if (type != null) {
+            typeTable.getAndSaveNicknameFor(type.makeOptional());
+          } else {
+            saveResourceTypeName(context);
+          }
+          addOutputImports(context, loopView.body());
+          break;
+        case COMMENT:
+        case PRINT:
+          break; // fall through
+        default:
+          throw new IllegalArgumentException("unrecognized output view kind: " + view.kind());
+      }
     }
   }
 
@@ -74,15 +127,25 @@ public class JavaSampleImportTransformer extends SampleImportTransformer {
     FieldConfig resourceFieldConfig =
         context.getMethodConfig().getPageStreaming().getResourcesFieldConfig();
     if (context.getFeatureConfig().useResourceNameFormatOption(resourceFieldConfig)) {
-      namer.getAndSaveElementResourceTypeName(typeTable, resourceFieldConfig);
+      context
+          .getNamer()
+          .getAndSaveElementResourceTypeName(context.getTypeTable(), resourceFieldConfig);
     } else {
-      typeTable.getAndSaveNicknameForElementType(resourceField);
+      context.getTypeTable().getAndSaveNicknameForElementType(resourceFieldConfig.getField());
     }
   }
 
   private void saveResponseTypeName(MethodContext context) {
-    if (!method.isOutputTypeEmpty()) {
-      context.getMethodModel().getAndSaveResponseTypeName(typeTable, namer);
+    if (!context.getMethodModel().isOutputTypeEmpty()) {
+      context
+          .getMethodModel()
+          .getAndSaveResponseTypeName(context.getTypeTable(), context.getNamer());
     }
+  }
+
+  private void saveResponseTypeNameForLongRunningMethod(MethodContext context) {
+    context
+        .getTypeTable()
+        .getAndSaveNicknameFor(context.getMethodConfig().getLongRunningConfig().getReturnType());
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
@@ -20,14 +20,14 @@ import com.google.api.codegen.config.TypeModel;
 import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.transformer.ImportTypeTable;
 import com.google.api.codegen.transformer.MethodContext;
-import com.google.api.codegen.transformer.SampleImportTransformer;
 import com.google.api.codegen.transformer.StandardImportSectionTransformer;
+import com.google.api.codegen.transformer.StandardSampleImportTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.viewmodel.CallingForm;
 import com.google.api.codegen.viewmodel.OutputView;
 import java.util.List;
 
-public class JavaSampleImportTransformer extends SampleImportTransformer {
+public class JavaSampleImportTransformer extends StandardSampleImportTransformer {
 
   private static final String API_FUTURE = "com.google.api.common.ApiFuture";
   private static final String BIDI_STEAMING_CALLABLE = "com.google.api.gax.rpc.BidiStream";
@@ -40,7 +40,7 @@ public class JavaSampleImportTransformer extends SampleImportTransformer {
   }
 
   @Override
-  protected void addSampleBodyImports(MethodContext context, CallingForm form) {
+  public void addSampleBodyImports(MethodContext context, CallingForm form) {
     ImportTypeTable typeTable = context.getTypeTable();
     MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
@@ -90,7 +90,7 @@ public class JavaSampleImportTransformer extends SampleImportTransformer {
   }
 
   @Override
-  protected void addOutputImports(MethodContext context, List<OutputView> views) {
+  public void addOutputImports(MethodContext context, List<OutputView> views) {
     ImportTypeTable typeTable = context.getTypeTable();
     for (OutputView view : views) {
       switch (view.kind()) {
@@ -121,7 +121,7 @@ public class JavaSampleImportTransformer extends SampleImportTransformer {
     }
   }
 
-  protected void addInitCodeImports(
+  public void addInitCodeImports(
       MethodContext context, ImportTypeTable initCodeTypeTable, Iterable<InitCodeNode> nodes) {
     super.addInitCodeImports(context, initCodeTypeTable, nodes);
     ImportTypeTable typeTable = context.getTypeTable();

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSamplesTransformer.java
@@ -29,6 +29,7 @@ import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SampleFileRegistry;
+import com.google.api.codegen.transformer.SampleTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.js.JSTypeTable;
 import com.google.api.codegen.viewmodel.DynamicLangSampleView;
@@ -55,8 +56,10 @@ public class NodeJSGapicSamplesTransformer implements ModelToViewTransformer<Pro
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
       new DynamicLangApiMethodTransformer(
           new NodeJSApiMethodParamTransformer(),
-          new InitCodeTransformer(new NodeJSImportSectionTransformer()),
-          SampleType.STANDALONE);
+          SampleTransformer.newBuilder()
+              .initCodeTransformer(new InitCodeTransformer(new NodeJSImportSectionTransformer()))
+              .sampleType(SampleType.STANDALONE)
+              .build());
   private final NodeJSMethodViewGenerator methodGenerator =
       new NodeJSMethodViewGenerator(apiMethodTransformer);
   private final PackageMetadataConfig packageConfig;

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSamplesTransformer.java
@@ -51,13 +51,15 @@ public class NodeJSGapicSamplesTransformer implements ModelToViewTransformer<Pro
   private static final String STANDALONE_SAMPLE_TEMPLATE_FILENAME = "nodejs/standalone_sample.snip";
 
   private final GapicCodePathMapper pathMapper;
+  private final NodeJSImportSectionTransformer importSectionTransformer =
+      new NodeJSImportSectionTransformer();
   private final FileHeaderTransformer fileHeaderTransformer =
-      new FileHeaderTransformer(new NodeJSImportSectionTransformer());
+      new FileHeaderTransformer(importSectionTransformer);
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
       new DynamicLangApiMethodTransformer(
           new NodeJSApiMethodParamTransformer(),
           SampleTransformer.newBuilder()
-              .initCodeTransformer(new InitCodeTransformer(new NodeJSImportSectionTransformer()))
+              .initCodeTransformer(new InitCodeTransformer(importSectionTransformer))
               .sampleType(SampleType.STANDALONE)
               .build());
   private final NodeJSMethodViewGenerator methodGenerator =

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
@@ -24,7 +24,6 @@ import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProtoApiModel;
-import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.nodejs.NodeJSUtils;
@@ -264,10 +263,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
       GapicMethodContext context, boolean packageHasMultipleServices) {
     OptionalArrayMethodView apiMethodView =
         new NodeJSMethodViewGenerator(
-                new DynamicLangApiMethodTransformer(
-                    new NodeJSApiMethodParamTransformer(),
-                    new InitCodeTransformer(),
-                    SampleType.IN_CODE))
+                new DynamicLangApiMethodTransformer(new NodeJSApiMethodParamTransformer()))
             .generateOneApiMethod(
                 context,
                 testCaseTransformer.createSmokeTestInitContext(context),

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -23,7 +23,6 @@ import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.ProductServiceConfig;
 import com.google.api.codegen.config.ProtoApiModel;
-import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.config.TypeModel;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
@@ -34,7 +33,6 @@ import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
 import com.google.api.codegen.transformer.GapicMethodContext;
 import com.google.api.codegen.transformer.GrpcStubTransformer;
-import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.PageStreamingTransformer;
@@ -72,8 +70,7 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer<Pro
   private final FileHeaderTransformer fileHeaderTransformer =
       new FileHeaderTransformer(new NodeJSImportSectionTransformer());
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
-      new DynamicLangApiMethodTransformer(
-          new NodeJSApiMethodParamTransformer(), new InitCodeTransformer(), SampleType.IN_CODE);
+      new DynamicLangApiMethodTransformer(new NodeJSApiMethodParamTransformer());
   private final NodeJSMethodViewGenerator methodGenerator =
       new NodeJSMethodViewGenerator(apiMethodTransformer);
   private final ServiceTransformer serviceTransformer = new ServiceTransformer();

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -24,7 +24,6 @@ import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.ProductConfig;
 import com.google.api.codegen.config.ProtoApiModel;
-import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.config.VersionBound;
 import com.google.api.codegen.nodejs.NodeJSUtils;
 import com.google.api.codegen.transformer.DynamicLangApiMethodTransformer;
@@ -32,7 +31,6 @@ import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
 import com.google.api.codegen.transformer.GapicMethodContext;
 import com.google.api.codegen.transformer.GrpcStubTransformer;
-import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.PackageMetadataTransformer;
@@ -162,10 +160,7 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer<
       GapicMethodContext context, boolean packageHasMultipleServices) {
     OptionalArrayMethodView apiMethodView =
         new NodeJSMethodViewGenerator(
-                new DynamicLangApiMethodTransformer(
-                    new NodeJSApiMethodParamTransformer(),
-                    new InitCodeTransformer(),
-                    SampleType.IN_CODE))
+                new DynamicLangApiMethodTransformer(new NodeJSApiMethodParamTransformer()))
             .generateOneApiMethod(
                 context,
                 testCaseTransformer.createSmokeTestInitContext(context),

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSamplesTransformer.java
@@ -31,6 +31,8 @@ import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SampleFileRegistry;
+import com.google.api.codegen.transformer.SampleImportTransformer;
+import com.google.api.codegen.transformer.SampleTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.php.PhpTypeTable;
 import com.google.api.codegen.viewmodel.DynamicLangSampleView;
@@ -52,8 +54,12 @@ public class PhpGapicSamplesTransformer implements ModelToViewTransformer<ProtoA
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
       new DynamicLangApiMethodTransformer(
           new PhpApiMethodParamTransformer(),
-          new InitCodeTransformer(new PhpImportSectionTransformer()),
-          SampleType.STANDALONE);
+          SampleTransformer.newBuilder()
+              .initCodeTransformer(new InitCodeTransformer(new PhpImportSectionTransformer()))
+              .sampleType(SampleType.STANDALONE)
+              .sampleImportTransformer(
+                  new SampleImportTransformer(new PhpImportSectionTransformer()))
+              .build());
   private final FileHeaderTransformer fileHeaderTransformer =
       new FileHeaderTransformer(new PhpImportSectionTransformer());
   private final GapicCodePathMapper pathMapper;

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSamplesTransformer.java
@@ -31,8 +31,8 @@ import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SampleFileRegistry;
-import com.google.api.codegen.transformer.SampleImportTransformer;
 import com.google.api.codegen.transformer.SampleTransformer;
+import com.google.api.codegen.transformer.StandardSampleImportTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.php.PhpTypeTable;
 import com.google.api.codegen.viewmodel.DynamicLangSampleView;
@@ -58,7 +58,7 @@ public class PhpGapicSamplesTransformer implements ModelToViewTransformer<ProtoA
               .initCodeTransformer(new InitCodeTransformer(new PhpImportSectionTransformer()))
               .sampleType(SampleType.STANDALONE)
               .sampleImportTransformer(
-                  new SampleImportTransformer(new PhpImportSectionTransformer()))
+                  new StandardSampleImportTransformer(new PhpImportSectionTransformer()))
               .build());
   private final FileHeaderTransformer fileHeaderTransformer =
       new FileHeaderTransformer(new PhpImportSectionTransformer());

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -81,7 +81,9 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer<ProtoA
   private GrpcStubTransformer grpcStubTransformer;
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
       new DynamicLangApiMethodTransformer(
-          new PhpApiMethodParamTransformer(), new InitCodeTransformer(), SampleType.IN_CODE);
+          new PhpApiMethodParamTransformer(),
+          new InitCodeTransformer(new PhpImportSectionTransformer()),
+          SampleType.IN_CODE);
   private final FileHeaderTransformer fileHeaderTransformer =
       new FileHeaderTransformer(new PhpImportSectionTransformer());
   private final PhpMethodViewGenerator methodGenerator =

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -25,7 +25,6 @@ import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProductServiceConfig;
 import com.google.api.codegen.config.ProtoApiModel;
-import com.google.api.codegen.config.SampleSpec.SampleType;
 import com.google.api.codegen.config.TypeModel;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
@@ -80,15 +79,16 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer<ProtoA
   private PathTemplateTransformer pathTemplateTransformer;
   private PageStreamingTransformer pageStreamingTransformer;
   private GrpcStubTransformer grpcStubTransformer;
+  private final PhpImportSectionTransformer importSectionTransformer =
+      new PhpImportSectionTransformer();
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
       new DynamicLangApiMethodTransformer(
           new PhpApiMethodParamTransformer(),
           SampleTransformer.newBuilder()
-              .initCodeTransformer(new InitCodeTransformer(new PhpImportSectionTransformer()))
-              .sampleType(SampleType.IN_CODE)
+              .initCodeTransformer(new InitCodeTransformer(importSectionTransformer))
               .build());
   private final FileHeaderTransformer fileHeaderTransformer =
-      new FileHeaderTransformer(new PhpImportSectionTransformer());
+      new FileHeaderTransformer(importSectionTransformer);
   private final PhpMethodViewGenerator methodGenerator =
       new PhpMethodViewGenerator(apiMethodTransformer);
   private final ProductServiceConfig productServiceConfig = new ProductServiceConfig();

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -39,6 +39,7 @@ import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.PageStreamingTransformer;
 import com.google.api.codegen.transformer.PathTemplateTransformer;
+import com.google.api.codegen.transformer.SampleTransformer;
 import com.google.api.codegen.transformer.ServiceTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.Name;
@@ -82,8 +83,10 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer<ProtoA
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
       new DynamicLangApiMethodTransformer(
           new PhpApiMethodParamTransformer(),
-          new InitCodeTransformer(new PhpImportSectionTransformer()),
-          SampleType.IN_CODE);
+          SampleTransformer.newBuilder()
+              .initCodeTransformer(new InitCodeTransformer(new PhpImportSectionTransformer()))
+              .sampleType(SampleType.IN_CODE)
+              .build());
   private final FileHeaderTransformer fileHeaderTransformer =
       new FileHeaderTransformer(new PhpImportSectionTransformer());
   private final PhpMethodViewGenerator methodGenerator =

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
@@ -35,6 +35,7 @@ import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.OutputTransformer;
 import com.google.api.codegen.transformer.SampleFileRegistry;
 import com.google.api.codegen.transformer.SampleImportTransformer;
+import com.google.api.codegen.transformer.SampleTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.py.PythonTypeTable;
 import com.google.api.codegen.viewmodel.DynamicLangSampleView;
@@ -62,11 +63,16 @@ public class PythonGapicSamplesTransformer implements ModelToViewTransformer<Pro
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
       new DynamicLangApiMethodTransformer(
           new PythonApiMethodParamTransformer(),
-          new InitCodeTransformer(importSectionTransformer),
-          sampleType,
-          new OutputTransformer(
-              new PythonSampleOutputImportTransformer(), new PythonSamplePrintArgTransformer()),
-          new SampleImportTransformer(new PythonImportSectionTransformer()));
+          SampleTransformer.newBuilder()
+              .initCodeTransformer(new InitCodeTransformer(importSectionTransformer))
+              .sampleType(sampleType)
+              .outputTransformer(
+                  new OutputTransformer(
+                      new PythonSampleOutputImportTransformer(),
+                      new PythonSamplePrintArgTransformer()))
+              .sampleImportTransformer(
+                  new SampleImportTransformer(new PythonImportSectionTransformer()))
+              .build());
   private final PythonMethodViewGenerator methodGenerator =
       new PythonMethodViewGenerator(apiMethodTransformer);
   private final GapicCodePathMapper pathMapper;

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
@@ -34,8 +34,8 @@ import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.OutputTransformer;
 import com.google.api.codegen.transformer.SampleFileRegistry;
-import com.google.api.codegen.transformer.SampleImportTransformer;
 import com.google.api.codegen.transformer.SampleTransformer;
+import com.google.api.codegen.transformer.StandardSampleImportTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.py.PythonTypeTable;
 import com.google.api.codegen.viewmodel.DynamicLangSampleView;
@@ -71,7 +71,7 @@ public class PythonGapicSamplesTransformer implements ModelToViewTransformer<Pro
                       new PythonSampleOutputImportTransformer(),
                       new PythonSamplePrintArgTransformer()))
               .sampleImportTransformer(
-                  new SampleImportTransformer(new PythonImportSectionTransformer()))
+                  new StandardSampleImportTransformer(new PythonImportSectionTransformer()))
               .build());
   private final PythonMethodViewGenerator methodGenerator =
       new PythonMethodViewGenerator(apiMethodTransformer);

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
@@ -34,6 +34,7 @@ import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.OutputTransformer;
 import com.google.api.codegen.transformer.SampleFileRegistry;
+import com.google.api.codegen.transformer.SampleImportTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.py.PythonTypeTable;
 import com.google.api.codegen.viewmodel.DynamicLangSampleView;
@@ -64,7 +65,8 @@ public class PythonGapicSamplesTransformer implements ModelToViewTransformer<Pro
           new InitCodeTransformer(importSectionTransformer),
           sampleType,
           new OutputTransformer(
-              new PythonSampleOutputImportTransformer(), new PythonSamplePrintArgTransformer()));
+              new PythonSampleOutputImportTransformer(), new PythonSamplePrintArgTransformer()),
+          new SampleImportTransformer(new PythonImportSectionTransformer()));
   private final PythonMethodViewGenerator methodGenerator =
       new PythonMethodViewGenerator(apiMethodTransformer);
   private final GapicCodePathMapper pathMapper;

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
@@ -71,7 +71,7 @@ public class PythonGapicSamplesTransformer implements ModelToViewTransformer<Pro
                       new PythonSampleOutputImportTransformer(),
                       new PythonSamplePrintArgTransformer()))
               .sampleImportTransformer(
-                  new StandardSampleImportTransformer(new PythonImportSectionTransformer()))
+                  new StandardSampleImportTransformer(importSectionTransformer))
               .build());
   private final PythonMethodViewGenerator methodGenerator =
       new PythonMethodViewGenerator(apiMethodTransformer);

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
@@ -38,7 +38,6 @@ import com.google.api.codegen.transformer.GrpcStubTransformer;
 import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
-import com.google.api.codegen.transformer.OutputTransformer;
 import com.google.api.codegen.transformer.PageStreamingTransformer;
 import com.google.api.codegen.transformer.PathTemplateTransformer;
 import com.google.api.codegen.transformer.SampleTransformer;
@@ -92,10 +91,9 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer<Pro
           new PythonApiMethodParamTransformer(),
           SampleTransformer.newBuilder()
               .sampleType(sampleType)
-              .initCodeTransformer(new InitCodeTransformer(new PythonImportSectionTransformer()))
-              .outputTransformer(new OutputTransformer())
+              .initCodeTransformer(new InitCodeTransformer(importSectionTransformer))
               .sampleImportTransformer(
-                  new StandardSampleImportTransformer(new PythonImportSectionTransformer()))
+                  new StandardSampleImportTransformer(importSectionTransformer))
               .build());
   private final PythonMethodViewGenerator methodGenerator =
       new PythonMethodViewGenerator(apiMethodTransformer);

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
@@ -38,8 +38,11 @@ import com.google.api.codegen.transformer.GrpcStubTransformer;
 import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
+import com.google.api.codegen.transformer.OutputTransformer;
 import com.google.api.codegen.transformer.PageStreamingTransformer;
 import com.google.api.codegen.transformer.PathTemplateTransformer;
+import com.google.api.codegen.transformer.SampleImportTransformer;
+import com.google.api.codegen.transformer.SampleTransformer;
 import com.google.api.codegen.transformer.ServiceTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.Name;
@@ -87,8 +90,13 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer<Pro
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
       new DynamicLangApiMethodTransformer(
           new PythonApiMethodParamTransformer(),
-          new InitCodeTransformer(importSectionTransformer),
-          sampleType);
+          SampleTransformer.newBuilder()
+              .sampleType(sampleType)
+              .initCodeTransformer(new InitCodeTransformer(new PythonImportSectionTransformer()))
+              .outputTransformer(new OutputTransformer())
+              .sampleImportTransformer(
+                  new SampleImportTransformer(new PythonImportSectionTransformer()))
+              .build());
   private final PythonMethodViewGenerator methodGenerator =
       new PythonMethodViewGenerator(apiMethodTransformer);
   private final ServiceTransformer serviceTransformer = new ServiceTransformer();

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
@@ -41,9 +41,9 @@ import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.OutputTransformer;
 import com.google.api.codegen.transformer.PageStreamingTransformer;
 import com.google.api.codegen.transformer.PathTemplateTransformer;
-import com.google.api.codegen.transformer.SampleImportTransformer;
 import com.google.api.codegen.transformer.SampleTransformer;
 import com.google.api.codegen.transformer.ServiceTransformer;
+import com.google.api.codegen.transformer.StandardSampleImportTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.NamePath;
@@ -95,7 +95,7 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer<Pro
               .initCodeTransformer(new InitCodeTransformer(new PythonImportSectionTransformer()))
               .outputTransformer(new OutputTransformer())
               .sampleImportTransformer(
-                  new SampleImportTransformer(new PythonImportSectionTransformer()))
+                  new StandardSampleImportTransformer(new PythonImportSectionTransformer()))
               .build());
   private final PythonMethodViewGenerator methodGenerator =
       new PythonMethodViewGenerator(apiMethodTransformer);

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
@@ -323,8 +323,7 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer<
             new DynamicLangApiMethodTransformer(
                 new PythonApiMethodParamTransformer(),
                 SampleTransformer.newBuilder()
-                    .initCodeTransformer(
-                        new InitCodeTransformer(new PythonImportSectionTransformer()))
+                    .initCodeTransformer(new InitCodeTransformer(importSectionTransformer))
                     .build()));
 
     return methodViewGenerator.generateOneApiMethod(context);

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
@@ -34,6 +34,7 @@ import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.PackageMetadataNamer;
 import com.google.api.codegen.transformer.PackageMetadataTransformer;
+import com.google.api.codegen.transformer.SampleTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.transformer.TestCaseTransformer;
 import com.google.api.codegen.util.py.PythonTypeTable;
@@ -321,7 +322,10 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer<
         new PythonMethodViewGenerator(
             new DynamicLangApiMethodTransformer(
                 new PythonApiMethodParamTransformer(),
-                new InitCodeTransformer(new PythonImportSectionTransformer())));
+                SampleTransformer.newBuilder()
+                    .initCodeTransformer(
+                        new InitCodeTransformer(new PythonImportSectionTransformer()))
+                    .build()));
 
     return methodViewGenerator.generateOneApiMethod(context);
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/MethodSampleView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/MethodSampleView.java
@@ -42,6 +42,8 @@ public abstract class MethodSampleView {
   /** The name of the sample function. */
   public abstract String sampleFunctionName();
 
+  public abstract ImportSectionView sampleImports();
+
   public static Builder newBuilder() {
     return new AutoValue_MethodSampleView.Builder();
   }
@@ -61,6 +63,8 @@ public abstract class MethodSampleView {
     public abstract Builder regionTag(String val);
 
     public abstract Builder sampleFunctionName(String val);
+
+    public abstract Builder sampleImports(ImportSectionView val);
 
     public abstract MethodSampleView build();
   }

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -16,8 +16,8 @@
       import org.apache.commons.cli.Options;
     @end
     // [START {@sample.regionTag}]
-    @if sample.sampleInitCode.importSection.appImports.size
-      {@importList(sample.sampleInitCode.importSection.appImports)}
+    @if sample.sampleImports.appImports.size
+      {@importList(sample.sampleImports.appImports)}
 
     @end
     public class {@sampleFile.classView.name} {

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -162,7 +162,7 @@
   // Do something
 
   @if apiMethod.hasReturnValue
-    {@apiMethod.responseTypeName} response = future.get();
+    {@apiMethod.callableMethod.genericAwareResponseType} response = future.get();
   @else
     future.get();
   @end

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -7901,12 +7901,29 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
         }
       };
 
+
   private static final BatchingDescriptor<AddCommentsRequest, Empty> ADD_COMMENTS_BATCHING_DESC =
       new BatchingDescriptor<AddCommentsRequest, Empty>() {
         @Override
         public PartitionKey getBatchPartitionKey(AddCommentsRequest request) {
           return new PartitionKey(request.getName());
         }
+=======
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START turing_prog_callable_streaming_bidi]
+import com.google.api.gax.rpc.BidiStream;
+import com.google.example.library.v1.Comment;
+import com.google.example.library.v1.DiscussBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.protobuf.ByteString;
+import java.nio.File;
+import java.nio.Files;
+import java.nio.Path;
+import java.nio.Paths;
+
 
         @Override
         public RequestBuilder<AddCommentsRequest> getRequestBuilder() {
@@ -7965,6 +7982,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   public static class Builder extends StubSettings.Builder<LibraryServiceStubSettings, Builder> {
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
 
+
     private final UnaryCallSettings.Builder<CreateShelfRequest, Shelf> createShelfSettings;
     private final UnaryCallSettings.Builder<GetShelfRequest, Shelf> getShelfSettings;
     private final PagedCallSettings.Builder<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings;
@@ -7995,6 +8013,15 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings;
     private final OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
     private final UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+=======
+// [START sample]
+import com.google.api.common.ApiFuture;
+import com.google.example.library.v1.FindRelatedBooksResponse;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import java.util.Arrays;
+import java.util.List;
+
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -8034,7 +8061,17 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     protected Builder(ClientContext clientContext) {
       super(clientContext);
 
+
       createShelfSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+=======
+// [START sample]
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+import java.util.Arrays;
+import java.util.List;
+
 
       getShelfSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
@@ -8043,7 +8080,18 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       deleteShelfSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+
       mergeShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+=======
+// [START sample]
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.FindRelatedBooksResponse;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+import java.util.Arrays;
+import java.util.List;
+
 
       createBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
@@ -8053,8 +8101,20 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       getBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+
       listBooksSettings = PagedCallSettings.newBuilder(
           LIST_BOOKS_PAGE_STR_FACT);
+=======
+// [START sample]
+import com.google.api.common.ApiFuture;
+import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.FindRelatedBooksResponse;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.ShelfName;
+import java.util.Arrays;
+import java.util.List;
+
 
       deleteBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
@@ -8075,7 +8135,18 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       getBookFromAbsolutelyAnywhereSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+
       updateBookIndexSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+=======
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
 
       streamShelvesSettings = ServerStreamingCallSettings.newBuilder();
 
@@ -8088,7 +8159,19 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       findRelatedBooksSettings = PagedCallSettings.newBuilder(
           FIND_RELATED_BOOKS_PAGE_STR_FACT);
 
+
       addTagSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+=======
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
 
       addLabelSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
@@ -8100,7 +8183,20 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       getBigNothingOperationSettings = OperationCallSettings.newBuilder();
 
+
       testOptionalRequiredFlatteningParamsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+=======
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.api.common.ApiFuture;
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.longrunning.Operation;
+
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
           createShelfSettings,
@@ -8155,9 +8251,23 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+
       builder.deleteShelfSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+=======
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START hopper]
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.longrunning.Operation;
+
 
       builder.mergeShelvesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
@@ -8219,9 +8329,17 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+
       builder.getBookFromArchiveSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+=======
+// [START sample]
+import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.example.library.v1.Comment;
+import com.google.example.library.v1.DiscussBookRequest;
+import com.google.example.library.v1.LibraryClient;
+
 
       builder.getBookFromAnywhereSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
@@ -8247,9 +8365,24 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+
       builder.addTagSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+=======
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 
       builder.addLabelSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
@@ -8310,6 +8443,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       return builder;
     }
 
+
     protected Builder(LibraryServiceStubSettings settings) {
       super(settings);
 
@@ -8343,6 +8477,16 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
       getBigNothingOperationSettings = settings.getBigNothingOperationSettings.toBuilder();
       testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
+=======
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
           createShelfSettings,
@@ -8371,6 +8515,36 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           testOptionalRequiredFlatteningParamsSettings
       );
     }
+
+=======
+    // [END canonical_core]
+  }
+
+  public static void main(String[] args) {
+    samplePublishSeries();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END canonical]
+============== file: src/main/java/samples/com/google/example/library/v1/publishseries/PublishSeriesRequestPiVersion.java ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
+package com.google.example.examples.library.v1.snippets;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 
     // NEXT_MAJOR_VER: remove 'throws Exception'
     /**
@@ -8408,12 +8582,24 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       return listShelvesSettings;
     }
 
+
     /**
      * Returns the builder for the settings used for calls to deleteShelf.
      */
     public UnaryCallSettings.Builder<DeleteShelfRequest, Empty> deleteShelfSettings() {
       return deleteShelfSettings;
     }
+=======
+// [START canonical]
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 
     /**
      * Returns the builder for the settings used for calls to mergeShelves.
@@ -8436,12 +8622,29 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       return publishSeriesSettings;
     }
 
+
     /**
      * Returns the builder for the settings used for calls to getBook.
      */
     public UnaryCallSettings.Builder<GetBookRequest, Book> getBookSettings() {
       return getBookSettings;
     }
+=======
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+// [START canonical]
+import com.google.api.common.ApiFuture;
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 
     /**
      * Returns the builder for the settings used for calls to listBooks.
@@ -8492,12 +8695,25 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       return getBookFromArchiveSettings;
     }
 
+
     /**
      * Returns the builder for the settings used for calls to getBookFromAnywhere.
      */
     public UnaryCallSettings.Builder<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings() {
       return getBookFromAnywhereSettings;
     }
+=======
+// [START canonical]
+import com.google.api.common.ApiFuture;
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.SeriesUuid;
+import com.google.example.library.v1.Shelf;
+import java.util.ArrayList;
+import java.util.List;
+
 
     /**
      * Returns the builder for the settings used for calls to getBookFromAbsolutelyAnywhere.
@@ -8534,12 +8750,20 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       return discussBookSettings;
     }
 
+
     /**
      * Returns the builder for the settings used for calls to monologAboutBook.
      */
     public StreamingCallSettings.Builder<DiscussBookRequest, Comment> monologAboutBookSettings() {
       return monologAboutBookSettings;
     }
+=======
+// [START babbage]
+import com.google.api.gax.rpc.ServerStream;
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.StreamBooksRequest;
+
 
     /**
      * Returns the builder for the settings used for calls to findRelatedBooks.
@@ -8569,6 +8793,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       return getBigBookSettings;
     }
 
+
     /**
      * Returns the builder for the settings used for calls to getBigBook.
      */
@@ -8576,6 +8801,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     public OperationCallSettings.Builder<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationSettings() {
       return getBigBookOperationSettings;
     }
+=======
+// [START sample]
+import com.google.api.gax.rpc.ServerStream;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.StreamShelvesRequest;
+import com.google.example.library.v1.StreamShelvesResponse;
+
 
     /**
      * Returns the builder for the settings used for calls to getBigNothing.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -707,7 +707,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
-import com.google.longrunning.Operation;
 
 public class GetBigBookOperationCallableLongRunningCallableWap {
   public static void sampleGetBigBook(String shelf) {
@@ -763,7 +762,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
-import com.google.longrunning.Operation;
 
 public class GetBigBookOperationCallableLongRunningCallableWap2 {
   public static void sampleGetBigBook(String shelf, String bigBookName) {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -128,6 +128,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 // [START turing_prog_callable_streaming_bidi]
+import com.google.api.gax.rpc.BidiStream;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
@@ -195,9 +196,12 @@ package com.google.example.examples.library.v1;
 
 // [START sample]
 import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
+import java.util.Arrays;
+import java.util.List;
 
 public class FindRelatedBooksCallableCallableListOdyssey {
   public static void sampleFindRelatedBooks() {
@@ -242,7 +246,12 @@ public class FindRelatedBooksCallableCallableListOdyssey {
 package com.google.example.examples.library.v1;
 
 // [START sample]
+import com.google.api.common.ApiFuture;
+import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import java.util.Arrays;
+import java.util.List;
 
 public class FindRelatedBooksFlattenedPagedOdyssey {
   public static void sampleFindRelatedBooks() {
@@ -278,10 +287,14 @@ public class FindRelatedBooksFlattenedPagedOdyssey {
 package com.google.example.examples.library.v1;
 
 // [START sample]
+import com.google.api.common.ApiFuture;
 import com.google.example.library.v1.FindRelatedBooksRequest;
+import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
+import java.util.Arrays;
+import java.util.List;
 
 public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   public static void sampleFindRelatedBooks() {
@@ -325,6 +338,8 @@ import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
+import java.util.Arrays;
+import java.util.List;
 
 public class FindRelatedBooksRequestPagedOdyssey {
   public static void sampleFindRelatedBooks() {
@@ -364,6 +379,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 // [START hopper]
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
 
@@ -409,6 +425,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 // [START hopper]
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
 
@@ -461,6 +478,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 // [START hopper]
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
@@ -510,6 +528,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 // [START hopper]
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
@@ -566,9 +585,11 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 // [START hopper]
+import com.google.api.common.ApiFuture;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
+import com.google.longrunning.Operation;
 
 public class GetBigBookCallableCallableWap {
   public static void sampleGetBigBook(String shelf) {
@@ -619,9 +640,11 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 // [START hopper]
+import com.google.api.common.ApiFuture;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
+import com.google.longrunning.Operation;
 
 public class GetBigBookCallableCallableWap2 {
   public static void sampleGetBigBook(String shelf, String bigBookName) {
@@ -679,9 +702,12 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 // [START hopper]
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
+import com.google.longrunning.Operation;
 
 public class GetBigBookOperationCallableLongRunningCallableWap {
   public static void sampleGetBigBook(String shelf) {
@@ -732,9 +758,12 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 // [START hopper]
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
+import com.google.longrunning.Operation;
 
 public class GetBigBookOperationCallableLongRunningCallableWap2 {
   public static void sampleGetBigBook(String shelf, String bigBookName) {
@@ -788,6 +817,8 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
 package com.google.example.examples.library.v1;
 
 // [START sample]
+import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
 
@@ -842,9 +873,11 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 // [START canonical]
+import com.google.api.common.ApiFuture;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
 import com.google.example.library.v1.Shelf;
 import java.util.ArrayList;
@@ -921,9 +954,11 @@ public class PublishSeriesCallableCallablePiVersion {
 package com.google.example.examples.library.v1;
 
 // [START canonical]
+import com.google.api.common.ApiFuture;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
 import com.google.example.library.v1.Shelf;
 import java.util.ArrayList;
@@ -973,6 +1008,7 @@ import org.apache.commons.cli.Options;
 // [START canonical]
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
 import com.google.example.library.v1.Shelf;
 import java.util.ArrayList;
@@ -1041,6 +1077,7 @@ package com.google.example.examples.library.v1;
 // [START canonical]
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
 import com.google.example.library.v1.Shelf;
 import java.util.ArrayList;
@@ -1081,6 +1118,7 @@ import org.apache.commons.cli.Options;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
 import com.google.example.library.v1.Shelf;
 import java.util.ArrayList;
@@ -1156,6 +1194,7 @@ package com.google.example.examples.library.v1;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
 import com.google.example.library.v1.Shelf;
 import java.util.ArrayList;
@@ -1195,6 +1234,8 @@ public class PublishSeriesRequestSecondEdition {
 package com.google.example.examples.library.v1;
 
 // [START babbage]
+import com.google.api.gax.rpc.ServerStream;
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.StreamBooksRequest;
 
@@ -1229,8 +1270,10 @@ public class StreamBooksCallableCallableStreamingServerProg {
 package com.google.example.examples.library.v1;
 
 // [START sample]
+import com.google.api.gax.rpc.ServerStream;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.StreamShelvesRequest;
+import com.google.example.library.v1.StreamShelvesResponse;
 
 public class StreamShelvesCallableCallableStreamingServerEmpty {
   public static void sampleStreamShelves() {
@@ -7901,29 +7944,12 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
         }
       };
 
-
   private static final BatchingDescriptor<AddCommentsRequest, Empty> ADD_COMMENTS_BATCHING_DESC =
       new BatchingDescriptor<AddCommentsRequest, Empty>() {
         @Override
         public PartitionKey getBatchPartitionKey(AddCommentsRequest request) {
           return new PartitionKey(request.getName());
         }
-=======
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START turing_prog_callable_streaming_bidi]
-import com.google.api.gax.rpc.BidiStream;
-import com.google.example.library.v1.Comment;
-import com.google.example.library.v1.DiscussBookRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.protobuf.ByteString;
-import java.nio.File;
-import java.nio.Files;
-import java.nio.Path;
-import java.nio.Paths;
-
 
         @Override
         public RequestBuilder<AddCommentsRequest> getRequestBuilder() {
@@ -7982,7 +8008,6 @@ import java.nio.Paths;
   public static class Builder extends StubSettings.Builder<LibraryServiceStubSettings, Builder> {
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
 
-
     private final UnaryCallSettings.Builder<CreateShelfRequest, Shelf> createShelfSettings;
     private final UnaryCallSettings.Builder<GetShelfRequest, Shelf> getShelfSettings;
     private final PagedCallSettings.Builder<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings;
@@ -8013,15 +8038,6 @@ import java.nio.Paths;
     private final UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings;
     private final OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
     private final UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
-=======
-// [START sample]
-import com.google.api.common.ApiFuture;
-import com.google.example.library.v1.FindRelatedBooksResponse;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-import java.util.Arrays;
-import java.util.List;
-
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -8061,17 +8077,7 @@ import java.util.List;
     protected Builder(ClientContext clientContext) {
       super(clientContext);
 
-
       createShelfSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
-=======
-// [START sample]
-import com.google.example.library.v1.FindRelatedBooksRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-import com.google.example.library.v1.ShelfName;
-import java.util.Arrays;
-import java.util.List;
-
 
       getShelfSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
@@ -8080,18 +8086,7 @@ import java.util.List;
 
       deleteShelfSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
-
       mergeShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
-=======
-// [START sample]
-import com.google.example.library.v1.FindRelatedBooksRequest;
-import com.google.example.library.v1.FindRelatedBooksResponse;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-import com.google.example.library.v1.ShelfName;
-import java.util.Arrays;
-import java.util.List;
-
 
       createBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
@@ -8101,20 +8096,8 @@ import java.util.List;
 
       getBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
-
       listBooksSettings = PagedCallSettings.newBuilder(
           LIST_BOOKS_PAGE_STR_FACT);
-=======
-// [START sample]
-import com.google.api.common.ApiFuture;
-import com.google.example.library.v1.FindRelatedBooksRequest;
-import com.google.example.library.v1.FindRelatedBooksResponse;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-import com.google.example.library.v1.ShelfName;
-import java.util.Arrays;
-import java.util.List;
-
 
       deleteBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
@@ -8135,18 +8118,7 @@ import java.util.List;
 
       getBookFromAbsolutelyAnywhereSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
-
       updateBookIndexSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
-=======
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-
 
       streamShelvesSettings = ServerStreamingCallSettings.newBuilder();
 
@@ -8159,19 +8131,7 @@ import com.google.example.library.v1.ShelfBookName;
       findRelatedBooksSettings = PagedCallSettings.newBuilder(
           FIND_RELATED_BOOKS_PAGE_STR_FACT);
 
-
       addTagSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
-=======
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-
 
       addLabelSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
@@ -8183,20 +8143,7 @@ import com.google.example.library.v1.ShelfBookName;
 
       getBigNothingOperationSettings = OperationCallSettings.newBuilder();
 
-
       testOptionalRequiredFlatteningParamsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
-=======
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.api.common.ApiFuture;
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-import com.google.longrunning.Operation;
-
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
           createShelfSettings,
@@ -8251,23 +8198,9 @@ import com.google.longrunning.Operation;
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
-
       builder.deleteShelfSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
-=======
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START hopper]
-import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.GetBookRequest;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
-import com.google.longrunning.Operation;
-
 
       builder.mergeShelvesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
@@ -8329,17 +8262,9 @@ import com.google.longrunning.Operation;
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
-
       builder.getBookFromArchiveSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
-=======
-// [START sample]
-import com.google.api.gax.rpc.ApiStreamObserver;
-import com.google.example.library.v1.Comment;
-import com.google.example.library.v1.DiscussBookRequest;
-import com.google.example.library.v1.LibraryClient;
-
 
       builder.getBookFromAnywhereSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
@@ -8365,24 +8290,9 @@ import com.google.example.library.v1.LibraryClient;
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
-
       builder.addTagSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
-=======
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesResponse;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
 
       builder.addLabelSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
@@ -8443,7 +8353,6 @@ import java.util.List;
       return builder;
     }
 
-
     protected Builder(LibraryServiceStubSettings settings) {
       super(settings);
 
@@ -8477,16 +8386,6 @@ import java.util.List;
       getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
       getBigNothingOperationSettings = settings.getBigNothingOperationSettings.toBuilder();
       testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
-=======
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesResponse;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
           createShelfSettings,
@@ -8515,36 +8414,6 @@ import java.util.List;
           testOptionalRequiredFlatteningParamsSettings
       );
     }
-
-=======
-    // [END canonical_core]
-  }
-
-  public static void main(String[] args) {
-    samplePublishSeries();
-  }
-}
-// FIXME: Insert here clean-up code.
-
-// [END canonical]
-============== file: src/main/java/samples/com/google/example/library/v1/publishseries/PublishSeriesRequestPiVersion.java ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
-package com.google.example.examples.library.v1.snippets;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.PublishSeriesResponse;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
 
     // NEXT_MAJOR_VER: remove 'throws Exception'
     /**
@@ -8582,24 +8451,12 @@ import java.util.List;
       return listShelvesSettings;
     }
 
-
     /**
      * Returns the builder for the settings used for calls to deleteShelf.
      */
     public UnaryCallSettings.Builder<DeleteShelfRequest, Empty> deleteShelfSettings() {
       return deleteShelfSettings;
     }
-=======
-// [START canonical]
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.PublishSeriesResponse;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
 
     /**
      * Returns the builder for the settings used for calls to mergeShelves.
@@ -8622,29 +8479,12 @@ import java.util.List;
       return publishSeriesSettings;
     }
 
-
     /**
      * Returns the builder for the settings used for calls to getBook.
      */
     public UnaryCallSettings.Builder<GetBookRequest, Book> getBookSettings() {
       return getBookSettings;
     }
-=======
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-// [START canonical]
-import com.google.api.common.ApiFuture;
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.PublishSeriesResponse;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
 
     /**
      * Returns the builder for the settings used for calls to listBooks.
@@ -8695,25 +8535,12 @@ import java.util.List;
       return getBookFromArchiveSettings;
     }
 
-
     /**
      * Returns the builder for the settings used for calls to getBookFromAnywhere.
      */
     public UnaryCallSettings.Builder<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings() {
       return getBookFromAnywhereSettings;
     }
-=======
-// [START canonical]
-import com.google.api.common.ApiFuture;
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.PublishSeriesRequest;
-import com.google.example.library.v1.PublishSeriesResponse;
-import com.google.example.library.v1.SeriesUuid;
-import com.google.example.library.v1.Shelf;
-import java.util.ArrayList;
-import java.util.List;
-
 
     /**
      * Returns the builder for the settings used for calls to getBookFromAbsolutelyAnywhere.
@@ -8750,20 +8577,12 @@ import java.util.List;
       return discussBookSettings;
     }
 
-
     /**
      * Returns the builder for the settings used for calls to monologAboutBook.
      */
     public StreamingCallSettings.Builder<DiscussBookRequest, Comment> monologAboutBookSettings() {
       return monologAboutBookSettings;
     }
-=======
-// [START babbage]
-import com.google.api.gax.rpc.ServerStream;
-import com.google.example.library.v1.Book;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.StreamBooksRequest;
-
 
     /**
      * Returns the builder for the settings used for calls to findRelatedBooks.
@@ -8793,7 +8612,6 @@ import com.google.example.library.v1.StreamBooksRequest;
       return getBigBookSettings;
     }
 
-
     /**
      * Returns the builder for the settings used for calls to getBigBook.
      */
@@ -8801,13 +8619,6 @@ import com.google.example.library.v1.StreamBooksRequest;
     public OperationCallSettings.Builder<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationSettings() {
       return getBigBookOperationSettings;
     }
-=======
-// [START sample]
-import com.google.api.gax.rpc.ServerStream;
-import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.StreamShelvesRequest;
-import com.google.example.library.v1.StreamShelvesResponse;
-
 
     /**
      * Returns the builder for the settings used for calls to getBigNothing.


### PR DESCRIPTION
- Add a default `SampleImportTransformer` to take care of import section for samples. It keeps track of types to import throughout init code, sample body and output part.
- Implement `JavaSampleImportTransformer` to make the import sections for Java complete. Those for Python and PHP will come later.
- Remove `sampleGenerator` functional interface which used to generate the initcode part for samples on the fly. Instead, we store an `initCodeTransformer` as a field of `SampleTransformer` since we need use it not only to generate `initCode`, but also to generate `sampleImportSection`.
- Convert `SampleTransformer` into an `AutoValue` to prevent the number of constructors from exploding.
- Other refactors to make `SampleTransformer` cleaner.