### PR TITLE
node: use latest gax

### DIFF
--- a/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
+++ b/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
@@ -20,8 +20,6 @@ auth_version:
   python:
     lower: '1.0.2'
     upper: '2.0dev'
-  nodejs:
-    lower: '0.9.8'
   ruby:
     lower: '0.6.1'
 
@@ -31,8 +29,6 @@ grpc_version:
   python:
     lower: '1.0.2'
     upper: '2.0dev'
-  nodejs:
-    lower: '1.1.2'
   ruby:
     lower: '1.0'
   java:
@@ -43,7 +39,7 @@ gax_version:
     lower: '0.15.7'
     upper: '0.16dev'
   nodejs:
-    lower: '0.17.1'
+    lower: '0.25.3'
   php:
     lower: '0.37.0'
   ruby:
@@ -65,9 +61,6 @@ proto_version:
   python:
     lower: '3.0.0'
     upper: '4.0dev'
-  nodejs:
-    # This is the version of ProtoBuf.js.
-    lower: '5.0.1'
   php:
     lower: '3.5.1'
   ruby:

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -92,7 +92,7 @@ $ npm install --save @google-cloud/library
     "Google Example Library API"
   ],
   "dependencies": {
-    "google-gax": "^0.17.1",
+    "google-gax": "^0.25.3",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0",
     "protobufjs": "^6.8.0"

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -59,7 +59,7 @@ $ npm install --save @google-cloud/multiple-services
     "Google Example API"
   ],
   "dependencies": {
-    "google-gax": "^0.17.1",
+    "google-gax": "^0.25.3",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0",
     "lodash.union": "^4.6.0"

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -58,7 +58,7 @@ $ npm install --save example
     "Google Fake API"
   ],
   "dependencies": {
-    "google-gax": "^0.17.1",
+    "google-gax": "^0.25.3",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0"
   },

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -92,7 +92,7 @@ $ npm install --save @google-cloud/library
     "Google Example Library API"
   ],
   "dependencies": {
-    "google-gax": "^0.17.1",
+    "google-gax": "^0.25.3",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0",
     "protobufjs": "^6.8.0"

--- a/src/test/java/com/google/api/codegen/testsrc/common/frozen_dependencies.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/frozen_dependencies.yaml
@@ -4,8 +4,6 @@ auth_version:
   python:
     lower: '1.0.2'
     upper: '2.0dev'
-  nodejs:
-    lower: '0.9.8'
   ruby:
     lower: '0.5.1'
 
@@ -14,7 +12,7 @@ gax_version:
     lower: '0.15.0'
     upper: '0.16.0'
   nodejs:
-    lower: '0.17.1'
+    lower: '0.25.3'
   php:
     lower: '0.6.*'
   ruby:
@@ -38,8 +36,6 @@ grpc_version:
   python:
     lower: '1.0.2'
     upper: '2.0dev'
-  nodejs:
-    lower: '0.15.0'
   php:
     lower: '0.14.1'
   ruby:
@@ -51,8 +47,6 @@ proto_version:
   python:
     lower: '3.0.0'
     upper: '4.0dev'
-  nodejs:
-    lower: '^0.8.3'
   php:
     lower: '0.7.*'
   ruby:


### PR DESCRIPTION
Use the latest gax for Node.js since some libraries need it.

Also, cleanup `dependencies.yaml` to remove stuff Node.js never uses.

Also, update `frozen_dependencies.yaml` (even though it's frozen) to bring Node.js baselines closer to the actual libraries.