### PR TITLE
[configgen] Fix comment indentation.

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/ConfigGenerator.java
+++ b/src/main/java/com/google/api/codegen/configgen/ConfigGenerator.java
@@ -66,7 +66,7 @@ public class ConfigGenerator extends NodeVisitor {
       if (!isFirst) {
         configBuilder.append(whitespace().trimTrailingFrom(line));
       } else if (line.trim().startsWith("#")) {
-        appendIndent().append(whitespace().trimTrailingFrom(line));
+        configBuilder.append(whitespace().trimTrailingFrom(line));
       } else {
         configBuilder
             .append(Strings.repeat(" ", indent - TAB_WIDTH))

--- a/src/main/resources/com/google/api/codegen/configgen/gapic_config.snip
+++ b/src/main/resources/com/google/api/codegen/configgen/gapic_config.snip
@@ -46,7 +46,7 @@
   @# A list of API interface configurations.
   interfaces:
   @join interface : interfaces
-    {@"  # "}The fully qualified name of the API interface.
+    @# The fully qualified name of the API interface.
     - name: {@interface.name}
       @# A list of resource collection configurations.
       @# Consists of a name_pattern and an entity_name.

--- a/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
@@ -28,7 +28,7 @@ license_header:
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.
 interfaces:
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.example.library.v1.LibraryService
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.

--- a/src/test/java/com/google/api/codegen/configgen/testdata/longrunning_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/longrunning_config.baseline
@@ -28,7 +28,7 @@ license_header:
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.
 interfaces:
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.longrunning.Operations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.

--- a/src/test/java/com/google/api/codegen/configgen/testdata/multiple_services_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/multiple_services_config.baseline
@@ -28,7 +28,7 @@ license_header:
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.
 interfaces:
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.cloud.example.v1.foo.IncrementerService
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -121,7 +121,7 @@ interfaces:
     retry_params_name: default
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.cloud.example.v1.foo.DecrementerService
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -214,7 +214,7 @@ interfaces:
     retry_params_name: default
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.cloud.example.v2.foo.IncrementerService
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -307,7 +307,7 @@ interfaces:
     retry_params_name: default
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.cloud.example.v2.foo.DecrementerService
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.

--- a/src/test/java/com/google/api/codegen/configgen/testdata/no_path_templates_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/no_path_templates_config.baseline
@@ -28,7 +28,7 @@ license_header:
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.
 interfaces:
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.cloud.example.v1.NoTemplatesAPIService
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
@@ -29,7 +29,7 @@ license_header:
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.
 interfaces:
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.simplecompute.v1.Addresses
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.


### PR DESCRIPTION
Reduces the indentation of the interface name comment by one level. This 
conforms the gapic config to Google style for yaml files.

Fixes #2653