### PR TITLE
Parse fixed resource names from regular CollectionConfigProto

### DIFF
--- a/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
@@ -61,4 +61,12 @@ public abstract class FixedResourceNameConfig implements ResourceNameConfig {
 
     return new AutoValue_FixedResourceNameConfig(entityName, entityName, fixedValue, file);
   }
+
+  /**
+   * Returns if the pathPattern is a fixed name resource. This primitively returns true iff the
+   * pathPattern contains a '{' char.
+   */
+  public static boolean isFixedResourceNameConfig(String pathPattern) {
+    return !pathPattern.contains("{");
+  }
 }

--- a/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.config;
 
+import com.google.api.codegen.FixedResourceNameValueProto;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.ProtoFile;
@@ -47,6 +48,30 @@ public abstract class FixedResourceNameConfig implements ResourceNameConfig {
   @Nullable
   public static FixedResourceNameConfig createFixedResourceNameConfig(
       DiagCollector diagCollector, String entityName, String fixedValue, @Nullable ProtoFile file) {
+
+    if (entityName == null || fixedValue == null) {
+      diagCollector.addDiag(
+          Diag.error(
+              SimpleLocation.TOPLEVEL,
+              "incorrectly configured FixedResourceNameConfig: name: "
+                  + entityName
+                  + ", value: "
+                  + fixedValue));
+      return null;
+    }
+
+    return new AutoValue_FixedResourceNameConfig(entityName, entityName, fixedValue, file);
+  }
+
+  // TODO(andrealin): Remove this method once all existing fixed resource names are removed.
+  @Nullable
+  public static FixedResourceNameConfig createFixedResourceNameConfig(
+      DiagCollector diagCollector,
+      FixedResourceNameValueProto fixedResourceNameValueProto,
+      @Nullable ProtoFile file) {
+
+    String entityName = fixedResourceNameValueProto.getEntityName();
+    String fixedValue = fixedResourceNameValueProto.getFixedValue();
 
     if (entityName == null || fixedValue == null) {
       diagCollector.addDiag(

--- a/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
@@ -14,7 +14,6 @@
  */
 package com.google.api.codegen.config;
 
-import com.google.api.codegen.FixedResourceNameValueProto;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.ProtoFile;
@@ -47,12 +46,7 @@ public abstract class FixedResourceNameConfig implements ResourceNameConfig {
 
   @Nullable
   public static FixedResourceNameConfig createFixedResourceNameConfig(
-      DiagCollector diagCollector,
-      FixedResourceNameValueProto fixedResourceNameValueProto,
-      @Nullable ProtoFile file) {
-
-    String entityName = fixedResourceNameValueProto.getEntityName();
-    String fixedValue = fixedResourceNameValueProto.getFixedValue();
+      DiagCollector diagCollector, String entityName, String fixedValue, @Nullable ProtoFile file) {
 
     if (entityName == null || fixedValue == null) {
       diagCollector.addDiag(

--- a/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
@@ -67,6 +67,6 @@ public abstract class FixedResourceNameConfig implements ResourceNameConfig {
    * pathPattern contains a '{' char.
    */
   public static boolean isFixedResourceNameConfig(String pathPattern) {
-    return !pathPattern.contains("{");
+    return !(pathPattern.contains("{") || pathPattern.contains("*"));
   }
 }

--- a/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
@@ -14,7 +14,6 @@
  */
 package com.google.api.codegen.config;
 
-import com.google.api.codegen.FixedResourceNameValueProto;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.ProtoFile;
@@ -48,30 +47,6 @@ public abstract class FixedResourceNameConfig implements ResourceNameConfig {
   @Nullable
   public static FixedResourceNameConfig createFixedResourceNameConfig(
       DiagCollector diagCollector, String entityName, String fixedValue, @Nullable ProtoFile file) {
-
-    if (entityName == null || fixedValue == null) {
-      diagCollector.addDiag(
-          Diag.error(
-              SimpleLocation.TOPLEVEL,
-              "incorrectly configured FixedResourceNameConfig: name: "
-                  + entityName
-                  + ", value: "
-                  + fixedValue));
-      return null;
-    }
-
-    return new AutoValue_FixedResourceNameConfig(entityName, entityName, fixedValue, file);
-  }
-
-  // TODO(andrealin): Remove this method once all existing fixed resource names are removed.
-  @Nullable
-  public static FixedResourceNameConfig createFixedResourceNameConfig(
-      DiagCollector diagCollector,
-      FixedResourceNameValueProto fixedResourceNameValueProto,
-      @Nullable ProtoFile file) {
-
-    String entityName = fixedResourceNameValueProto.getEntityName();
-    String fixedValue = fixedResourceNameValueProto.getFixedValue();
 
     if (entityName == null || fixedValue == null) {
       diagCollector.addDiag(

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -992,7 +992,10 @@ public abstract class GapicProductConfig implements ProductConfig {
     for (FixedResourceNameValueProto fixedConfigProto : fixedConfigProtos) {
       FixedResourceNameConfig fixedConfig =
           FixedResourceNameConfig.createFixedResourceNameConfig(
-              diagCollector, fixedConfigProto, file);
+              diagCollector,
+              fixedConfigProto.getEntityName(),
+              fixedConfigProto.getFixedValue(),
+              file);
       if (fixedConfig == null) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -19,6 +19,7 @@ import com.google.api.ResourceSet;
 import com.google.api.codegen.CollectionConfigProto;
 import com.google.api.codegen.CollectionOneofProto;
 import com.google.api.codegen.ConfigProto;
+import com.google.api.codegen.FixedResourceNameValueProto;
 import com.google.api.codegen.InterfaceConfigProto;
 import com.google.api.codegen.LanguageSettingsProto;
 import com.google.api.codegen.MethodConfigProto;
@@ -915,6 +916,11 @@ public abstract class GapicProductConfig implements ProductConfig {
       fixedResourceNamesBuilder.put(fixedResourceNameConfig.getEntityId(), fixedResourceNameConfig);
     }
 
+    // TODO(andrealin): Remove this once all fixed resource names are removed.
+    fixedResourceNamesBuilder.putAll(
+        createFixedResourceNameConfigs(
+            diagCollector, configProto.getFixedResourceNameValuesList(), file));
+
     singleResourceNamesBuilder.putAll(singleResourceNameConfigsMap);
   }
 
@@ -974,6 +980,25 @@ public abstract class GapicProductConfig implements ProductConfig {
           StringUtils.prependIfMissing(fullyQualifiedName, protoParser.getProtoPackage(file) + ".");
       singleResourceNameConfigsMap.put(fullyQualifiedName, singleResourceNameConfig);
     }
+  }
+
+  // TODO(andrealin): Remove this once existing fixed resource names are removed.
+  private static ImmutableMap<String, FixedResourceNameConfig> createFixedResourceNameConfigs(
+      DiagCollector diagCollector,
+      Iterable<FixedResourceNameValueProto> fixedConfigProtos,
+      @Nullable ProtoFile file) {
+    ImmutableMap.Builder<String, FixedResourceNameConfig> fixedConfigBuilder =
+        ImmutableMap.builder();
+    for (FixedResourceNameValueProto fixedConfigProto : fixedConfigProtos) {
+      FixedResourceNameConfig fixedConfig =
+          FixedResourceNameConfig.createFixedResourceNameConfig(
+              diagCollector, fixedConfigProto, file);
+      if (fixedConfig == null) {
+        continue;
+      }
+      fixedConfigBuilder.put(fixedConfig.getEntityId(), fixedConfig);
+    }
+    return fixedConfigBuilder.build();
   }
 
   private static ImmutableMap<String, ResourceNameOneofConfig> createResourceNameOneofConfigs(

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -916,6 +916,11 @@ public abstract class GapicProductConfig implements ProductConfig {
         createFixedResourceNameConfigs(
             diagCollector, configProto.getFixedResourceNameValuesList(), file));
 
+    if (diagCollector.getErrorCount() > 0) {
+      ToolUtil.reportDiags(diagCollector, true);
+      throw new RuntimeException();
+    }
+
     singleResourceNamesBuilder.putAll(singleResourceNameConfigsMap);
   }
 

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -85,7 +85,7 @@ message ConfigProto {
   // A list of resource name oneof configs.
   repeated CollectionOneofProto collection_oneofs = 16;
 
-  repeated FixedResourceNameValueProto fixed_resource_name_values = 17; // UNSUPPORTED.
+  repeated FixedResourceNameValueProto fixed_resource_name_values = 17; // DEPRECATED.
 
   // Set this value to toggle String format functions for resource name
   // entities. If this is not set, it will fallback to default behavior.
@@ -222,7 +222,7 @@ message CollectionOneofProto {
   repeated string collection_names = 2;
 }
 
-// UNSUPPORTED. Use CollectionConfigProto instead.
+// DEPRECATED. Use CollectionConfigProto instead.
 message FixedResourceNameValueProto {
   // Name to be used as a basis for generated methods and classes.
   string entity_name = 1;

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -85,7 +85,7 @@ message ConfigProto {
   // A list of resource name oneof configs.
   repeated CollectionOneofProto collection_oneofs = 16;
 
-  repeated FixedResourceNameValueProto fixed_resource_name_values = 17;
+  repeated FixedResourceNameValueProto fixed_resource_name_values = 17; // UNSUPPORTED.
 
   // Set this value to toggle String format functions for resource name
   // entities. If this is not set, it will fallback to default behavior.
@@ -222,6 +222,7 @@ message CollectionOneofProto {
   repeated string collection_names = 2;
 }
 
+// UNSUPPORTED. Use CollectionConfigProto instead.
 message FixedResourceNameValueProto {
   // Name to be used as a basis for generated methods and classes.
   string entity_name = 1;

--- a/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
@@ -22,7 +22,6 @@ import com.google.api.ResourceSet;
 import com.google.api.codegen.CollectionConfigProto;
 import com.google.api.codegen.CollectionOneofProto;
 import com.google.api.codegen.ConfigProto;
-import com.google.api.codegen.FixedResourceNameValueProto;
 import com.google.api.codegen.FlatteningConfigProto;
 import com.google.api.codegen.FlatteningGroupProto;
 import com.google.api.codegen.InterfaceConfigProto;
@@ -124,10 +123,10 @@ public class ResourceNameMessageConfigsTest {
                 CollectionConfigProto.newBuilder()
                     .setNamePattern(ARCHIVED_BOOK_PATH)
                     .setEntityName("archived_book"))
-            .addFixedResourceNameValues(
-                FixedResourceNameValueProto.newBuilder()
+            .addCollections(
+                CollectionConfigProto.newBuilder()
                     .setEntityName("deleted_book")
-                    .setFixedValue("_deleted-book_"))
+                    .setNamePattern("_deleted-book_"))
             .addInterfaces(
                 InterfaceConfigProto.newBuilder()
                     .addCollections(

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -36,9 +36,8 @@ collections:
   # the restriction of generated parse/format methods
   - name_pattern: archives/{archive_path}/books/{book_id=**}
     entity_name: archived_book
-fixed_resource_name_values:
-  - entity_name: deleted_book
-    fixed_value: _deleted-book_
+  - name_pattern: _deleted-book_
+    entity_name: deleted_book
 collection_oneofs:
   - oneof_name: book_oneof
     collection_names:


### PR DESCRIPTION
Deprecate FixedResourceNameValueProto; it will still be supported because Pubsub needs it right now before the change is made.

Any resource name entities, defined in CollectionConfigProto, that do not have params in their pattern will be treated as Fixed resource names.