### PR TITLE
Use EmptyMessage instead of Void for HTTP response wrapper type

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSchemaTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSchemaTypeNameConverter.java
@@ -52,7 +52,7 @@ public class JavaSchemaTypeNameConverter extends SchemaTypeNameConverter {
 
   private static String getPrimitiveTypeName(Schema schema) {
     if (schema == null) {
-      return "java.lang.Void";
+      return "com.google.api.gax.httpjson.EmptyMessage";
     }
     switch (schema.type()) {
       case INTEGER:
@@ -94,7 +94,7 @@ public class JavaSchemaTypeNameConverter extends SchemaTypeNameConverter {
     if (primitiveType.equals("java.lang.String")) {
       return "\"\"";
     }
-    if (primitiveType.equals("java.lang.Void")) {
+    if (primitiveType.equals("com.google.api.gax.httpjson.EmptyMessage")) {
       return "null";
     }
     throw new IllegalArgumentException("Schema is of unknown type.");
@@ -130,7 +130,7 @@ public class JavaSchemaTypeNameConverter extends SchemaTypeNameConverter {
     if (type.isStringType()) {
       return typeNameConverter.getTypeName("java.lang.String");
     } else if (type.isEmptyType()) {
-      return typeNameConverter.getTypeName("java.lang.Void");
+      return typeNameConverter.getTypeName("com.google.api.gax.httpjson.EmptyMessage");
     }
 
     return getTypeNameForElementType((DiscoveryField) type);
@@ -146,7 +146,7 @@ public class JavaSchemaTypeNameConverter extends SchemaTypeNameConverter {
   private TypeName getTypeNameForElementType(
       DiscoveryField fieldModel, BoxingBehavior boxingBehavior) {
     if (fieldModel == null) {
-      return new TypeName("java.lang.Void", "Void");
+      return new TypeName("com.google.api.gax.httpjson.EmptyMessage", "Void");
     }
     Schema schema = fieldModel.getOriginalDiscoveryField();
     String primitiveTypeName = getPrimitiveTypeName(schema);

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSchemaTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSchemaTypeNameConverter.java
@@ -146,7 +146,7 @@ public class JavaSchemaTypeNameConverter extends SchemaTypeNameConverter {
   private TypeName getTypeNameForElementType(
       DiscoveryField fieldModel, BoxingBehavior boxingBehavior) {
     if (fieldModel == null) {
-      return new TypeName("com.google.api.gax.httpjson.EmptyMessage", "Void");
+      return new TypeName("com.google.api.gax.httpjson.EmptyMessage", "EmptyMessage");
     }
     Schema schema = fieldModel.getOriginalDiscoveryField();
     String primitiveTypeName = getPrimitiveTypeName(schema);

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -823,7 +823,7 @@ public class JavaSurfaceTransformer {
         typeTable.saveNicknameFor(
             "com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider");
         typeTable.saveNicknameFor("com.google.api.gax.httpjson.GaxHttpJsonProperties");
-        typeTable.saveNicknameFor("java.lang.Void");
+        typeTable.saveNicknameFor("com.google.api.gax.httpjson.EmptyMessage");
         break;
     }
   }
@@ -883,7 +883,7 @@ public class JavaSurfaceTransformer {
         typeTable.saveNicknameFor("com.google.api.gax.httpjson.HttpJsonCallSettings");
         typeTable.saveNicknameFor("com.google.api.gax.httpjson.HttpJsonStubCallableFactory");
         typeTable.saveNicknameFor("com.google.common.collect.Sets");
-        typeTable.saveNicknameFor("java.lang.Void");
+        typeTable.saveNicknameFor("com.google.api.gax.httpjson.EmptyMessage");
         break;
     }
   }

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -12764,6 +12764,7 @@ import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.httpjson.EmptyMessage;
 import com.google.api.gax.httpjson.GaxHttpJsonProperties;
 import com.google.api.gax.httpjson.HttpJsonTransportChannel;
 import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
@@ -13077,6 +13078,7 @@ import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.httpjson.EmptyMessage;
 import com.google.api.gax.httpjson.GaxHttpJsonProperties;
 import com.google.api.gax.httpjson.HttpJsonTransportChannel;
 import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
@@ -13762,6 +13764,7 @@ import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.httpjson.ApiMessageHttpRequestFormatter;
 import com.google.api.gax.httpjson.ApiMessageHttpResponseParser;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
+import com.google.api.gax.httpjson.EmptyMessage;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.rpc.ClientContext;
@@ -14121,6 +14124,7 @@ import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.httpjson.ApiMessageHttpRequestFormatter;
 import com.google.api.gax.httpjson.ApiMessageHttpResponseParser;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
+import com.google.api.gax.httpjson.EmptyMessage;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
 import com.google.api.gax.httpjson.HttpJsonCallableFactory;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
@@ -14223,6 +14227,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.httpjson.EmptyMessage;
 import com.google.api.gax.paging.AbstractFixedSizeCollection;
 import com.google.api.gax.paging.AbstractPage;
 import com.google.api.gax.paging.AbstractPagedListResponse;
@@ -14595,7 +14600,7 @@ public class DummyObjectClient implements BackgroundResource {
    * </code></pre>
    */
   @BetaApi
-  public final UnaryCallable<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectCallable() {
+  public final UnaryCallable<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectCallable() {
     return stub.getResourceDummyObjectCallable();
   }
 
@@ -14690,7 +14695,7 @@ public class DummyObjectClient implements BackgroundResource {
    * </code></pre>
    */
   @BetaApi
-  public final UnaryCallable<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectCallable() {
+  public final UnaryCallable<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectCallable() {
     return stub.deleteDummyObjectCallable();
   }
 
@@ -14838,6 +14843,7 @@ import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.httpjson.EmptyMessage;
 import com.google.api.gax.httpjson.GaxHttpJsonProperties;
 import com.google.api.gax.httpjson.HttpJsonTransportChannel;
 import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
@@ -14910,14 +14916,14 @@ public class DummyObjectSettings extends ClientSettings<DummyObjectSettings> {
   /**
    * Returns the object with the settings used for calls to getResourceDummyObject.
    */
-  public UnaryCallSettings<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectSettings() {
+  public UnaryCallSettings<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectSettings() {
     return ((DummyObjectStubSettings) getStubSettings()).getResourceDummyObjectSettings();
   }
 
   /**
    * Returns the object with the settings used for calls to deleteDummyObject.
    */
-  public UnaryCallSettings<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectSettings() {
+  public UnaryCallSettings<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectSettings() {
     return ((DummyObjectStubSettings) getStubSettings()).deleteDummyObjectSettings();
   }
 
@@ -15051,14 +15057,14 @@ public class DummyObjectSettings extends ClientSettings<DummyObjectSettings> {
     /**
      * Returns the builder for the settings used for calls to getResourceDummyObject.
      */
-    public UnaryCallSettings.Builder<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectSettings() {
+    public UnaryCallSettings.Builder<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectSettings() {
       return getStubSettingsBuilder().getResourceDummyObjectSettings();
     }
 
     /**
      * Returns the builder for the settings used for calls to deleteDummyObject.
      */
-    public UnaryCallSettings.Builder<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectSettings() {
+    public UnaryCallSettings.Builder<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectSettings() {
       return getStubSettingsBuilder().deleteDummyObjectSettings();
     }
 
@@ -15094,6 +15100,7 @@ import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.httpjson.EmptyMessage;
 import com.google.api.gax.httpjson.GaxHttpJsonProperties;
 import com.google.api.gax.httpjson.HttpJsonTransportChannel;
 import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
@@ -15173,8 +15180,8 @@ public class DummyObjectStubSettings extends StubSettings<DummyObjectStubSetting
       .build();
 
   private final PagedCallSettings<ListResourcesDummyObjectsHttpRequest, ProjectsGetDummyObjectResources, ListResourcesDummyObjectsPagedResponse> listResourcesDummyObjectsSettings;
-  private final UnaryCallSettings<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectSettings;
-  private final UnaryCallSettings<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectSettings;
+  private final UnaryCallSettings<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectSettings;
+  private final UnaryCallSettings<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectSettings;
 
   /**
    * Returns the object with the settings used for calls to listResourcesDummyObjects.
@@ -15186,14 +15193,14 @@ public class DummyObjectStubSettings extends StubSettings<DummyObjectStubSetting
   /**
    * Returns the object with the settings used for calls to getResourceDummyObject.
    */
-  public UnaryCallSettings<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectSettings() {
+  public UnaryCallSettings<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectSettings() {
     return getResourceDummyObjectSettings;
   }
 
   /**
    * Returns the object with the settings used for calls to deleteDummyObject.
    */
-  public UnaryCallSettings<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectSettings() {
+  public UnaryCallSettings<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectSettings() {
     return deleteDummyObjectSettings;
   }
 
@@ -15351,8 +15358,8 @@ public class DummyObjectStubSettings extends StubSettings<DummyObjectStubSetting
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
 
     private final PagedCallSettings.Builder<ListResourcesDummyObjectsHttpRequest, ProjectsGetDummyObjectResources, ListResourcesDummyObjectsPagedResponse> listResourcesDummyObjectsSettings;
-    private final UnaryCallSettings.Builder<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectSettings;
-    private final UnaryCallSettings.Builder<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectSettings;
+    private final UnaryCallSettings.Builder<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectSettings;
+    private final UnaryCallSettings.Builder<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -15473,14 +15480,14 @@ public class DummyObjectStubSettings extends StubSettings<DummyObjectStubSetting
     /**
      * Returns the builder for the settings used for calls to getResourceDummyObject.
      */
-    public UnaryCallSettings.Builder<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectSettings() {
+    public UnaryCallSettings.Builder<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectSettings() {
       return getResourceDummyObjectSettings;
     }
 
     /**
      * Returns the builder for the settings used for calls to deleteDummyObject.
      */
-    public UnaryCallSettings.Builder<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectSettings() {
+    public UnaryCallSettings.Builder<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectSettings() {
       return deleteDummyObjectSettings;
     }
 
@@ -15510,6 +15517,7 @@ package com.google.cloud.simplecompute.v1.stub;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.httpjson.EmptyMessage;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.simplecompute.v1.Address;
 import com.google.cloud.simplecompute.v1.DeleteDummyObjectHttpRequest;
@@ -15544,12 +15552,12 @@ public abstract class DummyObjectStub implements BackgroundResource {
   }
 
   @BetaApi
-  public UnaryCallable<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectCallable() {
+  public UnaryCallable<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectCallable() {
     throw new UnsupportedOperationException("Not implemented: getResourceDummyObjectCallable()");
   }
 
   @BetaApi
-  public UnaryCallable<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectCallable() {
+  public UnaryCallable<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectCallable() {
     throw new UnsupportedOperationException("Not implemented: deleteDummyObjectCallable()");
   }
 
@@ -15582,6 +15590,7 @@ import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.httpjson.ApiMessageHttpRequestFormatter;
 import com.google.api.gax.httpjson.ApiMessageHttpResponseParser;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
+import com.google.api.gax.httpjson.EmptyMessage;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.rpc.ClientContext;
@@ -15636,8 +15645,8 @@ public class HttpJsonDummyObjectStub extends DummyObjectStub {
                   .build())
           .build();
   @InternalApi
-  public static final ApiMethodDescriptor<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectMethodDescriptor =
-      ApiMethodDescriptor.<GetResourceDummyObjectHttpRequest, Void>newBuilder()
+  public static final ApiMethodDescriptor<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectMethodDescriptor =
+      ApiMethodDescriptor.<GetResourceDummyObjectHttpRequest, EmptyMessage>newBuilder()
           .setFullMethodName("compute.dummyObjects.getResource")
           .setHttpMethod(HttpMethods.GET)
           .setRequestFormatter(
@@ -15650,8 +15659,8 @@ public class HttpJsonDummyObjectStub extends DummyObjectStub {
                   .build())
           .build();
   @InternalApi
-  public static final ApiMethodDescriptor<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectMethodDescriptor =
-      ApiMethodDescriptor.<DeleteDummyObjectHttpRequest, Void>newBuilder()
+  public static final ApiMethodDescriptor<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectMethodDescriptor =
+      ApiMethodDescriptor.<DeleteDummyObjectHttpRequest, EmptyMessage>newBuilder()
           .setFullMethodName("compute.dummyObjects.delete")
           .setHttpMethod(HttpMethods.DELETE)
           .setRequestFormatter(
@@ -15667,8 +15676,8 @@ public class HttpJsonDummyObjectStub extends DummyObjectStub {
 
   private final UnaryCallable<ListResourcesDummyObjectsHttpRequest, ProjectsGetDummyObjectResources> listResourcesDummyObjectsCallable;
   private final UnaryCallable<ListResourcesDummyObjectsHttpRequest, ListResourcesDummyObjectsPagedResponse> listResourcesDummyObjectsPagedCallable;
-  private final UnaryCallable<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectCallable;
-  private final UnaryCallable<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectCallable;
+  private final UnaryCallable<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectCallable;
+  private final UnaryCallable<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectCallable;
 
   private final HttpJsonStubCallableFactory callableFactory;
   public static final HttpJsonDummyObjectStub create(DummyObjectStubSettings settings) throws IOException {
@@ -15704,12 +15713,12 @@ public class HttpJsonDummyObjectStub extends DummyObjectStub {
         HttpJsonCallSettings.<ListResourcesDummyObjectsHttpRequest, ProjectsGetDummyObjectResources>newBuilder()
             .setMethodDescriptor(listResourcesDummyObjectsMethodDescriptor)
             .build();
-    HttpJsonCallSettings<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectTransportSettings =
-        HttpJsonCallSettings.<GetResourceDummyObjectHttpRequest, Void>newBuilder()
+    HttpJsonCallSettings<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectTransportSettings =
+        HttpJsonCallSettings.<GetResourceDummyObjectHttpRequest, EmptyMessage>newBuilder()
             .setMethodDescriptor(getResourceDummyObjectMethodDescriptor)
             .build();
-    HttpJsonCallSettings<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectTransportSettings =
-        HttpJsonCallSettings.<DeleteDummyObjectHttpRequest, Void>newBuilder()
+    HttpJsonCallSettings<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectTransportSettings =
+        HttpJsonCallSettings.<DeleteDummyObjectHttpRequest, EmptyMessage>newBuilder()
             .setMethodDescriptor(deleteDummyObjectMethodDescriptor)
             .build();
 
@@ -15732,12 +15741,12 @@ public class HttpJsonDummyObjectStub extends DummyObjectStub {
   }
 
   @BetaApi
-  public UnaryCallable<GetResourceDummyObjectHttpRequest, Void> getResourceDummyObjectCallable() {
+  public UnaryCallable<GetResourceDummyObjectHttpRequest, EmptyMessage> getResourceDummyObjectCallable() {
     return getResourceDummyObjectCallable;
   }
 
   @BetaApi
-  public UnaryCallable<DeleteDummyObjectHttpRequest, Void> deleteDummyObjectCallable() {
+  public UnaryCallable<DeleteDummyObjectHttpRequest, EmptyMessage> deleteDummyObjectCallable() {
     return deleteDummyObjectCallable;
   }
 
@@ -15798,6 +15807,7 @@ import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.httpjson.ApiMessageHttpRequestFormatter;
 import com.google.api.gax.httpjson.ApiMessageHttpResponseParser;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
+import com.google.api.gax.httpjson.EmptyMessage;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
 import com.google.api.gax.httpjson.HttpJsonCallableFactory;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
@@ -16593,6 +16603,7 @@ package com.google.cloud.simplecompute.v1;
 
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
+import com.google.api.gax.httpjson.EmptyMessage;
 import com.google.api.gax.httpjson.GaxHttpJsonProperties;
 import com.google.api.gax.httpjson.testing.MockHttpService;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;


### PR DESCRIPTION
This allows all interfaces that use `ApiMessage` to enforce that response objects have to be of type `ApiMessage`, which includes `EmptyMessage`. This replaces `java.lang.Void` as a response type.

Goes along with https://github.com/googleapis/gax-java/pull/678.