### PR TITLE
Generate LRO operation snapshot callable

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/StandardTransformationContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/StandardTransformationContext.java
@@ -1,4 +1,4 @@
-/* Copyright 2017 Google LLC
+/* Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/api/codegen/transformer/StandardTransformationContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/StandardTransformationContext.java
@@ -1,0 +1,55 @@
+/* Copyright 2017 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer;
+
+import com.google.api.codegen.config.GapicProductConfig;
+import com.google.auto.value.AutoValue;
+
+/**
+ * The context for transforming some API entity into a top-level view for client library generation.
+ */
+@AutoValue
+public abstract class StandardTransformationContext implements TransformationContext {
+  /**
+   * Create a context for transforming a schema.
+   *
+   * @param productConfig Contains client configuration.
+   * @param namer Names entities according to language-specific conventions.
+   * @param typeTable Manages the imports for the API entity view.
+   */
+  public static StandardTransformationContext create(
+      GapicProductConfig productConfig, SurfaceNamer namer, ImportTypeTable typeTable) {
+    return new AutoValue_StandardTransformationContext(namer, typeTable, productConfig);
+  }
+
+  @Override
+  public abstract SurfaceNamer getNamer();
+
+  @Override
+  public abstract ImportTypeTable getImportTypeTable();
+
+  @Override
+  public abstract GapicProductConfig getProductConfig();
+
+  @Override
+  public StandardTransformationContext withNewTypeTable() {
+    return create(getProductConfig(), getNamer(), getImportTypeTable().cloneEmpty());
+  }
+
+  @Override
+  public StandardTransformationContext withNewTypeTable(String newPackageName) {
+    return create(getProductConfig(), getNamer(), getImportTypeTable().cloneEmpty(newPackageName));
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -183,6 +183,16 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return rootPackageName + ".stub";
   }
 
+  public String getApiLroPackageName() {
+    return rootPackageName + ".longrunning";
+  }
+
+  public String getApiLroOperationCallableName() {
+    return getApiLroPackageName()
+        + "."
+        + nameFormatter.publicClassName(Name.upperCamel("OperationSnapshotCallable"));
+  }
+
   public String getNotImplementedString(String feature) {
     return "$ NOT IMPLEMENTED: " + feature + " $";
   }
@@ -775,6 +785,11 @@ public class SurfaceNamer extends NameFormatterDelegator {
   /** The name of the class that operates on a particular Discovery Document resource type. */
   public String getApiWrapperClassName(Document document) {
     return publicClassName(Name.anyCamel(document.name(), "Client"));
+  }
+
+  /** The name of the class that wraps Callables for the API LRO client. */
+  public String getApiLroOperationCallableName(Document document) {
+    return publicClassName(Name.anyCamel(document.name(), "OperationSnapshotCallable"));
   }
 
   public String getGrpcTransportClassName(InterfaceConfig interfaceConfig) {

--- a/src/main/java/com/google/api/codegen/viewmodel/OperationSnapshotCallableView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/OperationSnapshotCallableView.java
@@ -1,4 +1,4 @@
-/* Copyright 2016 Google LLC
+/* Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/api/codegen/viewmodel/OperationSnapshotCallableView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/OperationSnapshotCallableView.java
@@ -1,0 +1,37 @@
+/* Copyright 2016 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class OperationSnapshotCallableView {
+  public abstract String operationResourceName();
+
+  public abstract String operationSnapshotName();
+
+  public static Builder newBuilder() {
+    return new AutoValue_OperationSnapshotCallableView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder operationResourceName(String val);
+
+    public abstract Builder operationSnapshotName(String val);
+
+    public abstract OperationSnapshotCallableView build();
+  }
+}

--- a/src/main/resources/com/google/api/codegen/java/lro_client_factory.snip
+++ b/src/main/resources/com/google/api/codegen/java/lro_client_factory.snip
@@ -1,0 +1,51 @@
+@extends "java/common.snip"
+
+@snippet renderStubFileHeader(fileHeader)
+  {@license(fileHeader)}
+  package {@fileHeader.packageName};
+
+  {@importList(fileHeader.importSection.appImports)}
+@end
+
+@snippet generate(classFile)
+  {@renderStubFileHeader(classFile.fileHeader)}
+
+  {@classDoc(classFile.classView)}
+  @@Generated("by gapic-generator")
+  @@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  {@renderClass(classFile.classView)}
+@end
+
+@private classDoc(classView)
+  // AUTO-GENERATED DOCUMENTATION AND CLASS
+  /**
+   * Factory for creating {@classView.serviceName} LongRunningClient instances from
+   * a given stub class for the operation resource.
+   */
+@end
+
+@private renderClass(classView)
+  public class {@classView.lroClientFactoryName} {
+    @join constructor : classView.clientInstances
+      /* Create a {@classView.lroClientFactoryName} from a GlobalOperationsStub. */
+        public static {@classView.lroClientFactoryName} create(GlobalOperationStub operationStub) {
+          return new {@classView.lroClientFactoryName}<>(
+              operationStub,
+              operationStub.{@constructor.deleteGlobalOperationCallable}(),
+              operationStub.{@constructor.getGlobalOperationCallable}(),
+              new ApiFunction<String, deleteOperationRequestName>() {
+                public deleteOperationRequestName apply(String operationSelfLink) {
+                  return deleteOperationRequestName.newBuilder()
+                      .{@constructor.operationDeleteRequestSetter}(operationSelfLink)
+                      .build();
+                }
+              },
+              new ApiFunction<String, {@constructor.getOperationRequestName}>() {
+                public {@constructor.getOperationRequestName} apply(String operationSelfLink) {
+                  return {@constructor.getOperationRequestName}.newBuilder().{@constructor.operationGetRequestSetter}(operationSelfLink).build();
+                }
+              });
+        }
+    @end
+  }
+@end

--- a/src/main/resources/com/google/api/codegen/java/operation_callable.snip
+++ b/src/main/resources/com/google/api/codegen/java/operation_callable.snip
@@ -1,0 +1,49 @@
+@extends "java/common.snip"
+
+@snippet renderStubFileHeader(fileHeader)
+  {@license(fileHeader)}
+  package {@fileHeader.packageName};
+
+  {@importList(fileHeader.importSection.appImports)}
+@end
+
+@snippet generate(classFile)
+  {@renderStubFileHeader(classFile.fileHeader)}
+
+  {@classDoc()}
+  @@Generated("by gapic-generator")
+  @@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  {@renderClass(classFile.classView)}
+@end
+
+@private classDoc()
+  // AUTO-GENERATED DOCUMENTATION AND CLASS
+  /**
+   * A {@@code UnaryCallable} that wraps a UnaryCallable returning a
+   * long-running operation API resource and returns an OperationSnapshot instead.
+   */
+@end
+
+@private renderClass(classView)
+  public class OperationSnapshotCallable<RequestT>
+      extends UnaryCallable<RequestT, OperationSnapshot> {
+    private final UnaryCallable<RequestT, {@classView.operationResourceName}> innerCallable;
+
+    public OperationSnapshotCallable(UnaryCallable<RequestT, {@classView.operationResourceName}> innerCallable) {
+      this.innerCallable = innerCallable;
+    }
+
+    @@Override
+    public ApiFuture<OperationSnapshot> futureCall(RequestT request, ApiCallContext context) {
+      return ApiFutures.transform(
+          innerCallable.futureCall(request, context),
+          new ApiFunction<{@classView.operationResourceName}, OperationSnapshot>() {
+            @@Override
+            public OperationSnapshot apply({@classView.operationResourceName} operation) {
+              return {@classView.operationSnapshotName}.create(operation);
+            }
+          },
+          directExecutor());
+    }
+  }
+@end

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -12053,6 +12053,62 @@ public class HttpJsonAddressCallableFactory implements HttpJsonStubCallableFacto
  */
 
 package com.google.cloud.simplecompute.v1;
+============== file: src/main/java/com/google/cloud/simplecompute/v1/SimplecomputeOperationSnapshotCallable.java ==============
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.simplecompute.v1.longrunning;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.compute.v1.ComputeOperationSnapshot;
+import com.google.cloud.compute.v1.Operation;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * A {@code UnaryCallable} that wraps a UnaryCallable returning a
+ * long-running operation API resource and returns an OperationSnapshot instead.
+ */
+@Generated("by gapic-generator")
+@BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+public class OperationSnapshotCallable<RequestT>
+    extends UnaryCallable<RequestT, OperationSnapshot> {
+  private final UnaryCallable<RequestT, Operation> innerCallable;
+
+  public OperationSnapshotCallable(UnaryCallable<RequestT, Operation> innerCallable) {
+    this.innerCallable = innerCallable;
+  }
+
+  @Override
+  public ApiFuture<OperationSnapshot> futureCall(RequestT request, ApiCallContext context) {
+    return ApiFutures.transform(
+        innerCallable.futureCall(request, context),
+        new ApiFunction<Operation, OperationSnapshot>() {
+          @Override
+          public OperationSnapshot apply(Operation operation) {
+            return ComputeOperationSnapshot.create(operation);
+          }
+        },
+        directExecutor());
+  }
+}
 ============== file: build.gradle ==============
 buildscript {
   repositories {


### PR DESCRIPTION
Analogous to gax's [GrpcOperationSnapshotCallable](https://github.com/googleapis/gax-java/blob/master/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcOperationSnapshotCallable.java)

The Compute Operation type is hard-coded right now, and will later be put in the GAPIC config.