### PR TITLE
Get interfaces

### DIFF
--- a/src/main/java/com/google/api/codegen/config/ApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/ApiModel.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.config;
 
 import com.google.api.tools.framework.model.DiagCollector;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Wrapper class around the API models (e.g. protobuf Model, or Discovery Document).
@@ -34,7 +35,7 @@ public interface ApiModel {
   /** Return a list of scopes for authentication. */
   List<String> getAuthScopes(GapicProductConfig gapicProductConfig);
 
-  List<? extends InterfaceModel> getInterfaces();
+  List<? extends InterfaceModel> getInterfaces(@Nullable GapicProductConfig gapicProductConfig);
 
   List<? extends TypeModel> getAdditionalTypes();
 

--- a/src/main/java/com/google/api/codegen/config/DiscoApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoApiModel.java
@@ -48,7 +48,7 @@ public class DiscoApiModel implements ApiModel {
   }
 
   @Override
-  public List<DiscoInterfaceModel> getInterfaces() {
+  public List<DiscoInterfaceModel> getInterfaces(GapicProductConfig gapicProductConfig) {
     if (interfaceModels != null) {
       return interfaceModels;
     }

--- a/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
@@ -54,7 +54,7 @@ public class ProtoApiModel implements ApiModel {
 
   @Override
   public List<String> getAuthScopes(GapicProductConfig gapicProductConfig) {
-    return getAuthScopes(gapicProductConfig.getProtoParser(), getInterfaces());
+    return getAuthScopes(gapicProductConfig.getProtoParser(), getInterfaces(gapicProductConfig));
   }
 
   @VisibleForTesting
@@ -100,10 +100,10 @@ public class ProtoApiModel implements ApiModel {
   }
 
   @Override
-  public List<ProtoInterfaceModel> getInterfaces() {
+  public List<ProtoInterfaceModel> getInterfaces(GapicProductConfig productConfig) {
     if (interfaceModels == null) {
       interfaceModels =
-          ProtoModels.getInterfaces(protoModel)
+          ProtoModels.getInterfaces(protoModel, productConfig)
               .stream()
               .map(ProtoInterfaceModel::new)
               .collect(ImmutableList.toImmutableList());

--- a/src/main/java/com/google/api/codegen/configgen/mergers/InterfaceMerger.java
+++ b/src/main/java/com/google/api/codegen/configgen/mergers/InterfaceMerger.java
@@ -53,7 +53,7 @@ public class InterfaceMerger {
 
     ConfigNode interfacesValueNode =
         ListTransformer.generateList(
-            model.getInterfaces(), interfacesNode, this::generateInterfaceNode);
+            model.getInterfaces(null), interfacesNode, this::generateInterfaceNode);
     interfacesNode
         .setChild(interfacesValueNode)
         .setComment(new DefaultComment("A list of API interface configurations."));

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicRequestToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicRequestToViewTransformer.java
@@ -117,7 +117,7 @@ public class JavaDiscoGapicRequestToViewTransformer
     String packageName = productConfig.getPackageName();
     SurfaceNamer surfaceNamer = new JavaSurfaceNamer(packageName, packageName, nameFormatter);
 
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       DiscoGapicInterfaceContext context =
           JavaDiscoGapicSurfaceTransformer.newInterfaceContext(
               apiInterface,

--- a/src/main/java/com/google/api/codegen/gapic/LegacyGapicGenerator.java
+++ b/src/main/java/com/google/api/codegen/gapic/LegacyGapicGenerator.java
@@ -74,7 +74,7 @@ public class LegacyGapicGenerator implements CodeGenerator<Doc> {
 
     // Run the generator for each service.
     Map<String, GeneratedResult<Doc>> generated = new TreeMap<>();
-    for (Interface modelInterface : ProtoModels.getInterfaces(model)) {
+    for (Interface modelInterface : ProtoModels.getInterfaces(model, context.getApiConfig())) {
       if (context.getApiConfig().getInterfaceConfig(modelInterface) == null) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/gapic/ProtoModels.java
+++ b/src/main/java/com/google/api/codegen/gapic/ProtoModels.java
@@ -36,7 +36,7 @@ public class ProtoModels {
       return getInterfacesFromServiceConfig(model);
     }
 
-    // Assume valid service config if proto annotations parsing is not enabled.
+    // No service config was given, or we shouldn't parse it.
     return model.getSymbolTable().getInterfaces().asList();
   }
 

--- a/src/main/java/com/google/api/codegen/gapic/ProtoModels.java
+++ b/src/main/java/com/google/api/codegen/gapic/ProtoModels.java
@@ -14,10 +14,12 @@
  */
 package com.google.api.codegen.gapic;
 
+import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * An interface-based view of model, consisting of a strategy for getting the interfaces of the
@@ -27,8 +29,19 @@ public class ProtoModels {
 
   private ProtoModels() {}
 
+  /** Gets the interfaces for the apis in the model. */
+  public static List<Interface> getInterfaces(
+      Model model, @Nullable GapicProductConfig productConfig) {
+    if (productConfig == null || !productConfig.getProtoParser().isProtoAnnotationsEnabled()) {
+      return getInterfacesFromServiceConfig(model);
+    }
+
+    // Assume valid service config if proto annotations parsing is not enabled.
+    return model.getSymbolTable().getInterfaces().asList();
+  }
+
   /** Gets the interfaces for the apis in the service config. */
-  public static List<Interface> getInterfaces(Model model) {
+  public static List<Interface> getInterfacesFromServiceConfig(Model model) {
     return model
         .getServiceConfig()
         .getApisList()

--- a/src/main/java/com/google/api/codegen/gapic/ProtoModels.java
+++ b/src/main/java/com/google/api/codegen/gapic/ProtoModels.java
@@ -41,7 +41,7 @@ public class ProtoModels {
   }
 
   /** Gets the interfaces for the apis in the service config. */
-  public static List<Interface> getInterfacesFromServiceConfig(Model model) {
+  private static List<Interface> getInterfacesFromServiceConfig(Model model) {
     return model
         .getServiceConfig()
         .getApisList()

--- a/src/main/java/com/google/api/codegen/transformer/GapicInterfaceContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/GapicInterfaceContext.java
@@ -77,7 +77,7 @@ public abstract class GapicInterfaceContext implements InterfaceContext {
   private static Map<Interface, Interface> createGrpcRerouteMap(
       Model model, GapicProductConfig productConfig) {
     HashMap<Interface, Interface> grpcRerouteMap = new HashMap<>();
-    for (Interface apiInterface : ProtoModels.getInterfaces(model)) {
+    for (Interface apiInterface : ProtoModels.getInterfaces(model, productConfig)) {
       InterfaceConfig interfaceConfig = productConfig.getInterfaceConfig(apiInterface);
       if (interfaceConfig == null) {
         continue;

--- a/src/main/java/com/google/api/codegen/transformer/MockServiceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/MockServiceTransformer.java
@@ -42,7 +42,7 @@ public class MockServiceTransformer {
       return ImmutableList.of();
     }
 
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpBasicPackageTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpBasicPackageTransformer.java
@@ -90,7 +90,7 @@ public class CSharpBasicPackageTransformer implements ModelToViewTransformer<Pro
     List<ViewModel> surfaceDocs = new ArrayList<>();
     SurfaceNamer namer = new CSharpSurfaceNamer(productConfig.getPackageName(), ALIAS_MODE);
 
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientPackageTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientPackageTransformer.java
@@ -61,7 +61,7 @@ public class CSharpGapicClientPackageTransformer implements ModelToViewTransform
   @Override
   public List<ViewModel> transform(ProtoApiModel model, GapicProductConfig productConfig) {
     return Streams.findLast(
-            model.getInterfaces().stream().filter(productConfig::hasInterfaceConfig))
+            model.getInterfaces(productConfig).stream().filter(productConfig::hasInterfaceConfig))
         .map(i -> createInterfaceContext(i, productConfig))
         .map(this::generateCsProjView)
         .<List<ViewModel>>map(ImmutableList::of)

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
@@ -115,7 +115,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer<Prot
     CSharpFeatureConfig featureConfig = new CSharpFeatureConfig();
 
     InterfaceModel lastApiInterface = null;
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSmokeTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSmokeTestTransformer.java
@@ -71,7 +71,7 @@ public class CSharpGapicSmokeTestTransformer implements ModelToViewTransformer<P
     List<ViewModel> surfaceDocs = new ArrayList<>();
     SurfaceNamer namer = new CSharpSurfaceNamer(productConfig.getPackageName(), ALIAS_MODE);
 
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
@@ -76,7 +76,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer<Pr
     List<ViewModel> surfaceDocs = new ArrayList<>();
     SurfaceNamer namer = new CSharpSurfaceNamer(productConfig.getPackageName(), ALIAS_MODE);
 
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicUnitTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicUnitTestTransformer.java
@@ -80,7 +80,7 @@ public class CSharpGapicUnitTestTransformer implements ModelToViewTransformer<Pr
     List<ViewModel> surfaceDocs = new ArrayList<>();
     SurfaceNamer namer = new CSharpSurfaceNamer(productConfig.getPackageName(), ALIAS_MODE);
 
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTestTransformer.java
@@ -89,7 +89,7 @@ public class GoGapicSurfaceTestTransformer implements ModelToViewTransformer<Pro
     List<ViewModel> models = new ArrayList<ViewModel>();
     models.add(generateMockServiceView(model, productConfig, namer));
 
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       InterfaceConfig interfaceConfig = productConfig.getInterfaceConfig(apiInterface);
       if (interfaceConfig == null || interfaceConfig.getSmokeTestConfig() == null) {
         continue;
@@ -125,7 +125,7 @@ public class GoGapicSurfaceTestTransformer implements ModelToViewTransformer<Pro
               .grpcMethods(mockServiceTransformer.createMockGrpcMethodViews(context))
               .build());
     }
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -109,7 +109,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer<ProtoAp
   public List<ViewModel> transform(ProtoApiModel model, GapicProductConfig productConfig) {
     List<ViewModel> models = new ArrayList<>();
     GoSurfaceNamer namer = new GoSurfaceNamer(productConfig.getPackageName());
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSamplesTransformer.java
@@ -64,7 +64,7 @@ public class JavaGapicSamplesTransformer implements ModelToViewTransformer<Proto
     List<ViewModel> surfaceDocs = new ArrayList<>();
     SurfaceNamer namer = createSurfaceNamer(productConfig);
 
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
@@ -102,7 +102,7 @@ public class JavaSurfaceTestTransformer<ApiModelT extends ApiModel>
     SurfaceNamer namer = surfaceTransformer.createSurfaceNamer(productConfig);
 
     List<ViewModel> views = new ArrayList<>();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -115,7 +115,7 @@ public class JavaSurfaceTransformer {
     SurfaceNamer namer = surfaceTransformer.createSurfaceNamer(productConfig);
 
     List<ServiceDocView> serviceDocs = new ArrayList<>();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }
@@ -705,7 +705,7 @@ public class JavaSurfaceTransformer {
             productConfig, ImportSectionView.newBuilder().build(), namer));
 
     model
-        .getInterfaces()
+        .getInterfaces(productConfig)
         .stream()
         .filter(productConfig::hasInterfaceConfig)
         .map(InterfaceModel::getFullName)

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSamplesTransformer.java
@@ -87,7 +87,7 @@ public class NodeJSGapicSamplesTransformer implements ModelToViewTransformer<Pro
   private List<ViewModel> generateSampleClassesForModel(
       ApiModel model, GapicProductConfig productConfig) {
     ImmutableList.Builder<ViewModel> models = ImmutableList.builder();
-    Iterable<? extends InterfaceModel> interfaces = model.getInterfaces();
+    Iterable<? extends InterfaceModel> interfaces = model.getInterfaces(productConfig);
     for (InterfaceModel apiInterface : interfaces) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
@@ -118,7 +118,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
               .grpcMethods(mockServiceTransformer.createMockGrpcMethodViews(context))
               .build());
     }
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }
@@ -215,7 +215,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
 
   private List<ViewModel> createSmokeTestViews(ApiModel model, GapicProductConfig productConfig) {
     ImmutableList.Builder<ViewModel> views = ImmutableList.builder();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       InterfaceConfig interfaceConfig = productConfig.getInterfaceConfig(apiInterface);
       if (interfaceConfig == null || interfaceConfig.getSmokeTestConfig() == null) {
         continue;

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -97,7 +97,7 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer<Pro
   public List<ViewModel> transform(ProtoApiModel model, GapicProductConfig productConfig) {
     Collection<? extends InterfaceModel> apiInterfaces =
         model
-            .getInterfaces()
+            .getInterfaces(productConfig)
             .stream()
             .filter(productConfig::hasInterfaceConfig)
             .collect(ImmutableList.toImmutableList());

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -22,7 +22,6 @@ import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
-import com.google.api.codegen.config.ProductConfig;
 import com.google.api.codegen.config.ProtoApiModel;
 import com.google.api.codegen.config.VersionBound;
 import com.google.api.codegen.nodejs.NodeJSUtils;
@@ -137,7 +136,7 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer<
   private List<ApiMethodView> generateExampleMethods(
       ApiModel model, GapicProductConfig productConfig) {
     ImmutableList.Builder<ApiMethodView> exampleMethods = ImmutableList.builder();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       InterfaceConfig interfaceConfig = productConfig.getInterfaceConfig(apiInterface);
       if (interfaceConfig == null || interfaceConfig.getSmokeTestConfig() == null) {
         continue;
@@ -169,7 +168,7 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer<
   }
 
   private List<ViewModel> generateMetadataViews(
-      ApiModel model, ProductConfig productConfig, NodeJSPackageMetadataNamer namer) {
+      ApiModel model, GapicProductConfig productConfig, NodeJSPackageMetadataNamer namer) {
     ImmutableList.Builder<ViewModel> views = ImmutableList.builder();
     for (String template : TOP_LEVEL_FILES) {
       views.add(generateMetadataView(model, productConfig, template, namer));
@@ -179,7 +178,7 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer<
 
   private ViewModel generateMetadataView(
       ApiModel model,
-      ProductConfig productConfig,
+      GapicProductConfig productConfig,
       String template,
       NodeJSPackageMetadataNamer namer) {
     String noLeadingNodeDir =
@@ -197,7 +196,7 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer<
   }
 
   private List<PackageDependencyView> generateAdditionalDependencies(
-      ApiModel model, ProductConfig productConfig) {
+      ApiModel model, GapicProductConfig productConfig) {
     ImmutableList.Builder<PackageDependencyView> dependencies = ImmutableList.builder();
     dependencies.add(
         PackageDependencyView.create(
@@ -215,18 +214,18 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer<
     return dependencies.build();
   }
 
-  private boolean hasLongrunning(ApiModel model, ProductConfig productConfig) {
+  private boolean hasLongrunning(ApiModel model, GapicProductConfig productConfig) {
     return model
-        .getInterfaces()
+        .getInterfaces(productConfig)
         .stream()
         .map(productConfig::getInterfaceConfig)
         .filter(Objects::nonNull)
         .anyMatch(InterfaceConfig::hasLongRunningOperations);
   }
 
-  private boolean hasBatching(ApiModel model, ProductConfig productConfig) {
+  private boolean hasBatching(ApiModel model, GapicProductConfig productConfig) {
     return model
-        .getInterfaces()
+        .getInterfaces(productConfig)
         .stream()
         .map(productConfig::getInterfaceConfig)
         .filter(Objects::nonNull)
@@ -235,7 +234,7 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer<
 
   private boolean hasMixinApis(ApiModel model, GapicProductConfig productConfig) {
     return model
-        .getInterfaces()
+        .getInterfaces(productConfig)
         .stream()
         .filter(productConfig::hasInterfaceConfig)
         .map(i -> createContext(i, productConfig))

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSamplesTransformer.java
@@ -81,7 +81,7 @@ public class PhpGapicSamplesTransformer implements ModelToViewTransformer<ProtoA
   @Override
   public List<ViewModel> transform(ProtoApiModel model, GapicProductConfig productConfig) {
     ImmutableList.Builder<ViewModel> models = ImmutableList.builder();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTestTransformer.java
@@ -87,7 +87,7 @@ public class PhpGapicSurfaceTestTransformer implements ModelToViewTransformer<Pr
   @Override
   public List<ViewModel> transform(ProtoApiModel model, GapicProductConfig productConfig) {
     List<ViewModel> views = new ArrayList<>();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -120,7 +120,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer<ProtoA
   @Override
   public List<ViewModel> transform(ProtoApiModel model, GapicProductConfig productConfig) {
     List<ViewModel> surfaceDocs = new ArrayList<>();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSamplesTransformer.java
@@ -103,7 +103,7 @@ public class PythonGapicSamplesTransformer implements ModelToViewTransformer<Pro
     FeatureConfig featureConfig = new DefaultFeatureConfig();
     ImmutableList.Builder<ViewModel> serviceSurfaces = ImmutableList.builder();
 
-    for (InterfaceModel apiInterface : apiModel.getInterfaces()) {
+    for (InterfaceModel apiInterface : apiModel.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTestTransformer.java
@@ -106,7 +106,7 @@ public class PythonGapicSurfaceTestTransformer implements ModelToViewTransformer
     SurfaceNamer surfacePackageNamer = new PythonSurfaceNamer(productConfig.getPackageName());
     SurfaceNamer testPackageNamer =
         new PythonSurfaceNamer(surfacePackageNamer.getTestPackageName());
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }
@@ -251,7 +251,7 @@ public class PythonGapicSurfaceTestTransformer implements ModelToViewTransformer
     SurfaceNamer surfacePackageNamer = new PythonSurfaceNamer(productConfig.getPackageName());
     SurfaceNamer testPackageNamer =
         new PythonSurfaceNamer(surfacePackageNamer.getTestPackageName());
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       InterfaceConfig interfaceConfig = productConfig.getInterfaceConfig(apiInterface);
       if (interfaceConfig == null || interfaceConfig.getSmokeTestConfig() == null) {
         continue;

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
@@ -21,7 +21,6 @@ import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
-import com.google.api.codegen.config.ProductConfig;
 import com.google.api.codegen.config.ProductServiceConfig;
 import com.google.api.codegen.config.ProtoApiModel;
 import com.google.api.codegen.config.SampleSpec.SampleType;
@@ -142,7 +141,7 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer<Pro
     FeatureConfig featureConfig = new DefaultFeatureConfig();
     ImmutableList.Builder<ViewModel> serviceSurfaces = ImmutableList.builder();
 
-    for (InterfaceModel apiInterface : apiModel.getInterfaces()) {
+    for (InterfaceModel apiInterface : apiModel.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }
@@ -344,7 +343,8 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer<Pro
         .build();
   }
 
-  private ViewModel generateVersionedInitView(ProtoApiModel apiModel, ProductConfig productConfig) {
+  private ViewModel generateVersionedInitView(
+      ProtoApiModel apiModel, GapicProductConfig productConfig) {
     SurfaceNamer namer = new PythonSurfaceNamer(productConfig.getPackageName());
     boolean packageHasEnums = packageHasEnums(apiModel.getProtoModel());
     ImportSectionView imports =
@@ -371,9 +371,9 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer<Pro
   }
 
   private List<VersionIndexRequireView> versionedInitRequireViews(
-      ApiModel apiModel, ProductConfig productConfig, SurfaceNamer namer) {
+      ApiModel apiModel, GapicProductConfig productConfig, SurfaceNamer namer) {
     return apiModel
-        .getInterfaces()
+        .getInterfaces(productConfig)
         .stream()
         .map(intf -> productConfig.getInterfaceConfig(intf))
         .filter(Objects::nonNull)
@@ -401,12 +401,12 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer<Pro
   }
 
   private Iterable<ViewModel> generateTopLevelViews(
-      ProtoApiModel apiModel, ProductConfig productConfig) {
+      ProtoApiModel apiModel, GapicProductConfig productConfig) {
     return ImmutableList.of(generateTopLevelEntryPoint(apiModel, productConfig));
   }
 
   private ViewModel generateTopLevelEntryPoint(
-      ProtoApiModel apiModel, ProductConfig productConfig) {
+      ProtoApiModel apiModel, GapicProductConfig productConfig) {
     SurfaceNamer namer = new PythonSurfaceNamer(productConfig.getPackageName());
     boolean packageHasEnums = packageHasEnums(apiModel.getProtoModel());
     ImportSectionView imports =
@@ -436,9 +436,9 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer<Pro
   }
 
   private List<VersionIndexRequireView> topLevelRequireViews(
-      ApiModel apiModel, ProductConfig productConfig, SurfaceNamer namer) {
+      ApiModel apiModel, GapicProductConfig productConfig, SurfaceNamer namer) {
     return apiModel
-        .getInterfaces()
+        .getInterfaces(productConfig)
         .stream()
         .map(intf -> productConfig.getInterfaceConfig(intf))
         .filter(Objects::nonNull)

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
@@ -491,7 +491,10 @@ public class PythonImportSectionTransformer implements ImportSectionTransformer 
   }
 
   public ImportSectionView generateVersionedInitImportSection(
-      ApiModel apiModel, ProductConfig productConfig, SurfaceNamer namer, boolean packageHasEnums) {
+      ApiModel apiModel,
+      GapicProductConfig productConfig,
+      SurfaceNamer namer,
+      boolean packageHasEnums) {
     return ImportSectionView.newBuilder()
         .appImports(
             generateVersionedInitAppImports(apiModel, productConfig, namer, packageHasEnums))
@@ -504,9 +507,12 @@ public class PythonImportSectionTransformer implements ImportSectionTransformer 
   }
 
   private List<ImportFileView> generateVersionedInitAppImports(
-      ApiModel apiModel, ProductConfig productConfig, SurfaceNamer namer, boolean packageHasEnums) {
+      ApiModel apiModel,
+      GapicProductConfig productConfig,
+      SurfaceNamer namer,
+      boolean packageHasEnums) {
     Set<ImportFileView> imports = new TreeSet<>(importFileViewComparator());
-    for (InterfaceModel apiInterface : apiModel.getInterfaces()) {
+    for (InterfaceModel apiInterface : apiModel.getInterfaces(productConfig)) {
       InterfaceConfig interfaceConfig = productConfig.getInterfaceConfig(apiInterface);
       if (interfaceConfig == null) {
         continue;
@@ -525,7 +531,10 @@ public class PythonImportSectionTransformer implements ImportSectionTransformer 
   }
 
   public ImportSectionView generateTopLeveEntryPointImportSection(
-      ApiModel apiModel, ProductConfig productConfig, SurfaceNamer namer, boolean packageHasEnums) {
+      ApiModel apiModel,
+      GapicProductConfig productConfig,
+      SurfaceNamer namer,
+      boolean packageHasEnums) {
     return ImportSectionView.newBuilder()
         .appImports(
             generateTopLevelEntryPointAppImports(apiModel, productConfig, namer, packageHasEnums))
@@ -534,9 +543,12 @@ public class PythonImportSectionTransformer implements ImportSectionTransformer 
   }
 
   private List<ImportFileView> generateTopLevelEntryPointAppImports(
-      ApiModel apiModel, ProductConfig productConfig, SurfaceNamer namer, boolean packageHasEnums) {
+      ApiModel apiModel,
+      GapicProductConfig productConfig,
+      SurfaceNamer namer,
+      boolean packageHasEnums) {
     Set<ImportFileView> imports = new TreeSet<>(importFileViewComparator());
-    for (InterfaceModel apiInterface : apiModel.getInterfaces()) {
+    for (InterfaceModel apiInterface : apiModel.getInterfaces(productConfig)) {
       InterfaceConfig interfaceConfig = productConfig.getInterfaceConfig(apiInterface);
       if (interfaceConfig == null) {
         continue;

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
@@ -236,7 +236,7 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer<
 
   private boolean hasSmokeTests(ApiModel apiModel, GapicProductConfig productConfig) {
     return apiModel
-        .getInterfaces()
+        .getInterfaces(productConfig)
         .stream()
         .map(productConfig::getInterfaceConfig)
         .filter(Objects::nonNull)
@@ -299,7 +299,7 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer<
   private List<ApiMethodView> generateExampleMethods(
       ApiModel model, GapicProductConfig productConfig) {
     ImmutableList.Builder<ApiMethodView> exampleMethods = ImmutableList.builder();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       InterfaceConfig interfaceConfig = productConfig.getInterfaceConfig(apiInterface);
       if (interfaceConfig == null || interfaceConfig.getSmokeTestConfig() == null) {
         continue;

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTestTransformer.java
@@ -104,7 +104,7 @@ public class RubyGapicSurfaceTestTransformer implements ModelToViewTransformer<P
       ApiModel model, GapicProductConfig productConfig) {
     ImmutableList.Builder<ClientTestFileView> views = ImmutableList.builder();
     SurfaceNamer namer = new RubySurfaceNamer(productConfig.getPackageName());
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }
@@ -219,7 +219,7 @@ public class RubyGapicSurfaceTestTransformer implements ModelToViewTransformer<P
 
   private List<ViewModel> createSmokeTestViews(ApiModel model, GapicProductConfig productConfig) {
     ImmutableList.Builder<ViewModel> views = ImmutableList.builder();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       InterfaceConfig interfaceConfig = productConfig.getInterfaceConfig(apiInterface);
       if (interfaceConfig == null || interfaceConfig.getSmokeTestConfig() == null) {
         continue;

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -124,7 +124,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer<Proto
     SurfaceNamer namer = new RubySurfaceNamer(productConfig.getPackageName());
     FeatureConfig featureConfig = new RubyFeatureConfig();
     ImmutableList.Builder<ViewModel> serviceSurfaces = ImmutableList.builder();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }
@@ -220,7 +220,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer<Proto
     SurfaceNamer namer = new RubySurfaceNamer(productConfig.getPackageName());
 
     ImmutableList.Builder<VersionIndexRequireView> requireViews = ImmutableList.builder();
-    Iterable<? extends InterfaceModel> interfaces = model.getInterfaces();
+    Iterable<? extends InterfaceModel> interfaces = model.getInterfaces(productConfig);
     for (InterfaceModel apiInterface : interfaces) {
       InterfaceConfig interfaceConfig = productConfig.getInterfaceConfig(apiInterface);
       if (interfaceConfig == null) {
@@ -280,7 +280,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer<Proto
     List<String> modules = namer.getApiModules();
     InterfaceModel apiInterface =
         model
-            .getInterfaces()
+            .getInterfaces(productConfig)
             .stream()
             .filter(productConfig::hasInterfaceConfig)
             .findFirst()
@@ -342,7 +342,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer<Proto
 
     ImmutableList.Builder<VersionIndexRequireView> requireViews = ImmutableList.builder();
     List<String> modules = namer.getTopLevelApiModules();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       if (!productConfig.hasInterfaceConfig(apiInterface)) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
@@ -226,7 +226,7 @@ public class RubyPackageMetadataTransformer implements ModelToViewTransformer<Pr
   private List<ApiMethodView> generateExampleMethods(
       ApiModel model, GapicProductConfig productConfig) {
     ImmutableList.Builder<ApiMethodView> exampleMethods = ImmutableList.builder();
-    for (InterfaceModel apiInterface : model.getInterfaces()) {
+    for (InterfaceModel apiInterface : model.getInterfaces(productConfig)) {
       InterfaceConfig interfaceConfig = productConfig.getInterfaceConfig(apiInterface);
       if (interfaceConfig == null || interfaceConfig.getSmokeTestConfig() == null) {
         continue;
@@ -299,7 +299,7 @@ public class RubyPackageMetadataTransformer implements ModelToViewTransformer<Pr
 
     Collection<InterfaceModel> interfaceModels =
         model
-            .getInterfaces()
+            .getInterfaces(productConfig)
             .stream()
             .filter(productConfig::hasInterfaceConfig)
             .collect(ImmutableList.toImmutableList());

--- a/src/main/java/com/google/api/codegen/util/ProtoParser.java
+++ b/src/main/java/com/google/api/codegen/util/ProtoParser.java
@@ -57,6 +57,10 @@ import javax.annotation.Nullable;
 public class ProtoParser {
   private final boolean enableProtoAnnotations;
 
+  public boolean isProtoAnnotationsEnabled() {
+    return enableProtoAnnotations;
+  }
+
   public ProtoParser(boolean enableProtoAnnotations) {
     this.enableProtoAnnotations = enableProtoAnnotations;
   }


### PR DESCRIPTION
When service config is not given, just look at `model.getInterfaces()`. When service config is given, look at `model.getApis()`.

This blocks https://github.com/googleapis/gapic-generator/pull/2532