### PR TITLE
Remove argparse if there is no sample_argument_name specified

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -78,14 +78,16 @@
   @end
 
   def main():
-    import argparse
+    @if sample.sampleInitCode.argDefaultParams
+      import argparse
 
-    parser = argparse.ArgumentParser()
-    @join param : sample.sampleInitCode.argDefaultParams
-      parser.add_argument('--{@param.cliFlagName}', type={@param.typeName}, default={@renderInitValue(param.initValue)})
+      parser = argparse.ArgumentParser()
+      @join param : sample.sampleInitCode.argDefaultParams
+        parser.add_argument('--{@param.cliFlagName}', type={@param.typeName}, default={@renderInitValue(param.initValue)})
+      @end
+      args = parser.parse_args()
+
     @end
-    args = parser.parse_args()
-
     {@sample.sampleFunctionName}({@actualArgs(sample.sampleInitCode.argDefaultParams)})
 
   if __name__ == '__main__':

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4403,11 +4403,6 @@ def sample_find_related_books():
 # [END sample]
 
 def main():
-  import argparse
-
-  parser = argparse.ArgumentParser()
-  args = parser.parse_args()
-
   sample_find_related_books()
 
 if __name__ == '__main__':
@@ -4462,11 +4457,6 @@ def sample_find_related_books():
 # [END sample]
 
 def main():
-  import argparse
-
-  parser = argparse.ArgumentParser()
-  args = parser.parse_args()
-
   sample_find_related_books()
 
 if __name__ == '__main__':
@@ -4649,11 +4639,6 @@ def sample_monolog_about_book():
 # [END sample]
 
 def main():
-  import argparse
-
-  parser = argparse.ArgumentParser()
-  args = parser.parse_args()
-
   sample_monolog_about_book()
 
 if __name__ == '__main__':
@@ -4794,11 +4779,6 @@ def sample_publish_series():
 # [END canonical]
 
 def main():
-  import argparse
-
-  parser = argparse.ArgumentParser()
-  args = parser.parse_args()
-
   sample_publish_series()
 
 if __name__ == '__main__':
@@ -4847,11 +4827,6 @@ def sample_stream_books():
 # [END lovelace]
 
 def main():
-  import argparse
-
-  parser = argparse.ArgumentParser()
-  args = parser.parse_args()
-
   sample_stream_books()
 
 if __name__ == '__main__':
@@ -4898,11 +4873,6 @@ def sample_stream_shelves():
 # [END sample]
 
 def main():
-  import argparse
-
-  parser = argparse.ArgumentParser()
-  args = parser.parse_args()
-
   sample_stream_shelves()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix #2514