### PR TITLE
Samplegen: Split nodejs method sample and standalone sample snippets

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/init_code.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/init_code.snip
@@ -1,0 +1,92 @@
+@snippet initCode(apiMethod, init)
+  @if init.argDefaultLines
+    @join line : util.pretty(initCodeLines(init.argDefaultLines))
+      // {@line}
+    @end
+
+
+  @end
+  {@initCodeLines(init.lines)}
+  @if initializeRequestObject(apiMethod, init)
+    {@initializeRequestObject(apiMethod, init)}
+  @end
+@end
+
+@snippet initCodeLines(lines)
+  @join line : lines
+    @switch line.lineType.toString
+    @case "StructureInitLine"
+      {@initLineStructure(line)}
+    @case "ListInitLine"
+      {@initLineList(line)}
+    @case "MapInitLine"
+      {@initLineMap(line)}
+    @case "SimpleInitLine"
+      {@initLineSimple(line)}
+    @case "ReadFileInitLine"
+      {@initLineReadFile(line)}
+    @default
+      $unhandledCase: {@line.lineType.toString}$
+    @end
+  @end
+@end
+
+@private initLineReadFile(line)
+  const {@line.identifier} = fs.readFileSync({@renderInitValue(line.fileName)}).toString('base64');
+@end
+
+@private initLineStructure(line)
+  const {@line.identifier} = {
+    @join fieldSetting : line.fieldSettings on BREAK
+      {@fieldSetting.fieldName}: {@fieldSetting.identifier},
+    @end
+  };
+@end
+
+@private initLineList(line)
+    const {@line.identifier} = [{@varList(line.elementIdentifiers)}];
+@end
+
+@snippet varList(args)
+  @join arg : args on ", "
+    {@arg}
+  @end
+@end
+
+@private initLineMap(line)
+  const {@line.identifier} = {{@keyVarList(line.initEntries)}};
+@end
+
+@private keyVarList(mapEntries)
+  @join mapEntry : mapEntries vertical
+    {@mapEntry.key} : {@mapEntry.valueString},
+  @end
+@end
+
+@private initLineSimple(line)
+  const {@line.identifier} = {@renderInitValue(line.initValue)};
+@end
+
+@private renderInitValue(initValue)
+  @switch initValue.type
+  @case "SimpleInitValueView"
+    {@initValue.initialValue}
+  @case "FormattedInitValueView"
+    client.{@initValue.formatFunctionName}({@varList(initValue.formatArgs)})
+  @default
+    $unhandledCase: {@initValue.type}$
+  @end
+@end
+
+@private initializeRequestObject(apiMethod, init)
+    @switch init.fieldSettings.size.toString
+    @case "0"
+    @case "1"
+    @default
+      const request = {
+        @join fieldSetting : init.fieldSettings on BREAK
+          {@fieldSetting.fieldName}: {@fieldSetting.identifier},
+        @end
+      };
+    @end
+@end

--- a/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
@@ -1,4 +1,5 @@
 @extends "nodejs/common.snip"
+@extends "nodejs/init_code.snip"
 
 @snippet decorateSampleCode(apiMethod, coreSampleCode)
     @if apiMethod.hasApiVersion
@@ -343,86 +344,6 @@
     @end
 @end
 
-@snippet initCode(apiMethod, init)
-  @if init.argDefaultLines
-    @join line : util.pretty(initCodeLines(init.argDefaultLines))
-      // {@line}
-    @end
-
-
-  @end
-  {@initCodeLines(init.lines)}
-  @if initializeRequestObject(apiMethod, init)
-    {@initializeRequestObject(apiMethod, init)}
-  @end
-@end
-
-@snippet initCodeLines(lines)
-  @join line : lines
-    @switch line.lineType.toString
-    @case "StructureInitLine"
-      {@initLineStructure(line)}
-    @case "ListInitLine"
-      {@initLineList(line)}
-    @case "MapInitLine"
-      {@initLineMap(line)}
-    @case "SimpleInitLine"
-      {@initLineSimple(line)}
-    @case "ReadFileInitLine"
-      {@initLineReadFile(line)}
-    @default
-      $unhandledCase: {@line.lineType.toString}$
-    @end
-  @end
-@end
-
-@private initLineReadFile(line)
-  const {@line.identifier} = fs.readFileSync({@renderInitValue(line.fileName)}).toString('base64');
-@end
-
-@private initLineStructure(line)
-  const {@line.identifier} = {
-    @join fieldSetting : line.fieldSettings on BREAK
-      {@fieldSetting.fieldName}: {@fieldSetting.identifier},
-    @end
-  };
-@end
-
-@private initLineList(line)
-    const {@line.identifier} = [{@varList(line.elementIdentifiers)}];
-@end
-
-@snippet varList(args)
-  @join arg : args on ", "
-    {@arg}
-  @end
-@end
-
-@private initLineMap(line)
-  const {@line.identifier} = {{@keyVarList(line.initEntries)}};
-@end
-
-@private keyVarList(mapEntries)
-  @join mapEntry : mapEntries vertical
-    {@mapEntry.key} : {@mapEntry.valueString},
-  @end
-@end
-
-@private initLineSimple(line)
-  const {@line.identifier} = {@renderInitValue(line.initValue)};
-@end
-
-@private renderInitValue(initValue)
-  @switch initValue.type
-  @case "SimpleInitValueView"
-    {@initValue.initialValue}
-  @case "FormattedInitValueView"
-    client.{@initValue.formatFunctionName}({@varList(initValue.formatArgs)})
-  @default
-    $unhandledCase: {@initValue.type}$
-  @end
-@end
-
 @private sampleMethodCallArgList(apiMethod, init)
   @switch init.fieldSettings.size.toString
   @case "0"
@@ -434,19 +355,6 @@
   @default
     request
   @end
-@end
-
-@private initializeRequestObject(apiMethod, init)
-    @switch init.fieldSettings.size.toString
-    @case "0"
-    @case "1"
-    @default
-      const request = {
-        @join fieldSetting : init.fieldSettings on BREAK
-          {@fieldSetting.fieldName}: {@fieldSetting.identifier},
-        @end
-      };
-    @end
 @end
 
 @private promiseCallbacks(additionalCallback)

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -1,6 +1,5 @@
 @extends "nodejs/common.snip"
-@extends "nodejs/method_sample.snip"
-
+@extends "nodejs/init_code.snip"
 
 @snippet generate(sampleFile)
    //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "{@sampleFile.className}" ]
@@ -45,28 +44,212 @@
   @switch sample.callingForm
   @case "Request"
     @if apiMethod.hasReturnValue
-      {@methodCallSampleCodeWithReturnValue(apiMethod, sample.sampleInitCode, empty())}
+      {@methodCallSampleCodeWithReturnValue(apiMethod, sample.sampleInitCode)}
     @else
-      {@methodCallSampleCodeWithoutReturnValue(apiMethod, sample.sampleInitCode, empty())}
+      {@methodCallSampleCodeWithoutReturnValue(apiMethod, sample.sampleInitCode)}
     @end
   @case "RequestAsyncPaged"
-    {@methodCallSampleCodeForPagedResponse(apiMethod, sample.sampleInitCode, empty())}
+    {@methodCallSampleCodeForPagedResponse(apiMethod, sample.sampleInitCode)}
   @case "RequestAsyncPagedAll"
-    {@methodCallSampleCodeForPagedResponseIterative(apiMethod, sample.sampleInitCode, empty())}
+    {@methodCallSampleCodeForPagedResponseIterative(apiMethod, sample.sampleInitCode)}
   @case "RequestStreamingBidi"
-    {@bidiStreamingSampleCode(apiMethod, sample.sampleInitCode, empty())}
+    {@bidiStreamingSampleCode(apiMethod, sample.sampleInitCode)}
   @case "RequestStreamingClient"
-    {@clientStreamingSampleCode(apiMethod, sample.sampleInitCode, empty())}
+    {@clientStreamingSampleCode(apiMethod, sample.sampleInitCode)}
   @case "RequestStreamingServer"
     {@initCode(apiMethod, sample.sampleInitCode)}
       {@methodCallSampleCode(apiMethod, sample.sampleInitCode)}.on('data', response => {
           // doThingsWith(response)
       });
   @case "LongRunningEventEmitter"
-    {@methodCallSampleCodeLongrunningEventEmitter(apiMethod, sample.sampleInitCode, empty())}
+    {@methodCallSampleCodeLongrunningEventEmitter(apiMethod, sample.sampleInitCode)}
   @case "LongRunningPromise"
-    {@methodCallSampleCodeLongrunningPromise(apiMethod, sample.sampleInitCode, empty())}
+    {@methodCallSampleCodeLongrunningPromise(apiMethod, sample.sampleInitCode)}
   @default
     $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
   @end
+@end
+
+@private methodCallSampleCodeWithReturnValue(apiMethod, init)
+  {@initCode(apiMethod, init)}
+  {@methodCallSampleCodePrefix(apiMethod, init)}
+    .then(responses => {
+      const response = responses[0];
+      // doThingsWith(response)
+    })
+    .catch(err => {
+      console.error(err);
+    });
+@end
+
+@private methodCallSampleCodeWithoutReturnValue(apiMethod, init)
+  {@initCode(apiMethod, init)}
+  {@methodCallSampleCodePrefix(apiMethod, init)}.catch(err => {
+    console.error(err);
+  });
+@end
+
+@private methodCallSampleCodeForPagedResponse(apiMethod, init)
+  // Or obtain the paged response.
+  @if initCode(apiMethod, init)
+    {@initCode(apiMethod, init)}
+
+  @end
+
+  const options = {autoPaginate: false};
+  const callback = responses => {
+    // The actual resources in a response.
+    const resources = responses[0];
+    // The next request if the response shows that there are more responses.
+    const nextRequest = responses[1];
+    // The actual response object, if necessary.
+    // const rawResponse = responses[2];
+    for (let i = 0; i < resources.length; i += 1) {
+      // doThingsWith(resources[i]);
+    }
+    if (nextRequest) {
+      // Fetch the next page.
+      return client.{@apiMethod.name}(nextRequest, options).then(callback);
+    }
+  }
+  client.{@apiMethod.name}({@sampleMethodCallArgListAndComma(apiMethod, init)}options)
+    .then(callback)
+    .catch(err => {
+      console.error(err);
+    });
+@end
+
+@private methodCallSampleCodeForPagedResponseIterative(apiMethod, init)
+  // Iterate over all elements.
+  @if initCode(apiMethod, init)
+    {@initCode(apiMethod, init)}
+
+  @end
+  {@methodCallSampleCodePrefix(apiMethod, init)}
+    .then(responses => {
+      const resources = responses[0];
+      for (let i = 0; i < resources.length; i += 1) {
+        // doThingsWith(resources[i])
+      }
+    })
+    .catch(err => {
+      console.error(err);
+    });
+@end
+
+@snippet bidiStreamingSampleCode(apiMethod, init)
+    const stream = client.{@apiMethod.name}().on('data', response => {
+      // doThingsWith(response)
+    });
+    {@initCode(apiMethod, init)}
+    {@sampleWriteStreamingRequest(apiMethod)}
+@end
+
+@snippet clientStreamingSampleCode(apiMethod, init)
+    const stream = client.{@apiMethod.name}((err, response) => {
+      if (err) {
+        console.error(err);
+        return;
+      }
+      // doThingsWith(response)
+    });
+    {@initCode(apiMethod, init)}
+    {@sampleWriteStreamingRequest(apiMethod)}
+@end
+
+@private methodCallSampleCodeLongrunningEventEmitter(apiMethod, init)
+  {@initCode(apiMethod, init)}
+
+  // Handle the operation using the event emitter pattern.
+  {@methodCallSampleCodePrefix(apiMethod, init)}
+    .then(responses => {
+      const operation = responses[0];
+      const initialApiResponse = responses[1];
+
+      // Adding a listener for the "complete" event starts polling for the
+      // completion of the operation.
+      operation.on('complete', (result, metadata, finalApiResponse) => {
+        // doSomethingWith(result);
+      });
+
+      // Adding a listener for the "progress" event causes the callback to be
+      // called on any change in metadata when the operation is polled.
+      operation.on('progress', (metadata, apiResponse) => {
+        // doSomethingWith(metadata)
+      });
+
+      // Adding a listener for the "error" event handles any errors found during polling.
+      operation.on('error', err => {
+        // throw(err);
+      });
+    })
+    .catch(err => {
+      console.error(err);
+    });
+@end
+
+@private methodCallSampleCodeLongrunningPromise(apiMethod, init)
+  {@initCode(apiMethod, init)}
+
+  // Handle the operation using the promise pattern.
+  {@methodCallSampleCodePrefix(apiMethod, init)}
+    .then(responses => {
+      const operation = responses[0];
+      const initialApiResponse = responses[1];
+
+      // Operation@#promise starts polling for the completion of the LRO.
+      return operation.promise();
+    })
+    .then(responses => {
+      // The final result of the operation.
+      const result = responses[0];
+
+      // The metadata value of the completed operation.
+      const metadata = responses[1];
+
+      // The response of the api call returning the complete operation.
+      const finalApiResponse = responses[2];
+    })
+    .catch(err => {
+      console.error(err);
+    });
+@end
+
+@private methodCallSampleCode(apiMethod, init)
+    client.{@apiMethod.name}(\
+        {@sampleMethodCallArgList(apiMethod, init)})
+@end
+
+@private methodCallSampleCodePrefix(apiMethod, init)
+  @if sampleMethodCallArgList(apiMethod, init)
+    client.{@apiMethod.name}(\
+      {@sampleMethodCallArgList(apiMethod, init)})
+  @else
+    client.{@apiMethod.name}()
+  @end
+@end
+
+@private sampleMethodCallArgListAndComma(apiMethod, init)
+    @if sampleMethodCallArgList(apiMethod, init)
+        {@sampleMethodCallArgList(apiMethod, init)}, {@""}
+    @else
+    @end
+@end
+
+@private sampleMethodCallArgList(apiMethod, init)
+  @switch init.fieldSettings.size.toString
+  @case "0"
+    {}
+  @case "1"
+    @let field = init.fieldSettings.get(0)
+      {{@field.fieldName}: {@field.identifier}}
+    @end
+  @default
+    request
+  @end
+@end
+
+@private sampleWriteStreamingRequest(apiMethod)
+    // Write request objects.
+    stream.write(request);
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -1,5 +1,6 @@
 @extends "nodejs/method_sample.snip"
 @extends "nodejs/common.snip"
+@extends "nodejs/init_code.snip"
 
 @snippet generate(apiTest)
   {@lineComments(apiTest.fileHeader.copyrightLines)}


### PR DESCRIPTION
Start working on Node.js standalone samples. Split the snippets out in order not to break method samples.