### PR TITLE
Only run artman_smoke_tests on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -772,7 +772,9 @@ workflows:
       - artman_smoke_tests:
           requires:
             - install-gapic-generator
-          # TODO(andrealin): Only run this on the master branch after the job is shown to work
+          filters:
+            branches:
+              only: master
       - compute-discovery-test:
           requires:
             - install-gapic-generator


### PR DESCRIPTION
There's a very low chance that the artman_smoke_tests will fail, so let's not run them so we can free up circleCI machines.