### PR TITLE
Add test resources for routing headers

### DIFF
--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -11422,7 +11422,7 @@ namespace Google.Example.Library.V1
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}&book.read={request.Book.Read}"));
             _callPublishSeries = clientHelper.BuildApiCall<PublishSeriesRequest, PublishSeriesResponse>(
                 GrpcClient.PublishSeriesAsync, GrpcClient.PublishSeries, effectiveSettings.PublishSeriesSettings)
-                .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"shelf={request.Shelf}"));
+                .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"shelf.name={request.Shelf.Name}"));
             _callGetBook = clientHelper.BuildApiCall<GetBookRequest, Book>(
                 GrpcClient.GetBookAsync, GrpcClient.GetBook, effectiveSettings.GetBookSettings);
             _callListBooks = clientHelper.BuildApiCall<ListBooksRequest, ListBooksResponse>(

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -11421,7 +11421,8 @@ namespace Google.Example.Library.V1
                 GrpcClient.CreateBookAsync, GrpcClient.CreateBook, effectiveSettings.CreateBookSettings)
                 .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}&book.read={request.Book.Read}"));
             _callPublishSeries = clientHelper.BuildApiCall<PublishSeriesRequest, PublishSeriesResponse>(
-                GrpcClient.PublishSeriesAsync, GrpcClient.PublishSeries, effectiveSettings.PublishSeriesSettings);
+                GrpcClient.PublishSeriesAsync, GrpcClient.PublishSeries, effectiveSettings.PublishSeriesSettings)
+                .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"shelf={request.Shelf}"));
             _callGetBook = clientHelper.BuildApiCall<GetBookRequest, Book>(
                 GrpcClient.GetBookAsync, GrpcClient.GetBook, effectiveSettings.GetBookSettings);
             _callListBooks = clientHelper.BuildApiCall<ListBooksRequest, ListBooksResponse>(

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -494,7 +494,7 @@ func (c *LibClient) CreateBook(ctx context.Context, req *librarypb.CreateBookReq
 
 // PublishSeries creates a series of books.
 func (c *LibClient) PublishSeries(ctx context.Context, req *librarypb.PublishSeriesRequest, opts ...gax.CallOption) (*librarypb.PublishSeriesResponse, error) {
-    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "shelf", req.GetShelf()))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "shelf.name", req.GetShelf().GetName()))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.PublishSeries[0:len(c.CallOptions.PublishSeries):len(c.CallOptions.PublishSeries)], opts...)
     var resp *librarypb.PublishSeriesResponse

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -494,7 +494,8 @@ func (c *LibClient) CreateBook(ctx context.Context, req *librarypb.CreateBookReq
 
 // PublishSeries creates a series of books.
 func (c *LibClient) PublishSeries(ctx context.Context, req *librarypb.PublishSeriesRequest, opts ...gax.CallOption) (*librarypb.PublishSeriesResponse, error) {
-    ctx = insertMetadata(ctx, c.xGoogMetadata)
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "shelf", req.GetShelf()))
+    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.PublishSeries[0:len(c.CallOptions.PublishSeries):len(c.CallOptions.PublishSeries)], opts...)
     var resp *librarypb.PublishSeriesResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -6559,7 +6559,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
                   @Override
                   public Map<String, String> extract(PublishSeriesRequest request) {
                     ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("shelf", String.valueOf(request.getShelf()));
+                    params.put("shelf.name", String.valueOf(request.getShelf().getName()));
                     return params.build();
                   }
                 })

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -6554,6 +6554,15 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesTransportSettings =
         GrpcCallSettings.<PublishSeriesRequest, PublishSeriesResponse>newBuilder()
             .setMethodDescriptor(publishSeriesMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<PublishSeriesRequest>() {
+                  @Override
+                  public Map<String, String> extract(PublishSeriesRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("shelf", String.valueOf(request.getShelf()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<GetBookRequest, Book> getBookTransportSettings =
         GrpcCallSettings.<GetBookRequest, Book>newBuilder()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -4015,6 +4015,12 @@ class LibraryServiceClient {
       options = {};
     }
     options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'shelf': request.shelf
+      });
 
     return this._innerApiCalls.publishSeries(request, options, callback);
   }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -4019,7 +4019,7 @@ class LibraryServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers['x-goog-request-params'] =
       gax.routingHeader.fromParams({
-        'shelf': request.shelf
+        'shelf.name': request.shelf.name
       });
 
     return this._innerApiCalls.publishSeries(request, options, callback);

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -850,7 +850,7 @@ class LibraryServiceGapicClient
         }
 
         $requestParams = new RequestParamsHeaderDescriptor([
-          'shelf' => $request->getShelf(),
+          'shelf.name' => $request->getShelf()->getName(),
         ]);
         $optionalArgs['headers'] = isset($optionalArgs['headers'])
             ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -849,6 +849,13 @@ class LibraryServiceGapicClient
             $request->setReviewCopy($optionalArgs['reviewCopy']);
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'shelf' => $request->getShelf(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
         return $this->startCall(
             'PublishSeries',
             PublishSeriesResponse::class,
@@ -2673,6 +2680,13 @@ return [
                 'method' => 'post',
                 'uriTemplate' => '/v1/{name=bookShelves/*}/books',
                 'body' => 'book',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/{name=bookShelves/*}/books',
+                        'body' => 'book',
+                    ],
+                ],
                 'placeholders' => [
                     'name' => [
                         'getters' => [
@@ -2685,6 +2699,21 @@ return [
                 'method' => 'post',
                 'uriTemplate' => '/v1:publish',
                 'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/{shelf.name=shelves/*}:publish',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'shelf.name' => [
+                        'getters' => [
+                            'getShelf',
+                            'getName',
+                        ],
+                    ],
+                ]
             ],
             'GetBook' => [
                 'method' => 'get',

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -1706,7 +1706,7 @@ class LibraryServiceClient(object):
             metadata = []
         metadata = list(metadata)
         try:
-            routing_header = [('shelf', shelf)]
+            routing_header = [('shelf.name', shelf.name)]
         except AttributeError:
             pass
         else:

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -1702,6 +1702,17 @@ class LibraryServiceClient(object):
             edition=edition,
             review_copy=review_copy,
         )
+        if metadata is None:
+            metadata = []
+        metadata = list(metadata)
+        try:
+            routing_header = [('shelf', shelf)]
+        except AttributeError:
+            pass
+        else:
+            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
+            metadata.append(routing_metadata)
+
         return self._inner_api_calls['publish_series'](request, retry=retry, timeout=timeout, metadata=metadata)
 
     def get_book(

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -3023,7 +3023,7 @@ module Library
           defaults["publish_series"],
           exception_transformer: exception_transformer,
           params_extractor: proc do |request|
-            {'shelf' => request.shelf}
+            {'shelf.name' => request.shelf.name}
           end
         )
         @get_book = Google::Gax.create_api_call(

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -3021,7 +3021,10 @@ module Library
         @publish_series = Google::Gax.create_api_call(
           @library_service_stub.method(:publish_series),
           defaults["publish_series"],
-          exception_transformer: exception_transformer
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'shelf' => request.shelf}
+          end
         )
         @get_book = Google::Gax.create_api_call(
           @library_service_stub.method(:get_book),

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -3415,15 +3415,6 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<GetShelfRequest, Shelf> getShelfTransportSettings =
         GrpcCallSettings.<GetShelfRequest, Shelf>newBuilder()
             .setMethodDescriptor(getShelfMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<GetShelfRequest>() {
-                  @Override
-                  public Map<String, String> extract(GetShelfRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<ListShelvesRequest, ListShelvesResponse> listShelvesTransportSettings =
         GrpcCallSettings.<ListShelvesRequest, ListShelvesResponse>newBuilder()
@@ -3432,119 +3423,38 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<DeleteShelfRequest, Empty> deleteShelfTransportSettings =
         GrpcCallSettings.<DeleteShelfRequest, Empty>newBuilder()
             .setMethodDescriptor(deleteShelfMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<DeleteShelfRequest>() {
-                  @Override
-                  public Map<String, String> extract(DeleteShelfRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<MergeShelvesRequest, Shelf> mergeShelvesTransportSettings =
         GrpcCallSettings.<MergeShelvesRequest, Shelf>newBuilder()
             .setMethodDescriptor(mergeShelvesMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<MergeShelvesRequest>() {
-                  @Override
-                  public Map<String, String> extract(MergeShelvesRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<CreateBookRequest, Book> createBookTransportSettings =
         GrpcCallSettings.<CreateBookRequest, Book>newBuilder()
             .setMethodDescriptor(createBookMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<CreateBookRequest>() {
-                  @Override
-                  public Map<String, String> extract(CreateBookRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesTransportSettings =
         GrpcCallSettings.<PublishSeriesRequest, PublishSeriesResponse>newBuilder()
             .setMethodDescriptor(publishSeriesMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<PublishSeriesRequest>() {
-                  @Override
-                  public Map<String, String> extract(PublishSeriesRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("shelf.name", String.valueOf(request.getShelf().getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<GetBookRequest, Book> getBookTransportSettings =
         GrpcCallSettings.<GetBookRequest, Book>newBuilder()
             .setMethodDescriptor(getBookMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<GetBookRequest>() {
-                  @Override
-                  public Map<String, String> extract(GetBookRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<ListBooksRequest, ListBooksResponse> listBooksTransportSettings =
         GrpcCallSettings.<ListBooksRequest, ListBooksResponse>newBuilder()
             .setMethodDescriptor(listBooksMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<ListBooksRequest>() {
-                  @Override
-                  public Map<String, String> extract(ListBooksRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<DeleteBookRequest, Empty> deleteBookTransportSettings =
         GrpcCallSettings.<DeleteBookRequest, Empty>newBuilder()
             .setMethodDescriptor(deleteBookMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<DeleteBookRequest>() {
-                  @Override
-                  public Map<String, String> extract(DeleteBookRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<UpdateBookRequest, Book> updateBookTransportSettings =
         GrpcCallSettings.<UpdateBookRequest, Book>newBuilder()
             .setMethodDescriptor(updateBookMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<UpdateBookRequest>() {
-                  @Override
-                  public Map<String, String> extract(UpdateBookRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<MoveBookRequest, Book> moveBookTransportSettings =
         GrpcCallSettings.<MoveBookRequest, Book>newBuilder()
             .setMethodDescriptor(moveBookMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<MoveBookRequest>() {
-                  @Override
-                  public Map<String, String> extract(MoveBookRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<ListStringsRequest, ListStringsResponse> listStringsTransportSettings =
         GrpcCallSettings.<ListStringsRequest, ListStringsResponse>newBuilder()
@@ -3553,68 +3463,22 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<AddCommentsRequest, Empty> addCommentsTransportSettings =
         GrpcCallSettings.<AddCommentsRequest, Empty>newBuilder()
             .setMethodDescriptor(addCommentsMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<AddCommentsRequest>() {
-                  @Override
-                  public Map<String, String> extract(AddCommentsRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveTransportSettings =
         GrpcCallSettings.<GetBookFromArchiveRequest, BookFromArchive>newBuilder()
             .setMethodDescriptor(getBookFromArchiveMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<GetBookFromArchiveRequest>() {
-                  @Override
-                  public Map<String, String> extract(GetBookFromArchiveRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereTransportSettings =
         GrpcCallSettings.<GetBookFromAnywhereRequest, BookFromAnywhere>newBuilder()
             .setMethodDescriptor(getBookFromAnywhereMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<GetBookFromAnywhereRequest>() {
-                  @Override
-                  public Map<String, String> extract(GetBookFromAnywhereRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereTransportSettings =
         GrpcCallSettings.<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere>newBuilder()
             .setMethodDescriptor(getBookFromAbsolutelyAnywhereMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<GetBookFromAbsolutelyAnywhereRequest>() {
-                  @Override
-                  public Map<String, String> extract(GetBookFromAbsolutelyAnywhereRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    params.put("alt_book_name", String.valueOf(request.getAltBookName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<UpdateBookIndexRequest, Empty> updateBookIndexTransportSettings =
         GrpcCallSettings.<UpdateBookIndexRequest, Empty>newBuilder()
             .setMethodDescriptor(updateBookIndexMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<UpdateBookIndexRequest>() {
-                  @Override
-                  public Map<String, String> extract(UpdateBookIndexRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<StreamShelvesRequest, StreamShelvesResponse> streamShelvesTransportSettings =
         GrpcCallSettings.<StreamShelvesRequest, StreamShelvesResponse>newBuilder()
@@ -3639,41 +3503,14 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<AddTagRequest, AddTagResponse> addTagTransportSettings =
         GrpcCallSettings.<AddTagRequest, AddTagResponse>newBuilder()
             .setMethodDescriptor(addTagMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<AddTagRequest>() {
-                  @Override
-                  public Map<String, String> extract(AddTagRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("resource", String.valueOf(request.getResource()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<GetBookRequest, Operation> getBigBookTransportSettings =
         GrpcCallSettings.<GetBookRequest, Operation>newBuilder()
             .setMethodDescriptor(getBigBookMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<GetBookRequest>() {
-                  @Override
-                  public Map<String, String> extract(GetBookRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<GetBookRequest, Operation> getBigNothingTransportSettings =
         GrpcCallSettings.<GetBookRequest, Operation>newBuilder()
             .setMethodDescriptor(getBigNothingMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<GetBookRequest>() {
-                  @Override
-                  public Map<String, String> extract(GetBookRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsTransportSettings =
         GrpcCallSettings.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
@@ -3682,15 +3519,6 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<GetBookRequest, Book> privateGetBookTransportSettings =
         GrpcCallSettings.<GetBookRequest, Book>newBuilder()
             .setMethodDescriptor(privateGetBookMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<GetBookRequest>() {
-                  @Override
-                  public Map<String, String> extract(GetBookRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
             .build();
 
     this.createShelfCallable = callableFactory.createUnaryCallable(createShelfTransportSettings,settings.createShelfSettings(), clientContext);

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -3415,6 +3415,15 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<GetShelfRequest, Shelf> getShelfTransportSettings =
         GrpcCallSettings.<GetShelfRequest, Shelf>newBuilder()
             .setMethodDescriptor(getShelfMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<GetShelfRequest>() {
+                  @Override
+                  public Map<String, String> extract(GetShelfRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<ListShelvesRequest, ListShelvesResponse> listShelvesTransportSettings =
         GrpcCallSettings.<ListShelvesRequest, ListShelvesResponse>newBuilder()
@@ -3423,38 +3432,119 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<DeleteShelfRequest, Empty> deleteShelfTransportSettings =
         GrpcCallSettings.<DeleteShelfRequest, Empty>newBuilder()
             .setMethodDescriptor(deleteShelfMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<DeleteShelfRequest>() {
+                  @Override
+                  public Map<String, String> extract(DeleteShelfRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<MergeShelvesRequest, Shelf> mergeShelvesTransportSettings =
         GrpcCallSettings.<MergeShelvesRequest, Shelf>newBuilder()
             .setMethodDescriptor(mergeShelvesMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<MergeShelvesRequest>() {
+                  @Override
+                  public Map<String, String> extract(MergeShelvesRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<CreateBookRequest, Book> createBookTransportSettings =
         GrpcCallSettings.<CreateBookRequest, Book>newBuilder()
             .setMethodDescriptor(createBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<CreateBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(CreateBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesTransportSettings =
         GrpcCallSettings.<PublishSeriesRequest, PublishSeriesResponse>newBuilder()
             .setMethodDescriptor(publishSeriesMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<PublishSeriesRequest>() {
+                  @Override
+                  public Map<String, String> extract(PublishSeriesRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("shelf.name", String.valueOf(request.getShelf().getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<GetBookRequest, Book> getBookTransportSettings =
         GrpcCallSettings.<GetBookRequest, Book>newBuilder()
             .setMethodDescriptor(getBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<GetBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(GetBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<ListBooksRequest, ListBooksResponse> listBooksTransportSettings =
         GrpcCallSettings.<ListBooksRequest, ListBooksResponse>newBuilder()
             .setMethodDescriptor(listBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ListBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(ListBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<DeleteBookRequest, Empty> deleteBookTransportSettings =
         GrpcCallSettings.<DeleteBookRequest, Empty>newBuilder()
             .setMethodDescriptor(deleteBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<DeleteBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(DeleteBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<UpdateBookRequest, Book> updateBookTransportSettings =
         GrpcCallSettings.<UpdateBookRequest, Book>newBuilder()
             .setMethodDescriptor(updateBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<UpdateBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(UpdateBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<MoveBookRequest, Book> moveBookTransportSettings =
         GrpcCallSettings.<MoveBookRequest, Book>newBuilder()
             .setMethodDescriptor(moveBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<MoveBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(MoveBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<ListStringsRequest, ListStringsResponse> listStringsTransportSettings =
         GrpcCallSettings.<ListStringsRequest, ListStringsResponse>newBuilder()
@@ -3463,22 +3553,68 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<AddCommentsRequest, Empty> addCommentsTransportSettings =
         GrpcCallSettings.<AddCommentsRequest, Empty>newBuilder()
             .setMethodDescriptor(addCommentsMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<AddCommentsRequest>() {
+                  @Override
+                  public Map<String, String> extract(AddCommentsRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveTransportSettings =
         GrpcCallSettings.<GetBookFromArchiveRequest, BookFromArchive>newBuilder()
             .setMethodDescriptor(getBookFromArchiveMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<GetBookFromArchiveRequest>() {
+                  @Override
+                  public Map<String, String> extract(GetBookFromArchiveRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereTransportSettings =
         GrpcCallSettings.<GetBookFromAnywhereRequest, BookFromAnywhere>newBuilder()
             .setMethodDescriptor(getBookFromAnywhereMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<GetBookFromAnywhereRequest>() {
+                  @Override
+                  public Map<String, String> extract(GetBookFromAnywhereRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereTransportSettings =
         GrpcCallSettings.<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere>newBuilder()
             .setMethodDescriptor(getBookFromAbsolutelyAnywhereMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<GetBookFromAbsolutelyAnywhereRequest>() {
+                  @Override
+                  public Map<String, String> extract(GetBookFromAbsolutelyAnywhereRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    params.put("alt_book_name", String.valueOf(request.getAltBookName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<UpdateBookIndexRequest, Empty> updateBookIndexTransportSettings =
         GrpcCallSettings.<UpdateBookIndexRequest, Empty>newBuilder()
             .setMethodDescriptor(updateBookIndexMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<UpdateBookIndexRequest>() {
+                  @Override
+                  public Map<String, String> extract(UpdateBookIndexRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<StreamShelvesRequest, StreamShelvesResponse> streamShelvesTransportSettings =
         GrpcCallSettings.<StreamShelvesRequest, StreamShelvesResponse>newBuilder()
@@ -3503,14 +3639,41 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<AddTagRequest, AddTagResponse> addTagTransportSettings =
         GrpcCallSettings.<AddTagRequest, AddTagResponse>newBuilder()
             .setMethodDescriptor(addTagMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<AddTagRequest>() {
+                  @Override
+                  public Map<String, String> extract(AddTagRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("resource", String.valueOf(request.getResource()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<GetBookRequest, Operation> getBigBookTransportSettings =
         GrpcCallSettings.<GetBookRequest, Operation>newBuilder()
             .setMethodDescriptor(getBigBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<GetBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(GetBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<GetBookRequest, Operation> getBigNothingTransportSettings =
         GrpcCallSettings.<GetBookRequest, Operation>newBuilder()
             .setMethodDescriptor(getBigNothingMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<GetBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(GetBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsTransportSettings =
         GrpcCallSettings.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
@@ -3519,6 +3682,15 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<GetBookRequest, Book> privateGetBookTransportSettings =
         GrpcCallSettings.<GetBookRequest, Book>newBuilder()
             .setMethodDescriptor(privateGetBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<GetBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(GetBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
 
     this.createShelfCallable = callableFactory.createUnaryCallable(createShelfTransportSettings,settings.createShelfSettings(), clientContext);

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
@@ -120,7 +120,14 @@ service LibraryService {
 
   // Creates a book.
   rpc CreateBook(CreateBookRequest) returns (Book) {
-    option (google.api.http) = { post: "/v1/{name=bookShelves/*}/books" body: "book" };
+    option (google.api.http) = {
+      post: "/v1/{name=bookShelves/*}/books"
+      body: "book"
+      additional_bindings: {
+        post: "/v1/{name=bookShelves/*}/books"
+        body: "book"
+      }
+    };
     option (google.api.method_signature) = {
       fields: ["name", "book"]
     };
@@ -128,7 +135,13 @@ service LibraryService {
 
   // Creates a series of books.
   rpc PublishSeries(PublishSeriesRequest) returns (PublishSeriesResponse) {
-    option (google.api.http) = { post: "/v1:publish" body: "*" };
+    option (google.api.http) = {
+      post: "/v1:publish"
+      body: "*"
+      additional_bindings: {
+        post: "/v1/{shelf.name=shelves/*}:publish"
+        body: "*"
+    }};
     option (google.api.method_signature) = {
       fields: ["shelf", "books", "edition", "series_uuid"]
     };

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -210,6 +210,8 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 7000
+    header_request_params:
+      - shelf
     batching:
       thresholds:
         element_count_threshold: 6

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -211,7 +211,7 @@ interfaces:
     retry_params_name: default
     timeout_millis: 7000
     header_request_params:
-      - shelf
+      - shelf.name
     batching:
       thresholds:
         element_count_threshold: 6


### PR DESCRIPTION
Purely test resource changes.

Add a `shelf.name` header_request_param to the library_gapic.yaml, and add a corresponding `google.api.http` annotation to library.proto with the semantically same header request param.

Checking this in first will decrease the baseline diff for https://github.com/googleapis/gapic-generator/pull/2491.