### PR TITLE
Uses snake_case for proto variable naming of enable_string_format_functions_override

### DIFF
--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -95,7 +95,7 @@ message ConfigProto {
   // This option is exposed for backward compatibility of Java clients.
   // TODO(andrealin): Migrate this to a command-line option after migrating
   // off artman.
-  .google.protobuf.BoolValue enableStringFormatFunctionsOverride = 22;
+  .google.protobuf.BoolValue enable_string_format_functions_override = 22;
 
   // A list of message resource name configurations.
   repeated ResourceNameMessageConfigProto resource_name_generation = 20;


### PR DESCRIPTION
This field  hasn't been used at all in the wild so it's ok to change it right now