### PR TITLE
Add Gapic config v2

### DIFF
--- a/src/main/proto/com/google/api/codegen/config_v2.proto
+++ b/src/main/proto/com/google/api/codegen/config_v2.proto
@@ -1,0 +1,749 @@
+syntax = "proto3";
+
+package com.google.api.codegen;
+
+import "google/protobuf/wrappers.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "ConfigProtoDesc";
+option java_package = "com.google.api.codegen";
+
+// `ConfigProto` specifies the configuration of code generation for
+// GAPIC. The user provides it via a YAML file; this message here
+// represents the schema for this file.
+//
+// Example of a YAML configuration:
+//
+//     type: com.google.api.codegen.ConfigProto
+//     generator:
+//       id: java
+//     interfaces:
+//     - name: google.example.library.v1.LibraryService
+//       collections:
+//       - name_pattern: shelves/{shelf}
+//         entity_name: shelf
+//       - name_pattern: shelves/{shelf}/books/{book}
+//         entity_name: book
+//         ...
+//       retry_codes_def:
+//       - name: idempotent
+//         retry_codes:
+//         ...
+//       - name: non_idempotent
+//         retry_codes:
+//       retry_params_def:
+//       - name: default
+//         ...
+//       methods:
+//       - name: PublishBooks
+//         flattening:
+//           groups:
+//           - parameters:
+//             - name
+//           - parameters:
+//             - name
+//             - version
+//         page_streaming:
+//           request:
+//             token_field: page_token
+//           response:
+//             token_field: next_page_token
+//             resources_field: books
+//         batching:
+//           thresholds:
+//             element_count_threshold: 5
+//             request_byte_threshold: 16384
+//           batch_descriptor:
+//             batched_field: pictures
+//             request_discriminator_fields:
+//             - album
+//             - labels
+//             subresponse_field: pic_id
+//         retry_codes_name: idempotent
+//         retry_params_name: default
+//         field_name_patterns:
+//           name: book
+//       - name: GetBook
+//       ...
+//     ...
+message ConfigProto {
+  // The settings of generated code in a specific language.
+  map<string, LanguageSettingsProto> language_settings = 4;
+
+  // The language of the generated code.
+  string language = 5; // UNSUPPORTED.
+
+  // The configuration for the license header to put on generated files.
+  LicenseHeaderProto license_header = 7;
+
+  // A list of API interface configurations.
+  repeated InterfaceConfigProto interfaces = 10;
+
+  // A list of resource name collection configs. This must be consistent with
+  // collections defined in the interfaces.
+  repeated CollectionConfigProto collections = 15;
+
+  // A list of resource name oneof configs.
+  repeated CollectionOneofProto collection_oneofs = 16;
+
+  repeated FixedResourceNameValueProto fixed_resource_name_values = 17;
+
+  // Set this value to toggle String format functions for resource name
+  // entities. If this is not set, it will fallback to default behavior.
+  // This option is exposed for backward compatibility of Java clients.
+  // TODO(andrealin): Migrate this to a command-line option after migrating
+  // off artman.
+  // [DEPRECATED]
+  .google.protobuf.BoolValue enable_string_format_functions_override = 22;
+
+  // A list of message resource name configurations.
+  repeated ResourceNameMessageConfigProto resource_name_generation = 20;
+
+  // A required field to specify the version of GAPIC config schema.
+  // It is versioned using Semantic Versioning 2.0.0 (semver) and follows the
+  // semver specification. Currently, the only valid value is "1.0.0".
+  string config_schema_version = 21;
+}
+
+message LanguageSettingsProto {
+  // Package name used for the language.
+  string package_name = 1;
+
+  // Location of the domain layer, if any, that the user should use
+  // instead of the generated client.
+  string domain_layer_location = 2;
+
+  // Set the interface name to be used when generating GAPIC code for
+  // particular interfaces. Keys are fully qualified interface names;
+  // values are unqualified interface names (to specify the package/namespace,
+  // use the package_name setting).
+  map<string, string> interface_names = 4;
+
+  // Overrides ConfigProto::license_header.
+  LicenseHeaderProto license_header_override = 5;
+
+  // The release level of the client in the language
+  ReleaseLevel release_level = 6;
+}
+
+// ReleaseLevel indicates the stage of development of a piece of code and
+// relatedly what the promises are on quality.
+// ALPHA: Not feature complete, expect breaking changes
+// BETA: Feature complete, minimal breaking changes
+// GA: General availability, no breaking changes without major version bump
+enum ReleaseLevel {
+  UNSET_RELEASE_LEVEL = 0;
+  ALPHA = 1;
+  BETA = 2;
+  GA = 3;
+  DEPRECATED = 4;
+}
+
+message LicenseHeaderProto {
+  // The file containing the copyright line(s).
+  string copyright_file = 1; // DEPRECATED. The Google copyright will always be used.
+
+  // The file containing the raw license header without any copyright line(s).
+  string license_file = 2;
+}
+
+message InterfaceConfigProto {
+  // The fully qualified name of the API interface.
+  string name = 1;
+
+  // Language specific documentation. Injected after proto docs.
+  map<string, string> lang_doc = 2;
+
+  // Configuration of smoke test.
+  SmokeTestConfigProto smoke_test = 5;
+
+  // A list of resource collection configurations.
+  repeated CollectionConfigProto collections = 10;
+
+  // A list of method configurations.
+  repeated MethodConfigProto methods = 20;
+
+  // Definition for retryable codes
+  repeated RetryCodesDefinitionProto retry_codes_def = 30;
+
+  // Definition for retry/backoff parameters
+  repeated RetryParamsDefinitionProto retry_params_def = 31;
+
+  // Params that are always required to construct an instance of the
+  // API wrapper class.
+  repeated string required_constructor_params = 50;
+}
+
+message SmokeTestConfigProto {
+  // The name of the method used in the smoke test.
+  // There must be a flattening defined in that method, and that
+  // flattened method will be used as the one to generate a smoke test on.
+  string method = 1;
+
+  // A list describing the name and the value of the init fields.
+  repeated string init_fields = 2;
+
+  reserved 3;
+}
+
+message CollectionConfigProto {
+  // A pattern to describe the names of the resources of this
+  // collection, using the platform's conventions for URI patterns. A
+  // generator may use this to generate methods to compose and
+  // decompose such names. The pattern should use named placeholders
+  // as in `shelves/{shelf}/books/{book}`; those will be taken as
+  // hints for the parameter names of the generated methods.  If
+  // empty, no name methods are generated.
+  string name_pattern = 1;
+
+  // Name to be used as a basis for generated methods and classes.
+  string entity_name = 2;
+
+  repeated CollectionLanguageOverridesProto language_overrides = 3;
+}
+
+message CollectionLanguageOverridesProto {
+  // The language of the generated code.
+  string language = 1;
+
+  // The entity name to override the default with
+  string entity_name = 2;
+
+  // Optional fully-qualified type-name of a common resource-name
+  string common_resource_name = 3;
+}
+
+message CollectionOneofProto {
+  // Name to be used as a basis for generated methods and classes.
+  string oneof_name = 1;
+
+  // A list of the entity names of the CollectionConfigs to be included in the
+  // oneof collection.
+  repeated string collection_names = 2;
+}
+
+message FixedResourceNameValueProto {
+  // Name to be used as a basis for generated methods and classes.
+  string entity_name = 1;
+
+  // The fixed, unformatted string value accepted by this configuration.
+  string fixed_value = 2;
+}
+
+// `MethodConfigProto` describes the generator configuration for a method.
+message MethodConfigProto {
+  // The fully qualified name of the method.
+  string name = 1;
+
+  // Specifies the configuration for parameter flattening.
+  FlatteningConfigProto flattening = 2;
+
+  // Specifies the configuration for paging.
+  PageStreamingConfigProto page_streaming = 3;
+
+  // Specifies the configuration for gRPC-streaming responses.
+  // Note that this is for configuring paged gRPC-streaming responses.
+  // Some method can be gRPC-streaming even if this field does not exist.
+  PageStreamingConfigProto grpc_streaming = 13;
+
+  // Specifies the configuration for retryable codes.
+  // The name must be defined in InterfaceConfigProto::retry_codes_def.
+  string retry_codes_name = 4;
+
+  // Specifies the configuration for retry/backoff parameters.
+  // The name must be defined in InterfaceConfigProto::retry_params_def.
+  string retry_params_name = 5;
+
+  // Specifies the default timeout for a non-retrying call. If the call is
+  // retrying, refer to `retry_params_name` instead.
+  uint64 timeout_millis = 11; // UNSUPPORTED.
+
+  // Specifies the configuration for batching.
+  BatchingConfigProto batching = 6;
+
+  reserved 7;
+
+  // Fields that are always required for a request to be valid.
+  repeated string required_fields = 8;
+
+  // Maps the field name of the request type to entity_name of CollectionConfigProto.
+  // It is used to specify the string pattern that the field must follow.
+  map<string, string> field_name_patterns = 9;
+
+  // Specifies complex structure fields that need to be initialized by the sample code for
+  // the sample to be usable.
+  repeated string sample_code_init_fields = 10;
+
+  // Specifies sets of parameter values to be used together in a
+  // sample. If this is not set, no samples are output.
+  //
+  // UNDER DEVELOPMENT: Usage of this field for sample generation is
+  // still being developed. For now, continue using
+  // `sample_code_init_fields` to generate in-code samples.
+  repeated SampleValueSet sample_value_sets = 16;
+
+  // Defines combinations of method calling forms (sample code
+  // structures as output by the client library generator) and
+  // `sample_value_sets` that should be combined to generate samples.
+  //
+  // UNDER DEVELOPMENT: Usage of this field for sample generation is
+  // still being developed. For now, continue using
+  // `sample_code_init_fields` to generate in-code samples.
+  SampleConfiguration samples = 17;
+
+  // Route calls through a different gRPC interface than the one this method
+  // is contained in. This specifically supports the Pub/Sub IAM hack to route
+  // IAM methods to IamPolicy for Pub/Sub.
+  string reroute_to_grpc_interface = 12;
+
+  // TODO: Remove this config once there are no use cases.
+  // Specifies the list of the method's input message fields (including nested
+  // ones, using the dot notation), which should be url-encoded in
+  // "x-goog-request-params" header
+  repeated string header_request_params = 14; // UNSUPPORTED.
+
+  repeated SurfaceTreatmentProto surface_treatments = 20;
+
+  // Set the resource name treatment for fields
+  ResourceNameTreatment resource_name_treatment = 15;
+
+  // Long-running settings.
+  LongRunningConfigProto long_running = 30;
+
+}
+
+// `SampleValueSet` defines a set of parameter values used in
+// generating samples.
+message SampleValueSet {
+  // An identifier, unique to a particular API method, for this set of
+  // values.
+  string id = 1;
+
+  // A short, user-visible name for this set of values. This name may
+  // be used in a UI menu, for example.
+  string title = 2;
+
+  // A longer description for this set of values. This may be
+  // used in the sample itself or in a UI element such as hoverbox.
+  string description = 3;
+
+  // How to initialize the request object for the RPC.
+  SampleParameters parameters = 4;
+
+  // How to process a successful response from the client library
+  // function being exemplified.
+  repeated OutputSpec on_success = 5;
+}
+
+// `SampleInitAttribute` controls request object initialization.
+message SampleParameters {
+  // A set of default values to be used together in samples. Each
+  // member of can be specified in one of two formats:
+  // * `DOTTED.RESOURCE.NAME=VALUE`, to specify the entire value of
+  //   `NAME`.  If `VALUE` is not specified, it is treated as the
+  //    default zero value for `NAME`'s type.
+  // * `DOTTED.RESOURCE.NAME%FIELD=VALUE`, if `NAME` is required to be
+  //   a specially formatted string using `FIELD` as one of possibly
+  //   several placeholders.
+  repeated string defaults = 1;
+
+  // Attributes governing how to init request object.
+  // Each attribute must have unique, non-overlapping, path.
+  repeated SampleInitAttribute attributes = 2;
+}
+
+// `SampleInitAttribute` controls how a sample initializes the request object.
+message SampleInitAttribute {
+  // Required. The part of the request object this attribute is talking about.
+  string parameter = 1;
+
+  // In a sample, the call to client lib method is itself in a function.
+  // If `sample_argument_name` is not empty, the part of the request object specified by `path`
+  // should be accepted as a parameter, with the given name, to the sample function.
+  string sample_argument_name = 2;
+
+  // If `read_file` is true, then during sample initialization, the value of this
+  // attribute gets replaced by the contents of the local file with the given name.
+  // This is only allowed when this parameter is a bytes field.
+  // If this parameter is required or optional, the original value of this parameter
+  // is the file name.
+  // If this parameter is repeated, the original value of this parameter is a list of
+  // comma-separated list of file names.
+  bool read_file = 3;
+
+  // The description of the parameter passed to the sample function.
+  // Should only be specified when `sample_argument_name` is specified.
+  string description = 4;
+}
+
+// `SampleConfiguration` defines combinations of "calling forms"
+// (sample code structures as output by the client library generator)
+// and sample value sets that should be combined to generate samples.
+message SampleConfiguration {
+
+  // `SampleTypeConfiguration` defines the samples that will show up
+  // as a particular sample type. If order matters for this sample
+  // type, the order of the samples is taken to be primarily the order
+  // in which the `calling_forms` appear, and secondarily, for each
+  // such form, the order in which the `value_sets` appear.
+  message SampleTypeConfiguration {
+    // One or more expressions matching the method calling forms
+    // (defined by the client generator) applicable to this
+    // method. Any expressions that do not match a calling form in a
+    // particular language are ignored for that language. If not
+    // specified, samples are generated for all such forms.
+    //
+    // An expression matches an ID if the sequence of characters in
+    // the expression before the first "*", if any, match the initial
+    // sequence of characters in the ID. This allows for prefix
+    // matching. In particular, the expression "*" will
+    // match all IDs.
+    //
+    // TODO(vchudnov-g): Point to a reference listing the possible calling forms
+    // for each method type.
+    repeated string calling_forms = 1;
+
+    // One or more expressions matching the
+    // `MethodConfigProto.sample_value_sets.id`s defined for this
+    // method. Any expressions on this list that do not match a
+    // `SampleValueSet.id` cause a fatal error during code
+    // generation. If not specified or if empty, no samples of this
+    // type will be generated.
+    //
+    // An expression matches an ID if the sequence of characters in
+    // the expression before the first "*", if any, match the initial
+    // sequence of characters in the ID. This allows for prefix
+    // matching. In particular, the expression "*" will
+    // match all IDs.
+    repeated string value_sets = 2;
+
+    // The region tag value to be used inside each of these particular
+    // samples to bracket off (in language-specific comments)
+    // important areas of the sample. A region tag value can only
+    // consist of word characters (letters, numbers, or underscores)
+    // as well as the special tokens "%m", "%c", and "%v" (no quotes)
+    // which get replaced by each sample's method name, calling form,
+    // and value set, respectively. If not specified, `region_tag`
+    // defaults to "sample".
+    string region_tag = 3;
+  }
+
+  // The configuration for in-code samples, which appear in the format
+  // and location idiomatic to each generated language. The various
+  // in-code samples will be presented in the order in which they are
+  // configured here. If this field is not specified, one in-code
+  // sample will be produced for this method.
+  repeated SampleTypeConfiguration in_code = 1;
+
+  // The configuration for stand-alone, runnable samples in each
+  // generated language. If this field is not specified, a stand-alone
+  // sample is generated for every combination of calling form and
+  // `MethodConfigProto.sample_value_sets`, if the latter is defined.
+  //
+  // If multiple samples configured here would result in files
+  // clobbering each other (ie. two files with the same path but not
+  // with identical calling forms, value sets, and region tags), an
+  // exception is raised.
+  repeated SampleTypeConfiguration standalone = 2;
+
+  // The configuration for user-parametrized samples ("API explorer
+  // samples") that can be displayed in, for example, an interactive
+  // UI. The various explorer samples will be presented in the order
+  // in which they are configured here. If this field is not
+  // specified, an explorer sample is generated for every combination
+  // of calling form and `MethodConfigProto.sample_value_sets`, if the
+  // latter is defined.
+  //
+  // If multiple samples configured here would result in files
+  // clobbering each other (ie. two files with the same path but not
+  // with identical calling forms, value sets, and region tags), an
+  // exception is raised.
+  repeated SampleTypeConfiguration api_explorer = 3;
+}
+
+// `FlatteningConfigProto` describes the parameter groups for which a
+// generator should produce method overloads which allow a client to
+// directly pass request message fields as method parameters.  This
+// information may or may not be used, depending on the target
+// language.
+message FlatteningConfigProto {
+  // Specifies a list of flattening groups.
+  repeated FlatteningGroupProto groups = 1;
+}
+
+// `FlatteningGroupProto` represents a list of parameters to be flattened.
+message FlatteningGroupProto {
+  // The list of parameters to include in this flattening group. Each
+  // parameter must be a field of the request message.
+  repeated string parameters = 1;
+
+  string flattening_group_name = 2; // DEPRECATED.
+
+  // Map flattening parameters listed in parameters field to a resource name
+  // treatment. This is used to override the resource_name_treament setting in
+  // MethodConfigProto.
+  map<string, ResourceNameTreatment> parameter_resource_name_treatment = 3;
+}
+
+// The ResourceNameTreatment enum can be used to specify how to treat the
+// resource name formats defined in the field_name_patterns
+// and response_field_name_patterns fields.
+// UNSET: default value
+// NONE: the collection configs will not be used by the generated code.
+// VALIDATE: string fields will be validated by the client against the
+// specified resource name formats.
+// STATIC_TYPES: the client will use generated types for resource names.
+// SAMPLE_ONLY: the generated types for resource names will only be used in samples.
+enum ResourceNameTreatment {
+  UNSET_TREATMENT = 0;
+  NONE = 1;
+  VALIDATE = 2;
+  STATIC_TYPES = 3;
+  SAMPLE_ONLY = 4;
+}
+
+// `PageStreamingConfigProto` describes information for generating a method which
+// transforms a paging list rpc into a stream of resources.
+message PageStreamingConfigProto {
+  // Specifies request information of the list method.
+  PageStreamingRequestProto request = 1;
+
+  // Specifies response information of the list method.
+  PageStreamingResponseProto response = 2;
+}
+
+// `PageStreamingRequestProto` defines which fields match the paging pattern in
+// the request.
+message PageStreamingRequestProto {
+  // The name of the field in the request containing the page token.
+  string token_field = 1;
+
+  // Optional. The name of the field, if present, specifying the maximum number
+  // of elements to be returned in the response.
+  string page_size_field = 2;
+}
+
+// `PageStreamingResponseProto` defines which fields match the paging pattern in
+// the response.
+message PageStreamingResponseProto {
+  // The name of the field in the response containing the next page
+  // token.
+  string token_field = 1;
+
+  // The name of the field in the response containing the list of
+  // resources belonging to the page.
+  string resources_field = 2;
+}
+
+// `RetryConfigDefinitionProto` specifies, by name,
+// GRPC codes that a method should consider retryable.
+message RetryCodesDefinitionProto {
+  string name = 1;
+  repeated string retry_codes = 2;
+}
+
+// `RetryParamsDefinitionProto` specifies, by name,
+// the backoff behavior of a method when retrying.
+message RetryParamsDefinitionProto {
+  string name = 1;
+
+  uint64 initial_retry_delay_millis = 2;
+  double retry_delay_multiplier = 3;
+  uint64 max_retry_delay_millis = 4;
+
+  uint64 initial_rpc_timeout_millis = 5;
+  double rpc_timeout_multiplier = 6;
+  uint64 max_rpc_timeout_millis = 7;
+
+  uint64 total_timeout_millis = 8;
+}
+
+// `BatchingConfigProto` defines the batching configuration for an API method.
+message BatchingConfigProto {
+  // The thresholds which trigger a batched request to be sent.
+  BatchingSettingsProto thresholds = 1;
+
+  // The request and response fields used in batching.
+  BatchingDescriptorProto batch_descriptor = 2;
+}
+
+// `BatchingSettingsProto` specifies a set of batching thresholds, each of
+// which acts as a trigger to send a batch of messages as a request. At least
+// one threshold must be positive nonzero.
+message BatchingSettingsProto {
+  // The number of elements of a field collected into a batch which, if
+  // exceeded, causes the batch to be sent.
+  uint32 element_count_threshold = 1;
+
+  // The aggregated size of the batched field which, if exceeded, causes the
+  // batch to be sent. This size is computed by aggregating the sizes of the
+  // request field to be batched, not of the entire request message.
+  uint64 request_byte_threshold = 2;
+
+  // The duration, in milliseconds, after which a batch should be sent,
+  // starting from the addition of the first message to that batch.
+  uint64 delay_threshold_millis = 3;
+
+  // The maximum number of elements collected in a batch that could be accepted by server.
+  uint32 element_count_limit = 4;
+
+  // The maximum size of the request that could be accepted by server.
+  uint32 request_byte_limit = 5;
+
+  uint32 flow_control_element_limit = 6;
+
+  uint32 flow_control_byte_limit = 7;
+
+  FlowControlLimitExceededBehaviorProto flow_control_limit_exceeded_behavior = 8;
+}
+
+enum FlowControlLimitExceededBehaviorProto {
+  UNSET_BEHAVIOR = 0;
+  THROW_EXCEPTION = 1;
+  BLOCK = 2;
+  IGNORE = 3;
+}
+
+// `BatchingDescriptorProto` specifies the fields of the request message to be
+// used for batching, and, optionally, the fields of the response message to be
+// used for demultiplexing.
+message BatchingDescriptorProto {
+  // The repeated field in the request message to be aggregated by batching.
+  string batched_field = 1;
+
+  // A list of the fields in the request message. Two requests will be batched
+  // together only if the values of every field specified in
+  // `request_discriminator_fields` is equal between the two requests.
+  repeated string discriminator_fields = 2;
+
+  // Optional. When present, indicates the field in the response message to be
+  // used to demultiplex the response into multiple response messages, in
+  // correspondence with the multiple request messages originally batched
+  // together.
+  string subresponse_field = 3;
+}
+
+// `ResourceNameMessageConfigProto` specifies the fields of a message that
+// support a resource name type.
+message ResourceNameMessageConfigProto {
+  // The simple name of the message.
+  string message_name = 1;
+
+  // A list of field simple names and corresponding entity names, as defined in
+  // the collection configs.
+  map<string, string> field_entity_map = 2;
+}
+
+// SurfaceTreatmentProto describes treatments to the code generation
+// that are expected to be different for each language.
+message SurfaceTreatmentProto {
+  // The languages affected by this treatment.
+  repeated string include_languages = 1;
+
+  // The visibility of the surface.
+  VisibilityProto visibility = 2;
+
+  // Whether the method is deprecated.
+  ReleaseLevel release_level = 3;
+}
+
+enum VisibilityProto {
+  UNSET_VISIBILITY = 0;
+  PUBLIC = 1;
+  PACKAGE = 2;
+  PRIVATE = 3;
+  DISABLED = 4;
+}
+
+// LongRunningProto describes settings to use when generating API methods
+// that use the long-running operation pattern.
+message LongRunningConfigProto {
+  // The fully-qualified type that is returned from an Operation when it is
+  // complete.
+  string return_type = 1;
+
+  // The fully-qualified type of the metadata of an Operation.
+  string metadata_type = 2;
+
+  // Whether or not the server implements delete.
+  bool implements_delete = 3;
+
+  // Whether or not the server implements cancel.
+  bool implements_cancel = 4;
+
+  // Initial delay after which first poll request will be made.
+  uint64 initial_poll_delay_millis = 5;
+
+  // Multiplier to gradually increase delay between subsequent polls until it
+  // reaches max_poll_delay_millis.
+  double poll_delay_multiplier = 6;
+
+  // Maximum time between two subsequent poll requests.
+  uint64 max_poll_delay_millis = 7;
+
+  // Total polling timeout.
+  uint64 total_poll_timeout_millis = 8;
+}
+
+message OutputSpec {
+  message LoopStatement {
+    // The collection over which to iterate.
+    // Exactly one of `map` and `collection` should be specified.
+    string collection = 1;
+
+    // The iteration variable.
+    // Required and should only be specified if `collection` is specified.
+    string variable = 2;
+
+    // The contents of the loop.
+    repeated OutputSpec body = 3;
+
+    // The map over which to iterate.
+    // Exactly one of `map` and `collection` should be specified.
+    string map = 4;
+
+    // The iteration variable for key.
+    // Can only be specified when `map` is specified.
+    // At least one of `key` and `value` should be specified if `map` is specified.
+    string key = 5;
+
+    // The iteration variable for value.
+    // Can only be specified when `map` is specified.
+    // At least one of `key` and `value` should be specified if `map` is specified.
+    string value = 6;
+  }
+
+  // Exactly one of the following should be set.
+
+  // A loop construct.
+  LoopStatement loop = 1;
+
+  // The elements of `print` consist of a printf-like format string
+  // followed by variables to be interpolated in the string (for
+  // example, ["%s=%s", thing.variable, thing.value]).  These
+  // variables must either be `$resp` or have been previously defined
+  // by `loop` or `define`.
+  //
+  // Note that this field name is singular because the array
+  // represents a single print statement. A newline will be
+  // automatically appended to the print statement.
+  repeated string print = 2;
+
+  // A variable definition construct, of the form
+  // `name=var[. field...]`, where `name` is the new variable being
+  // defined, `var` is either `$resp` or a variable that was
+  // previously defined by `loop` or `define`, and everything to the
+  // right of the period is any valid sequence of subfield or
+  // bracketed list subscripts or map keys to dereference a descendant
+  // of `var`.
+  string define = 3;
+
+  // The first element of `comment` is a printf-like format string, and
+  // subsequent elements are variable names (not values) to be interpolated in
+  // the string. The variable names will be converted to a language-idiomatic
+  // style (snake case or camel case). The interpolated format string will then
+  // be rendered as a comment in a language-idiomatic style.
+  //
+  // Like `print`, a newline will be automatically appended to the comment.
+  repeated string comment = 4;
+}

--- a/src/main/proto/com/google/api/codegen/v2/config_v2.proto
+++ b/src/main/proto/com/google/api/codegen/v2/config_v2.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-package com.google.api.codegen;
+package com.google.api.codegen.v2;
 
 import "google/protobuf/wrappers.proto";
 
 option java_multiple_files = true;
 option java_outer_classname = "ConfigProtoDesc";
-option java_package = "com.google.api.codegen";
+option java_package = "com.google.api.codegen.v2";
 
 // `ConfigProto` specifies the configuration of code generation for
 // GAPIC. The user provides it via a YAML file; this message here


### PR DESCRIPTION
Copy config.proto into config_v2.proto, in a new v2 package.

The target branch, origin/gapic_config_v2, is currently just a copy of the master branch. This PR will be checked in to origin/gapic_config_v2 while we bootstrap.