### PR TITLE
Update Java google-common-protos to 1.15.0

### DIFF
--- a/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
+++ b/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
@@ -80,7 +80,7 @@ google-common-protos_version:
     name_override: googleapis-common-protos
     lower: '1.3.1'
   java:
-    lower: '1.12.0'
+    lower: '1.15.0'
 
 google-iam-v1_version:
   csharp:


### PR DESCRIPTION
So that freshly generated Java clients using proto annotations will compile.

v1.15.0 introduces many of the annotations.