### PR TITLE
nodejs: do not throw unhandled rejection

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -242,6 +242,10 @@
                 function() {
                   const args = Array.prototype.slice.call(arguments, 0);
                   return stub[methodName].apply(stub, args);
+                },
+              err =>
+                function() {
+                  throw err;
                 }
             ),
             defaults[methodName],

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -3581,6 +3581,10 @@ class LibraryServiceClient {
             function() {
               const args = Array.prototype.slice.call(arguments, 0);
               return stub[methodName].apply(stub, args);
+            },
+          err =>
+            function() {
+              throw err;
             }
         ),
         defaults[methodName],
@@ -3607,6 +3611,10 @@ class LibraryServiceClient {
             function() {
               const args = Array.prototype.slice.call(arguments, 0);
               return stub[methodName].apply(stub, args);
+            },
+          err =>
+            function() {
+              throw err;
             }
         ),
         defaults[methodName],

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -297,6 +297,10 @@ class DecrementerServiceClient {
             function() {
               const args = Array.prototype.slice.call(arguments, 0);
               return stub[methodName].apply(stub, args);
+            },
+          err =>
+            function() {
+              throw err;
             }
         ),
         defaults[methodName],
@@ -611,6 +615,10 @@ class IncrementerServiceClient {
             function() {
               const args = Array.prototype.slice.call(arguments, 0);
               return stub[methodName].apply(stub, args);
+            },
+          err =>
+            function() {
+              throw err;
             }
         ),
         defaults[methodName],

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -287,6 +287,10 @@ class NoTemplatesApiServiceClient {
             function() {
               const args = Array.prototype.slice.call(arguments, 0);
               return stub[methodName].apply(stub, args);
+            },
+          err =>
+            function() {
+              throw err;
             }
         ),
         defaults[methodName],


### PR DESCRIPTION
Fixes #2065, https://github.com/googleapis/nodejs-text-to-speech/issues/12, and https://github.com/googleapis/gax-nodejs/issues/121.

I originally expected to fix it in the new TypeScript generator but since the quick fix is easy and many users are affected, let's just do it here. If any stub cannot be initialized for whatever reason (invalid path to credentials file is one possible reason), we'll not fail the constructor, but all the stubs will throw when called. The difference is that those exceptions can be caught by users.

