### PR TITLE
SampleGen: Access map entries in output handling

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
@@ -398,7 +398,22 @@ public class OutputTransformer {
             valueSet.getId(),
             config.input());
       } else if (token == '{') {
-        throw new UnsupportedOperationException("map indexing not supported yet");
+        Preconditions.checkArgument(
+            type.isMap(),
+            "%s:%s: %s is not a map field",
+            context.getMethodModel().getSimpleName(),
+            valueSet.getId(),
+            config.input());
+        TypeModel keyType = type.getMapKeyType();
+        config.scan();
+        accessors.add(context.getNamer().getMapKeyAccessorName(keyType, config.tokenStr()));
+        type = type.getMapValueType();
+        Preconditions.checkArgument(
+            config.scan() == '}',
+            "%s:%s: expected '}': %s",
+            context.getMethodModel().getSimpleName(),
+            valueSet.getId(),
+            config.input());
       } else {
         throw new IllegalArgumentException(
             String.format(

--- a/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
@@ -406,6 +406,7 @@ public class OutputTransformer {
             config.input());
         TypeModel keyType = type.getMapKeyType();
         config.scan();
+        keyType.validateValue(config.tokenStr());
         accessors.add(context.getNamer().getMapKeyAccessorName(keyType, config.tokenStr()));
         type = type.getMapValueType();
         Preconditions.checkArgument(

--- a/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
@@ -398,6 +398,7 @@ public class OutputTransformer {
             valueSet.getId(),
             config.input());
       } else if (token == '{') {
+        // TODO: honor https://github.com/googleapis/gapic-generator/issues/2600
         Preconditions.checkArgument(
             type.isMap(),
             "%s:%s: %s is not a map field",

--- a/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/OutputTransformer.java
@@ -405,7 +405,31 @@ public class OutputTransformer {
             valueSet.getId(),
             config.input());
         TypeModel keyType = type.getMapKeyType();
-        config.scan();
+        int keyToken = config.scan();
+        if (keyType.isStringType()) {
+          Preconditions.checkArgument(
+              keyToken == Scanner.STRING,
+              "%s:%s: expected string type for map key: %s",
+              context.getMethodModel().getSimpleName(),
+              valueSet.getId(),
+              config.input());
+        } else if (keyType.isBooleanType()) {
+          // `true` and `false` are the only valid literals here
+          Preconditions.checkArgument(
+              keyToken == Scanner.IDENT,
+              "%s:%s: expected boolean type for map key: %s",
+              context.getMethodModel().getSimpleName(),
+              valueSet.getId(),
+              config.input());
+        } else {
+          // Protobuf map keys can only be strings, booleans or integers
+          Preconditions.checkArgument(
+              keyToken == Scanner.INT,
+              "%s:%s: expected integral type for map key: %s",
+              context.getMethodModel().getSimpleName(),
+              valueSet.getId(),
+              config.input());
+        }
         keyType.validateValue(config.tokenStr());
         accessors.add(context.getNamer().getMapKeyAccessorName(keyType, config.tokenStr()));
         type = type.getMapValueType();

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -1633,6 +1633,16 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return getNotImplementedString("SurfaceNamer.getFieldAccessorName");
   }
 
+  /**
+   * Returns the expression to get the value of a map entry by its key.
+   *
+   * <p>Note that the returned value includes the language-specific syntax for accessing a map entry
+   * by key. For example, the returned value will be `.get("key")` in Java, and `["key"]` in Python.
+   */
+  public String getMapKeyAccessorName(TypeModel keyType, String key) {
+    return getNotImplementedString("SurfaceNamer.getMapKeyAccessorName");
+  }
+
   public String getSampleResponseVarName(MethodContext context, CallingForm form) {
     MethodConfig config = context.getMethodConfig();
     if (config.getPageStreaming() != null) {

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -24,6 +24,7 @@ import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProtoInterfaceModel;
+import com.google.api.codegen.config.ProtoTypeRef;
 import com.google.api.codegen.config.ResourceNameConfig;
 import com.google.api.codegen.config.ResourceNameType;
 import com.google.api.codegen.config.TransportProtocol;
@@ -413,6 +414,12 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   @Override
   public String getIndexAccessorName(int index) {
     return String.format(".get(%d)", index);
+  }
+
+  @Override
+  public String getMapKeyAccessorName(TypeModel keyType, String key) {
+    return String.format(
+        ".get(%s)", getModelTypeFormatter().renderPrimitiveValue((ProtoTypeRef) keyType, key));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -575,6 +575,11 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
+  public String getMapKeyAccessorName(TypeModel keyType, String key) {
+    return String.format("[%s]", getModelTypeFormatter().renderPrimitiveValue(keyType, key));
+  }
+
+  @Override
   public List<String> getPrintSpecs(String spec, List<String> args) {
     spec = spec.replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n").replace("`", "\\`");
     if (args.isEmpty()) {

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -287,6 +287,11 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
+  public String getMapKeyAccessorName(TypeModel keyType, String key) {
+    return String.format("[%s]", getModelTypeFormatter().renderPrimitiveValue(keyType, key));
+  }
+
+  @Override
   public String getFormattedPrintArgName(TypeModel type, String variable, List<String> accessors) {
     String arg = "$" + variable + String.join("", accessors);
     if (type != null && type instanceof ProtoTypeRef && type.isMessage()) {

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -528,6 +528,11 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
+  public String getMapKeyAccessorName(TypeModel keyType, String key) {
+    return String.format("[%s]", getModelTypeFormatter().renderPrimitiveValue(keyType, key));
+  }
+
+  @Override
   public String getSampleResponseVarName(MethodContext context, CallingForm form) {
     return Name.anyCamel(super.getSampleResponseVarName(context, form))
         .toLowerUnderscore()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -941,7 +941,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
-import com.google.protobuf.ListValue;
 
 // [START sample]
 /*
@@ -952,7 +951,6 @@ import com.google.protobuf.ListValue;
  * import com.google.example.library.v1.GetBookRequest;
  * import com.google.example.library.v1.LibraryClient;
  * import com.google.example.library.v1.ShelfBookName;
- * import com.google.protobuf.ListValue;
  */
 public class GetBookCallableCallableTestOnSuccessMap {
   public static void sampleGetBook() {
@@ -967,12 +965,9 @@ public class GetBookCallableCallableTestOnSuccessMap {
       // Do something
 
       Book response = future.get();
-      ListValue stringKeyVal = response.getMapListValueValueMap().get("key");
-      ListValue anotherStringKeyVal = response.getMapListValueValueMap().get("123");
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
       int mapValueField = response.getMapMessageValueMap().get("key").getField();
-      System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("key"));
       System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("quoted_key"));
       System.out.printf("Test printing enum fields of a map value: %s\n", response.getMapMessageValueMap().get("key").getAlignment());
     } catch (Exception exception) {
@@ -995,7 +990,6 @@ package com.google.example.examples.library.v1;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
-import com.google.protobuf.ListValue;
 
 // [START sample]
 /*
@@ -1004,7 +998,6 @@ import com.google.protobuf.ListValue;
  * import com.google.example.library.v1.Book;
  * import com.google.example.library.v1.LibraryClient;
  * import com.google.example.library.v1.ShelfBookName;
- * import com.google.protobuf.ListValue;
  */
 public class GetBookFlattenedTestOnSuccessMap {
   public static void sampleGetBook() {
@@ -1012,12 +1005,9 @@ public class GetBookFlattenedTestOnSuccessMap {
     try (LibraryClient libraryClient = LibraryClient.create()) {
       ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
       Book response = libraryClient.getBook(name.toString());
-      ListValue stringKeyVal = response.getMapListValueValueMap().get("key");
-      ListValue anotherStringKeyVal = response.getMapListValueValueMap().get("123");
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
       int mapValueField = response.getMapMessageValueMap().get("key").getField();
-      System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("key"));
       System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("quoted_key"));
       System.out.printf("Test printing enum fields of a map value: %s\n", response.getMapMessageValueMap().get("key").getAlignment());
     } catch (Exception exception) {
@@ -1041,7 +1031,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
-import com.google.protobuf.ListValue;
 
 // [START sample]
 /*
@@ -1051,7 +1040,6 @@ import com.google.protobuf.ListValue;
  * import com.google.example.library.v1.GetBookRequest;
  * import com.google.example.library.v1.LibraryClient;
  * import com.google.example.library.v1.ShelfBookName;
- * import com.google.protobuf.ListValue;
  */
 public class GetBookRequestTestOnSuccessMap {
   public static void sampleGetBook() {
@@ -1062,12 +1050,9 @@ public class GetBookRequestTestOnSuccessMap {
         .setName(name.toString())
         .build();
       Book response = libraryClient.getBook(request);
-      ListValue stringKeyVal = response.getMapListValueValueMap().get("key");
-      ListValue anotherStringKeyVal = response.getMapListValueValueMap().get("123");
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
       int mapValueField = response.getMapMessageValueMap().get("key").getField();
-      System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("key"));
       System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("quoted_key"));
       System.out.printf("Test printing enum fields of a map value: %s\n", response.getMapMessageValueMap().get("key").getAlignment());
     } catch (Exception exception) {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -932,6 +932,157 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
 // FIXME: Insert here clean-up code.
 
 // [END hopper]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBookCallableCallableTestOnSuccessMap.java ==============
+// DO NOT EDIT! This is a generated sample ("Callable",  "test_on_success_map")
+package com.google.example.examples.library.v1;
+
+import com.google.api.core.ApiFuture;
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.protobuf.ListValue;
+
+// [START sample]
+/*
+ * Please include the following imports to run this sample.
+ *
+ * import com.google.api.core.ApiFuture;
+ * import com.google.example.library.v1.Book;
+ * import com.google.example.library.v1.GetBookRequest;
+ * import com.google.example.library.v1.LibraryClient;
+ * import com.google.example.library.v1.ShelfBookName;
+ * import com.google.protobuf.ListValue;
+ */
+public class GetBookCallableCallableTestOnSuccessMap {
+  public static void sampleGetBook() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      ApiFuture<Book> future = libraryClient.getBookCallable().futureCall(request);
+
+      // Do something
+
+      Book response = future.get();
+      ListValue stringKeyVal = response.getMapListValueValueMap().get("key");
+      ListValue anotherStringKeyVal = response.getMapListValueValueMap().get("123");
+      String intKeyVal = response.getMapStringValueMap().get(123);
+      String booleanKeyVal = response.getMapBoolKeyMap().get(true);
+      int mapValueField = response.getMapMessageValueMap().get("key").getField();
+      System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("key"));
+      System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("quoted_key"));
+      System.out.printf("Test printing enum fields of a map value: %s\n", response.getMapMessageValueMap().get("key").getAlignment());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleGetBook();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBookFlattenedTestOnSuccessMap.java ==============
+// DO NOT EDIT! This is a generated sample ("Flattened",  "test_on_success_map")
+package com.google.example.examples.library.v1;
+
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.protobuf.ListValue;
+
+// [START sample]
+/*
+ * Please include the following imports to run this sample.
+ *
+ * import com.google.example.library.v1.Book;
+ * import com.google.example.library.v1.LibraryClient;
+ * import com.google.example.library.v1.ShelfBookName;
+ * import com.google.protobuf.ListValue;
+ */
+public class GetBookFlattenedTestOnSuccessMap {
+  public static void sampleGetBook() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      Book response = libraryClient.getBook(name.toString());
+      ListValue stringKeyVal = response.getMapListValueValueMap().get("key");
+      ListValue anotherStringKeyVal = response.getMapListValueValueMap().get("123");
+      String intKeyVal = response.getMapStringValueMap().get(123);
+      String booleanKeyVal = response.getMapBoolKeyMap().get(true);
+      int mapValueField = response.getMapMessageValueMap().get("key").getField();
+      System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("key"));
+      System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("quoted_key"));
+      System.out.printf("Test printing enum fields of a map value: %s\n", response.getMapMessageValueMap().get("key").getAlignment());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleGetBook();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
+============== file: samples/src/main/java/com/google/example/examples/library/v1/GetBookRequestTestOnSuccessMap.java ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
+package com.google.example.examples.library.v1;
+
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.protobuf.ListValue;
+
+// [START sample]
+/*
+ * Please include the following imports to run this sample.
+ *
+ * import com.google.example.library.v1.Book;
+ * import com.google.example.library.v1.GetBookRequest;
+ * import com.google.example.library.v1.LibraryClient;
+ * import com.google.example.library.v1.ShelfBookName;
+ * import com.google.protobuf.ListValue;
+ */
+public class GetBookRequestTestOnSuccessMap {
+  public static void sampleGetBook() {
+    // [START sample_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      Book response = libraryClient.getBook(request);
+      ListValue stringKeyVal = response.getMapListValueValueMap().get("key");
+      ListValue anotherStringKeyVal = response.getMapListValueValueMap().get("123");
+      String intKeyVal = response.getMapStringValueMap().get(123);
+      String booleanKeyVal = response.getMapBoolKeyMap().get(true);
+      int mapValueField = response.getMapMessageValueMap().get("key").getField();
+      System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("key"));
+      System.out.printf("Test printing map fields: %s\n", response.getMapListValueValueMap().get("quoted_key"));
+      System.out.printf("Test printing enum fields of a map value: %s\n", response.getMapMessageValueMap().get("key").getAlignment());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END sample_core]
+  }
+
+  public static void main(String[] args) {
+    sampleGetBook();
+  }
+}
+// FIXME: Insert here clean-up code.
+
+// [END sample]
 ============== file: samples/src/main/java/com/google/example/examples/library/v1/MonologAboutBookCallableCallableStreamingClientProg.java ==============
 // DO NOT EDIT! This is a generated sample ("CallableStreamingClient",  "prog")
 package com.google.example.examples.library.v1;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -584,6 +584,42 @@ const argv = require(`yargs`)
   .argv;
 
 sampleGetBigBook(argv.shelf, argv.big_book_name);
+============== file: src/samples/v1/get_book_request_test_on_success_map.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+
+const library = require('@google-cloud/library').v1;
+
+function sampleGetBook() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  client.getBook({name: formattedName})
+    .then(responses => {
+      const response = responses[0];
+      const stringKeyVal = response.mapListValueValue['key'];
+      const anotherStringKeyVal = response.mapListValueValue['123'];
+      const intKeyVal = response.mapStringValue[123];
+      const booleanKeyVal = response.mapBoolKey[true];
+      const mapValueField = response.mapMessageValue['key'].field;
+      console.log(`Test printing map fields: ${response.mapListValueValue['key']}`);
+      console.log(`Test printing map fields: ${response.mapListValueValue['quoted_key']}`);
+      console.log(`Test printing enum fields of a map value: ${response.mapMessageValue['key'].alignment}`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleGetBook();
 ============== file: src/samples/v1/monolog_about_book_request_streaming_client_prog.js ==============
 // DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "prog")
 'use strict';
@@ -966,6 +1002,9 @@ const FieldMask = {
  *   resource, but *not* its import, other_shared_type
  *
  *   This object should have the same structure as [Used]{@link google.test.shared.data.Used}
+ *
+ * @property {Object.<boolean, string>} mapBoolKey
+ *   For testing accessing map fields in samplegen
  *
  * @typedef Book
  * @memberof google.example.library.v1

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -600,12 +600,9 @@ function sampleGetBook() {
   client.getBook({name: formattedName})
     .then(responses => {
       const response = responses[0];
-      const stringKeyVal = response.mapListValueValue['key'];
-      const anotherStringKeyVal = response.mapListValueValue['123'];
       const intKeyVal = response.mapStringValue[123];
       const booleanKeyVal = response.mapBoolKey[true];
       const mapValueField = response.mapMessageValue['key'].field;
-      console.log(`Test printing map fields: ${response.mapListValueValue['key']}`);
       console.log(`Test printing map fields: ${response.mapListValueValue['quoted_key']}`);
       console.log(`Test printing enum fields of a map value: ${response.mapMessageValue['key'].alignment}`);
     })

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -3476,6 +3476,60 @@ $shelf = $options['shelf'];
 $bigBookName = $options['big_book_name'];
 
 sampleGetBigBook($shelf, $bigBookName);
+============== file: src/V1/samples/getBook/GetBookRequestTestOnSuccessMap.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
+ */
+
+// [START sample]
+require __DIR__ . '/../../../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+function sampleGetBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+
+    try {
+        $response = $libraryServiceClient->getBook($formattedName);
+        $stringKeyVal = $response->getMapListValueValue()['key'];
+        $anotherStringKeyVal = $response->getMapListValueValue()['123'];
+        $intKeyVal = $response->getMapStringValue()[123];
+        $booleanKeyVal = $response->getMapBoolKey()[true];
+        $mapValueField = $response->getMapMessageValue()['key']->getField();
+        printf("Test printing map fields: %s" . PHP_EOL, print_r($response->getMapListValueValue()['key'], true));
+        printf("Test printing map fields: %s" . PHP_EOL, print_r($response->getMapListValueValue()['quoted_key'], true));
+        printf("Test printing enum fields of a map value: %s" . PHP_EOL, $response->getMapMessageValue()['key']->getAlignment());
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleGetBook();
 ============== file: src/V1/samples/monologAboutBook/MonologAboutBookRequestStreamingClientAsyncProg.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -3513,12 +3513,9 @@ function sampleGetBook()
 
     try {
         $response = $libraryServiceClient->getBook($formattedName);
-        $stringKeyVal = $response->getMapListValueValue()['key'];
-        $anotherStringKeyVal = $response->getMapListValueValue()['123'];
         $intKeyVal = $response->getMapStringValue()[123];
         $booleanKeyVal = $response->getMapBoolKey()[true];
         $mapValueField = $response->getMapMessageValue()['key']->getField();
-        printf("Test printing map fields: %s" . PHP_EOL, print_r($response->getMapListValueValue()['key'], true));
         printf("Test printing map fields: %s" . PHP_EOL, print_r($response->getMapListValueValue()['quoted_key'], true));
         printf("Test printing enum fields of a map value: %s" . PHP_EOL, $response->getMapMessageValue()['key']->getAlignment());
     } finally {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4592,6 +4592,62 @@ def main():
 
 if __name__ == '__main__':
   main()
+============== file: samples/google/cloud/example/library_v1/gapic/get_book/get_book_request_test_on_success_map.py ==============
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-library
+
+import sys
+
+# [START sample]
+
+from google.cloud.example import library_v1
+from google.cloud.example.library_v1 import enums
+
+def sample_get_book():
+  """"""
+
+  # [START sample_core]
+
+  client = library_v1.LibraryServiceClient()
+
+  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+
+  response = client.get_book(name)
+  string_key_val = response.map_list_value_value['key']
+  another_string_key_val = response.map_list_value_value['123']
+  int_key_val = response.map_string_value[123]
+  boolean_key_val = response.map_bool_key[True]
+  map_value_field = response.map_message_value['key'].field
+  print('Test printing map fields: {}'.format(response.map_list_value_value['key']))
+  print('Test printing map fields: {}'.format(response.map_list_value_value['quoted_key']))
+  print('Test printing enum fields of a map value: {}'.format(enums.SomeMessage.Alignment(response.map_message_value['key'].alignment).name))
+
+  # [END sample_core]
+# [END sample]
+
+def main():
+  sample_get_book()
+
+if __name__ == '__main__':
+  main()
 ============== file: samples/google/cloud/example/library_v1/gapic/monolog_about_book/monolog_about_book_request_streaming_client_prog.py ==============
 # -*- coding: utf-8 -*-
 #

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4631,12 +4631,9 @@ def sample_get_book():
   name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
 
   response = client.get_book(name)
-  string_key_val = response.map_list_value_value['key']
-  another_string_key_val = response.map_list_value_value['123']
   int_key_val = response.map_string_value[123]
   boolean_key_val = response.map_bool_key[True]
   map_value_field = response.map_message_value['key'].field
-  print('Test printing map fields: {}'.format(response.map_list_value_value['key']))
   print('Test printing map fields: {}'.format(response.map_list_value_value['quoted_key']))
   print('Test printing enum fields of a map value: {}'.format(enums.SomeMessage.Alignment(response.map_message_value['key'].alignment).name))
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -2003,6 +2003,9 @@ module Google
         #   @return [Google::Test::Shared::Data::Used]
         #     Tests Python doc generation: should generate a dummy file for shared_type
         #     resource, but *not* its import, other_shared_type
+        # @!attribute [rw] map_bool_key
+        #   @return [Hash{true, false => String}]
+        #     For testing accessing map fields in samplegen
         class Book
           module Rating
             # GOOD enum description

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library.proto
@@ -499,6 +499,9 @@ message Book {
   // Tests Python doc generation: should generate a dummy file for shared_type
   // resource, but *not* its import, other_shared_type
   google.test.shared.data.Used resource = 29;
+
+  // For testing accessing map fields in samplegen
+  map<bool, string>  map_bool_key = 30;
 }
 
 // A single book in the archives.

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -334,20 +334,15 @@ interfaces:
         defaults:
         - name="test_on_success_map"
       on_success:
-        - define: string_key_val = $resp.map_list_value_value{key}
-        - define: another_string_key_val = $resp.map_list_value_value{123}
         - define: int_key_val = $resp.map_string_value{123}
         - define: boolean_key_val = $resp.map_bool_key{true}
-        - define: map_value_field = $resp.map_message_value{key}.field
-        - print:
-          - "Test printing map fields: %s"
-          - $resp.map_list_value_value{key}
+        - define: map_value_field = $resp.map_message_value{"key"}.field
         - print:
           - "Test printing map fields: %s"
           - $resp.map_list_value_value{"quoted_key"}
         - print:
           - "Test printing enum fields of a map value: %s"
-          - $resp.map_message_value{key}.alignment
+          - $resp.map_message_value{"key"}.alignment
     samples:
       in_code:
       - calling_forms: "foo"

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -328,10 +328,33 @@ interfaces:
       parameters:
         defaults:
         - name="Unreal book"
+    - id: test_on_success_map
+      title: "test maps in response handling"
+      parameters:
+        defaults:
+        - name="test_on_success_map"
+      on_success:
+        - define: string_key_val = $resp.map_list_value_value{key}
+        - define: another_string_key_val = $resp.map_list_value_value{123}
+        - define: int_key_val = $resp.map_string_value{123}
+        - define: boolean_key_val = $resp.map_bool_key{true}
+        - define: map_value_field = $resp.map_message_value{key}.field
+        - print:
+          - "Test printing map fields: %s"
+          - $resp.map_list_value_value{key}
+        - print:
+          - "Test printing map fields: %s"
+          - $resp.map_list_value_value{"quoted_key"}
+        - print:
+          - "Test printing enum fields of a map value: %s"
+          - $resp.map_message_value{key}.alignment
     samples:
       in_code:
       - calling_forms: "foo"
         value_sets: not_here
+      standalone:
+      - calling_forms: ".*"
+        value_sets: test_on_success_map
   - name: ListBooks
     flattening:
       groups:

--- a/src/test/java/com/google/api/codegen/transformer/OutputTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/OutputTransformerTest.java
@@ -256,7 +256,7 @@ public class OutputTransformerTest {
   }
 
   @Test
-  public void testAccessorNewVariableWithMapKeyFail() {
+  public void testAccessorNewVariableMapKeyInvalidBooleanFail() {
     Scanner scanner = new Scanner("old_var.property{not_boolean}");
     when(namer.localVarName(Name.from("old_var"))).thenReturn("oldVar");
     TypeModel oldVarTypeModel = mock(TypeModel.class);
@@ -281,6 +281,34 @@ public class OutputTransformerTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).contains("Could not assign value 'not_boolean' to type bool");
+    }
+  }
+
+  @Test
+  public void testAccessorNewVariableMapKeyUnquoatedStringFail() {
+    Scanner scanner = new Scanner("old_var.property{unquoted_string}");
+    when(namer.localVarName(Name.from("old_var"))).thenReturn("oldVar");
+    TypeModel oldVarTypeModel = mock(TypeModel.class);
+    assertThat(parent.put("old_var", oldVarTypeModel, "OldVarType")).isTrue();
+    when(oldVarTypeModel.isMessage()).thenReturn(true);
+    when(oldVarTypeModel.isRepeated()).thenReturn(false);
+    when(oldVarTypeModel.isMap()).thenReturn(false);
+    FieldModel propertyFieldModel = mock(FieldModel.class);
+    when(oldVarTypeModel.getField("property")).thenReturn(propertyFieldModel);
+    TypeModel propertyTypeModel = mock(TypeModel.class);
+    when(propertyFieldModel.getType()).thenReturn(propertyTypeModel);
+    when(propertyTypeModel.isRepeated()).thenReturn(true);
+    when(propertyTypeModel.isMap()).thenReturn(true);
+    when(namer.getFieldGetFunctionName(propertyFieldModel)).thenReturn("getProperty");
+    when(namer.getFieldAccessorName(propertyFieldModel)).thenReturn(".getProperty()");
+    TypeModel stringTypeModel = ProtoTypeRef.create(TypeRef.fromPrimitiveName("string"));
+    when(propertyTypeModel.getMapKeyType()).thenReturn(stringTypeModel);
+    when(propertyTypeModel.getMapValueType()).thenReturn(stringTypeModel);
+    try {
+      accessorNewVariable(scanner, context, valueSet, parent, "newVar", false, form);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).contains("expected string type for map key");
     }
   }
 


### PR DESCRIPTION
Allow accessing the value of a map entry by the key using `{}`. e.g., `$resp.map{key}`