### PR TITLE
Add test resources for google.api.http in client/bidi streaming

### DIFF
--- a/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
@@ -470,6 +470,15 @@ interfaces:
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: StreamShelves
+    # FIXME: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - name
+    # FIXME: Configure which fields are required.
+    required_fields:
+    - name
     # FIXME: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
@@ -510,6 +519,8 @@ interfaces:
     retry_codes_name: non_idempotent
     # FIXME: Configure the retryable params for this method.
     retry_params_name: default
+    field_name_patterns:
+      name: book
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: MonologAboutBook
@@ -527,9 +538,11 @@ interfaces:
     - comment
     - image
     # FIXME: Configure the retryable codes for this method.
-    retry_codes_name: non_idempotent
+    retry_codes_name: idempotent
     # FIXME: Configure the retryable params for this method.
     retry_params_name: default
+    field_name_patterns:
+      name: book
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: BabbleAboutBook

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -9100,7 +9100,6 @@ namespace Google.Example.Library.V1
 
         /// <summary>
         /// Test bidi-streaming.
-        /// gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
         /// </summary>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
@@ -12245,7 +12244,6 @@ namespace Google.Example.Library.V1
 
         /// <summary>
         /// Test bidi-streaming.
-        /// gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
         /// </summary>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -1850,7 +1850,10 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument
-            StreamShelvesRequest request = new StreamShelvesRequest();
+            StreamShelvesRequest request = new StreamShelvesRequest
+            {
+                Name = new BookName("[SHELF_ID]", "[BOOK_ID]").ToString(),
+            };
             // Make the request, returning a streaming response
             LibraryServiceClient.StreamShelvesStream streamingResponse = libraryServiceClient.StreamShelves(request);
 
@@ -1921,7 +1924,7 @@ namespace Google.Example.Library.V1.Snippets
                 // Initialize a request
                 DiscussBookRequest request = new DiscussBookRequest
                 {
-                    Name = "",
+                    Name = new BookName("[SHELF_ID]", "[BOOK_ID]").ToString(),
                 };
                 // Stream a request to the server
                 await duplexStream.WriteAsync(request);
@@ -9026,6 +9029,28 @@ namespace Google.Example.Library.V1
         /// Test server streaming
         /// gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
         /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to stream.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The server stream.
+        /// </returns>
+        public virtual StreamShelvesStream StreamShelves(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => StreamShelves(
+                new StreamShelvesRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test server streaming
+        /// gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -15439,6 +15464,45 @@ namespace Google.Example.Library.V1
    }
 
    // [END lovelace]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+ }
+============== file: Samples/StreamShelvesFlattenedEmpty.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+ // DO NOT EDIT! This is a generated sample ("Flattened",  "empty")
+
+ // [START sample]
+ // FIXME: import section
+
+ class StreamShelvesFlattenedEmpty
+ {
+   // FIXME: sample function documentation
+   public static void SampleStreamShelves()
+   {
+   	// FIXME: instantiate a client
+     // FIXME: construct a request
+     // FIXME: call the API
+     // FIXME: inspect the results
+   }
+
+   // [END sample]
    public static void Main(String[] args)
    {
    	// FIXME: pass in commandline arguments

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -286,10 +286,10 @@ func defaultCallOptions() *CallOptions {
         GetBookFromAnywhere: retry[[2]string{"default", "idempotent"}],
         GetBookFromAbsolutelyAnywhere: retry[[2]string{"default", "idempotent"}],
         UpdateBookIndex: retry[[2]string{"default", "idempotent"}],
-        StreamShelves: retry[[2]string{"default", "idempotent"}],
+        StreamShelves: retry[[2]string{"default", "non_idempotent"}],
         StreamBooks: retry[[2]string{"default", "idempotent"}],
         DiscussBook: retry[[2]string{"default", "non_idempotent"}],
-        MonologAboutBook: retry[[2]string{"default", "non_idempotent"}],
+        MonologAboutBook: retry[[2]string{"default", "idempotent"}],
         BabbleAboutBook: retry[[2]string{"default", "non_idempotent"}],
         FindRelatedBooks: retry[[2]string{"default", "idempotent"}],
         AddLabel: retry[[2]string{"default", "non_idempotent"}],
@@ -3431,7 +3431,10 @@ func TestLibraryServiceStreamShelves(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var request *librarypb.StreamShelvesRequest = &librarypb.StreamShelvesRequest{}
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var request = &librarypb.StreamShelvesRequest{
+        Name: formattedName,
+    }
 
     c, err := NewClient(context.Background(), clientOpt)
     if err != nil {
@@ -3461,7 +3464,10 @@ func TestLibraryServiceStreamShelvesError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var request *librarypb.StreamShelvesRequest = &librarypb.StreamShelvesRequest{}
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var request = &librarypb.StreamShelvesRequest{
+        Name: formattedName,
+    }
 
     c, err := NewClient(context.Background(), clientOpt)
     if err != nil {
@@ -3567,9 +3573,9 @@ func TestLibraryServiceDiscussBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var name string = "name3373707"
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
     var request = &librarypb.DiscussBookRequest{
-        Name: name,
+        Name: formattedName,
     }
 
     c, err := NewClient(context.Background(), clientOpt)
@@ -3606,9 +3612,9 @@ func TestLibraryServiceDiscussBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var name string = "name3373707"
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
     var request = &librarypb.DiscussBookRequest{
-        Name: name,
+        Name: formattedName,
     }
 
     c, err := NewClient(context.Background(), clientOpt)
@@ -3648,9 +3654,9 @@ func TestLibraryServiceMonologAboutBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var name string = "name3373707"
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
     var request = &librarypb.DiscussBookRequest{
-        Name: name,
+        Name: formattedName,
     }
 
     c, err := NewClient(context.Background(), clientOpt)
@@ -3684,9 +3690,9 @@ func TestLibraryServiceMonologAboutBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var name string = "name3373707"
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
     var request = &librarypb.DiscussBookRequest{
-        Name: name,
+        Name: formattedName,
     }
 
     c, err := NewClient(context.Background(), clientOpt)

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -759,7 +759,6 @@ func (c *LibClient) StreamBooks(ctx context.Context, req *librarypb.StreamBooksR
 }
 
 // DiscussBook test bidi-streaming.
-// gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *LibClient) DiscussBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_DiscussBookClient, error) {
     ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.DiscussBook[0:len(c.CallOptions.DiscussBook):len(c.CallOptions.DiscussBook)], opts...)
@@ -776,7 +775,6 @@ func (c *LibClient) DiscussBook(ctx context.Context, opts ...gax.CallOption) (li
 }
 
 // MonologAboutBook test client streaming.
-// gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *LibClient) MonologAboutBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_MonologAboutBookClient, error) {
     ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.MonologAboutBook[0:len(c.CallOptions.MonologAboutBook):len(c.CallOptions.MonologAboutBook)], opts...)

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -760,7 +760,8 @@ func (c *LibClient) StreamBooks(ctx context.Context, req *librarypb.StreamBooksR
 
 // DiscussBook test bidi-streaming.
 func (c *LibClient) DiscussBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_DiscussBookClient, error) {
-    ctx = insertMetadata(ctx, c.xGoogMetadata)
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", req.GetName()))
+    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.DiscussBook[0:len(c.CallOptions.DiscussBook):len(c.CallOptions.DiscussBook)], opts...)
     var resp librarypb.LibraryService_DiscussBookClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -776,7 +777,8 @@ func (c *LibClient) DiscussBook(ctx context.Context, opts ...gax.CallOption) (li
 
 // MonologAboutBook test client streaming.
 func (c *LibClient) MonologAboutBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_MonologAboutBookClient, error) {
-    ctx = insertMetadata(ctx, c.xGoogMetadata)
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", req.GetName()))
+    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.MonologAboutBook[0:len(c.CallOptions.MonologAboutBook):len(c.CallOptions.MonologAboutBook)], opts...)
     var resp librarypb.LibraryService_MonologAboutBookClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -5008,7 +5008,6 @@ public class LibraryClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
    * Test bidi-streaming.
-   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
    *
    * Sample code:
    * <pre><code>
@@ -5034,7 +5033,6 @@ public class LibraryClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
    * Test client streaming.
-   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
    *
    * Sample code:
    * <pre><code>
@@ -8311,10 +8309,28 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<DiscussBookRequest, Comment> discussBookTransportSettings =
         GrpcCallSettings.<DiscussBookRequest, Comment>newBuilder()
             .setMethodDescriptor(discussBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<DiscussBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(DiscussBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<DiscussBookRequest, Comment> monologAboutBookTransportSettings =
         GrpcCallSettings.<DiscussBookRequest, Comment>newBuilder()
             .setMethodDescriptor(monologAboutBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<DiscussBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(DiscussBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<DiscussBookRequest, Empty> babbleAboutBookTransportSettings =
         GrpcCallSettings.<DiscussBookRequest, Empty>newBuilder()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -512,7 +512,7 @@ public class DiscussBookCallableCallableStreamingBidiProg {
           libraryClient.discussBookCallable().call();
 
       // String imageFileName = "image_file.jpg";
-      String name = "BASIC";
+      String formattedName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
       String fileName = "comment_file";
       Path path = Paths.get(fileName);
       byte[] data = Files.readAllBytes(path);
@@ -524,7 +524,7 @@ public class DiscussBookCallableCallableStreamingBidiProg {
       data = Files.readAllBytes(path);
       ByteString image = ByteString.copyFrom(data);
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
-        .setName(name)
+        .setName(formattedName)
         .setComment(comment2)
         .setImage(image)
         .build();
@@ -1943,9 +1943,9 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-      String name = "BASIC";
+      String formattedName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
-        .setName(name)
+        .setName(formattedName)
         .build();
       requestObserver.onNext(request);
     } catch (Exception exception) {
@@ -2618,7 +2618,10 @@ public class StreamShelvesCallableCallableStreamingServerEmpty {
   public static void sampleStreamShelves() {
     // [START sample_core]
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+      String formattedName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+      StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
+        .setName(formattedName)
+        .build();
 
       ServerStream<StreamShelvesResponse> stream = libraryClient.streamShelvesCallable().call(request);
       for (StreamShelvesResponse responseItem : stream) {
@@ -4968,7 +4971,10 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+   *   String formattedName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+   *   StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
+   *     .setName(formattedName)
+   *     .build();
    *
    *   ServerStream&lt;StreamShelvesResponse&gt; stream = libraryClient.streamShelvesCallable().call(request);
    *   for (StreamShelvesResponse response : stream) {
@@ -5015,9 +5021,9 @@ public class LibraryClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryClient.discussBookCallable().call();
    *
-   *   String name = "";
+   *   String formattedName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
-   *     .setName(name)
+   *     .setName(formattedName)
    *     .build();
    *   bidiStream.send(request);
    *   for (Comment response : bidiStream) {
@@ -5057,9 +5063,9 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   String name = "";
+   *   String formattedName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
-   *     .setName(name)
+   *     .setName(formattedName)
    *     .build();
    *   requestObserver.onNext(request);
    * }
@@ -9999,7 +10005,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
       builder.streamShelvesSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
       builder.streamBooksSettings()
@@ -11585,7 +11591,10 @@ public class LibraryClientTest {
       .addAllShelves(shelves)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+    String formattedName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+    StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
+      .setName(formattedName)
+      .build();
 
     MockStreamObserver<StreamShelvesResponse> responseObserver = new MockStreamObserver<>();
 
@@ -11603,7 +11612,10 @@ public class LibraryClientTest {
   public void streamShelvesExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+    String formattedName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+    StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
+      .setName(formattedName)
+      .build();
 
     MockStreamObserver<StreamShelvesResponse> responseObserver = new MockStreamObserver<>();
 
@@ -11687,9 +11699,9 @@ public class LibraryClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    String name = "name3373707";
+    String formattedName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
-      .setName(name)
+      .setName(formattedName)
       .build();
 
     MockStreamObserver<Comment> responseObserver = new MockStreamObserver<>();
@@ -11712,9 +11724,9 @@ public class LibraryClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    String name = "name3373707";
+    String formattedName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
-      .setName(name)
+      .setName(formattedName)
       .build();
 
     MockStreamObserver<Comment> responseObserver = new MockStreamObserver<>();

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -1826,6 +1826,10 @@ const ListShelvesResponse = {
 
 /**
  * Request message for LibraryService.StreamShelves.
+ *
+ * @property {string} name
+ *   The name of the shelf to stream.
+ *
  * @typedef StreamShelvesRequest
  * @memberof google.example.library.v1
  * @see [google.example.library.v1.StreamShelvesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
@@ -5431,8 +5435,10 @@ class LibraryServiceClient {
    * Test server streaming
    * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
    *
-   * @param {Object} [request]
+   * @param {Object} request
    *   The request object that will be sent.
+   * @param {string} [request.name]
+   *   The name of the shelf to stream.
    * @param {Object} [options]
    *   Optional parameters. You can override the default settings for this call, e.g, timeout,
    *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
@@ -5454,9 +5460,7 @@ class LibraryServiceClient {
    */
   streamShelves(request, options) {
     options = options || {};
-    if (request === undefined) {
-      request = {};
-    }
+
     return this._innerApiCalls.streamShelves(request, options);
   }
 
@@ -5495,7 +5499,6 @@ class LibraryServiceClient {
 
   /**
    * Test bidi-streaming.
-   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
    *
    * @param {Object} [options]
    *   Optional parameters. You can override the default settings for this call, e.g, timeout,
@@ -5525,13 +5528,18 @@ class LibraryServiceClient {
    */
   discussBook(options) {
     options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'name': request.name
+      });
 
     return this._innerApiCalls.discussBook(options);
   }
 
   /**
    * Test client streaming.
-   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
    *
    * @param {Object} [options]
    *   Optional parameters. You can override the default settings for this call, e.g, timeout,
@@ -5571,6 +5579,12 @@ class LibraryServiceClient {
       options = {};
     }
     options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'name': request.name
+      });
 
     return this._innerApiCalls.monologAboutBook(null, options, callback);
   }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -362,7 +362,7 @@ function sampleDiscussBook(imageFileName) {
     console.log(response);
   });
   // const imageFileName = 'image_file.jpg';
-  const name = 'BASIC';
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
   const fileName = 'comment_file';
   const comment = fs.readFileSync(fileName).toString('base64');
   const comment2 = {
@@ -370,7 +370,7 @@ function sampleDiscussBook(imageFileName) {
   };
   const image = fs.readFileSync(imageFileName).toString('base64');
   const request = {
-    name: name,
+    name: formattedName,
     comment: comment2,
     image: image,
   };
@@ -1129,9 +1129,9 @@ function sampleMonologAboutBook() {
     }
     console.log(`The stage of the comment is: ${response.stage}`);
   });
-  const name = 'BASIC';
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
   const request = {
-    name: name,
+    name: formattedName,
   };
   // Write request objects.
   stream.write(request);
@@ -1360,8 +1360,8 @@ const library = require('@google-cloud/library').v1;
 /** Testing calling forms */
 function sampleStreamShelves() {
   const client = new library.LibraryServiceClient();
-
-    client.streamShelves({}).on('data', response => {
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+    client.streamShelves({name: formattedName}).on('data', response => {
       console.log(response);
     });
 }
@@ -5437,7 +5437,7 @@ class LibraryServiceClient {
    *
    * @param {Object} request
    *   The request object that will be sent.
-   * @param {string} [request.name]
+   * @param {string} request.name
    *   The name of the shelf to stream.
    * @param {Object} [options]
    *   Optional parameters. You can override the default settings for this call, e.g, timeout,
@@ -5453,8 +5453,8 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   *
-   * client.streamShelves({}).on('data', response => {
+   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * client.streamShelves({name: formattedName}).on('data', response => {
    *   // doThingsWith(response)
    * });
    */
@@ -5519,9 +5519,9 @@ class LibraryServiceClient {
    * const stream = client.discussBook().on('data', response => {
    *   // doThingsWith(response)
    * });
-   * const name = '';
+   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
    * const request = {
-   *   name: name,
+   *   name: formattedName,
    * };
    * // Write request objects.
    * stream.write(request);
@@ -5566,9 +5566,9 @@ class LibraryServiceClient {
    *   }
    *   // doThingsWith(response)
    * });
-   * const name = '';
+   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
    * const request = {
-   *   name: name,
+   *   name: formattedName,
    * };
    * // Write request objects.
    * stream.write(request);
@@ -6653,7 +6653,7 @@ module.exports = LibraryServiceClient;
         },
         "StreamShelves": {
           "timeout_millis": 30000,
-          "retry_codes_name": "idempotent",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "StreamBooks": {
@@ -6668,7 +6668,7 @@ module.exports = LibraryServiceClient;
         },
         "MonologAboutBook": {
           "timeout_millis": 30000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "BabbleAboutBook": {
@@ -7906,7 +7906,10 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const request = {};
+      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const request = {
+        name: formattedName,
+      };
 
       // Mock response
       const shelvesElement = {};
@@ -7937,7 +7940,10 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const request = {};
+      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const request = {
+        name: formattedName,
+      };
 
       // Mock Grpc layer
       client._innerApiCalls.streamShelves = mockServerStreamingGrpcMethod(request, null, error);
@@ -8033,9 +8039,9 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const name = 'name3373707';
+      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
       const request = {
-        name: name,
+        name: formattedName,
       };
 
       // Mock response
@@ -8066,9 +8072,9 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const name = 'name3373707';
+      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
       const request = {
-        name: name,
+        name: formattedName,
       };
 
       // Mock Grpc layer

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -1544,6 +1544,8 @@ class LibraryServiceGapicClient
      *
      * @param array $optionalArgs {
      *     Optional.
+     *     @type string $name
+     *          The name of the shelf to stream.
      *     @type int $timeoutMillis
      *          Timeout to use for this call.
      * }
@@ -1556,6 +1558,9 @@ class LibraryServiceGapicClient
     public function streamShelves(array $optionalArgs = [])
     {
         $request = new StreamShelvesRequest();
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
 
         return $this->startCall(
             'StreamShelves',
@@ -1613,7 +1618,6 @@ class LibraryServiceGapicClient
 
     /**
      * Test bidi-streaming.
-     * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
      *
      * Sample code:
      * ```
@@ -1669,6 +1673,13 @@ class LibraryServiceGapicClient
      */
     public function discussBook(array $optionalArgs = [])
     {
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
         return $this->startCall(
             'DiscussBook',
             Comment::class,
@@ -1680,7 +1691,6 @@ class LibraryServiceGapicClient
 
     /**
      * Test client streaming.
-     * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
      *
      * Sample code:
      * ```
@@ -1724,6 +1734,13 @@ class LibraryServiceGapicClient
      */
     public function monologAboutBook(array $optionalArgs = [])
     {
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
         return $this->startCall(
             'MonologAboutBook',
             Comment::class,

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -1532,8 +1532,9 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
      *     // Read all responses until the stream is complete
-     *     $stream = $libraryServiceClient->streamShelves();
+     *     $stream = $libraryServiceClient->streamShelves($formattedName);
      *     foreach ($stream->readAll() as $element) {
      *         // doSomethingWith($element);
      *     }
@@ -1542,10 +1543,9 @@ class LibraryServiceGapicClient
      * }
      * ```
      *
+     * @param string $name The name of the shelf to stream.
      * @param array $optionalArgs {
      *     Optional.
-     *     @type string $name
-     *          The name of the shelf to stream.
      *     @type int $timeoutMillis
      *          Timeout to use for this call.
      * }
@@ -1555,12 +1555,10 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function streamShelves(array $optionalArgs = [])
+    public function streamShelves($name, array $optionalArgs = [])
     {
         $request = new StreamShelvesRequest();
-        if (isset($optionalArgs['name'])) {
-            $request->setName($optionalArgs['name']);
-        }
+        $request->setName($name);
 
         return $this->startCall(
             'StreamShelves',
@@ -1623,9 +1621,9 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $name = '';
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
      *     $request = new DiscussBookRequest();
-     *     $request->setName($name);
+     *     $request->setName($formattedName);
      *     // Write all requests to the server, then read all responses until the
      *     // stream is complete
      *     $requests = [$request];
@@ -1696,9 +1694,9 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $name = '';
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
      *     $request = new DiscussBookRequest();
-     *     $request->setName($name);
+     *     $request->setName($formattedName);
      *     // Write data to server and wait for a response
      *     $requests = [$request];
      *     $stream = $libraryServiceClient->monologAboutBook();
@@ -3442,14 +3440,14 @@ function sampleDiscussBook($imageFileName)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $imageFileName = 'image_file.jpg';
-    $name = 'BASIC';
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
     $fileName = 'comment_file';
     $comment = file_get_contents($fileName);
     $comment2 = new Comment();
     $comment2->setComment($comment);
     $image = file_get_contents($imageFileName);
     $request = new DiscussBookRequest();
-    $request->setName($name);
+    $request->setName($formattedName);
     $request->setComment($comment2);
     $request->setImage($image);
 
@@ -3530,14 +3528,14 @@ function sampleDiscussBook($imageFileName)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $imageFileName = 'image_file.jpg';
-    $name = 'BASIC';
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
     $fileName = 'comment_file';
     $comment = file_get_contents($fileName);
     $comment2 = new Comment();
     $comment2->setComment($comment);
     $image = file_get_contents($imageFileName);
     $request = new DiscussBookRequest();
-    $request->setName($name);
+    $request->setName($formattedName);
     $request->setComment($comment2);
     $request->setImage($image);
 
@@ -4342,9 +4340,9 @@ function sampleMonologAboutBook()
 
     $libraryServiceClient = new LibraryServiceClient();
 
-    $name = 'BASIC';
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
     $request = new DiscussBookRequest();
-    $request->setName($name);
+    $request->setName($formattedName);
 
     try {
         // Write data as it becomes available, then wait for a response
@@ -4399,9 +4397,9 @@ function sampleMonologAboutBook()
 
     $libraryServiceClient = new LibraryServiceClient();
 
-    $name = 'BASIC';
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
     $request = new DiscussBookRequest();
-    $request->setName($name);
+    $request->setName($formattedName);
 
     try {
         // Write data to server and wait for a response
@@ -4733,9 +4731,11 @@ function sampleStreamShelves()
 
     $libraryServiceClient = new LibraryServiceClient();
 
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+
     try {
         // Read all responses until the stream is complete
-        $stream = $libraryServiceClient->streamShelves();
+        $stream = $libraryServiceClient->streamShelves($formattedName);
         foreach ($stream->readAll() as $responseItem) {
             printf("%s" . PHP_EOL, print_r($responseItem, true));
         }
@@ -6377,9 +6377,9 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
+        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
 
-
-        $serverStream = $client->streamShelves();
+        $serverStream = $client->streamShelves($formattedName);
         $this->assertInstanceOf(ServerStream::class, $serverStream);
 
         $responses = iterator_to_array($serverStream->readAll());
@@ -6396,6 +6396,9 @@ class LibraryServiceClientTest extends GeneratedTest
         $actualRequestObject = $actualRequests[0]->getRequestObject();
         $this->assertSame('/google.example.library.v1.LibraryService/StreamShelves', $actualFuncCall);
 
+        $actualValue = $actualRequestObject->getName();
+
+        $this->assertProtobufEquals($formattedName, $actualValue);
 
         $this->assertTrue($transport->isExhausted());
     }
@@ -6424,9 +6427,9 @@ class LibraryServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
 
         // Mock request
+        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
 
-
-        $serverStream = $client->streamShelves();
+        $serverStream = $client->streamShelves($formattedName);
         $results = $serverStream->readAll();
 
         try {
@@ -6586,15 +6589,15 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
-        $name = 'name3373707';
+        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
         $request = new DiscussBookRequest();
-        $request->setName($name);
-        $name2 = 'name2-1052831874';
+        $request->setName($formattedName);
+        $formattedName2 = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
         $request2 = new DiscussBookRequest();
-        $request2->setName($name2);
-        $name3 = 'name3-1052831873';
+        $request2->setName($formattedName2);
+        $formattedName3 = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
         $request3 = new DiscussBookRequest();
-        $request3->setName($name3);
+        $request3->setName($formattedName3);
 
         $bidi = $client->discussBook();
         $this->assertInstanceOf(BidiStream::class, $bidi);

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -2587,7 +2587,7 @@ class LibraryServiceClient(object):
 
     def stream_shelves(
             self,
-            name=None,
+            name,
             retry=google.api_core.gapic_v1.method.DEFAULT,
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):
@@ -2600,7 +2600,9 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> for element in client.stream_shelves():
+            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>>
+            >>> for element in client.stream_shelves(name):
             ...     # process element
             ...     pass
 
@@ -2712,8 +2714,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> # TODO: Initialize `name`:
-            >>> name = ''
+            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -2770,8 +2771,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> # TODO: Initialize `name`:
-            >>> name = ''
+            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -3849,7 +3849,7 @@ config = {
         },
         "StreamShelves": {
           "timeout_millis": 30000,
-          "retry_codes_name": "idempotent",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "StreamBooks": {
@@ -3864,7 +3864,7 @@ config = {
         },
         "MonologAboutBook": {
           "timeout_millis": 30000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "BabbleAboutBook": {
@@ -4797,7 +4797,7 @@ def sample_discuss_book(image_file_name):
 
   if isinstance(image_file_name, six.binary_type):
     image_file_name = image_file_name.decode('utf-8')
-  name = 'BASIC'
+  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
   file_name = 'comment_file'
   with io.open(file_name, 'rb') as f:
     comment = f.read()
@@ -5265,7 +5265,7 @@ def sample_monolog_about_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = 'BASIC'
+  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
   request = {'name': name}
 
   requests = [request]
@@ -5571,7 +5571,9 @@ def sample_stream_shelves():
 
   client = library_v1.LibraryServiceClient()
 
-  for response_item in client.stream_shelves():
+  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+
+  for response_item in client.stream_shelves(name):
     print(response_item)
 
   # [END sample_core]
@@ -6526,13 +6528,16 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
 
-        response = client.stream_shelves()
+        # Setup Request
+        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+
+        response = client.stream_shelves(name)
         resources = list(response)
         assert len(resources) == 1
         assert expected_response == resources[0]
 
         assert len(channel.requests) == 1
-        expected_request = library_pb2.StreamShelvesRequest()
+        expected_request = library_pb2.StreamShelvesRequest(name=name)
         actual_request = channel.requests[0][1]
         assert expected_request == actual_request
 
@@ -6544,8 +6549,11 @@ class TestLibraryServiceClient(object):
             create_channel.return_value = channel
             client = library_v1.LibraryServiceClient()
 
+        # Setup request
+        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+
         with pytest.raises(CustomException):
-            client.stream_shelves()
+            client.stream_shelves(name)
 
     def test_stream_books(self):
         # Setup Expected Response
@@ -6606,7 +6614,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = 'name3373707'
+        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -6631,7 +6639,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = 'name3373707'
+        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)
@@ -6655,7 +6663,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = 'name3373707'
+        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -6678,7 +6686,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = 'name3373707'
+        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -2587,6 +2587,7 @@ class LibraryServiceClient(object):
 
     def stream_shelves(
             self,
+            name=None,
             retry=google.api_core.gapic_v1.method.DEFAULT,
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):
@@ -2604,6 +2605,7 @@ class LibraryServiceClient(object):
             ...     pass
 
         Args:
+            name (str): The name of the shelf to stream.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will not
                 be retried.
@@ -2621,6 +2623,7 @@ class LibraryServiceClient(object):
                     failed for any reason.
             google.api_core.exceptions.RetryError: If the request failed due
                     to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
         """
         # Wrap the transport method to add retry and timeout logic.
         if 'stream_shelves' not in self._inner_api_calls:
@@ -2631,7 +2634,9 @@ class LibraryServiceClient(object):
                 client_info=self._client_info,
             )
 
-        request = library_pb2.StreamShelvesRequest()
+        request = library_pb2.StreamShelvesRequest(
+            name=name,
+        )
         return self._inner_api_calls['stream_shelves'](request, retry=retry, timeout=timeout, metadata=metadata)
 
     def stream_books(
@@ -2699,7 +2704,6 @@ class LibraryServiceClient(object):
             metadata=None):
         """
         Test bidi-streaming.
-        gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 
         EXPERIMENTAL: This method interface might change in the future.
 
@@ -2758,7 +2762,6 @@ class LibraryServiceClient(object):
             metadata=None):
         """
         Test client streaming.
-        gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 
         EXPERIMENTAL: This method interface might change in the future.
 
@@ -4293,7 +4296,6 @@ class LibraryServiceGrpcTransport(object):
         """Return the gRPC stub for :meth:`LibraryServiceClient.discuss_book`.
 
         Test bidi-streaming.
-        gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -4307,7 +4309,6 @@ class LibraryServiceGrpcTransport(object):
         """Return the gRPC stub for :meth:`LibraryServiceClient.monolog_about_book`.
 
         Test client streaming.
-        gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 
         Returns:
             Callable: A callable which accepts the appropriate

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -3940,12 +3940,13 @@ module Library
       #   require "library"
       #
       #   library_client = Library.new(version: :v1)
-      #   library_client.stream_shelves.each do |element|
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_client.stream_shelves(formatted_name).each do |element|
       #     # Process element.
       #   end
 
       def stream_shelves \
-          name: nil,
+          name,
           options: nil
         req = {
           name: name
@@ -4008,10 +4009,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library.new(version: :v1)
-      #
-      #   # TODO: Initialize `name`:
-      #   name = ''
-      #   request = { name: name }
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   request = { name: formatted_name }
       #   requests = [request]
       #   library_client.discuss_book(requests).each do |element|
       #     # Process element.
@@ -4043,10 +4042,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library.new(version: :v1)
-      #
-      #   # TODO: Initialize `name`:
-      #   name = ''
-      #   request = { name: name }
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   request = { name: formatted_name }
       #   requests = [request]
       #   response = library_client.monolog_about_book(requests)
 
@@ -4920,7 +4917,7 @@ end
         },
         "StreamShelves": {
           "timeout_millis": 30000,
-          "retry_codes_name": "idempotent",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "StreamBooks": {
@@ -4935,7 +4932,7 @@ end
         },
         "MonologAboutBook": {
           "timeout_millis": 30000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "BabbleAboutBook": {
@@ -5211,13 +5208,13 @@ def sample_discuss_book(image_file_name)
   library_client = Library.new version: :v1
 
   # image_file_name = "image_file.jpg"
-  name = "BASIC"
+  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
   file_name = "comment_file"
   comment = File.binread file_name
   comment_2 = { comment: comment }
   image = File.binread image_file_name
   request = {
-    name: name,
+    name: formatted_name,
     comment: comment_2,
     image: image
   }
@@ -5663,8 +5660,8 @@ def sample_monolog_about_book
   # Instantiate a client
   library_client = Library.new version: :v1
 
-  name = "BASIC"
-  request = { name: name }
+  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  request = { name: formatted_name }
 
   requests = [request]
   response = library_client.monolog_about_book(requests, sample)
@@ -5945,7 +5942,9 @@ def sample_stream_shelves
   # Instantiate a client
   library_client = Library.new version: :v1
 
-  library_client.stream_shelves.each do |element|
+  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+
+  library_client.stream_shelves(formatted_name).each do |element|
     puts element
   end
 
@@ -7498,6 +7497,9 @@ describe Library::V1::LibraryServiceClient do
     custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#stream_shelves."
 
     it 'invokes stream_shelves without error' do
+      # Create request parameters
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+
       # Create expected grpc response
       shelves_element = {}
       shelves = [shelves_element]
@@ -7505,7 +7507,9 @@ describe Library::V1::LibraryServiceClient do
       expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::StreamShelvesResponse)
 
       # Mock Grpc layer
-      mock_method = proc do
+      mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::StreamShelvesRequest, request)
+        assert_equal(formatted_name, request.name)
         OpenStruct.new(execute: [expected_response])
       end
       mock_stub = MockGrpcClientStub_v1.new(:stream_shelves, mock_method)
@@ -7518,7 +7522,7 @@ describe Library::V1::LibraryServiceClient do
           client = Library.new(version: :v1)
 
           # Call method
-          response = client.stream_shelves
+          response = client.stream_shelves(formatted_name)
 
           # Verify the response
           assert_equal(1, response.count)
@@ -7528,8 +7532,13 @@ describe Library::V1::LibraryServiceClient do
     end
 
     it 'invokes stream_shelves with error' do
+      # Create request parameters
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+
       # Mock Grpc layer
-      mock_method = proc do
+      mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::StreamShelvesRequest, request)
+        assert_equal(formatted_name, request.name)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:stream_shelves, mock_method)
@@ -7543,7 +7552,7 @@ describe Library::V1::LibraryServiceClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError do
-            client.stream_shelves
+            client.stream_shelves(formatted_name)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.
@@ -7634,8 +7643,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes discuss_book without error' do
       # Create request parameters
-      name = ''
-      request = { name: name }
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      request = { name: formatted_name }
 
       # Create expected grpc response
       user_name = "userName339340927"
@@ -7647,7 +7656,7 @@ describe Library::V1::LibraryServiceClient do
       mock_method = proc do |requests|
         request = requests.first
         assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
-        assert_equal(name, request.name)
+        assert_equal(formatted_name, request.name)
         OpenStruct.new(execute: [expected_response])
       end
       mock_stub = MockGrpcClientStub_v1.new(:discuss_book, mock_method)
@@ -7671,14 +7680,14 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes discuss_book with error' do
       # Create request parameters
-      name = ''
-      request = { name: name }
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      request = { name: formatted_name }
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
-        assert_equal(name, request.name)
+        assert_equal(formatted_name, request.name)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:discuss_book, mock_method)
@@ -7707,8 +7716,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes monolog_about_book without error' do
       # Create request parameters
-      name = ''
-      request = { name: name }
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      request = { name: formatted_name }
 
       # Create expected grpc response
       user_name = "userName339340927"
@@ -7720,7 +7729,7 @@ describe Library::V1::LibraryServiceClient do
       mock_method = proc do |requests|
         request = requests.first
         assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
-        assert_equal(name, request.name)
+        assert_equal(formatted_name, request.name)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v1.new(:monolog_about_book, mock_method)
@@ -7743,14 +7752,14 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes monolog_about_book with error' do
       # Create request parameters
-      name = ''
-      request = { name: name }
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      request = { name: formatted_name }
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
-        assert_equal(name, request.name)
+        assert_equal(formatted_name, request.name)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:monolog_about_book, mock_method)

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -2129,6 +2129,9 @@ module Google
         class ListShelvesResponse; end
 
         # Request message for LibraryService.StreamShelves.
+        # @!attribute [rw] name
+        #   @return [String]
+        #     The name of the shelf to stream.
         class StreamShelvesRequest; end
 
         # Response message for LibraryService.StreamShelves.
@@ -3124,12 +3127,18 @@ module Library
         @discuss_book = Google::Gax.create_api_call(
           @library_service_stub.method(:discuss_book),
           defaults["discuss_book"],
-          exception_transformer: exception_transformer
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'name' => request.name}
+          end
         )
         @monolog_about_book = Google::Gax.create_api_call(
           @library_service_stub.method(:monolog_about_book),
           defaults["monolog_about_book"],
-          exception_transformer: exception_transformer
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'name' => request.name}
+          end
         )
         @babble_about_book = Google::Gax.create_api_call(
           @library_service_stub.method(:babble_about_book),
@@ -3918,6 +3927,8 @@ module Library
       # Test server streaming
       # gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
       #
+      # @param name [String]
+      #   The name of the shelf to stream.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -3933,8 +3944,13 @@ module Library
       #     # Process element.
       #   end
 
-      def stream_shelves options: nil
-        req = Google::Example::Library::V1::StreamShelvesRequest.new
+      def stream_shelves \
+          name: nil,
+          options: nil
+        req = {
+          name: name
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::StreamShelvesRequest)
         @stream_shelves.call(req, options)
       end
 
@@ -3972,7 +3988,6 @@ module Library
       end
 
       # Test bidi-streaming.
-      # gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
       #
       # @param reqs [Enumerable<Google::Example::Library::V1::DiscussBookRequest>]
       #   The input requests.
@@ -4010,7 +4025,6 @@ module Library
       end
 
       # Test client streaming.
-      # gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
       #
       # @param reqs [Enumerable<Google::Example::Library::V1::DiscussBookRequest>]
       #   The input requests.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -1170,7 +1170,10 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
    *
    *   ServerStream&lt;StreamShelvesResponse&gt; stream = libraryServiceClient.streamShelvesCallable().call(request);
    *   for (StreamShelvesResponse response : stream) {
@@ -1210,7 +1213,6 @@ public class LibraryServiceClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
    * Test bidi-streaming.
-   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
    *
    * Sample code:
    * <pre><code>
@@ -1218,9 +1220,9 @@ public class LibraryServiceClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryServiceClient.discussBookCallable().call();
    *
-   *   String name = "";
+   *   BookOneOfName name = DeletedBookName.of();
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
-   *     .setName(name)
+   *     .setName(name.toString())
    *     .build();
    *   bidiStream.send(request);
    *   for (Comment response : bidiStream) {
@@ -1236,7 +1238,6 @@ public class LibraryServiceClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
    * Test client streaming.
-   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
    *
    * Sample code:
    * <pre><code>
@@ -1261,9 +1262,9 @@ public class LibraryServiceClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryServiceClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   String name = "";
+   *   BookOneOfName name = DeletedBookName.of();
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
-   *     .setName(name)
+   *     .setName(name.toString())
    *     .build();
    *   requestObserver.onNext(request);
    * }
@@ -1301,9 +1302,9 @@ public class LibraryServiceClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryServiceClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   String name = "";
+   *   BookOneOfName name = DeletedBookName.of();
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
-   *     .setName(name)
+   *     .setName(name.toString())
    *     .build();
    *   requestObserver.onNext(request);
    * }
@@ -3570,10 +3571,28 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<DiscussBookRequest, Comment> discussBookTransportSettings =
         GrpcCallSettings.<DiscussBookRequest, Comment>newBuilder()
             .setMethodDescriptor(discussBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<DiscussBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(DiscussBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<DiscussBookRequest, Comment> monologAboutBookTransportSettings =
         GrpcCallSettings.<DiscussBookRequest, Comment>newBuilder()
             .setMethodDescriptor(monologAboutBookMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<DiscussBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(DiscussBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<DiscussBookRequest, Empty> babbleAboutBookTransportSettings =
         GrpcCallSettings.<DiscussBookRequest, Empty>newBuilder()
@@ -5466,7 +5485,10 @@ public class LibraryServiceClientTest {
   public void streamShelvesTest() throws Exception {
     StreamShelvesResponse expectedResponse = StreamShelvesResponse.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
-    StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+    ShelfName name = ShelfName.of("[SHELF_ID]");
+    StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
+      .setName(name.toString())
+      .build();
 
     MockStreamObserver<StreamShelvesResponse> responseObserver = new MockStreamObserver<>();
 
@@ -5484,7 +5506,10 @@ public class LibraryServiceClientTest {
   public void streamShelvesExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
+    ShelfName name = ShelfName.of("[SHELF_ID]");
+    StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
+      .setName(name.toString())
+      .build();
 
     MockStreamObserver<StreamShelvesResponse> responseObserver = new MockStreamObserver<>();
 
@@ -5568,9 +5593,9 @@ public class LibraryServiceClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    String name = "name3373707";
+    BookOneOfName name = DeletedBookName.of();
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
-      .setName(name)
+      .setName(name.toString())
       .build();
 
     MockStreamObserver<Comment> responseObserver = new MockStreamObserver<>();
@@ -5593,9 +5618,9 @@ public class LibraryServiceClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    String name = "name3373707";
+    BookOneOfName name = DeletedBookName.of();
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
-      .setName(name)
+      .setName(name.toString())
       .build();
 
     MockStreamObserver<Comment> responseObserver = new MockStreamObserver<>();

--- a/src/test/java/com/google/api/codegen/testsrc/common/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library.proto
@@ -220,14 +220,14 @@ service LibraryService {
   // Test bidi-streaming.
   rpc DiscussBook(stream DiscussBookRequest) returns (stream Comment) {
     // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-    option (google.api.http) = { post: "/v1/{name=bookShelves/*/books/*}:discuss" body: "*" };
+    option (google.api.http) = { post: "/v1/{name=archives/*/books/*}:discuss" body: "*" };
     option (google.api.method_signature) = "name";
   }
 
   // Test client streaming.
   rpc MonologAboutBook(stream DiscussBookRequest) returns (Comment) {
     // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-    option (google.api.http) = { get: "/v1/{name=bookShelves/*/books/*}:monolog" body: "*" };
+    option (google.api.http) = { get: "/v1/{name=archives/*/books/*}:monolog" body: "*" };
     option (google.api.method_signature) = "name";
   }
 

--- a/src/test/java/com/google/api/codegen/testsrc/common/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library.proto
@@ -220,14 +220,14 @@ service LibraryService {
   // Test bidi-streaming.
   rpc DiscussBook(stream DiscussBookRequest) returns (stream Comment) {
     // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-
+    option (google.api.http) = { post: "/v1/{name=bookShelves/*/books/*}:discuss" body: "*" };
     option (google.api.method_signature) = "name";
   }
 
   // Test client streaming.
   rpc MonologAboutBook(stream DiscussBookRequest) returns (Comment) {
     // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-
+    option (google.api.http) = { get: "/v1/{name=bookShelves/*/books/*}:monolog" body: "*" };
     option (google.api.method_signature) = "name";
   }
 
@@ -581,6 +581,10 @@ message ListShelvesResponse {
 
 // Request message for LibraryService.StreamShelves.
 message StreamShelvesRequest {
+  // The name of the shelf to stream.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Shelf"];
 }
 
 // Response message for LibraryService.StreamShelves.
@@ -854,7 +858,8 @@ message DiscussBookRequest {
   // of the stream and this is not specified, the name in the previous
   // message will be reused.
   string name = 1 [
-    (google.api.field_behavior) = REQUIRED];
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = "google.example.library.v1.Book"];
 
   // The new comment.
   Comment comment = 2;

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -579,9 +579,17 @@ interfaces:
     grpc_streaming:
       response:
         resources_field: shelves
-    retry_codes_name: idempotent
+    retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 30000
+    field_name_patterns:
+      name: book
+    flattening:
+      groups:
+        - parameters:
+            - name
+    required_fields:
+      - name
     sample_value_sets:
       # callingFormCheck: empty java: CallableStreamingServer
       # callingFormCheck: empty nodejs: RequestStreamingServer
@@ -642,6 +650,8 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 30000
+    field_name_patterns:
+      name: book
     sample_value_sets:
       # callingFormCheck: prog java: CallableStreamingBidi
       # callingFormCheck: prog nodejs: RequestStreamingBidi
@@ -675,8 +685,10 @@ interfaces:
     # required_fields makes a difference on sample code.
     required_fields:
     - name
-    retry_codes_name: non_idempotent
+    retry_codes_name: idempotent
     retry_params_name: default
+    field_name_patterns:
+      name: book
     timeout_millis: 30000
     sample_value_sets:
       # callingFormCheck: prog java: CallableStreamingClient


### PR DESCRIPTION
Just change the library.proto and library_gapic.yaml and baseline files to add `(google.api.http)` annotations to client and bidi streaming methods.

For https://github.com/googleapis/gapic-generator/issues/2668. This PR will make the bug-fix PR cleaner and easier to read. This PR only represents what happens now.