### PR TITLE
Add ./gradlew build command to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,7 @@ jobs:
           command: |
             export RUNNING_IN_ARTMAN_DOCKER=True
             rm -rf gapic-generator/.git/
-            gapic-generator/gradlew -p gapic-generator fatJar createToolPaths
+            gapic-generator/gradlew -p gapic-generator build fatJar createToolPaths
       - persist_to_workspace:
           # Save the toolkit and googleapis installations in workspace for later CircleCI jobs.
           root: /tmp/workspace


### PR DESCRIPTION
This will at the very least catch an existing javadoc task error.