### PR TITLE
go: add pkg level doc for context use

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -13,12 +13,12 @@
     //
     // Use of Context
     //
-    // The ctx passed to NewClient is used for authentication requests and gRPC
-    // transport setup, but not for future calls performed using the client.
-    // These calls use the ctx passed to individual methods on the client.
+    // The ctx passed to NewClient is used for authentication requests and
+    // for the underlying connection, which is shared between requests.
+    // Individual methods on the client use the ctx given to them.
     //
-    // Using deadlines on requests is recommended. See more information at
-    // https://golang.org/pkg/context/.
+    // For information about setting deadlines, reusing contexts, and more
+    // please visit godoc.org/cloud.google.com/go
     @if view.domainLayerLocation
         //
         // Use the client at {@view.domainLayerLocation} in preference to this.

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -20,7 +20,7 @@
     // To close the open connection, use the Close() method.
     //
     // For information about setting deadlines, reusing contexts, and more
-    // please visit godoc.org/cloud.google.com/go
+    // please visit godoc.org/cloud.google.com/go.
     @if view.domainLayerLocation
         //
         // Use the client at {@view.domainLayerLocation} in preference to this.

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -14,7 +14,7 @@
     // Use of Context
     //
     // The ctx passed to NewClient is used for authentication requests and
-    // for creating the underlying connection, but is not used across methods.
+    // for creating the underlying connection, but is not used for subsequent calls.
     // Individual methods on the client use the ctx given to them.
     //
     // To close the open connection, use the Close() method.

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -14,8 +14,10 @@
     // Use of Context
     //
     // The ctx passed to NewClient is used for authentication requests and
-    // for the underlying connection, which is shared between requests.
+    // for creating the underlying connection, but is not used across methods.
     // Individual methods on the client use the ctx given to them.
+    //
+    // To close the open connection, use the Close() method.
     //
     // For information about setting deadlines, reusing contexts, and more
     // please visit godoc.org/cloud.google.com/go

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -10,6 +10,16 @@
     @join line : view.packageDoc
         // {@line}
     @end
+    //
+    // Use of Context
+    //
+    // NewClient and all client methods require a context. NewClient context is
+    // used for authentication requests as well as gRPC transport setup, but not
+    // for any future calls. Context passed to client methods are used for the
+    // lifetime of the request.
+    //
+    // Using deadlines on requests is recommended. See more information at
+    // https://golang.org/pkg/context/.
     @if view.domainLayerLocation
         //
         // Use the client at {@view.domainLayerLocation} in preference to this.

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -13,10 +13,9 @@
     //
     // Use of Context
     //
-    // NewClient and all client methods require a context. NewClient context is
-    // used for authentication requests as well as gRPC transport setup, but not
-    // for any future calls. Context passed to client methods are used for the
-    // lifetime of the request.
+    // The ctx passed to NewClient is used for authentication requests and gRPC
+    // transport setup, but not for future calls performed using the client.
+    // These calls use the ctx passed to individual methods on the client.
     //
     // Using deadlines on requests is recommended. See more information at
     // https://golang.org/pkg/context/.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -97,8 +97,10 @@ func TestLibClientSmoke(t *testing.T) {
 // Use of Context
 //
 // The ctx passed to NewClient is used for authentication requests and
-// for the underlying connection, which is shared between requests.
+// for creating the underlying connection, but is not used across methods.
 // Individual methods on the client use the ctx given to them.
+//
+// To close the open connection, use the Close() method.
 //
 // For information about setting deadlines, reusing contexts, and more
 // please visit godoc.org/cloud.google.com/go

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -96,12 +96,12 @@ func TestLibClientSmoke(t *testing.T) {
 //
 // Use of Context
 //
-// The ctx passed to NewClient is used for authentication requests and gRPC
-// transport setup, but not for future calls performed using the client.
-// These calls use the ctx passed to individual methods on the client.
+// The ctx passed to NewClient is used for authentication requests and
+// for the underlying connection, which is shared between requests.
+// Individual methods on the client use the ctx given to them.
 //
-// Using deadlines on requests is recommended. See more information at
-// https://golang.org/pkg/context/.
+// For information about setting deadlines, reusing contexts, and more
+// please visit godoc.org/cloud.google.com/go
 //
 // Use the client at cloud.google.com/go/library in preference to this.
 package library // import "cloud.google.com/go/library/apiv1"

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -96,10 +96,9 @@ func TestLibClientSmoke(t *testing.T) {
 //
 // Use of Context
 //
-// NewClient and all client methods require a context. NewClient context is
-// used for authentication requests as well as gRPC transport setup, but not
-// for any future calls. Context passed to client methods are used for the
-// lifetime of the request.
+// The ctx passed to NewClient is used for authentication requests and gRPC
+// transport setup, but not for future calls performed using the client.
+// These calls use the ctx passed to individual methods on the client.
 //
 // Using deadlines on requests is recommended. See more information at
 // https://golang.org/pkg/context/.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -103,7 +103,7 @@ func TestLibClientSmoke(t *testing.T) {
 // To close the open connection, use the Close() method.
 //
 // For information about setting deadlines, reusing contexts, and more
-// please visit godoc.org/cloud.google.com/go
+// please visit godoc.org/cloud.google.com/go.
 //
 // Use the client at cloud.google.com/go/library in preference to this.
 package library // import "cloud.google.com/go/library/apiv1"

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -97,7 +97,7 @@ func TestLibClientSmoke(t *testing.T) {
 // Use of Context
 //
 // The ctx passed to NewClient is used for authentication requests and
-// for creating the underlying connection, but is not used across methods.
+// for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //
 // To close the open connection, use the Close() method.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -94,6 +94,16 @@ func TestLibClientSmoke(t *testing.T) {
 //
 // A simple Google Example Library API.
 //
+// Use of Context
+//
+// NewClient and all client methods require a context. NewClient context is
+// used for authentication requests as well as gRPC transport setup, but not
+// for any future calls. Context passed to client methods are used for the
+// lifetime of the request.
+//
+// Using deadlines on requests is recommended. See more information at
+// https://golang.org/pkg/context/.
+//
 // Use the client at cloud.google.com/go/library in preference to this.
 package library // import "cloud.google.com/go/library/apiv1"
 


### PR DESCRIPTION
Adds a package-level comment regarding the use of `context` in client initialization & method invocation.

Fixes #2612 

@jadekler can you give a +1 on the language. I copied it entirely, but tweaked things a tad.