### PR TITLE
Add @Deprecated to formatString[ResourceName] functions in Java

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -186,6 +186,7 @@ public class PathTemplateTransformer {
         getSingleResourceNameConfigsUsedByInterface(context)) {
       FormatResourceFunctionView.Builder function =
           FormatResourceFunctionView.newBuilder()
+              .resourceName(namer.getResourceTypeName(resourceNameConfig))
               .entityName(resourceNameConfig.getEntityName())
               .name(namer.getFormatFunctionName(interfaceConfig, resourceNameConfig))
               .pathTemplateName(namer.getPathTemplateName(interfaceConfig, resourceNameConfig))

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -229,6 +229,7 @@ public class PathTemplateTransformer {
                 .pathTemplateName(namer.getPathTemplateName(interfaceConfig, resourceNameConfig))
                 .pathTemplateGetterName(
                     namer.getPathTemplateNameGetter(interfaceConfig, resourceNameConfig))
+                .entityNameTypeName(namer.getResourceTypeName(resourceNameConfig))
                 .entityNameParamName(namer.getEntityNameParamName(resourceNameConfig))
                 .outputResourceId(var);
         functions.add(function.build());

--- a/src/main/java/com/google/api/codegen/viewmodel/FormatResourceFunctionView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/FormatResourceFunctionView.java
@@ -23,6 +23,8 @@ public abstract class FormatResourceFunctionView {
 
   public abstract String name();
 
+  public abstract String resourceName();
+
   public abstract List<ResourceIdParamView> resourceIdParams();
 
   public abstract String pathTemplateName();
@@ -40,6 +42,8 @@ public abstract class FormatResourceFunctionView {
     public abstract Builder entityName(String val);
 
     public abstract Builder name(String val);
+
+    public abstract Builder resourceName(String val);
 
     public abstract Builder resourceIdParams(List<ResourceIdParamView> val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/ParseResourceFunctionView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ParseResourceFunctionView.java
@@ -26,6 +26,8 @@ public abstract class ParseResourceFunctionView {
 
   public abstract String pathTemplateGetterName();
 
+  public abstract String entityNameTypeName();
+
   public abstract String entityNameParamName();
 
   public abstract String outputResourceId();
@@ -45,6 +47,8 @@ public abstract class ParseResourceFunctionView {
     public abstract Builder pathTemplateGetterName(String val);
 
     public abstract Builder entityNameParamName(String val);
+
+    public abstract Builder entityNameTypeName(String val);
 
     public abstract Builder outputResourceId(String val);
 

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -248,7 +248,10 @@
   /**
    * Formats a string containing the fully-qualified path to represent
    * a {@function.entityName} resource.
+   *
+   * @@deprecated Use the {@@link {@function.resourceName}} class instead.
    */
+  @@Deprecated
   public static final String {@function.name}(\
       {@formatResourceFunctionParams(function.resourceIdParams)}) {
     return {@function.pathTemplateName}.instantiate(

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -276,7 +276,10 @@
   /**
    * Parses the {@function.outputResourceId} from the given fully-qualified path which
    * represents a {@function.entityName} resource.
+   *
+   * @@deprecated Use the {@@link {@function.entityNameTypeName}} class instead.
    */
+  @@Deprecated
   public static final String {@function.name}(String {@function.entityNameParamName}) {
     return {@function.pathTemplateName}.parse({@function.entityNameParamName})\
       .get("{@function.outputResourceId}");

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -2726,7 +2726,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Formats a string containing the fully-qualified path to represent
    * a shelf resource.
+   *
+   * @deprecated Use the {@link ShelfName} class instead.
    */
+  @Deprecated
   public static final String formatShelfName(String shelfId) {
     return SHELF_PATH_TEMPLATE.instantiate(
         "shelf_id", shelfId);
@@ -2735,7 +2738,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Formats a string containing the fully-qualified path to represent
    * a shelf_book resource.
+   *
+   * @deprecated Use the {@link ShelfBookName} class instead.
    */
+  @Deprecated
   public static final String formatShelfBookName(String shelfId, String bookId) {
     return SHELF_BOOK_PATH_TEMPLATE.instantiate(
         "shelf_id", shelfId,
@@ -2745,7 +2751,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Formats a string containing the fully-qualified path to represent
    * a return resource.
+   *
+   * @deprecated Use the {@link ReturnName} class instead.
    */
+  @Deprecated
   public static final String formatReturnName(String shelf, String book, String return_) {
     return RETURN_PATH_TEMPLATE.instantiate(
         "shelf", shelf,
@@ -2756,7 +2765,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Formats a string containing the fully-qualified path to represent
    * a project resource.
+   *
+   * @deprecated Use the {@link com.google.cloud.ProjectName} class instead.
    */
+  @Deprecated
   public static final String formatProjectName(String project) {
     return PROJECT_PATH_TEMPLATE.instantiate(
         "project", project);
@@ -2765,7 +2777,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Formats a string containing the fully-qualified path to represent
    * a archived_book resource.
+   *
+   * @deprecated Use the {@link ArchivedBookName} class instead.
    */
+  @Deprecated
   public static final String formatArchivedBookName(String archivePath, String bookId) {
     return ARCHIVED_BOOK_PATH_TEMPLATE.instantiate(
         "archive_path", archivePath,

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -2790,7 +2790,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Parses the shelf_id from the given fully-qualified path which
    * represents a shelf resource.
+   *
+   * @deprecated Use the {@link ShelfName} class instead.
    */
+  @Deprecated
   public static final String parseShelfIdFromShelfName(String shelfName) {
     return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf_id");
   }
@@ -2798,7 +2801,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Parses the shelf_id from the given fully-qualified path which
    * represents a shelf_book resource.
+   *
+   * @deprecated Use the {@link ShelfBookName} class instead.
    */
+  @Deprecated
   public static final String parseShelfIdFromShelfBookName(String shelfBookName) {
     return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("shelf_id");
   }
@@ -2806,7 +2812,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Parses the book_id from the given fully-qualified path which
    * represents a shelf_book resource.
+   *
+   * @deprecated Use the {@link ShelfBookName} class instead.
    */
+  @Deprecated
   public static final String parseBookIdFromShelfBookName(String shelfBookName) {
     return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("book_id");
   }
@@ -2814,7 +2823,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Parses the shelf from the given fully-qualified path which
    * represents a return resource.
+   *
+   * @deprecated Use the {@link ReturnName} class instead.
    */
+  @Deprecated
   public static final String parseShelfFromReturnName(String returnName) {
     return RETURN_PATH_TEMPLATE.parse(returnName).get("shelf");
   }
@@ -2822,7 +2834,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Parses the book from the given fully-qualified path which
    * represents a return resource.
+   *
+   * @deprecated Use the {@link ReturnName} class instead.
    */
+  @Deprecated
   public static final String parseBookFromReturnName(String returnName) {
     return RETURN_PATH_TEMPLATE.parse(returnName).get("book");
   }
@@ -2830,7 +2845,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Parses the return from the given fully-qualified path which
    * represents a return resource.
+   *
+   * @deprecated Use the {@link ReturnName} class instead.
    */
+  @Deprecated
   public static final String parseReturnFromReturnName(String returnName) {
     return RETURN_PATH_TEMPLATE.parse(returnName).get("return");
   }
@@ -2838,7 +2856,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Parses the project from the given fully-qualified path which
    * represents a project resource.
+   *
+   * @deprecated Use the {@link com.google.cloud.ProjectName} class instead.
    */
+  @Deprecated
   public static final String parseProjectFromProjectName(String projectName) {
     return PROJECT_PATH_TEMPLATE.parse(projectName).get("project");
   }
@@ -2846,7 +2867,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Parses the archive_path from the given fully-qualified path which
    * represents a archived_book resource.
+   *
+   * @deprecated Use the {@link ArchivedBookName} class instead.
    */
+  @Deprecated
   public static final String parseArchivePathFromArchivedBookName(String archivedBookName) {
     return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("archive_path");
   }
@@ -2854,7 +2878,10 @@ public class LibraryClient implements BackgroundResource {
   /**
    * Parses the book_id from the given fully-qualified path which
    * represents a archived_book resource.
+   *
+   * @deprecated Use the {@link ArchivedBookName} class instead.
    */
+  @Deprecated
   public static final String parseBookIdFromArchivedBookName(String archivedBookName) {
     return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("book_id");
   }


### PR DESCRIPTION
These formatString functions are causing us pain when we try to refresh clients.

Statically-typed resource name classes are superior to the `formatString*` functions, and it is more cluttering than helpful to have both the classes and the formatting functions. We might as well just always use the resource name classes.