### PR TITLE
Fix broken bazel tests

### DIFF
--- a/src/test/java/com/google/api/codegen/MixedPathTestDataLocator.java
+++ b/src/test/java/com/google/api/codegen/MixedPathTestDataLocator.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -30,8 +31,11 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 /**
- * A test data locator which first tries to find the specified resource on a file system, and if the
- * file was not found this class fallbacks to the default ({@link ClassPathTestDataLocator})
+ * Prefer using this class instead of {@link
+ * com.google.api.tools.framework.model.testing.TestDataLocator}.
+ *
+ * <p>A test data locator which first tries to find the specified resource on a file system, and if
+ * the file was not found this class fallbacks to the default ({@link ClassPathTestDataLocator})
  * implementation.
  *
  * <p>This behavior is useful for cases when some parts of test infrastructure expect an actual file
@@ -48,6 +52,10 @@ public class MixedPathTestDataLocator extends ClassPathTestDataLocator {
   public MixedPathTestDataLocator(Class<?> classContext, String... pathPrefixes) {
     super(classContext);
     this.pathPrefixes = ImmutableList.copyOf(pathPrefixes);
+  }
+
+  public static MixedPathTestDataLocator create(Class<?> classContext) {
+    return new MixedPathTestDataLocator(classContext, Paths.get("src", "test", "java").toString());
   }
 
   @Nullable
@@ -69,7 +77,7 @@ public class MixedPathTestDataLocator extends ClassPathTestDataLocator {
   @Override
   public String fetchTestData(URL url) {
     if ("file".equals(url.getProtocol())) {
-      try (Reader reader = new InputStreamReader(url.openStream())) {
+      try (Reader reader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)) {
         return CharStreams.toString(reader);
       } catch (IOException e) {
         // Ignore, fallback to parent's implementation.

--- a/src/test/java/com/google/api/codegen/MixedPathTestDataLocator.java
+++ b/src/test/java/com/google/api/codegen/MixedPathTestDataLocator.java
@@ -31,8 +31,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 /**
- * Prefer using this class instead of {@link
- * com.google.api.tools.framework.model.testing.TestDataLocator}.
+ * Prefer using this class instead of {@code TestDataLocator}.
  *
  * <p>A test data locator which first tries to find the specified resource on a file system, and if
  * the file was not found this class fallbacks to the default ({@link ClassPathTestDataLocator})

--- a/src/test/java/com/google/api/codegen/config/GapicConfigProducerTest.java
+++ b/src/test/java/com/google/api/codegen/config/GapicConfigProducerTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.codegen.CodegenTestUtil;
 import com.google.api.codegen.ConfigProto;
+import com.google.api.codegen.MixedPathTestDataLocator;
 import com.google.api.codegen.common.TargetLanguage;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.Model;
@@ -36,7 +37,7 @@ public class GapicConfigProducerTest {
 
   @Test
   public void missingConfigSchemaVersion() {
-    TestDataLocator locator = TestDataLocator.create(GapicConfigProducerTest.class);
+    TestDataLocator locator = MixedPathTestDataLocator.create(this.getClass());
     locator.addTestDataSource(CodegenTestUtil.class, "testsrc/common");
     locator.addTestDataSource(CodegenTestUtil.class, "testsrc/libraryproto");
     model =

--- a/src/test/java/com/google/api/codegen/configgen/ConfigGenerationTest.java
+++ b/src/test/java/com/google/api/codegen/configgen/ConfigGenerationTest.java
@@ -29,8 +29,7 @@ import org.junit.Test;
 
 public class ConfigGenerationTest extends ConfigBaselineTestCase {
 
-  private final TestDataLocator testDataLocator =
-      new MixedPathTestDataLocator(this.getClass(), Paths.get("src", "test", "java").toString());
+  private final TestDataLocator testDataLocator = MixedPathTestDataLocator.create(this.getClass());
 
   @Override
   protected TestDataLocator getTestDataLocator() {

--- a/src/test/java/com/google/api/codegen/discogapic/DiscoConfigGenerationTest.java
+++ b/src/test/java/com/google/api/codegen/discogapic/DiscoConfigGenerationTest.java
@@ -27,8 +27,7 @@ import org.junit.Test;
 
 public class DiscoConfigGenerationTest extends DiscoConfigBaselineTestCase {
 
-  private final TestDataLocator testDataLocator =
-      new MixedPathTestDataLocator(this.getClass(), Paths.get("src", "test", "java").toString());
+  private final TestDataLocator testDataLocator = MixedPathTestDataLocator.create(this.getClass());
 
   @Override
   protected String baselineFileName() {

--- a/src/test/java/com/google/api/codegen/discogapic/DiscoGapicTestBase.java
+++ b/src/test/java/com/google/api/codegen/discogapic/DiscoGapicTestBase.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -53,8 +52,7 @@ public abstract class DiscoGapicTestBase extends ConfigBaselineTestCase {
   @Nullable private final String packageConfigFileName;
   protected ConfigProto config;
   private List<CodeGenerator<?>> discoGapicGenerators;
-  private final TestDataLocator testDataLocator =
-      new MixedPathTestDataLocator(this.getClass(), Paths.get("src", "test", "java").toString());
+  private final TestDataLocator testDataLocator = MixedPathTestDataLocator.create(this.getClass());
 
   public DiscoGapicTestBase(
       TargetLanguage language,

--- a/src/test/java/com/google/api/codegen/gapic/GapicTestBase2.java
+++ b/src/test/java/com/google/api/codegen/gapic/GapicTestBase2.java
@@ -18,6 +18,7 @@ import com.google.api.Service;
 import com.google.api.codegen.ArtifactType;
 import com.google.api.codegen.CodegenTestUtil;
 import com.google.api.codegen.ConfigProto;
+import com.google.api.codegen.MixedPathTestDataLocator;
 import com.google.api.codegen.common.CodeGenerator;
 import com.google.api.codegen.common.GeneratedResult;
 import com.google.api.codegen.common.TargetLanguage;
@@ -30,6 +31,7 @@ import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.stages.Merged;
 import com.google.api.tools.framework.model.testing.ConfigBaselineTestCase;
+import com.google.api.tools.framework.model.testing.TestDataLocator;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -56,6 +58,7 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
   private final String baselineFile;
   private final String protoPackage;
   private final String clientPackage;
+  private final TestDataLocator testDataLocator = MixedPathTestDataLocator.create(this.getClass());
 
   public GapicTestBase2(
       TargetLanguage language,
@@ -82,6 +85,11 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
     getTestDataLocator().addTestDataSource(CodegenTestUtil.class, dir);
     getTestDataLocator().addTestDataSource(getClass(), "testdata/" + dir);
     getTestDataLocator().addTestDataSource(CodegenTestUtil.class, "testsrc/common");
+  }
+
+  @Override
+  protected TestDataLocator getTestDataLocator() {
+    return this.testDataLocator;
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/packagegen/PackageGeneratorAppTest.java
+++ b/src/test/java/com/google/api/codegen/packagegen/PackageGeneratorAppTest.java
@@ -62,8 +62,7 @@ public class PackageGeneratorAppTest extends ConfigBaselineTestCase {
   private String language;
   private String packageConfig;
   private PackagingArtifactType artifactType;
-  private final TestDataLocator testDataLocator =
-      new MixedPathTestDataLocator(this.getClass(), Paths.get("src", "test", "java").toString());
+  private final TestDataLocator testDataLocator = MixedPathTestDataLocator.create(this.getClass());
 
   @Override
   protected boolean suppressDiagnosis() {

--- a/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.codegen.CodegenTestUtil;
 import com.google.api.codegen.ConfigProto;
+import com.google.api.codegen.MixedPathTestDataLocator;
 import com.google.api.codegen.common.TargetLanguage;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.MethodModel;
@@ -47,7 +48,7 @@ public class GoGapicSurfaceTransformerTest {
 
   @BeforeClass
   public static void setupClass() {
-    TestDataLocator locator = TestDataLocator.create(GoGapicSurfaceTransformerTest.class);
+    TestDataLocator locator = MixedPathTestDataLocator.create(GoGapicSurfaceTransformerTest.class);
     model =
         CodegenTestUtil.readModel(
             locator,


### PR DESCRIPTION
Using `MixedPathTestDataLocator` instead of `TestDataLocator`.

Also fix encoding issue (add `UTF-8`) in `MixedPathTestDataLocator` and add `MixedPathTestDataLocator.create(Class<?>)` method as a drop-in replacement for `TestDataLocator.create(Class<?>)`.