### PR TITLE
Added MoreExecutors

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -846,9 +846,6 @@ public class JavaSurfaceTransformer {
     typeTable.saveNicknameFor("com.google.common.collect.ImmutableMap");
 
     InterfaceConfig interfaceConfig = context.getInterfaceConfig();
-    if (interfaceConfig.hasPageStreamingMethods()) {
-      typeTable.saveNicknameFor("com.google.common.util.concurrent.MoreExecutors");
-    }
     if (interfaceConfig.hasGrpcStreamingMethods(
         GrpcStreamingConfig.GrpcStreamingType.BidiStreaming)) {
       typeTable.saveNicknameFor("com.google.api.gax.rpc.BidiStreamingCallable");
@@ -950,6 +947,7 @@ public class JavaSurfaceTransformer {
     typeTable.saveNicknameFor("com.google.api.gax.rpc.PageContext");
     typeTable.saveNicknameFor("com.google.common.base.Function");
     typeTable.saveNicknameFor("com.google.common.collect.Iterables");
+    typeTable.saveNicknameFor("com.google.common.util.concurrent.MoreExecutors");
     typeTable.saveNicknameFor("javax.annotation.Generated");
     typeTable.saveNicknameFor("java.util.Iterator");
     typeTable.saveNicknameFor("java.util.List");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -846,6 +846,9 @@ public class JavaSurfaceTransformer {
     typeTable.saveNicknameFor("com.google.common.collect.ImmutableMap");
 
     InterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    if (interfaceConfig.hasPageStreamingMethods()) {
+      typeTable.saveNicknameFor("com.google.common.util.concurrent.MoreExecutors");
+    }
     if (interfaceConfig.hasGrpcStreamingMethods(
         GrpcStreamingConfig.GrpcStreamingType.BidiStreaming)) {
       typeTable.saveNicknameFor("com.google.api.gax.rpc.BidiStreamingCallable");

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -171,7 +171,8 @@
               public {@pagedResponseClass.pagedResponseTypeName} apply({@pagedResponseClass.pageTypeName} input) {
                 return new {@pagedResponseClass.pagedResponseTypeName}(input);
               }
-            });
+            },
+            MoreExecutors.directExecutor());
       }
 
       private {@pagedResponseClass.pagedResponseTypeName}({@pagedResponseClass.pageTypeName} page) {

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -11597,7 +11597,7 @@ import com.google.cloud.simplecompute.v1.stub.AddressStub;
 import com.google.cloud.simplecompute.v1.stub.AddressStubSettings;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.MoreExecutors
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -14239,7 +14239,7 @@ import com.google.cloud.simplecompute.v1.stub.DummyObjectStub;
 import com.google.cloud.simplecompute.v1.stub.DummyObjectStubSettings;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.MoreExecutors
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -12582,7 +12582,8 @@ public class AddressClient implements BackgroundResource {
             public AggregatedListAddressesPagedResponse apply(AggregatedListAddressesPage input) {
               return new AggregatedListAddressesPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private AggregatedListAddressesPagedResponse(AggregatedListAddressesPage page) {
@@ -12669,7 +12670,8 @@ public class AddressClient implements BackgroundResource {
             public ListAddressesPagedResponse apply(ListAddressesPage input) {
               return new ListAddressesPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private ListAddressesPagedResponse(ListAddressesPage page) {
@@ -14743,7 +14745,8 @@ public class DummyObjectClient implements BackgroundResource {
             public ListResourcesDummyObjectsPagedResponse apply(ListResourcesDummyObjectsPage input) {
               return new ListResourcesDummyObjectsPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private ListResourcesDummyObjectsPagedResponse(ListResourcesDummyObjectsPage page) {

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -22,7 +22,6 @@ import com.google.api.resourcenames.ResourceName;
 import com.google.api.resourcenames.ResourceNameFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.MoreExecutors
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -11598,6 +11597,7 @@ import com.google.cloud.simplecompute.v1.stub.AddressStub;
 import com.google.cloud.simplecompute.v1.stub.AddressStubSettings;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -14239,6 +14239,7 @@ import com.google.cloud.simplecompute.v1.stub.DummyObjectStub;
 import com.google.cloud.simplecompute.v1.stub.DummyObjectStubSettings;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -22,6 +22,7 @@ import com.google.api.resourcenames.ResourceName;
 import com.google.api.resourcenames.ResourceNameFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.MoreExecutors
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -128,6 +128,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.rpc.BidiStream;
+import com.google.common.util.concurrent.MoreExecutors
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -128,7 +128,6 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.rpc.BidiStream;
-import com.google.common.util.concurrent.MoreExecutors
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
@@ -1594,6 +1593,7 @@ import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.stub.LibraryServiceStub;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -1593,7 +1593,7 @@ import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.MoreExecutors
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.stub.LibraryServiceStub;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -5257,7 +5257,8 @@ public class LibraryClient implements BackgroundResource {
             public ListShelvesPagedResponse apply(ListShelvesPage input) {
               return new ListShelvesPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private ListShelvesPagedResponse(ListShelvesPage page) {
@@ -5344,7 +5345,8 @@ public class LibraryClient implements BackgroundResource {
             public ListBooksPagedResponse apply(ListBooksPage input) {
               return new ListBooksPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private ListBooksPagedResponse(ListBooksPage page) {
@@ -5431,7 +5433,8 @@ public class LibraryClient implements BackgroundResource {
             public ListStringsPagedResponse apply(ListStringsPage input) {
               return new ListStringsPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private ListStringsPagedResponse(ListStringsPage page) {
@@ -5550,7 +5553,8 @@ public class LibraryClient implements BackgroundResource {
             public FindRelatedBooksPagedResponse apply(FindRelatedBooksPage input) {
               return new FindRelatedBooksPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private FindRelatedBooksPagedResponse(FindRelatedBooksPage page) {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -109,7 +109,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.MoreExecutors
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.example.noPathTemplates.v1.IncrementRequest;
 import com.google.gcloud.example.stub.NoTemplatesApiServiceStub;
 import com.google.gcloud.example.stub.NoTemplatesApiServiceStubSettings;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -109,6 +109,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors
 import com.google.example.noPathTemplates.v1.IncrementRequest;
 import com.google.gcloud.example.stub.NoTemplatesApiServiceStub;
 import com.google.gcloud.example.stub.NoTemplatesApiServiceStubSettings;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -116,7 +116,7 @@ import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.MoreExecutors
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerEnum;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.stub.LibraryServiceStub;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -3439,7 +3439,8 @@ public class LibraryClient implements BackgroundResource {
             public ListShelvesPagedResponse apply(ListShelvesPage input) {
               return new ListShelvesPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private ListShelvesPagedResponse(ListShelvesPage page) {
@@ -3526,7 +3527,8 @@ public class LibraryClient implements BackgroundResource {
             public ListBooksPagedResponse apply(ListBooksPage input) {
               return new ListBooksPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private ListBooksPagedResponse(ListBooksPage page) {
@@ -3613,7 +3615,8 @@ public class LibraryClient implements BackgroundResource {
             public ListStringsPagedResponse apply(ListStringsPage input) {
               return new ListStringsPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private ListStringsPagedResponse(ListStringsPage page) {
@@ -3732,7 +3735,8 @@ public class LibraryClient implements BackgroundResource {
             public FindRelatedBooksPagedResponse apply(FindRelatedBooksPage input) {
               return new FindRelatedBooksPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private FindRelatedBooksPagedResponse(FindRelatedBooksPage page) {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -116,6 +116,7 @@ import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerEnum;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.stub.LibraryServiceStub;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -115,7 +115,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.MoreExecutors
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.example.library.v1.stub.LibraryServiceStub;
 import com.google.example.library.v1.stub.LibraryServiceStubSettings;
 import com.google.longrunning.Operation;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -115,6 +115,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors
 import com.google.example.library.v1.stub.LibraryServiceStub;
 import com.google.example.library.v1.stub.LibraryServiceStubSettings;
 import com.google.longrunning.Operation;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -1814,7 +1814,8 @@ public class LibraryServiceClient implements BackgroundResource {
             public ListShelvesPagedResponse apply(ListShelvesPage input) {
               return new ListShelvesPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private ListShelvesPagedResponse(ListShelvesPage page) {
@@ -1901,7 +1902,8 @@ public class LibraryServiceClient implements BackgroundResource {
             public ListBooksPagedResponse apply(ListBooksPage input) {
               return new ListBooksPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private ListBooksPagedResponse(ListBooksPage page) {
@@ -1988,7 +1990,8 @@ public class LibraryServiceClient implements BackgroundResource {
             public ListStringsPagedResponse apply(ListStringsPage input) {
               return new ListStringsPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private ListStringsPagedResponse(ListStringsPage page) {
@@ -2075,7 +2078,8 @@ public class LibraryServiceClient implements BackgroundResource {
             public FindRelatedBooksPagedResponse apply(FindRelatedBooksPage input) {
               return new FindRelatedBooksPagedResponse(input);
             }
-          });
+          },
+          MoreExecutors.directExecutor());
     }
 
     private FindRelatedBooksPagedResponse(FindRelatedBooksPage page) {


### PR DESCRIPTION
Fixing [Remove warnings #4384](https://github.com/googleapis/google-cloud-java/issues/4384)

`ApiFutures.transform()` without an executor is deprecated.  Adding an explicit `MoreExecutors.directExecutor()` to use the non-deprecated variant of the method.