### PR TITLE
Deprecate copyright_file in GAPIC config

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/mergers/ConfigMerger.java
+++ b/src/main/java/com/google/api/codegen/configgen/mergers/ConfigMerger.java
@@ -27,7 +27,6 @@ import com.google.api.codegen.configgen.nodes.metadata.FixmeComment;
 
 /** Merges the gapic config from an ApiModel into a ConfigNode. */
 public class ConfigMerger {
-  private static final String CONFIG_DEFAULT_COPYRIGHT_FILE = "copyright-google.txt";
   private static final String CONFIG_DEFAULT_LICENSE_FILE = "license-header-apache-2.0.txt";
   private static final String CONFIG_PROTO_TYPE = ConfigProto.getDescriptor().getFullName();
   private static final String CONFIG_SCHEMA_VERSION = "1.0.0";
@@ -126,22 +125,16 @@ public class ConfigMerger {
       return;
     }
 
-    FieldConfigNode copyrightFileNode =
-        FieldConfigNode.createStringPair(
-                NodeFinder.getNextLine(licenseHeaderNode),
-                "copyright_file",
-                CONFIG_DEFAULT_COPYRIGHT_FILE)
-            .setComment(new DefaultComment("The file containing the copyright line(s)."));
     FieldConfigNode licenseFileNode =
         FieldConfigNode.createStringPair(
-                NodeFinder.getNextLine(copyrightFileNode),
+                NodeFinder.getNextLine(licenseHeaderNode),
                 "license_file",
                 CONFIG_DEFAULT_LICENSE_FILE)
             .setComment(
                 new DefaultComment(
                     "The file containing the raw license header without any copyright line(s)."));
     licenseHeaderNode
-        .setChild(copyrightFileNode.insertNext(licenseFileNode))
+        .setChild(licenseFileNode)
         .setComment(
             new DefaultComment(
                 "The configuration for the license header to put on generated files."));

--- a/src/main/java/com/google/api/codegen/configgen/transformer/DiscoConfigTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/DiscoConfigTransformer.java
@@ -39,7 +39,6 @@ import java.util.TreeMap;
 /** Generates the config view object using a model and output path. */
 public class DiscoConfigTransformer {
   private static final String CONFIG_TEMPLATE_FILE = "configgen/gapic_config.snip";
-  private static final String CONFIG_DEFAULT_COPYRIGHT_FILE = "copyright-google.txt";
   private static final String CONFIG_DEFAULT_LICENSE_FILE = "license-header-apache-2.0.txt";
   private static final String CONFIG_PROTO_TYPE = ConfigProto.getDescriptor().getFullName();
   private static final String DEFAULT_CONFIG_SCHEMA_VERSION = "1.0.0";
@@ -95,10 +94,7 @@ public class DiscoConfigTransformer {
   }
 
   private LicenseView generateLicense() {
-    return LicenseView.newBuilder()
-        .copyrightFile(CONFIG_DEFAULT_COPYRIGHT_FILE)
-        .licenseFile(CONFIG_DEFAULT_LICENSE_FILE)
-        .build();
+    return LicenseView.newBuilder().licenseFile(CONFIG_DEFAULT_LICENSE_FILE).build();
   }
 
   private List<InterfaceView> generateInterfaces(

--- a/src/main/java/com/google/api/codegen/configgen/viewmodel/LicenseView.java
+++ b/src/main/java/com/google/api/codegen/configgen/viewmodel/LicenseView.java
@@ -19,8 +19,6 @@ import com.google.auto.value.AutoValue;
 /** Represents the configuration for the license header to put on generated files. */
 @AutoValue
 public abstract class LicenseView {
-  /** The file containing the copyright line(s). */
-  public abstract String copyrightFile();
 
   /** The file containing the raw license header without any copyright line(s). */
   public abstract String licenseFile();
@@ -31,7 +29,6 @@ public abstract class LicenseView {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder copyrightFile(String val);
 
     public abstract Builder licenseFile(String val);
 

--- a/src/main/java/com/google/api/codegen/util/LicenseHeaderUtil.java
+++ b/src/main/java/com/google/api/codegen/util/LicenseHeaderUtil.java
@@ -78,13 +78,7 @@ public class LicenseHeaderUtil {
   }
 
   public ImmutableList<String> loadCopyrightLines() {
-    String filepath;
-    if (licenseHeader == null || Strings.isNullOrEmpty(licenseHeader.getCopyrightFile())) {
-      filepath = DEFAULT_COPYRIGHT_FILE;
-    } else {
-      filepath = licenseHeader.getCopyrightFile();
-    }
-    return getResourceLines(filepath);
+    return getResourceLines(DEFAULT_COPYRIGHT_FILE);
   }
 
   private ImmutableList<String> getResourceLines(String resourceFileName) {

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -141,7 +141,7 @@ enum ReleaseLevel {
 
 message LicenseHeaderProto {
   // The file containing the copyright line(s).
-  string copyright_file = 1;
+  string copyright_file = 1; // DEPRECATED. The Google copyright will always be used.
 
   // The file containing the raw license header without any copyright line(s).
   string license_file = 2;

--- a/src/main/resources/com/google/api/codegen/configgen/gapic_config.snip
+++ b/src/main/resources/com/google/api/codegen/configgen/gapic_config.snip
@@ -36,8 +36,6 @@
 @private renderLicense(license)
   @# The configuration for the license header to put on generated files.
   license_header:
-    @# The file containing the copyright line(s).
-    copyright_file: {@license.copyrightFile}
     @# The file containing the raw license header without any copyright line(s).
     license_file: {@license.licenseFile}
 @end

--- a/src/test/java/com/google/api/codegen/config/testdata/missing_config_schema_version.yaml
+++ b/src/test/java/com/google/api/codegen/config/testdata/missing_config_schema_version.yaml
@@ -4,7 +4,6 @@ language_settings:
   go:
     package_name: cloud.google.com/go/myapi/apiv1
 license_header:
-  copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.example.myproto.v1.MyProto

--- a/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
@@ -22,8 +22,6 @@ language_settings:
     package_name: library.v1
 # The configuration for the license header to put on generated files.
 license_header:
-  # The file containing the copyright line(s).
-  copyright_file: copyright-google.txt
   # The file containing the raw license header without any copyright line(s).
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.

--- a/src/test/java/com/google/api/codegen/configgen/testdata/longrunning_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/longrunning_config.baseline
@@ -22,8 +22,6 @@ language_settings:
     package_name: google.longrunning
 # The configuration for the license header to put on generated files.
 license_header:
-  # The file containing the copyright line(s).
-  copyright_file: copyright-google.txt
   # The file containing the raw license header without any copyright line(s).
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.

--- a/src/test/java/com/google/api/codegen/configgen/testdata/multiple_services_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/multiple_services_config.baseline
@@ -22,8 +22,6 @@ language_settings:
     package_name: v1.foo
 # The configuration for the license header to put on generated files.
 license_header:
-  # The file containing the copyright line(s).
-  copyright_file: copyright-google.txt
   # The file containing the raw license header without any copyright line(s).
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.

--- a/src/test/java/com/google/api/codegen/configgen/testdata/no_path_templates_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/no_path_templates_config.baseline
@@ -22,8 +22,6 @@ language_settings:
     package_name: example.v1
 # The configuration for the license header to put on generated files.
 license_header:
-  # The file containing the copyright line(s).
-  copyright_file: copyright-google.txt
   # The file containing the raw license header without any copyright line(s).
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
@@ -23,8 +23,6 @@ language_settings:
     package_name: simplecompute.v1
 # The configuration for the license header to put on generated files.
 license_header:
-  # The file containing the copyright line(s).
-  copyright_file: copyright-google.txt
   # The file containing the raw license header without any copyright line(s).
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_gapic.yaml
@@ -18,8 +18,6 @@ language_settings:
     package_name: simplecompute.v1
 # The configuration for the license header to put on generated files.
 license_header:
-  # The file containing the copyright line(s).
-  copyright_file: copyright-google.txt
   # The file containing the raw license header without any copyright line(s).
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -27,7 +27,6 @@ language_settings:
   csharp:
     package_name: Google.Example.Library.V1
 license_header:
-  copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt
 collections:
   - name_pattern: shelves/{shelf_id}

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -27,6 +27,7 @@ language_settings:
   csharp:
     package_name: Google.Example.Library.V1
 license_header:
+  copyright_file: copyright-google.txt # Test that the deprecated field is still parseable.
   license_file: license-header-apache-2.0.txt
 collections:
   - name_pattern: shelves/{shelf_id}

--- a/src/test/java/com/google/api/codegen/testsrc/common/longrunning_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/longrunning_gapic.yaml
@@ -19,7 +19,6 @@ language_settings:
   nodejs:
     package_name: longrunning
 license_header:
-  copyright_file: copyright-google.txt
   license_file: license-header-bsd-3-clause.txt
 interfaces:
 - name: google.longrunning.Operations

--- a/src/test/java/com/google/api/codegen/testsrc/common/multiple_services_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/multiple_services_gapic.yaml
@@ -14,7 +14,6 @@ language_settings:
     package_name: multiple-services.v1
     domain_layer_location: google-cloud
 license_header:
-  copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.cloud.example.v1.foo.IncrementerService

--- a/src/test/java/com/google/api/codegen/testsrc/showcase/showcase_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/showcase/showcase_gapic.yaml
@@ -22,8 +22,6 @@ language_settings:
     package_name: showcase.v1alpha2
 # The configuration for the license header to put on generated files.
 license_header:
-  # The file containing the copyright line(s).
-  copyright_file: copyright-google.txt
   # The file containing the raw license header without any copyright line(s).
   license_file: license-header-apache-2.0.txt
 # A list of API interface configurations.

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
@@ -5,7 +5,6 @@ language_settings:
   go:
     package_name: cloud.google.com/go/gopher/apiv1
 license_header:
-  copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.example.myproto.v1.Gopher

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/singleservice_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/singleservice_gapic.yaml
@@ -4,7 +4,6 @@ language_settings:
   go:
     package_name: cloud.google.com/go/singleservice/apiv1
 license_header:
-  copyright_file: copyright-google.txt
   license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.example.odd.v1.OddlyNamed

--- a/src/test/java/com/google/api/codegen/util/LicenseHeaderUtilTest.java
+++ b/src/test/java/com/google/api/codegen/util/LicenseHeaderUtilTest.java
@@ -47,10 +47,7 @@ public class LicenseHeaderUtilTest {
 
     ConfigProto configProto =
         ConfigProto.newBuilder()
-            .setLicenseHeader(
-                LicenseHeaderProto.newBuilder()
-                    .setCopyrightFile(DEFAULT_COPYRIGHT_FILE)
-                    .setLicenseFile(DEFAULT_LICENSE_FILE))
+            .setLicenseHeader(LicenseHeaderProto.newBuilder().setLicenseFile(DEFAULT_LICENSE_FILE))
             .build();
     explicitHeaderUtil =
         LicenseHeaderUtil.create(


### PR DESCRIPTION
Don't generate `copyright_file` in configgen either.

We still have to be able to handle GAPIC configs that contain the `copyright_file` field, and we can't remove it while we're in a prod freeze.