### PR TITLE
Validate method signature [WIP]

### DIFF
--- a/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
@@ -108,7 +108,12 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
     if (!FlatteningConfigProto.getDefaultInstance().equals(methodConfigProto.getFlattening())) {
       flattening =
           FlatteningConfig.createFlatteningConfigs(
-              diagCollector, messageConfigs, resourceNameConfigs, methodConfigProto, methodModel);
+              diagCollector,
+              messageConfigs,
+              resourceNameConfigs,
+              methodConfigProto,
+              methodModel,
+              language);
       if (flattening == null) {
         error = true;
       }

--- a/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
@@ -443,15 +443,14 @@ public abstract class FlatteningConfig {
   }
 
   private void validateFlattening(TargetLanguage language) {
+    validateNoNonTerminalRepeatedField();
+
     switch (language) {
-        // TODO(andrealin): What other languages have this feature?
       case PYTHON:
       case RUBY:
+      case CSHARP:
         validateRequiredArgumentsFirst();
-        validateNoNonTerminalRepeatedField();
-        break;
       default:
-        break;
     }
   }
 }

--- a/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
@@ -446,6 +446,7 @@ public abstract class FlatteningConfig {
     switch (language) {
         // TODO(andrealin): What other languages have this feature?
       case PYTHON:
+      case RUBY:
         validateRequiredArgumentsFirst();
         validateNoNonTerminalRepeatedField();
         break;

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -144,7 +144,8 @@ public abstract class GapicMethodConfig extends MethodConfig {
               resourceNameConfigs,
               methodConfigProto,
               methodModel,
-              protoParser);
+              protoParser,
+              language);
       if (flattening == null) {
         error = true;
       }

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -482,7 +482,8 @@ public class TestCaseTransformer {
             .symbolTable(table)
             .fieldConfigMap(fieldConfigMap);
     if (context.isFlattenedMethodContext()) {
-      contextBuilder.initFields(context.getFlatteningConfig().getFlattenedFields());
+      FlatteningConfig flatteningConfig = context.getFlatteningConfig();
+      contextBuilder.initFields(FlatteningConfig.getFlattenedFields(flatteningConfig));
     }
     return contextBuilder.build();
   }

--- a/src/test/java/com/google/api/codegen/config/FlatteningConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/FlatteningConfigTest.java
@@ -1,23 +1,27 @@
 package com.google.api.codegen.config;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.common.collect.ImmutableMap;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
+import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 public class FlatteningConfigTest {
 
+  @Rule public final ExpectedException exception = ExpectedException.none();
+
   private static FieldModel repeatedField = Mockito.mock(FieldModel.class);
-  private static FieldConfig repeatedFieldConfig = FieldConfig.createDefaultFieldConfig(repeatedField);
+  private static FieldConfig repeatedFieldConfig =
+      FieldConfig.createDefaultFieldConfig(repeatedField);
 
   private static FieldModel optionalSingularField = Mockito.mock(FieldModel.class);
-  private static FieldConfig optionalSingularFieldConfig = FieldConfig.createDefaultFieldConfig(optionalSingularField);
+  private static FieldConfig optionalSingularFieldConfig =
+      FieldConfig.createDefaultFieldConfig(optionalSingularField);
 
   private static FieldModel requiredField = Mockito.mock(FieldModel.class);
-  private static FieldConfig requiredFieldConfig = FieldConfig.createDefaultFieldConfig(requiredField);
+  private static FieldConfig requiredFieldConfig =
+      FieldConfig.createDefaultFieldConfig(requiredField);
 
   private static FlatteningConfig emptyFlattening = Mockito.mock(FlatteningConfig.class);
 
@@ -28,92 +32,134 @@ public class FlatteningConfigTest {
     // Calling isRepeated and isRequired on mocks will default to "false" if not stubbed.
 
     // Only stub the construction of the FlatteningConfigs.
-    Mockito.when(emptyFlattening.getFlattenedFieldConfigs()).thenReturn(
-        ImmutableMap.of());
-    Mockito.when(emptyFlattening.validateNoNonTerminalRepeatedField()).thenCallRealMethod();
-    Mockito.when(emptyFlattening.validateRequiredArgumentsFirst()).thenCallRealMethod();
+    Mockito.when(emptyFlattening.getFlattenedFieldConfigs()).thenReturn(ImmutableMap.of());
+    Mockito.doCallRealMethod().when(emptyFlattening).validateNoNonTerminalRepeatedField();
+    Mockito.doCallRealMethod().when(emptyFlattening).validateRequiredArgumentsFirst();
   }
 
   @Test
   public void testValidateRequiredArguments() {
-
-    assertThat(emptyFlattening.validateRequiredArgumentsFirst()).isTrue();
-
-    FlatteningConfig allRequiredFields = Mockito.mock(FlatteningConfig.class);
-    Mockito.when(allRequiredFields.validateRequiredArgumentsFirst()).thenCallRealMethod();
-    Mockito.when(allRequiredFields.getFlattenedFieldConfigs()).thenReturn(
-        ImmutableMap.of(
-            "required", requiredFieldConfig,
-            "required2", requiredFieldConfig,
-            "required3", requiredFieldConfig));
-    assertThat(allRequiredFields.validateRequiredArgumentsFirst()).isTrue();
-
-    FlatteningConfig allOptionalFields = Mockito.mock(FlatteningConfig.class);
-    Mockito.when(allOptionalFields.validateRequiredArgumentsFirst()).thenCallRealMethod();
-    Mockito.when(allOptionalFields.getFlattenedFieldConfigs()).thenReturn(
-        ImmutableMap.of(
-            "optional", optionalSingularFieldConfig,
-            "optional2", optionalSingularFieldConfig,
-            "optional3", optionalSingularFieldConfig));
-    assertThat(allOptionalFields.validateRequiredArgumentsFirst()).isTrue();
-
-    FlatteningConfig mixedFieldsTrue = Mockito.mock(FlatteningConfig.class);
-    Mockito.when(mixedFieldsTrue.validateRequiredArgumentsFirst()).thenCallRealMethod();
-    Mockito.when(mixedFieldsTrue.getFlattenedFieldConfigs()).thenReturn(
-        ImmutableMap.of(
-            "required", requiredFieldConfig,
-            "optional2", optionalSingularFieldConfig,
-            "optional3", optionalSingularFieldConfig));
-    assertThat(mixedFieldsTrue.validateRequiredArgumentsFirst()).isTrue();
-
-    FlatteningConfig mixedFieldsFalse = Mockito.mock(FlatteningConfig.class);
-    Mockito.when(mixedFieldsFalse.validateRequiredArgumentsFirst()).thenCallRealMethod();
-    Mockito.when(mixedFieldsFalse.getFlattenedFieldConfigs()).thenReturn(
-        ImmutableMap.of(
-            "required", requiredFieldConfig,
-            "optional2", optionalSingularFieldConfig,
-            "required3", requiredFieldConfig));
-    assertThat(mixedFieldsFalse.validateRequiredArgumentsFirst()).isFalse();
+    emptyFlattening.validateRequiredArgumentsFirst();
   }
 
   @Test
-  public void testValidateNoNonTerminalRepeatedField() {
-    assertThat(emptyFlattening.validateNoNonTerminalRepeatedField()).isTrue();
-
-    FlatteningConfig allRepeatedFields = Mockito.mock(FlatteningConfig.class);
-    Mockito.when(allRepeatedFields.validateNoNonTerminalRepeatedField()).thenCallRealMethod();
-    Mockito.when(allRepeatedFields.getFlattenedFieldConfigs()).thenReturn(
-        ImmutableMap.of(
-            "repeated", repeatedFieldConfig,
-            "repeated2", repeatedFieldConfig,
-            "repeated3", repeatedFieldConfig));
-    assertThat(allRepeatedFields.validateNoNonTerminalRepeatedField()).isFalse();
-
-    FlatteningConfig allOptionalFields = Mockito.mock(FlatteningConfig.class);
-    Mockito.when(allOptionalFields.validateNoNonTerminalRepeatedField()).thenCallRealMethod();
-    Mockito.when(allOptionalFields.getFlattenedFieldConfigs()).thenReturn(
-        ImmutableMap.of(
-            "optional", optionalSingularFieldConfig,
-            "optional2", optionalSingularFieldConfig,
-            "optional3", optionalSingularFieldConfig));
-    assertThat(allOptionalFields.validateNoNonTerminalRepeatedField()).isTrue();
-
-    FlatteningConfig mixedFieldsTrue = Mockito.mock(FlatteningConfig.class);
-    Mockito.when(mixedFieldsTrue.validateNoNonTerminalRepeatedField()).thenCallRealMethod();
-    Mockito.when(mixedFieldsTrue.getFlattenedFieldConfigs()).thenReturn(
-        ImmutableMap.of(
-            "optional", optionalSingularFieldConfig,
-            "optional2", optionalSingularFieldConfig,
-            "required3", repeatedFieldConfig));
-    assertThat(mixedFieldsTrue.validateNoNonTerminalRepeatedField()).isTrue();
-
-    FlatteningConfig mixedFieldsFalse = Mockito.mock(FlatteningConfig.class);
-    Mockito.when(mixedFieldsFalse.validateNoNonTerminalRepeatedField()).thenCallRealMethod();
-    Mockito.doReturn(ImmutableMap.of(
-        "repeated", repeatedFieldConfig,
-        "optional2", optionalSingularFieldConfig,
-        "repeated3", repeatedFieldConfig)).when(mixedFieldsFalse).getFlattenedFieldConfigs();
-    assertThat(mixedFieldsFalse.validateNoNonTerminalRepeatedField()).isFalse();
+  public void testValidateRequiredArgumentsAllRequired() {
+    FlatteningConfig allRequiredFields = Mockito.mock(FlatteningConfig.class);
+    Mockito.doCallRealMethod().when(allRequiredFields).validateRequiredArgumentsFirst();
+    Mockito.when(allRequiredFields.getFlattenedFieldConfigs())
+        .thenReturn(
+            ImmutableMap.of(
+                "required", requiredFieldConfig,
+                "required2", requiredFieldConfig,
+                "required3", requiredFieldConfig));
+    allRequiredFields.validateRequiredArgumentsFirst();
   }
 
+  @Test
+  public void testValidateRequiredArgumentsAllOptional() {
+    FlatteningConfig allOptionalFields = Mockito.mock(FlatteningConfig.class);
+    Mockito.doCallRealMethod().when(allOptionalFields).validateRequiredArgumentsFirst();
+    Mockito.when(allOptionalFields.getFlattenedFieldConfigs())
+        .thenReturn(
+            ImmutableMap.of(
+                "optional", optionalSingularFieldConfig,
+                "optional2", optionalSingularFieldConfig,
+                "optional3", optionalSingularFieldConfig));
+    allOptionalFields.validateRequiredArgumentsFirst();
+  }
+
+  @Test
+  public void testValidateRequiredArgumentsMixedTrue() {
+    FlatteningConfig mixedFieldsTrue = Mockito.mock(FlatteningConfig.class);
+    Mockito.doCallRealMethod().when(mixedFieldsTrue).validateRequiredArgumentsFirst();
+    Mockito.when(mixedFieldsTrue.getFlattenedFieldConfigs())
+        .thenReturn(
+            ImmutableMap.of(
+                "required", requiredFieldConfig,
+                "optional2", optionalSingularFieldConfig,
+                "optional3", optionalSingularFieldConfig));
+    mixedFieldsTrue.validateRequiredArgumentsFirst();
+  }
+
+  @Test
+  public void testValidateRequiredArgumentsMixedFalse() {
+    FlatteningConfig mixedFieldsFalse = Mockito.mock(FlatteningConfig.class);
+    Mockito.doCallRealMethod().when(mixedFieldsFalse).validateRequiredArgumentsFirst();
+    Mockito.when(mixedFieldsFalse.getFlattenedFieldConfigs())
+        .thenReturn(
+            ImmutableMap.of(
+                "required", requiredFieldConfig,
+                "optional2", optionalSingularFieldConfig,
+                "required3", requiredFieldConfig));
+
+    exception.expect(IllegalArgumentException.class);
+
+    mixedFieldsFalse.validateRequiredArgumentsFirst();
+  }
+
+  @Test
+  public void testValidateRepeatedConditionOnEmpty() {
+    emptyFlattening.validateNoNonTerminalRepeatedField();
+  }
+
+  @Test
+  public void testValidateRepeatedConditionOnAllRepeated() {
+    FlatteningConfig allRepeatedFields = Mockito.mock(FlatteningConfig.class);
+    Mockito.doCallRealMethod().when(allRepeatedFields).validateNoNonTerminalRepeatedField();
+    Mockito.when(allRepeatedFields.getFlattenedFieldConfigs())
+        .thenReturn(
+            ImmutableMap.of(
+                "repeated", repeatedFieldConfig,
+                "repeated2", repeatedFieldConfig,
+                "repeated3", repeatedFieldConfig));
+
+    exception.expect(IllegalArgumentException.class);
+
+    allRepeatedFields.validateNoNonTerminalRepeatedField();
+  }
+
+  @Test
+  public void testValidateRepeatedConditionOnAllOptional() {
+    FlatteningConfig allOptionalFields = Mockito.mock(FlatteningConfig.class);
+    Mockito.doCallRealMethod().when(allOptionalFields).validateNoNonTerminalRepeatedField();
+    Mockito.when(allOptionalFields.getFlattenedFieldConfigs())
+        .thenReturn(
+            ImmutableMap.of(
+                "optional", optionalSingularFieldConfig,
+                "optional2", optionalSingularFieldConfig,
+                "optional3", optionalSingularFieldConfig));
+
+    allOptionalFields.validateNoNonTerminalRepeatedField();
+  }
+
+  @Test
+  public void testValidateRepeatedConditionOnAllLastRequired() {
+    FlatteningConfig mixedFieldsTrue = Mockito.mock(FlatteningConfig.class);
+    Mockito.doCallRealMethod().when(mixedFieldsTrue).validateNoNonTerminalRepeatedField();
+    Mockito.when(mixedFieldsTrue.getFlattenedFieldConfigs())
+        .thenReturn(
+            ImmutableMap.of(
+                "optional", optionalSingularFieldConfig,
+                "optional2", optionalSingularFieldConfig,
+                "required3", repeatedFieldConfig));
+
+    mixedFieldsTrue.validateNoNonTerminalRepeatedField();
+  }
+
+  @Test
+  public void testValidateRepeatedConditionOnMixedFalse() {
+    FlatteningConfig mixedFieldsFalse = Mockito.mock(FlatteningConfig.class);
+    Mockito.doCallRealMethod().when(mixedFieldsFalse).validateNoNonTerminalRepeatedField();
+    Mockito.doReturn(
+            ImmutableMap.of(
+                "repeated", repeatedFieldConfig,
+                "optional2", optionalSingularFieldConfig,
+                "repeated3", repeatedFieldConfig))
+        .when(mixedFieldsFalse)
+        .getFlattenedFieldConfigs();
+
+    exception.expect(IllegalArgumentException.class);
+
+    mixedFieldsFalse.validateNoNonTerminalRepeatedField();
+  }
 }

--- a/src/test/java/com/google/api/codegen/config/FlatteningConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/FlatteningConfigTest.java
@@ -1,0 +1,119 @@
+package com.google.api.codegen.config;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+public class FlatteningConfigTest {
+
+  private static FieldModel repeatedField = Mockito.mock(FieldModel.class);
+  private static FieldConfig repeatedFieldConfig = FieldConfig.createDefaultFieldConfig(repeatedField);
+
+  private static FieldModel optionalSingularField = Mockito.mock(FieldModel.class);
+  private static FieldConfig optionalSingularFieldConfig = FieldConfig.createDefaultFieldConfig(optionalSingularField);
+
+  private static FieldModel requiredField = Mockito.mock(FieldModel.class);
+  private static FieldConfig requiredFieldConfig = FieldConfig.createDefaultFieldConfig(requiredField);
+
+  private static FlatteningConfig emptyFlattening = Mockito.mock(FlatteningConfig.class);
+
+  @BeforeClass
+  public static void setUp() {
+    Mockito.when(repeatedField.isRepeated()).thenReturn(true);
+    Mockito.when(requiredField.isRequired()).thenReturn(true);
+    // Calling isRepeated and isRequired on mocks will default to "false" if not stubbed.
+
+    // Only stub the construction of the FlatteningConfigs.
+    Mockito.when(emptyFlattening.getFlattenedFieldConfigs()).thenReturn(
+        ImmutableMap.of());
+    Mockito.when(emptyFlattening.validateNoNonTerminalRepeatedField()).thenCallRealMethod();
+    Mockito.when(emptyFlattening.validateRequiredArgumentsFirst()).thenCallRealMethod();
+  }
+
+  @Test
+  public void testValidateRequiredArguments() {
+
+    assertThat(emptyFlattening.validateRequiredArgumentsFirst()).isTrue();
+
+    FlatteningConfig allRequiredFields = Mockito.mock(FlatteningConfig.class);
+    Mockito.when(allRequiredFields.validateRequiredArgumentsFirst()).thenCallRealMethod();
+    Mockito.when(allRequiredFields.getFlattenedFieldConfigs()).thenReturn(
+        ImmutableMap.of(
+            "required", requiredFieldConfig,
+            "required2", requiredFieldConfig,
+            "required3", requiredFieldConfig));
+    assertThat(allRequiredFields.validateRequiredArgumentsFirst()).isTrue();
+
+    FlatteningConfig allOptionalFields = Mockito.mock(FlatteningConfig.class);
+    Mockito.when(allOptionalFields.validateRequiredArgumentsFirst()).thenCallRealMethod();
+    Mockito.when(allOptionalFields.getFlattenedFieldConfigs()).thenReturn(
+        ImmutableMap.of(
+            "optional", optionalSingularFieldConfig,
+            "optional2", optionalSingularFieldConfig,
+            "optional3", optionalSingularFieldConfig));
+    assertThat(allOptionalFields.validateRequiredArgumentsFirst()).isTrue();
+
+    FlatteningConfig mixedFieldsTrue = Mockito.mock(FlatteningConfig.class);
+    Mockito.when(mixedFieldsTrue.validateRequiredArgumentsFirst()).thenCallRealMethod();
+    Mockito.when(mixedFieldsTrue.getFlattenedFieldConfigs()).thenReturn(
+        ImmutableMap.of(
+            "required", requiredFieldConfig,
+            "optional2", optionalSingularFieldConfig,
+            "optional3", optionalSingularFieldConfig));
+    assertThat(mixedFieldsTrue.validateRequiredArgumentsFirst()).isTrue();
+
+    FlatteningConfig mixedFieldsFalse = Mockito.mock(FlatteningConfig.class);
+    Mockito.when(mixedFieldsFalse.validateRequiredArgumentsFirst()).thenCallRealMethod();
+    Mockito.when(mixedFieldsFalse.getFlattenedFieldConfigs()).thenReturn(
+        ImmutableMap.of(
+            "required", requiredFieldConfig,
+            "optional2", optionalSingularFieldConfig,
+            "required3", requiredFieldConfig));
+    assertThat(mixedFieldsFalse.validateRequiredArgumentsFirst()).isFalse();
+  }
+
+  @Test
+  public void testValidateNoNonTerminalRepeatedField() {
+    assertThat(emptyFlattening.validateNoNonTerminalRepeatedField()).isTrue();
+
+    FlatteningConfig allRepeatedFields = Mockito.mock(FlatteningConfig.class);
+    Mockito.when(allRepeatedFields.validateNoNonTerminalRepeatedField()).thenCallRealMethod();
+    Mockito.when(allRepeatedFields.getFlattenedFieldConfigs()).thenReturn(
+        ImmutableMap.of(
+            "repeated", repeatedFieldConfig,
+            "repeated2", repeatedFieldConfig,
+            "repeated3", repeatedFieldConfig));
+    assertThat(allRepeatedFields.validateNoNonTerminalRepeatedField()).isFalse();
+
+    FlatteningConfig allOptionalFields = Mockito.mock(FlatteningConfig.class);
+    Mockito.when(allOptionalFields.validateNoNonTerminalRepeatedField()).thenCallRealMethod();
+    Mockito.when(allOptionalFields.getFlattenedFieldConfigs()).thenReturn(
+        ImmutableMap.of(
+            "optional", optionalSingularFieldConfig,
+            "optional2", optionalSingularFieldConfig,
+            "optional3", optionalSingularFieldConfig));
+    assertThat(allOptionalFields.validateNoNonTerminalRepeatedField()).isTrue();
+
+    FlatteningConfig mixedFieldsTrue = Mockito.mock(FlatteningConfig.class);
+    Mockito.when(mixedFieldsTrue.validateNoNonTerminalRepeatedField()).thenCallRealMethod();
+    Mockito.when(mixedFieldsTrue.getFlattenedFieldConfigs()).thenReturn(
+        ImmutableMap.of(
+            "optional", optionalSingularFieldConfig,
+            "optional2", optionalSingularFieldConfig,
+            "required3", repeatedFieldConfig));
+    assertThat(mixedFieldsTrue.validateNoNonTerminalRepeatedField()).isTrue();
+
+    FlatteningConfig mixedFieldsFalse = Mockito.mock(FlatteningConfig.class);
+    Mockito.when(mixedFieldsFalse.validateNoNonTerminalRepeatedField()).thenCallRealMethod();
+    Mockito.doReturn(ImmutableMap.of(
+        "repeated", repeatedFieldConfig,
+        "optional2", optionalSingularFieldConfig,
+        "repeated3", repeatedFieldConfig)).when(mixedFieldsFalse).getFlattenedFieldConfigs();
+    assertThat(mixedFieldsFalse.validateNoNonTerminalRepeatedField()).isFalse();
+  }
+
+}

--- a/src/test/java/com/google/api/codegen/config/FlatteningConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/FlatteningConfigTest.java
@@ -1,3 +1,17 @@
+/* Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.api.codegen.config;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
@@ -435,10 +435,10 @@ public class ResourceNameMessageConfigsTest {
     flatteningConfigs.remove(flatteningConfigFromGapicConfig.get());
 
     // Check the flattenings from the protofile annotations.
-    flatteningConfigs.sort(Comparator.comparingInt(c -> Iterables.size(c.getFlattenedFields())));
+    flatteningConfigs.sort(Comparator.comparingInt(c -> Iterables.size(FlatteningConfig.getFlattenedFields(c))));
 
     FlatteningConfig shelfFlattening = flatteningConfigs.get(0);
-    assertThat(Iterables.size(shelfFlattening.getFlattenedFields())).isEqualTo(1);
+    assertThat(Iterables.size(FlatteningConfig.getFlattenedFields(shelfFlattening))).isEqualTo(1);
 
     FieldConfig nameConfig = shelfFlattening.getFlattenedFieldConfigs().get("name");
     assertThat(nameConfig.getResourceNameTreatment()).isEqualTo(ResourceNameTreatment.STATIC_TYPES);
@@ -446,7 +446,7 @@ public class ResourceNameMessageConfigsTest {
         .isEqualTo(GAPIC_SHELF_PATH);
 
     FlatteningConfig shelfAndBookFlattening = flatteningConfigs.get(1);
-    assertThat(Iterables.size(shelfAndBookFlattening.getFlattenedFields())).isEqualTo(2);
+    assertThat(Iterables.size(FlatteningConfig.getFlattenedFields(shelfAndBookFlattening))).isEqualTo(2);
 
     FieldConfig nameConfig2 = shelfAndBookFlattening.getFlattenedFieldConfigs().get("name");
     assertThat(nameConfig2.getResourceNameTreatment())

--- a/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
@@ -397,7 +397,8 @@ public class ResourceNameMessageConfigsTest {
                 resourceNameConfigs,
                 methodConfigProto,
                 methodModel,
-                protoParser));
+                protoParser,
+                TargetLanguage.JAVA));
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
     List<Diag> warningDiags =
         diagCollector

--- a/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
@@ -435,7 +435,8 @@ public class ResourceNameMessageConfigsTest {
     flatteningConfigs.remove(flatteningConfigFromGapicConfig.get());
 
     // Check the flattenings from the protofile annotations.
-    flatteningConfigs.sort(Comparator.comparingInt(c -> Iterables.size(FlatteningConfig.getFlattenedFields(c))));
+    flatteningConfigs.sort(
+        Comparator.comparingInt(c -> Iterables.size(FlatteningConfig.getFlattenedFields(c))));
 
     FlatteningConfig shelfFlattening = flatteningConfigs.get(0);
     assertThat(Iterables.size(FlatteningConfig.getFlattenedFields(shelfFlattening))).isEqualTo(1);
@@ -446,7 +447,8 @@ public class ResourceNameMessageConfigsTest {
         .isEqualTo(GAPIC_SHELF_PATH);
 
     FlatteningConfig shelfAndBookFlattening = flatteningConfigs.get(1);
-    assertThat(Iterables.size(FlatteningConfig.getFlattenedFields(shelfAndBookFlattening))).isEqualTo(2);
+    assertThat(Iterables.size(FlatteningConfig.getFlattenedFields(shelfAndBookFlattening)))
+        .isEqualTo(2);
 
     FieldConfig nameConfig2 = shelfAndBookFlattening.getFlattenedFieldConfigs().get("name");
     assertThat(nameConfig2.getResourceNameTreatment())


### PR DESCRIPTION
Implement this part of the API Client Configuration doc:

> If an RPC lists a nested field in (google.api.method_signature).fields, none of the referenced fields may be repeated except for the last one. Code generators implementing this feature must error with a descriptive error message if encountering a non-terminal repeated field as a field name.
> 
> If any fields are required arguments, all required arguments are expected to appear before any optional ones. Code generators implementing this feature should error with a descriptive error message if encountering a required field after an optional one, and must do so if the resulting client library would not be valid.


Blocked on implementing parsing of method signatures with nested fields.