### PR TITLE
Sanitize Node.js standalone sample templates

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -30,15 +30,15 @@
 # FIXME: Replace the following function calls with calls to functions that emit full standalone samples. These stubs have been adapted from method_sample.snip
 @snippet standaloneSample(apiMethod, sample)
 
-  const {@apiMethod.localPackageName} = require('{@apiMethod.packageName}').{@apiMethod.apiVersion};
+  @if apiMethod.hasApiVersion
+    const {@apiMethod.localPackageName} = require('{@apiMethod.packageName}').{@apiMethod.apiVersion};
 
+  @else
+    const {@apiMethod.localPackageName} = require('{@apiMethod.packageName}');
 
+  @end
   function {@sample.sampleFunctionName}({@formalArgs(sample.sampleInitCode.argDefaultParams)}) {
-    @if apiMethod.hasApiVersion
-      const client = new {@apiMethod.localPackageName}.{@apiMethod.apiVersion}.{@apiMethod.apiClassName}();
-    @else
-      const client = new {@apiMethod.localPackageName}.{@apiClassName}({})
-    @end
+    const client = new {@apiMethod.localPackageName}.{@apiMethod.apiClassName}();
     @switch sample.callingForm
     @case "Request"
       @if apiMethod.hasReturnValue

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -39,7 +39,7 @@
   @end
   function {@sample.sampleFunctionName}({@formalArgs(sample.sampleInitCode.argDefaultParams)}) {
     @if apiMethod.hasApiVersion
-      const client = new {@apiMethod.localPackageName}.{@apiMethod.apiVersion}.{@apiMethod.apiClassName}({})
+      const client = new {@apiMethod.localPackageName}.{@apiMethod.apiVersion}.{@apiMethod.apiClassName}()
     @else
       const client = new {@apiMethod.localPackageName}.{@apiClassName}({})
     @end

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -2,16 +2,21 @@
 @extends "nodejs/init_code.snip"
 
 @snippet generate(sampleFile)
-   //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "{@sampleFile.className}" ]
-  'use strict';
   @let apiMethod = sampleFile.libraryMethod
     @let sample = apiMethod.samples.get(0)
+      // DO NOT EDIT! This is a generated sample ("{@sample.callingForm}",  "{@sample.valueSet.id}")
+      'use strict';
       // [START {@sample.regionTag}]
       // [START {@sample.regionTag}_core]
       {@standaloneSample(apiMethod, sample)}
       // [END {@sample.regionTag}_core]
       // tslint:disable-next-line:no-any
       // [END {@sample.regionTag}]
+      @if sample.sampleInitCode.argDefaultParams
+        {@processCliArguments(sample)}
+
+      @end
+      {@sample.sampleFunctionName}({@argvArgs(sample.sampleInitCode.argDefaultParams)});
     @end
   @end
 @end
@@ -60,11 +65,6 @@
     @end
   }
 
-  @if sample.sampleInitCode.argDefaultParams
-    {@processCliArguments(sample)}
-
-  @end
-  {@sample.sampleFunctionName}({@argvArgs(sample.sampleInitCode.argDefaultParams)});
 @end
 
 @private processResponse(sample)

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -29,16 +29,19 @@
 #
 # FIXME: Replace the following function calls with calls to functions that emit full standalone samples. These stubs have been adapted from method_sample.snip
 @snippet standaloneSample(apiMethod, sample)
-  function {@sample.sampleFunctionName}({@formalArgs(sample.sampleInitCode.argDefaultParams)}) {
+
+  @if apiMethod.hasApiVersion
+    const {@apiMethod.localPackageName} = require('{@apiMethod.packageName}').{@apiMethod.apiVersion};
+
+  @else
     const {@apiMethod.localPackageName} = require('{@apiMethod.packageName}');
+
+  @end
+  function {@sample.sampleFunctionName}({@formalArgs(sample.sampleInitCode.argDefaultParams)}) {
     @if apiMethod.hasApiVersion
-      const client = new {@apiMethod.localPackageName}.{@apiMethod.apiVersion}.{@apiMethod.apiClassName}({
-        // optional auth parameters.
-      })
+      const client = new {@apiMethod.localPackageName}.{@apiMethod.apiVersion}.{@apiMethod.apiClassName}({})
     @else
-      const client = new {@apiMethod.localPackageName}.{@apiClassName}({
-        // optional auth parameters.
-      })
+      const client = new {@apiMethod.localPackageName}.{@apiClassName}({})
     @end
     @switch sample.callingForm
     @case "Request"

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -8,33 +8,14 @@
    // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
   @let apiMethod = sampleFile.libraryMethod
-     @let sample = apiMethod.samples.get(0)
-       // [START {@sample.regionTag}]
-
-       // FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-       //      calling form: "{@sample.callingForm.toString}"
-       //        region tag: "{@sample.regionTag}"
-       //         className: "{@sampleFile.className}"
-       //          valueSet: "{@sample.valueSet.id}" ("{@sample.valueSet.title}")
-       //       description: "{@sample.valueSet.description}"
-       //        {@sample.valueSet.parameters}
-       //      apiMethod "{@apiMethod.name}" of type "{@apiMethod.type}"
-
-       // [START {@sample.regionTag}_core]
-
-       // FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-       /*
-       {@standaloneSample(apiMethod, sample)}
-       */
-       // [END {@sample.regionTag}_core]
-
-       // FIXME: Insert here clean-up code.
-       // tslint:disable-next-line:no-any
-       // [END {@sample.regionTag}]
-     @end
-   @end
+    @let sample = apiMethod.samples.get(0)
+      // [START {@sample.regionTag}]
+      // [START {@sample.regionTag}_core]
+      {@standaloneSample(apiMethod, sample)}
+      // [END {@sample.regionTag}_core]
+      // [END {@sample.regionTag}]
+    @end
+  @end
 @end
 
 # The structure of this should be parallel to that of method_sample.snip:@incodeSample
@@ -42,6 +23,16 @@
 # FIXME: Replace the following function calls with calls to functions that emit full standalone samples. These stubs have been adapted from method_sample.snip
 @snippet standaloneSample(apiMethod, sample)
   function {@sample.sampleFunctionName}({@formalArgs(sample.sampleInitCode.argDefaultParams)}) {
+    const {@apiMethod.localPackageName} = require('{@apiMethod.packageName}');
+    @if apiMethod.hasApiVersion
+      const client = new {@apiMethod.localPackageName}.{@apiMethod.apiVersion}.{@apiMethod.apiClassName}({
+        // optional auth parameters.
+      })
+    @else
+      const client = new {@apiMethod.localPackageName}.{@apiClassName}({
+        // optional auth parameters.
+      })
+    @end
     @switch sample.callingForm
     @case "Request"
       @if apiMethod.hasReturnValue
@@ -87,7 +78,7 @@
 @end
 
 @private processCliArguments(sample)
-  require(`yargs`)
+  argv = require(`yargs`)
     @join param : sample.sampleInitCode.argDefaultParams
       .default('{@param.cliFlagName}', {@renderInitValue(param.initValue)})
     @end

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -3,16 +3,14 @@
 
 @snippet generate(sampleFile)
    //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "{@sampleFile.className}" ]
-   //// STUB standalone sample "{@sampleFile.className}" /////
-
-   // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+  'use strict';
   @let apiMethod = sampleFile.libraryMethod
     @let sample = apiMethod.samples.get(0)
       // [START {@sample.regionTag}]
       // [START {@sample.regionTag}_core]
       {@standaloneSample(apiMethod, sample)}
       // [END {@sample.regionTag}_core]
+      // tslint:disable-next-line:no-any
       // [END {@sample.regionTag}]
     @end
   @end

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -30,13 +30,9 @@
 # FIXME: Replace the following function calls with calls to functions that emit full standalone samples. These stubs have been adapted from method_sample.snip
 @snippet standaloneSample(apiMethod, sample)
 
-  @if apiMethod.hasApiVersion
-    const {@apiMethod.localPackageName} = require('{@apiMethod.packageName}').{@apiMethod.apiVersion};
+  const {@apiMethod.localPackageName} = require('{@apiMethod.packageName}').{@apiMethod.apiVersion};
 
-  @else
-    const {@apiMethod.localPackageName} = require('{@apiMethod.packageName}');
 
-  @end
   function {@sample.sampleFunctionName}({@formalArgs(sample.sampleInitCode.argDefaultParams)}) {
     @if apiMethod.hasApiVersion
       const client = new {@apiMethod.localPackageName}.{@apiMethod.apiVersion}.{@apiMethod.apiClassName}();

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -6,12 +6,16 @@
     @let sample = apiMethod.samples.get(0)
       // DO NOT EDIT! This is a generated sample ("{@sample.callingForm}",  "{@sample.valueSet.id}")
       'use strict';
+
       // [START {@sample.regionTag}]
       // [START {@sample.regionTag}_core]
+
       {@standaloneSample(apiMethod, sample)}
+
       // [END {@sample.regionTag}_core]
       // tslint:disable-next-line:no-any
       // [END {@sample.regionTag}]
+
       @if sample.sampleInitCode.argDefaultParams
         {@processCliArguments(sample)}
 

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -39,7 +39,7 @@
   @end
   function {@sample.sampleFunctionName}({@formalArgs(sample.sampleInitCode.argDefaultParams)}) {
     @if apiMethod.hasApiVersion
-      const client = new {@apiMethod.localPackageName}.{@apiMethod.apiVersion}.{@apiMethod.apiClassName}()
+      const client = new {@apiMethod.localPackageName}.{@apiMethod.apiVersion}.{@apiMethod.apiClassName}();
     @else
       const client = new {@apiMethod.localPackageName}.{@apiClassName}({})
     @end

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -250,10 +250,7 @@ module.exports.default = Object.assign({}, module.exports);
 
 ============== file: src/samples/v1/discuss_book_request_streaming_bidi_prog.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookRequestStreamingBidiProg" ]
-//// STUB standalone sample "DiscussBookRequestStreamingBidiProg" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START turing_prog_request_streaming_bidi]
 // [START turing_prog_request_streaming_bidi_core]
 function sampleDiscussBook(imageFileName) {
@@ -287,13 +284,11 @@ argv = require(`yargs`)
 
 sampleDiscussBook(argv.image_file_name);
 // [END turing_prog_request_streaming_bidi_core]
+// tslint:disable-next-line:no-any
 // [END turing_prog_request_streaming_bidi]
 ============== file: src/samples/v1/find_related_books_request_async_paged_all_odyssey.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestAsyncPagedAllOdyssey" ]
-//// STUB standalone sample "FindRelatedBooksRequestAsyncPagedAllOdyssey" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START sample]
 // [START sample_core]
 function sampleFindRelatedBooks() {
@@ -326,13 +321,11 @@ function sampleFindRelatedBooks() {
 
 sampleFindRelatedBooks();
 // [END sample_core]
+// tslint:disable-next-line:no-any
 // [END sample]
 ============== file: src/samples/v1/find_related_books_request_async_paged_odyssey.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestAsyncPagedOdyssey" ]
-//// STUB standalone sample "FindRelatedBooksRequestAsyncPagedOdyssey" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START sample]
 // [START sample_core]
 function sampleFindRelatedBooks() {
@@ -377,13 +370,11 @@ function sampleFindRelatedBooks() {
 
 sampleFindRelatedBooks();
 // [END sample_core]
+// tslint:disable-next-line:no-any
 // [END sample]
 ============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningEventEmitterWap" ]
-//// STUB standalone sample "GetBigBookLongRunningEventEmitterWap" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START hopper]
 // [START hopper_core]
 function sampleGetBigBook(shelf) {
@@ -428,13 +419,11 @@ argv = require(`yargs`)
 
 sampleGetBigBook(argv.shelf);
 // [END hopper_core]
+// tslint:disable-next-line:no-any
 // [END hopper]
 ============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap2.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningEventEmitterWap2" ]
-//// STUB standalone sample "GetBigBookLongRunningEventEmitterWap2" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START hopper]
 // [START hopper_core]
 function sampleGetBigBook(shelf, bigBookName) {
@@ -480,13 +469,11 @@ argv = require(`yargs`)
 
 sampleGetBigBook(argv.shelf, argv.big_book_name);
 // [END hopper_core]
+// tslint:disable-next-line:no-any
 // [END hopper]
 ============== file: src/samples/v1/get_big_book_long_running_promise_wap.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningPromiseWap" ]
-//// STUB standalone sample "GetBigBookLongRunningPromiseWap" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START hopper]
 // [START hopper_core]
 function sampleGetBigBook(shelf) {
@@ -524,13 +511,11 @@ argv = require(`yargs`)
 
 sampleGetBigBook(argv.shelf);
 // [END hopper_core]
+// tslint:disable-next-line:no-any
 // [END hopper]
 ============== file: src/samples/v1/get_big_book_long_running_promise_wap2.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningPromiseWap2" ]
-//// STUB standalone sample "GetBigBookLongRunningPromiseWap2" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START hopper]
 // [START hopper_core]
 function sampleGetBigBook(shelf, bigBookName) {
@@ -569,13 +554,11 @@ argv = require(`yargs`)
 
 sampleGetBigBook(argv.shelf, argv.big_book_name);
 // [END hopper_core]
+// tslint:disable-next-line:no-any
 // [END hopper]
 ============== file: src/samples/v1/monolog_about_book_request_streaming_client_prog.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookRequestStreamingClientProg" ]
-//// STUB standalone sample "MonologAboutBookRequestStreamingClientProg" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START sample]
 // [START sample_core]
 function sampleMonologAboutBook() {
@@ -600,13 +583,11 @@ function sampleMonologAboutBook() {
 
 sampleMonologAboutBook();
 // [END sample_core]
+// tslint:disable-next-line:no-any
 // [END sample]
 ============== file: src/samples/v1/publish_series_request_pi_version.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestPiVersion" ]
-//// STUB standalone sample "PublishSeriesRequestPiVersion" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START canonical]
 // [START canonical_core]
 function samplePublishSeries(shelfName, edition) {
@@ -665,13 +646,11 @@ argv = require(`yargs`)
 
 samplePublishSeries(argv.shelf_name, argv.edition);
 // [END canonical_core]
+// tslint:disable-next-line:no-any
 // [END canonical]
 ============== file: src/samples/v1/publish_series_request_second_edition.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestSecondEdition" ]
-//// STUB standalone sample "PublishSeriesRequestSecondEdition" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START canonical]
 // [START canonical_core]
 function samplePublishSeries() {
@@ -701,13 +680,11 @@ function samplePublishSeries() {
 
 samplePublishSeries();
 // [END canonical_core]
+// tslint:disable-next-line:no-any
 // [END canonical]
 ============== file: src/samples/v1/stream_books_request_streaming_server_prog.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksRequestStreamingServerProg" ]
-//// STUB standalone sample "StreamBooksRequestStreamingServerProg" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START lovelace]
 // [START lovelace_core]
 function sampleStreamBooks() {
@@ -723,13 +700,11 @@ function sampleStreamBooks() {
 
 sampleStreamBooks();
 // [END lovelace_core]
+// tslint:disable-next-line:no-any
 // [END lovelace]
 ============== file: src/samples/v1/stream_shelves_request_streaming_server_empty.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesRequestStreamingServerEmpty" ]
-//// STUB standalone sample "StreamShelvesRequestStreamingServerEmpty" /////
-
-// FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
-
+'use strict';
 // [START sample]
 // [START sample_core]
 function sampleStreamShelves() {
@@ -745,6 +720,7 @@ function sampleStreamShelves() {
 
 sampleStreamShelves();
 // [END sample_core]
+// tslint:disable-next-line:no-any
 // [END sample]
 ============== file: src/v1/doc/google/example/library/v1/doc_book_from_anywhere.js ==============
 // Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -258,6 +258,7 @@ module.exports.default = Object.assign({}, module.exports);
 
 const library = require('@google-cloud/library').v1;
 
+
 function sampleDiscussBook(imageFileName) {
   const client = new library.v1.LibraryServiceClient();
   const stream = client.discussBook().on('data', response => {
@@ -300,6 +301,7 @@ sampleDiscussBook(argv.image_file_name);
 
 const library = require('@google-cloud/library').v1;
 
+
 function sampleFindRelatedBooks() {
   const client = new library.v1.LibraryServiceClient();
   // Iterate over all elements.
@@ -340,6 +342,7 @@ sampleFindRelatedBooks();
 
 
 const library = require('@google-cloud/library').v1;
+
 
 function sampleFindRelatedBooks() {
   const client = new library.v1.LibraryServiceClient();
@@ -394,6 +397,7 @@ sampleFindRelatedBooks();
 
 const library = require('@google-cloud/library').v1;
 
+
 function sampleGetBigBook(shelf) {
   const client = new library.v1.LibraryServiceClient();
   // const shelf = 'Novel';
@@ -446,6 +450,7 @@ sampleGetBigBook(argv.shelf);
 
 
 const library = require('@google-cloud/library').v1;
+
 
 function sampleGetBigBook(shelf, bigBookName) {
   const client = new library.v1.LibraryServiceClient();
@@ -501,6 +506,7 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 
 const library = require('@google-cloud/library').v1;
 
+
 function sampleGetBigBook(shelf) {
   const client = new library.v1.LibraryServiceClient();
   // const shelf = 'Novel';
@@ -546,6 +552,7 @@ sampleGetBigBook(argv.shelf);
 
 
 const library = require('@google-cloud/library').v1;
+
 
 function sampleGetBigBook(shelf, bigBookName) {
   const client = new library.v1.LibraryServiceClient();
@@ -594,6 +601,7 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 
 const library = require('@google-cloud/library').v1;
 
+
 function sampleMonologAboutBook() {
   const client = new library.v1.LibraryServiceClient();
   const stream = client.monologAboutBook((err, response) => {
@@ -626,6 +634,7 @@ sampleMonologAboutBook();
 
 
 const library = require('@google-cloud/library').v1;
+
 
 function samplePublishSeries(shelfName, edition) {
   const client = new library.v1.LibraryServiceClient();
@@ -694,6 +703,7 @@ samplePublishSeries(argv.shelf_name, argv.edition);
 
 const library = require('@google-cloud/library').v1;
 
+
 function samplePublishSeries() {
   const client = new library.v1.LibraryServiceClient();
   const shelf = {};
@@ -732,6 +742,7 @@ samplePublishSeries();
 
 const library = require('@google-cloud/library').v1;
 
+
 function sampleStreamBooks() {
   const client = new library.v1.LibraryServiceClient();
   const name = 'BASIC';
@@ -755,6 +766,7 @@ sampleStreamBooks();
 
 
 const library = require('@google-cloud/library').v1;
+
 
 function sampleStreamShelves() {
   const client = new library.v1.LibraryServiceClient();

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -258,9 +258,8 @@ module.exports.default = Object.assign({}, module.exports);
 
 const library = require('@google-cloud/library').v1;
 
-
 function sampleDiscussBook(imageFileName) {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
   const stream = client.discussBook().on('data', response => {
     console.log(response);
   });
@@ -301,9 +300,8 @@ sampleDiscussBook(argv.image_file_name);
 
 const library = require('@google-cloud/library').v1;
 
-
 function sampleFindRelatedBooks() {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
   // Iterate over all elements.
   const namesElement = 'Odyssey';
   const names = [namesElement];
@@ -343,9 +341,8 @@ sampleFindRelatedBooks();
 
 const library = require('@google-cloud/library').v1;
 
-
 function sampleFindRelatedBooks() {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
   // Or obtain the paged response.
   const namesElement = 'Odyssey';
   const names = [namesElement];
@@ -397,9 +394,8 @@ sampleFindRelatedBooks();
 
 const library = require('@google-cloud/library').v1;
 
-
 function sampleGetBigBook(shelf) {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
   // const shelf = 'Novel';
   const formattedName = client.bookPath(shelf, 'War and Peace');
 
@@ -451,9 +447,8 @@ sampleGetBigBook(argv.shelf);
 
 const library = require('@google-cloud/library').v1;
 
-
 function sampleGetBigBook(shelf, bigBookName) {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
   const formattedName = client.bookPath(shelf, bigBookName);
@@ -506,9 +501,8 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 
 const library = require('@google-cloud/library').v1;
 
-
 function sampleGetBigBook(shelf) {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
   // const shelf = 'Novel';
   const formattedName = client.bookPath(shelf, 'War and Peace');
 
@@ -553,9 +547,8 @@ sampleGetBigBook(argv.shelf);
 
 const library = require('@google-cloud/library').v1;
 
-
 function sampleGetBigBook(shelf, bigBookName) {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
   const formattedName = client.bookPath(shelf, bigBookName);
@@ -601,9 +594,8 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 
 const library = require('@google-cloud/library').v1;
 
-
 function sampleMonologAboutBook() {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
   const stream = client.monologAboutBook((err, response) => {
     if (err) {
       console.error(err);
@@ -635,9 +627,8 @@ sampleMonologAboutBook();
 
 const library = require('@google-cloud/library').v1;
 
-
 function samplePublishSeries(shelfName, edition) {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
   // const shelfName = 'Math';
   // const edition = 123;
   const shelf = {
@@ -703,9 +694,8 @@ samplePublishSeries(argv.shelf_name, argv.edition);
 
 const library = require('@google-cloud/library').v1;
 
-
 function samplePublishSeries() {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
   const shelf = {};
   const books = [];
   const seriesUuid = {};
@@ -742,9 +732,8 @@ samplePublishSeries();
 
 const library = require('@google-cloud/library').v1;
 
-
 function sampleStreamBooks() {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
   const name = 'BASIC';
     client.streamBooks({name: name}).on('data', response => {
         console.log(response);
@@ -767,9 +756,8 @@ sampleStreamBooks();
 
 const library = require('@google-cloud/library').v1;
 
-
 function sampleStreamShelves() {
-  const client = new library.v1.LibraryServiceClient();
+  const client = new library.LibraryServiceClient();
 
     client.streamShelves({}).on('data', response => {
         console.log(response);

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -251,8 +251,10 @@ module.exports.default = Object.assign({}, module.exports);
 ============== file: src/samples/v1/discuss_book_request_streaming_bidi_prog.js ==============
 // DO NOT EDIT! This is a generated sample ("RequestStreamingBidi",  "prog")
 'use strict';
+
 // [START turing_prog_request_streaming_bidi]
 // [START turing_prog_request_streaming_bidi_core]
+
 function sampleDiscussBook(imageFileName) {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -278,9 +280,11 @@ function sampleDiscussBook(imageFileName) {
   stream.write(request);
 }
 
+
 // [END turing_prog_request_streaming_bidi_core]
 // tslint:disable-next-line:no-any
 // [END turing_prog_request_streaming_bidi]
+
 argv = require(`yargs`)
   .default('image_file_name', 'image_file.jpg')
   .argv;
@@ -289,8 +293,10 @@ sampleDiscussBook(argv.image_file_name);
 ============== file: src/samples/v1/find_related_books_request_async_paged_all_odyssey.js ==============
 // DO NOT EDIT! This is a generated sample ("RequestAsyncPagedAll",  "odyssey")
 'use strict';
+
 // [START sample]
 // [START sample_core]
+
 function sampleFindRelatedBooks() {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -319,15 +325,19 @@ function sampleFindRelatedBooks() {
     });
 }
 
+
 // [END sample_core]
 // tslint:disable-next-line:no-any
 // [END sample]
+
 sampleFindRelatedBooks();
 ============== file: src/samples/v1/find_related_books_request_async_paged_odyssey.js ==============
 // DO NOT EDIT! This is a generated sample ("RequestAsyncPaged",  "odyssey")
 'use strict';
+
 // [START sample]
 // [START sample_core]
+
 function sampleFindRelatedBooks() {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -368,15 +378,19 @@ function sampleFindRelatedBooks() {
     });
 }
 
+
 // [END sample_core]
 // tslint:disable-next-line:no-any
 // [END sample]
+
 sampleFindRelatedBooks();
 ============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap.js ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "wap")
 'use strict';
+
 // [START hopper]
 // [START hopper_core]
+
 function sampleGetBigBook(shelf) {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -413,9 +427,11 @@ function sampleGetBigBook(shelf) {
     });
 }
 
+
 // [END hopper_core]
 // tslint:disable-next-line:no-any
 // [END hopper]
+
 argv = require(`yargs`)
   .default('shelf', 'Novel')
   .argv;
@@ -424,8 +440,10 @@ sampleGetBigBook(argv.shelf);
 ============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap2.js ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "wap2")
 'use strict';
+
 // [START hopper]
 // [START hopper_core]
+
 function sampleGetBigBook(shelf, bigBookName) {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -462,9 +480,11 @@ function sampleGetBigBook(shelf, bigBookName) {
     });
 }
 
+
 // [END hopper_core]
 // tslint:disable-next-line:no-any
 // [END hopper]
+
 argv = require(`yargs`)
   .default('shelf', 'Novel')
   .default('big_book_name', 'War and Peace')
@@ -474,8 +494,10 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 ============== file: src/samples/v1/get_big_book_long_running_promise_wap.js ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "wap")
 'use strict';
+
 // [START hopper]
 // [START hopper_core]
+
 function sampleGetBigBook(shelf) {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -505,9 +527,11 @@ function sampleGetBigBook(shelf) {
     });
 }
 
+
 // [END hopper_core]
 // tslint:disable-next-line:no-any
 // [END hopper]
+
 argv = require(`yargs`)
   .default('shelf', 'Novel')
   .argv;
@@ -516,8 +540,10 @@ sampleGetBigBook(argv.shelf);
 ============== file: src/samples/v1/get_big_book_long_running_promise_wap2.js ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "wap2")
 'use strict';
+
 // [START hopper]
 // [START hopper_core]
+
 function sampleGetBigBook(shelf, bigBookName) {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -547,9 +573,11 @@ function sampleGetBigBook(shelf, bigBookName) {
     });
 }
 
+
 // [END hopper_core]
 // tslint:disable-next-line:no-any
 // [END hopper]
+
 argv = require(`yargs`)
   .default('shelf', 'Novel')
   .default('big_book_name', 'War and Peace')
@@ -559,8 +587,10 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 ============== file: src/samples/v1/monolog_about_book_request_streaming_client_prog.js ==============
 // DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "prog")
 'use strict';
+
 // [START sample]
 // [START sample_core]
+
 function sampleMonologAboutBook() {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -581,15 +611,19 @@ function sampleMonologAboutBook() {
   stream.write(request);
 }
 
+
 // [END sample_core]
 // tslint:disable-next-line:no-any
 // [END sample]
+
 sampleMonologAboutBook();
 ============== file: src/samples/v1/publish_series_request_pi_version.js ==============
 // DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
 'use strict';
+
 // [START canonical]
 // [START canonical_core]
+
 function samplePublishSeries(shelfName, edition) {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -639,9 +673,11 @@ function samplePublishSeries(shelfName, edition) {
     });
 }
 
+
 // [END canonical_core]
 // tslint:disable-next-line:no-any
 // [END canonical]
+
 argv = require(`yargs`)
   .default('shelf_name', 'Math')
   .default('edition', 123)
@@ -651,8 +687,10 @@ samplePublishSeries(argv.shelf_name, argv.edition);
 ============== file: src/samples/v1/publish_series_request_second_edition.js ==============
 // DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
 'use strict';
+
 // [START canonical]
 // [START canonical_core]
+
 function samplePublishSeries() {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -678,15 +716,19 @@ function samplePublishSeries() {
     });
 }
 
+
 // [END canonical_core]
 // tslint:disable-next-line:no-any
 // [END canonical]
+
 samplePublishSeries();
 ============== file: src/samples/v1/stream_books_request_streaming_server_prog.js ==============
 // DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "prog")
 'use strict';
+
 // [START lovelace]
 // [START lovelace_core]
+
 function sampleStreamBooks() {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -698,15 +740,19 @@ function sampleStreamBooks() {
     });
 }
 
+
 // [END lovelace_core]
 // tslint:disable-next-line:no-any
 // [END lovelace]
+
 sampleStreamBooks();
 ============== file: src/samples/v1/stream_shelves_request_streaming_server_empty.js ==============
 // DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "empty")
 'use strict';
+
 // [START sample]
 // [START sample_core]
+
 function sampleStreamShelves() {
   const library = require('@google-cloud/library');
   const client = new library.v1.LibraryServiceClient({
@@ -718,9 +764,11 @@ function sampleStreamShelves() {
     });
 }
 
+
 // [END sample_core]
 // tslint:disable-next-line:no-any
 // [END sample]
+
 sampleStreamShelves();
 ============== file: src/v1/doc/google/example/library/v1/doc_book_from_anywhere.js ==============
 // Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -249,7 +249,7 @@ module.exports.v1 = gapic.v1;
 module.exports.default = Object.assign({}, module.exports);
 
 ============== file: src/samples/v1/discuss_book_request_streaming_bidi_prog.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "DiscussBookRequestStreamingBidiProg" ]
+// DO NOT EDIT! This is a generated sample ("RequestStreamingBidi",  "prog")
 'use strict';
 // [START turing_prog_request_streaming_bidi]
 // [START turing_prog_request_streaming_bidi_core]
@@ -278,16 +278,16 @@ function sampleDiscussBook(imageFileName) {
   stream.write(request);
 }
 
+// [END turing_prog_request_streaming_bidi_core]
+// tslint:disable-next-line:no-any
+// [END turing_prog_request_streaming_bidi]
 argv = require(`yargs`)
   .default('image_file_name', 'image_file.jpg')
   .argv;
 
 sampleDiscussBook(argv.image_file_name);
-// [END turing_prog_request_streaming_bidi_core]
-// tslint:disable-next-line:no-any
-// [END turing_prog_request_streaming_bidi]
 ============== file: src/samples/v1/find_related_books_request_async_paged_all_odyssey.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestAsyncPagedAllOdyssey" ]
+// DO NOT EDIT! This is a generated sample ("RequestAsyncPagedAll",  "odyssey")
 'use strict';
 // [START sample]
 // [START sample_core]
@@ -319,12 +319,12 @@ function sampleFindRelatedBooks() {
     });
 }
 
-sampleFindRelatedBooks();
 // [END sample_core]
 // tslint:disable-next-line:no-any
 // [END sample]
+sampleFindRelatedBooks();
 ============== file: src/samples/v1/find_related_books_request_async_paged_odyssey.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestAsyncPagedOdyssey" ]
+// DO NOT EDIT! This is a generated sample ("RequestAsyncPaged",  "odyssey")
 'use strict';
 // [START sample]
 // [START sample_core]
@@ -368,12 +368,12 @@ function sampleFindRelatedBooks() {
     });
 }
 
-sampleFindRelatedBooks();
 // [END sample_core]
 // tslint:disable-next-line:no-any
 // [END sample]
+sampleFindRelatedBooks();
 ============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningEventEmitterWap" ]
+// DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "wap")
 'use strict';
 // [START hopper]
 // [START hopper_core]
@@ -413,16 +413,16 @@ function sampleGetBigBook(shelf) {
     });
 }
 
+// [END hopper_core]
+// tslint:disable-next-line:no-any
+// [END hopper]
 argv = require(`yargs`)
   .default('shelf', 'Novel')
   .argv;
 
 sampleGetBigBook(argv.shelf);
-// [END hopper_core]
-// tslint:disable-next-line:no-any
-// [END hopper]
 ============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap2.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningEventEmitterWap2" ]
+// DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "wap2")
 'use strict';
 // [START hopper]
 // [START hopper_core]
@@ -462,17 +462,17 @@ function sampleGetBigBook(shelf, bigBookName) {
     });
 }
 
+// [END hopper_core]
+// tslint:disable-next-line:no-any
+// [END hopper]
 argv = require(`yargs`)
   .default('shelf', 'Novel')
   .default('big_book_name', 'War and Peace')
   .argv;
 
 sampleGetBigBook(argv.shelf, argv.big_book_name);
-// [END hopper_core]
-// tslint:disable-next-line:no-any
-// [END hopper]
 ============== file: src/samples/v1/get_big_book_long_running_promise_wap.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningPromiseWap" ]
+// DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "wap")
 'use strict';
 // [START hopper]
 // [START hopper_core]
@@ -505,16 +505,16 @@ function sampleGetBigBook(shelf) {
     });
 }
 
+// [END hopper_core]
+// tslint:disable-next-line:no-any
+// [END hopper]
 argv = require(`yargs`)
   .default('shelf', 'Novel')
   .argv;
 
 sampleGetBigBook(argv.shelf);
-// [END hopper_core]
-// tslint:disable-next-line:no-any
-// [END hopper]
 ============== file: src/samples/v1/get_big_book_long_running_promise_wap2.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningPromiseWap2" ]
+// DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "wap2")
 'use strict';
 // [START hopper]
 // [START hopper_core]
@@ -547,17 +547,17 @@ function sampleGetBigBook(shelf, bigBookName) {
     });
 }
 
+// [END hopper_core]
+// tslint:disable-next-line:no-any
+// [END hopper]
 argv = require(`yargs`)
   .default('shelf', 'Novel')
   .default('big_book_name', 'War and Peace')
   .argv;
 
 sampleGetBigBook(argv.shelf, argv.big_book_name);
-// [END hopper_core]
-// tslint:disable-next-line:no-any
-// [END hopper]
 ============== file: src/samples/v1/monolog_about_book_request_streaming_client_prog.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookRequestStreamingClientProg" ]
+// DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "prog")
 'use strict';
 // [START sample]
 // [START sample_core]
@@ -581,12 +581,12 @@ function sampleMonologAboutBook() {
   stream.write(request);
 }
 
-sampleMonologAboutBook();
 // [END sample_core]
 // tslint:disable-next-line:no-any
 // [END sample]
+sampleMonologAboutBook();
 ============== file: src/samples/v1/publish_series_request_pi_version.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestPiVersion" ]
+// DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
 'use strict';
 // [START canonical]
 // [START canonical_core]
@@ -639,17 +639,17 @@ function samplePublishSeries(shelfName, edition) {
     });
 }
 
+// [END canonical_core]
+// tslint:disable-next-line:no-any
+// [END canonical]
 argv = require(`yargs`)
   .default('shelf_name', 'Math')
   .default('edition', 123)
   .argv;
 
 samplePublishSeries(argv.shelf_name, argv.edition);
-// [END canonical_core]
-// tslint:disable-next-line:no-any
-// [END canonical]
 ============== file: src/samples/v1/publish_series_request_second_edition.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestSecondEdition" ]
+// DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
 'use strict';
 // [START canonical]
 // [START canonical_core]
@@ -678,12 +678,12 @@ function samplePublishSeries() {
     });
 }
 
-samplePublishSeries();
 // [END canonical_core]
 // tslint:disable-next-line:no-any
 // [END canonical]
+samplePublishSeries();
 ============== file: src/samples/v1/stream_books_request_streaming_server_prog.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksRequestStreamingServerProg" ]
+// DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "prog")
 'use strict';
 // [START lovelace]
 // [START lovelace_core]
@@ -698,12 +698,12 @@ function sampleStreamBooks() {
     });
 }
 
-sampleStreamBooks();
 // [END lovelace_core]
 // tslint:disable-next-line:no-any
 // [END lovelace]
+sampleStreamBooks();
 ============== file: src/samples/v1/stream_shelves_request_streaming_server_empty.js ==============
-//// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesRequestStreamingServerEmpty" ]
+// DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "empty")
 'use strict';
 // [START sample]
 // [START sample_core]
@@ -718,10 +718,10 @@ function sampleStreamShelves() {
     });
 }
 
-sampleStreamShelves();
 // [END sample_core]
 // tslint:disable-next-line:no-any
 // [END sample]
+sampleStreamShelves();
 ============== file: src/v1/doc/google/example/library/v1/doc_book_from_anywhere.js ==============
 // Copyright 2019 Google LLC
 //

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -255,23 +255,12 @@ module.exports.default = Object.assign({}, module.exports);
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START turing_prog_request_streaming_bidi]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "RequestStreamingBidi"
-//        region tag: "turing_prog_request_streaming_bidi"
-//         className: "DiscussBookRequestStreamingBidiProg"
-//          valueSet: "prog" ("Programming Books")
-//       description: "Testing calling forms"
-//        [name=BASIC, comment.comment = comment_file, image= "image_file.jpg"]
-//      apiMethod "discussBook" of type "OptionalArrayMethod"
-
 // [START turing_prog_request_streaming_bidi_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function sampleDiscussBook(imageFileName) {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
   const stream = client.discussBook().on('data', response => {
     console.log(response);
   });
@@ -292,16 +281,12 @@ function sampleDiscussBook(imageFileName) {
   stream.write(request);
 }
 
-require(`yargs`)
+argv = require(`yargs`)
   .default('image_file_name', 'image_file.jpg')
   .argv;
 
 sampleDiscussBook(argv.image_file_name);
-*/
 // [END turing_prog_request_streaming_bidi_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END turing_prog_request_streaming_bidi]
 ============== file: src/samples/v1/find_related_books_request_async_paged_all_odyssey.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestAsyncPagedAllOdyssey" ]
@@ -310,23 +295,12 @@ sampleDiscussBook(argv.image_file_name);
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START sample]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "RequestAsyncPagedAll"
-//        region tag: "sample"
-//         className: "FindRelatedBooksRequestAsyncPagedAllOdyssey"
-//          valueSet: "odyssey" ("The Odyssey")
-//       description: "Testing calling forms"
-//        [names[0]=Odyssey, shelves[0]=Classics]
-//      apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
-
 // [START sample_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function sampleFindRelatedBooks() {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
   // Iterate over all elements.
   const namesElement = 'Odyssey';
   const names = [namesElement];
@@ -351,11 +325,7 @@ function sampleFindRelatedBooks() {
 }
 
 sampleFindRelatedBooks();
-*/
 // [END sample_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END sample]
 ============== file: src/samples/v1/find_related_books_request_async_paged_odyssey.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "FindRelatedBooksRequestAsyncPagedOdyssey" ]
@@ -364,23 +334,12 @@ sampleFindRelatedBooks();
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START sample]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "RequestAsyncPaged"
-//        region tag: "sample"
-//         className: "FindRelatedBooksRequestAsyncPagedOdyssey"
-//          valueSet: "odyssey" ("The Odyssey")
-//       description: "Testing calling forms"
-//        [names[0]=Odyssey, shelves[0]=Classics]
-//      apiMethod "findRelatedBooks" of type "PagedOptionalArrayMethod"
-
 // [START sample_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function sampleFindRelatedBooks() {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
   // Or obtain the paged response.
   const namesElement = 'Odyssey';
   const names = [namesElement];
@@ -417,11 +376,7 @@ function sampleFindRelatedBooks() {
 }
 
 sampleFindRelatedBooks();
-*/
 // [END sample_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END sample]
 ============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningEventEmitterWap" ]
@@ -430,23 +385,12 @@ sampleFindRelatedBooks();
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START hopper]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "LongRunningEventEmitter"
-//        region tag: "hopper"
-//         className: "GetBigBookLongRunningEventEmitterWap"
-//          valueSet: "wap" ("GetBigBook: 'War and Peace'")
-//       description: "Testing calling forms"
-//        [name%shelf_id=Novel, name%book_id="War and Peace"]
-//      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
-
 // [START hopper_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function sampleGetBigBook(shelf) {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
   // const shelf = 'Novel';
   const formattedName = client.bookPath(shelf, 'War and Peace');
 
@@ -478,16 +422,12 @@ function sampleGetBigBook(shelf) {
     });
 }
 
-require(`yargs`)
+argv = require(`yargs`)
   .default('shelf', 'Novel')
   .argv;
 
 sampleGetBigBook(argv.shelf);
-*/
 // [END hopper_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END hopper]
 ============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap2.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningEventEmitterWap2" ]
@@ -496,23 +436,12 @@ sampleGetBigBook(argv.shelf);
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START hopper]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "LongRunningEventEmitter"
-//        region tag: "hopper"
-//         className: "GetBigBookLongRunningEventEmitterWap2"
-//          valueSet: "wap2" ("GetBigBook: 'War and Peace'")
-//       description: "Testing resource name overlap"
-//        [name%shelf_id=Novel, name%book_id="War and Peace"]
-//      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
-
 // [START hopper_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function sampleGetBigBook(shelf, bigBookName) {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
   const formattedName = client.bookPath(shelf, bigBookName);
@@ -544,17 +473,13 @@ function sampleGetBigBook(shelf, bigBookName) {
     });
 }
 
-require(`yargs`)
+argv = require(`yargs`)
   .default('shelf', 'Novel')
   .default('big_book_name', 'War and Peace')
   .argv;
 
 sampleGetBigBook(argv.shelf, argv.big_book_name);
-*/
 // [END hopper_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END hopper]
 ============== file: src/samples/v1/get_big_book_long_running_promise_wap.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningPromiseWap" ]
@@ -563,23 +488,12 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START hopper]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "LongRunningPromise"
-//        region tag: "hopper"
-//         className: "GetBigBookLongRunningPromiseWap"
-//          valueSet: "wap" ("GetBigBook: 'War and Peace'")
-//       description: "Testing calling forms"
-//        [name%shelf_id=Novel, name%book_id="War and Peace"]
-//      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
-
 // [START hopper_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function sampleGetBigBook(shelf) {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
   // const shelf = 'Novel';
   const formattedName = client.bookPath(shelf, 'War and Peace');
 
@@ -604,16 +518,12 @@ function sampleGetBigBook(shelf) {
     });
 }
 
-require(`yargs`)
+argv = require(`yargs`)
   .default('shelf', 'Novel')
   .argv;
 
 sampleGetBigBook(argv.shelf);
-*/
 // [END hopper_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END hopper]
 ============== file: src/samples/v1/get_big_book_long_running_promise_wap2.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "GetBigBookLongRunningPromiseWap2" ]
@@ -622,23 +532,12 @@ sampleGetBigBook(argv.shelf);
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START hopper]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "LongRunningPromise"
-//        region tag: "hopper"
-//         className: "GetBigBookLongRunningPromiseWap2"
-//          valueSet: "wap2" ("GetBigBook: 'War and Peace'")
-//       description: "Testing resource name overlap"
-//        [name%shelf_id=Novel, name%book_id="War and Peace"]
-//      apiMethod "getBigBook" of type "LongRunningOptionalArrayMethod"
-
 // [START hopper_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function sampleGetBigBook(shelf, bigBookName) {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
   const formattedName = client.bookPath(shelf, bigBookName);
@@ -663,17 +562,13 @@ function sampleGetBigBook(shelf, bigBookName) {
     });
 }
 
-require(`yargs`)
+argv = require(`yargs`)
   .default('shelf', 'Novel')
   .default('big_book_name', 'War and Peace')
   .argv;
 
 sampleGetBigBook(argv.shelf, argv.big_book_name);
-*/
 // [END hopper_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END hopper]
 ============== file: src/samples/v1/monolog_about_book_request_streaming_client_prog.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "MonologAboutBookRequestStreamingClientProg" ]
@@ -682,23 +577,12 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START sample]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "RequestStreamingClient"
-//        region tag: "sample"
-//         className: "MonologAboutBookRequestStreamingClientProg"
-//          valueSet: "prog" ("Programming Books")
-//       description: "Testing calling forms"
-//        [name=BASIC]
-//      apiMethod "monologAboutBook" of type "OptionalArrayMethod"
-
 // [START sample_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function sampleMonologAboutBook() {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
   const stream = client.monologAboutBook((err, response) => {
     if (err) {
       console.error(err);
@@ -715,11 +599,7 @@ function sampleMonologAboutBook() {
 }
 
 sampleMonologAboutBook();
-*/
 // [END sample_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END sample]
 ============== file: src/samples/v1/publish_series_request_pi_version.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestPiVersion" ]
@@ -728,23 +608,12 @@ sampleMonologAboutBook();
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START canonical]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "Request"
-//        region tag: "canonical"
-//         className: "PublishSeriesRequestPiVersion"
-//          valueSet: "pi_version" ("Pi version")
-//       description: "Testing calling forms"
-//        [shelf.name=Math, series_uuid.series_string=xyz3141592654, edition=123]
-//      apiMethod "publishSeries" of type "OptionalArrayMethod"
-
 // [START canonical_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function samplePublishSeries(shelfName, edition) {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
   // const shelfName = 'Math';
   // const edition = 123;
   const shelf = {
@@ -789,17 +658,13 @@ function samplePublishSeries(shelfName, edition) {
     });
 }
 
-require(`yargs`)
+argv = require(`yargs`)
   .default('shelf_name', 'Math')
   .default('edition', 123)
   .argv;
 
 samplePublishSeries(argv.shelf_name, argv.edition);
-*/
 // [END canonical_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END canonical]
 ============== file: src/samples/v1/publish_series_request_second_edition.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "PublishSeriesRequestSecondEdition" ]
@@ -808,23 +673,12 @@ samplePublishSeries(argv.shelf_name, argv.edition);
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START canonical]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "Request"
-//        region tag: "canonical"
-//         className: "PublishSeriesRequestSecondEdition"
-//          valueSet: "second_edition" ("Second edition")
-//       description: "Testing calling forms"
-//        [edition=2]
-//      apiMethod "publishSeries" of type "OptionalArrayMethod"
-
 // [START canonical_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function samplePublishSeries() {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
   const shelf = {};
   const books = [];
   const seriesUuid = {};
@@ -846,11 +700,7 @@ function samplePublishSeries() {
 }
 
 samplePublishSeries();
-*/
 // [END canonical_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END canonical]
 ============== file: src/samples/v1/stream_books_request_streaming_server_prog.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamBooksRequestStreamingServerProg" ]
@@ -859,23 +709,12 @@ samplePublishSeries();
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START lovelace]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "RequestStreamingServer"
-//        region tag: "lovelace"
-//         className: "StreamBooksRequestStreamingServerProg"
-//          valueSet: "prog" ("Programming Books")
-//       description: "Testing calling forms"
-//        [name=BASIC]
-//      apiMethod "streamBooks" of type "OptionalArrayMethod"
-
 // [START lovelace_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function sampleStreamBooks() {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
   const name = 'BASIC';
     client.streamBooks({name: name}).on('data', response => {
         console.log(response);
@@ -883,11 +722,7 @@ function sampleStreamBooks() {
 }
 
 sampleStreamBooks();
-*/
 // [END lovelace_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END lovelace]
 ============== file: src/samples/v1/stream_shelves_request_streaming_server_empty.js ==============
 //// [ This is an auto-generated sample file produced by the gapic-generator. Sample name: "StreamShelvesRequestStreamingServerEmpty" ]
@@ -896,23 +731,12 @@ sampleStreamBooks();
 // FIXME: Insert here set-up comments that we never want to display in cloudsite. These are seen by users perusing the samples directly in the repository.
 
 // [START sample]
-
-// FIXME: Insert here boilerplate code not directly related to the method call itself.
-
-//      calling form: "RequestStreamingServer"
-//        region tag: "sample"
-//         className: "StreamShelvesRequestStreamingServerEmpty"
-//          valueSet: "empty" ("Server streaming")
-//       description: "Testing calling forms"
-//        []
-//      apiMethod "streamShelves" of type "OptionalArrayMethod"
-
 // [START sample_core]
-
-// FIXME: Insert here code to prepare the request fields, make the call, process the response.
-
-/*
 function sampleStreamShelves() {
+  const library = require('@google-cloud/library');
+  const client = new library.v1.LibraryServiceClient({
+    // optional auth parameters.
+  })
 
     client.streamShelves({}).on('data', response => {
         console.log(response);
@@ -920,11 +744,7 @@ function sampleStreamShelves() {
 }
 
 sampleStreamShelves();
-*/
 // [END sample_core]
-
-// FIXME: Insert here clean-up code.
-// tslint:disable-next-line:no-any
 // [END sample]
 ============== file: src/v1/doc/google/example/library/v1/doc_book_from_anywhere.js ==============
 // Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -255,11 +255,11 @@ module.exports.default = Object.assign({}, module.exports);
 // [START turing_prog_request_streaming_bidi]
 // [START turing_prog_request_streaming_bidi_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function sampleDiscussBook(imageFileName) {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
   const stream = client.discussBook().on('data', response => {
     console.log(response);
   });
@@ -297,11 +297,11 @@ sampleDiscussBook(argv.image_file_name);
 // [START sample]
 // [START sample_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function sampleFindRelatedBooks() {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
   // Iterate over all elements.
   const namesElement = 'Odyssey';
   const names = [namesElement];
@@ -338,11 +338,11 @@ sampleFindRelatedBooks();
 // [START sample]
 // [START sample_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function sampleFindRelatedBooks() {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
   // Or obtain the paged response.
   const namesElement = 'Odyssey';
   const names = [namesElement];
@@ -391,11 +391,11 @@ sampleFindRelatedBooks();
 // [START hopper]
 // [START hopper_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function sampleGetBigBook(shelf) {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
   // const shelf = 'Novel';
   const formattedName = client.bookPath(shelf, 'War and Peace');
 
@@ -444,11 +444,11 @@ sampleGetBigBook(argv.shelf);
 // [START hopper]
 // [START hopper_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function sampleGetBigBook(shelf, bigBookName) {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
   const formattedName = client.bookPath(shelf, bigBookName);
@@ -498,11 +498,11 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 // [START hopper]
 // [START hopper_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function sampleGetBigBook(shelf) {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
   // const shelf = 'Novel';
   const formattedName = client.bookPath(shelf, 'War and Peace');
 
@@ -544,11 +544,11 @@ sampleGetBigBook(argv.shelf);
 // [START hopper]
 // [START hopper_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function sampleGetBigBook(shelf, bigBookName) {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
   const formattedName = client.bookPath(shelf, bigBookName);
@@ -591,11 +591,11 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 // [START sample]
 // [START sample_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function sampleMonologAboutBook() {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
   const stream = client.monologAboutBook((err, response) => {
     if (err) {
       console.error(err);
@@ -624,11 +624,11 @@ sampleMonologAboutBook();
 // [START canonical]
 // [START canonical_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function samplePublishSeries(shelfName, edition) {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
   // const shelfName = 'Math';
   // const edition = 123;
   const shelf = {
@@ -691,11 +691,11 @@ samplePublishSeries(argv.shelf_name, argv.edition);
 // [START canonical]
 // [START canonical_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function samplePublishSeries() {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
   const shelf = {};
   const books = [];
   const seriesUuid = {};
@@ -729,11 +729,11 @@ samplePublishSeries();
 // [START lovelace]
 // [START lovelace_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function sampleStreamBooks() {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
   const name = 'BASIC';
     client.streamBooks({name: name}).on('data', response => {
         console.log(response);
@@ -753,11 +753,11 @@ sampleStreamBooks();
 // [START sample]
 // [START sample_core]
 
+
+const library = require('@google-cloud/library').v1;
+
 function sampleStreamShelves() {
-  const library = require('@google-cloud/library');
-  const client = new library.v1.LibraryServiceClient({
-    // optional auth parameters.
-  })
+  const client = new library.v1.LibraryServiceClient({})
 
     client.streamShelves({}).on('data', response => {
         console.log(response);

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -259,7 +259,7 @@ module.exports.default = Object.assign({}, module.exports);
 const library = require('@google-cloud/library').v1;
 
 function sampleDiscussBook(imageFileName) {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
   const stream = client.discussBook().on('data', response => {
     console.log(response);
   });
@@ -301,7 +301,7 @@ sampleDiscussBook(argv.image_file_name);
 const library = require('@google-cloud/library').v1;
 
 function sampleFindRelatedBooks() {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
   // Iterate over all elements.
   const namesElement = 'Odyssey';
   const names = [namesElement];
@@ -342,7 +342,7 @@ sampleFindRelatedBooks();
 const library = require('@google-cloud/library').v1;
 
 function sampleFindRelatedBooks() {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
   // Or obtain the paged response.
   const namesElement = 'Odyssey';
   const names = [namesElement];
@@ -395,7 +395,7 @@ sampleFindRelatedBooks();
 const library = require('@google-cloud/library').v1;
 
 function sampleGetBigBook(shelf) {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
   // const shelf = 'Novel';
   const formattedName = client.bookPath(shelf, 'War and Peace');
 
@@ -448,7 +448,7 @@ sampleGetBigBook(argv.shelf);
 const library = require('@google-cloud/library').v1;
 
 function sampleGetBigBook(shelf, bigBookName) {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
   const formattedName = client.bookPath(shelf, bigBookName);
@@ -502,7 +502,7 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 const library = require('@google-cloud/library').v1;
 
 function sampleGetBigBook(shelf) {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
   // const shelf = 'Novel';
   const formattedName = client.bookPath(shelf, 'War and Peace');
 
@@ -548,7 +548,7 @@ sampleGetBigBook(argv.shelf);
 const library = require('@google-cloud/library').v1;
 
 function sampleGetBigBook(shelf, bigBookName) {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
   const formattedName = client.bookPath(shelf, bigBookName);
@@ -595,7 +595,7 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 const library = require('@google-cloud/library').v1;
 
 function sampleMonologAboutBook() {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
   const stream = client.monologAboutBook((err, response) => {
     if (err) {
       console.error(err);
@@ -628,7 +628,7 @@ sampleMonologAboutBook();
 const library = require('@google-cloud/library').v1;
 
 function samplePublishSeries(shelfName, edition) {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
   // const shelfName = 'Math';
   // const edition = 123;
   const shelf = {
@@ -695,7 +695,7 @@ samplePublishSeries(argv.shelf_name, argv.edition);
 const library = require('@google-cloud/library').v1;
 
 function samplePublishSeries() {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
   const shelf = {};
   const books = [];
   const seriesUuid = {};
@@ -733,7 +733,7 @@ samplePublishSeries();
 const library = require('@google-cloud/library').v1;
 
 function sampleStreamBooks() {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
   const name = 'BASIC';
     client.streamBooks({name: name}).on('data', response => {
         console.log(response);
@@ -757,7 +757,7 @@ sampleStreamBooks();
 const library = require('@google-cloud/library').v1;
 
 function sampleStreamShelves() {
-  const client = new library.v1.LibraryServiceClient()
+  const client = new library.v1.LibraryServiceClient();
 
     client.streamShelves({}).on('data', response => {
         console.log(response);

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -259,7 +259,7 @@ module.exports.default = Object.assign({}, module.exports);
 const library = require('@google-cloud/library').v1;
 
 function sampleDiscussBook(imageFileName) {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
   const stream = client.discussBook().on('data', response => {
     console.log(response);
   });
@@ -301,7 +301,7 @@ sampleDiscussBook(argv.image_file_name);
 const library = require('@google-cloud/library').v1;
 
 function sampleFindRelatedBooks() {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
   // Iterate over all elements.
   const namesElement = 'Odyssey';
   const names = [namesElement];
@@ -342,7 +342,7 @@ sampleFindRelatedBooks();
 const library = require('@google-cloud/library').v1;
 
 function sampleFindRelatedBooks() {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
   // Or obtain the paged response.
   const namesElement = 'Odyssey';
   const names = [namesElement];
@@ -395,7 +395,7 @@ sampleFindRelatedBooks();
 const library = require('@google-cloud/library').v1;
 
 function sampleGetBigBook(shelf) {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
   // const shelf = 'Novel';
   const formattedName = client.bookPath(shelf, 'War and Peace');
 
@@ -448,7 +448,7 @@ sampleGetBigBook(argv.shelf);
 const library = require('@google-cloud/library').v1;
 
 function sampleGetBigBook(shelf, bigBookName) {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
   const formattedName = client.bookPath(shelf, bigBookName);
@@ -502,7 +502,7 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 const library = require('@google-cloud/library').v1;
 
 function sampleGetBigBook(shelf) {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
   // const shelf = 'Novel';
   const formattedName = client.bookPath(shelf, 'War and Peace');
 
@@ -548,7 +548,7 @@ sampleGetBigBook(argv.shelf);
 const library = require('@google-cloud/library').v1;
 
 function sampleGetBigBook(shelf, bigBookName) {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
   const formattedName = client.bookPath(shelf, bigBookName);
@@ -595,7 +595,7 @@ sampleGetBigBook(argv.shelf, argv.big_book_name);
 const library = require('@google-cloud/library').v1;
 
 function sampleMonologAboutBook() {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
   const stream = client.monologAboutBook((err, response) => {
     if (err) {
       console.error(err);
@@ -628,7 +628,7 @@ sampleMonologAboutBook();
 const library = require('@google-cloud/library').v1;
 
 function samplePublishSeries(shelfName, edition) {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
   // const shelfName = 'Math';
   // const edition = 123;
   const shelf = {
@@ -695,7 +695,7 @@ samplePublishSeries(argv.shelf_name, argv.edition);
 const library = require('@google-cloud/library').v1;
 
 function samplePublishSeries() {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
   const shelf = {};
   const books = [];
   const seriesUuid = {};
@@ -733,7 +733,7 @@ samplePublishSeries();
 const library = require('@google-cloud/library').v1;
 
 function sampleStreamBooks() {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
   const name = 'BASIC';
     client.streamBooks({name: name}).on('data', response => {
         console.log(response);
@@ -757,7 +757,7 @@ sampleStreamBooks();
 const library = require('@google-cloud/library').v1;
 
 function sampleStreamShelves() {
-  const client = new library.v1.LibraryServiceClient({})
+  const client = new library.v1.LibraryServiceClient()
 
     client.streamShelves({}).on('data', response => {
         console.log(response);


### PR DESCRIPTION
- add `'use strict';`
- remove placeholders
- correctly use `yargs`
- initialize the client
- move `require` outside sample function