### PR TITLE
Remove implements_cancel & implements_delete

### DIFF
--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -32,8 +32,6 @@ import org.threeten.bp.Duration;
 public abstract class LongRunningConfig {
 
   // Default values for LongRunningConfig fields.
-  static final boolean LRO_IMPLEMENTS_CANCEL = true;
-  static final boolean LRO_IMPLEMENTS_DELETE = true;
   static final int LRO_INITIAL_POLL_DELAY_MILLIS = 500;
   static final double LRO_POLL_DELAY_MULTIPLIER = 1.5;
   static final int LRO_MAX_POLL_DELAY_MILLIS = 5000;
@@ -44,12 +42,6 @@ public abstract class LongRunningConfig {
 
   /** Returns the message type for the metadata field of an operation. */
   public abstract TypeModel getMetadataType();
-
-  /** Reports whether or not the service implements delete. */
-  public abstract boolean implementsDelete();
-
-  /** Reports whether or not the service implements cancel. */
-  public abstract boolean implementsCancel();
 
   /** Returns initial delay after which first poll request will be made. */
   public abstract Duration getInitialPollDelay();
@@ -168,8 +160,6 @@ public abstract class LongRunningConfig {
     return new AutoValue_LongRunningConfig(
         ProtoTypeRef.create(returnType),
         ProtoTypeRef.create(metadataType),
-        LRO_IMPLEMENTS_CANCEL,
-        LRO_IMPLEMENTS_DELETE,
         initialPollDelay,
         LRO_POLL_DELAY_MULTIPLIER,
         maxPollDelay,
@@ -260,8 +250,6 @@ public abstract class LongRunningConfig {
     return new AutoValue_LongRunningConfig(
         ProtoTypeRef.create(returnType),
         ProtoTypeRef.create(metadataType),
-        longRunningConfigProto.getImplementsDelete(),
-        longRunningConfigProto.getImplementsCancel(),
         initialPollDelay,
         pollDelayMultiplier,
         maxPollDelay,

--- a/src/main/java/com/google/api/codegen/transformer/LongRunningTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/LongRunningTransformer.java
@@ -41,8 +41,6 @@ public class LongRunningTransformer {
         .isEmptyOperation(lroConfig.getReturnType().isEmptyType())
         .isEmptyMetadata(lroConfig.getMetadataType().isEmptyType())
         .metadataTypeName(metadataTypeName)
-        .implementsDelete(lroConfig.implementsDelete())
-        .implementsCancel(lroConfig.implementsCancel())
         .initialPollDelay(lroConfig.getInitialPollDelay().toMillis())
         .pollDelayMultiplier(lroConfig.getPollDelayMultiplier())
         .maxPollDelay(lroConfig.getMaxPollDelay().toMillis())

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -237,8 +237,6 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer<Pro
               .isEmptyOperation(lroConfig.getReturnType().isEmptyType())
               .isEmptyMetadata(lroConfig.getMetadataType().isEmptyType())
               .metadataTypeName(context.getImportTypeTable().getFullNameFor(metadataType))
-              .implementsCancel(true)
-              .implementsDelete(true)
               .initialPollDelay(lroConfig.getInitialPollDelay().toMillis())
               .pollDelayMultiplier(lroConfig.getPollDelayMultiplier())
               .maxPollDelay(lroConfig.getMaxPollDelay().toMillis())

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -259,8 +259,6 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer<ProtoA
               .isEmptyOperation(lroConfig.getReturnType().isEmptyType())
               .isEmptyMetadata(lroConfig.getMetadataType().isEmptyType())
               .metadataTypeName(context.getImportTypeTable().getFullNameFor(metadataType))
-              .implementsCancel(true)
-              .implementsDelete(true)
               .initialPollDelay(lroConfig.getInitialPollDelay().toMillis())
               .pollDelayMultiplier(lroConfig.getPollDelayMultiplier())
               .maxPollDelay(lroConfig.getMaxPollDelay().toMillis())

--- a/src/main/java/com/google/api/codegen/viewmodel/LongRunningOperationDetailView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/LongRunningOperationDetailView.java
@@ -32,10 +32,6 @@ public abstract class LongRunningOperationDetailView {
 
   public abstract String metadataTypeName();
 
-  public abstract boolean implementsDelete();
-
-  public abstract boolean implementsCancel();
-
   public abstract String methodName();
 
   @Nullable
@@ -66,10 +62,6 @@ public abstract class LongRunningOperationDetailView {
     public abstract Builder isEmptyMetadata(boolean val);
 
     public abstract Builder metadataTypeName(String val);
-
-    public abstract Builder implementsDelete(boolean val);
-
-    public abstract Builder implementsCancel(boolean val);
 
     public abstract Builder methodName(String val);
 

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -666,10 +666,10 @@ message LongRunningConfigProto {
   string metadata_type = 2;
 
   // Whether or not the server implements delete.
-  bool implements_delete = 3;
+  bool implements_delete = 3; // DEPRECATED.
 
   // Whether or not the server implements cancel.
-  bool implements_cancel = 4;
+  bool implements_cancel = 4; // DEPRECATED.
 
   // Initial delay after which first poll request will be made.
   uint64 initial_poll_delay_millis = 5;

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -407,25 +407,6 @@
         return op.lro.Name()
     }
 
-    @if lro.implementsCancel
-        // Cancel starts asynchronous cancellation on a long-running operation.
-        // The server makes a best effort to cancel the operation, but success is not guaranteed.
-        // Clients can use Poll or other methods to check whether the cancellation succeeded or whether the operation
-        // completed despite cancellation. On successful cancellation, the operation is not deleted;
-        // instead, op.Poll returns an error with code Canceled.
-        func (op *{@lro.clientReturnTypeName}) Cancel(ctx context.Context, opts ...gax.CallOption) error {
-            return op.lro.Cancel(ctx, opts...)
-        }
-    @end
-
-    @if lro.implementsDelete
-        // Delete deletes a long-running operation.
-        // This method indicates that the client is no longer interested in the operation result.
-        // It does not cancel the operation.
-        func (op *{@lro.clientReturnTypeName}) Delete(ctx context.Context, opts ...gax.CallOption) error {
-            return op.lro.Delete(ctx, opts...)
-        }
-    @end
 @end
 
 @private pollMetadataDoc(lro)

--- a/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
@@ -70,8 +70,6 @@ public class LongRunningConfigTest {
   private static final LongRunningConfigProto lroConfigProtoWithPollSettings =
       baseLroConfigProto
           .toBuilder()
-          .setImplementsCancel(TEST_IMPLEMENTS_CANCEL)
-          .setImplementsDelete(TEST_IMPLEMENTS_DELETE)
           .setInitialPollDelayMillis(TEST_INITIAL_POLL_DELAY)
           .setPollDelayMultiplier(TEST_POLL_DELAY_MULTIPLIER)
           .setMaxPollDelayMillis(TEST_MAX_POLL_DELAY)
@@ -130,10 +128,6 @@ public class LongRunningConfigTest {
         .isEqualTo(LongRunningConfig.LRO_POLL_DELAY_MULTIPLIER);
     assertThat(longRunningConfig.getTotalPollTimeout().toMillis())
         .isEqualTo(LongRunningConfig.LRO_TOTAL_POLL_TIMEOUT_MILLS);
-    assertThat(longRunningConfig.implementsCancel())
-        .isEqualTo(LongRunningConfig.LRO_IMPLEMENTS_CANCEL);
-    assertThat(longRunningConfig.implementsDelete())
-        .isEqualTo(LongRunningConfig.LRO_IMPLEMENTS_DELETE);
   }
 
   @Test
@@ -161,8 +155,6 @@ public class LongRunningConfigTest {
     assertThat(longRunningConfig.getPollDelayMultiplier()).isEqualTo(TEST_POLL_DELAY_MULTIPLIER);
     assertThat(longRunningConfig.getTotalPollTimeout().toMillis())
         .isEqualTo(TEST_TOTAL_POLL_TIMEOUT);
-    assertThat(longRunningConfig.implementsCancel()).isEqualTo(TEST_IMPLEMENTS_CANCEL);
-    assertThat(longRunningConfig.implementsDelete()).isEqualTo(TEST_IMPLEMENTS_DELETE);
   }
 
   @Test
@@ -191,10 +183,6 @@ public class LongRunningConfigTest {
         .isEqualTo(LongRunningConfig.LRO_POLL_DELAY_MULTIPLIER);
     assertThat(longRunningConfig.getTotalPollTimeout().toMillis())
         .isEqualTo(LongRunningConfig.LRO_TOTAL_POLL_TIMEOUT_MILLS);
-    assertThat(longRunningConfig.implementsCancel())
-        .isEqualTo(LongRunningConfig.LRO_IMPLEMENTS_CANCEL);
-    assertThat(longRunningConfig.implementsDelete())
-        .isEqualTo(LongRunningConfig.LRO_IMPLEMENTS_DELETE);
   }
 
   @Test
@@ -229,8 +217,6 @@ public class LongRunningConfigTest {
     assertThat(longRunningConfig.getPollDelayMultiplier()).isEqualTo(TEST_POLL_DELAY_MULTIPLIER);
     assertThat(longRunningConfig.getTotalPollTimeout().toMillis())
         .isEqualTo(TEST_TOTAL_POLL_TIMEOUT);
-    assertThat(longRunningConfig.implementsCancel()).isEqualTo(TEST_IMPLEMENTS_CANCEL);
-    assertThat(longRunningConfig.implementsDelete()).isEqualTo(TEST_IMPLEMENTS_DELETE);
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -1129,15 +1129,6 @@ func (op *GetBigBookOperation) Name() string {
     return op.lro.Name()
 }
 
-// Cancel starts asynchronous cancellation on a long-running operation.
-// The server makes a best effort to cancel the operation, but success is not guaranteed.
-// Clients can use Poll or other methods to check whether the cancellation succeeded or whether the operation
-// completed despite cancellation. On successful cancellation, the operation is not deleted;
-// instead, op.Poll returns an error with code Canceled.
-func (op *GetBigBookOperation) Cancel(ctx context.Context, opts ...gax.CallOption) error {
-    return op.lro.Cancel(ctx, opts...)
-}
-
 // GetBigNothingOperation manages a long-running operation from GetBigNothing.
 type GetBigNothingOperation struct {
     lro *longrunning.Operation
@@ -1194,13 +1185,6 @@ func (op *GetBigNothingOperation) Name() string {
     return op.lro.Name()
 }
 
-
-// Delete deletes a long-running operation.
-// This method indicates that the client is no longer interested in the operation result.
-// It does not cancel the operation.
-func (op *GetBigNothingOperation) Delete(ctx context.Context, opts ...gax.CallOption) error {
-    return op.lro.Delete(ctx, opts...)
-}
 ============== file: cloud.google.com/go/library/apiv1/library_client_example_test.go ==============
 // Copyright 2019 Google LLC
 //

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -841,7 +841,6 @@ interfaces:
     long_running:
       return_type: google.example.library.v1.Book
       metadata_type: google.example.library.v1.GetBigBookMetadata
-      implements_cancel: true
       initial_poll_delay_millis: 3000
       poll_delay_multiplier: 1.3
       max_poll_delay_millis: 30000
@@ -931,7 +930,6 @@ interfaces:
     long_running:
       return_type: google.protobuf.Empty
       metadata_type: google.example.library.v1.GetBigBookMetadata
-      implements_delete: true
       initial_poll_delay_millis: 3000
       poll_delay_multiplier: 1.3
       max_poll_delay_millis: 60000


### PR DESCRIPTION
* deprecates `implements_cancel` and `implements_delete` LRO config options
* removes associated Java code
* removes usage in Go snippet

For those interested, only 1 API used this feature and it was migrated to using a manual file for these generated methods, [here](https://code-review.googlesource.com/c/gocloud/+/39450).