### PR TITLE
Treat ResourceNameConfig.entityName as Name

### DIFF
--- a/src/main/java/com/google/api/codegen/config/AnyResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/AnyResourceNameConfig.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.config;
 
+import com.google.api.codegen.util.Name;
 import com.google.api.tools.framework.model.ProtoFile;
 import javax.annotation.Nullable;
 
@@ -42,12 +43,12 @@ public class AnyResourceNameConfig implements ResourceNameConfig {
 
   @Override
   public String getEntityId() {
-    return getEntityName();
+    return ENTITY_NAME;
   }
 
   @Override
-  public String getEntityName() {
-    return ENTITY_NAME;
+  public Name getEntityName() {
+    return Name.from(ENTITY_NAME);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
@@ -59,7 +59,8 @@ public abstract class FixedResourceNameConfig implements ResourceNameConfig {
       return null;
     }
 
-    return new AutoValue_FixedResourceNameConfig(entityName, entityName, fixedValue, file);
+    return new AutoValue_FixedResourceNameConfig(
+        entityName, ResourceNameMessageConfig.entityNameToName(entityName), fixedValue, file);
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -1014,7 +1014,7 @@ public abstract class GapicProductConfig implements ProductConfig {
       if (oneofConfig == null) {
         continue;
       }
-      oneofConfigBuilder.put(oneofConfig.getEntityName(), oneofConfig);
+      oneofConfigBuilder.put(oneofConfig.getEntityId(), oneofConfig);
     }
     return oneofConfigBuilder.build();
   }

--- a/src/main/java/com/google/api/codegen/config/ResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameConfig.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.config;
 
+import com.google.api.codegen.util.Name;
 import com.google.api.tools.framework.model.ProtoFile;
 import javax.annotation.Nullable;
 
@@ -23,7 +24,7 @@ public interface ResourceNameConfig {
   String getEntityId();
 
   /** Returns the name used as a basis for generating methods. */
-  String getEntityName();
+  Name getEntityName();
 
   @Nullable
   String getCommonResourceName();

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfig.java
@@ -77,8 +77,6 @@ public abstract class ResourceNameMessageConfig {
     return new AutoValue_ResourceNameMessageConfig(message.getFullName(), fieldEntityMap);
   }
 
-  // Proto annotations use UpperCamelCase for resource names,
-  // and GAPIC config uses lower_snake_case, so we have to support both formats.
   static String getFullyQualifiedMessageName(String defaultPackage, String messageName) {
     if (messageName.contains(".")) {
       return messageName;
@@ -87,7 +85,9 @@ public abstract class ResourceNameMessageConfig {
     }
   }
 
-  public static Name entityNameToName(String original) {
+  // Proto annotations use UpperCamelCase for resource names,
+  // and GAPIC config uses lower_snake_case, so we have to support both formats.
+  static Name entityNameToName(String original) {
     if (original.contains("_")) {
       return Name.from(original);
     } else {

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfig.java
@@ -17,6 +17,7 @@ package com.google.api.codegen.config;
 import com.google.api.Resource;
 import com.google.api.ResourceSet;
 import com.google.api.codegen.ResourceNameMessageConfigProto;
+import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.ProtoParser;
 import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.MessageType;
@@ -76,11 +77,21 @@ public abstract class ResourceNameMessageConfig {
     return new AutoValue_ResourceNameMessageConfig(message.getFullName(), fieldEntityMap);
   }
 
+  // Proto annotations use UpperCamelCase for resource names,
+  // and GAPIC config uses lower_snake_case, so we have to support both formats.
   static String getFullyQualifiedMessageName(String defaultPackage, String messageName) {
     if (messageName.contains(".")) {
       return messageName;
     } else {
       return defaultPackage + "." + messageName;
+    }
+  }
+
+  public static Name entityNameToName(String original) {
+    if (original.contains("_")) {
+      return Name.from(original);
+    } else {
+      return Name.anyCamel(original);
     }
   }
 

--- a/src/main/java/com/google/api/codegen/config/ResourceNameOneofConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameOneofConfig.java
@@ -17,6 +17,7 @@ package com.google.api.codegen.config;
 import com.google.api.Resource;
 import com.google.api.ResourceSet;
 import com.google.api.codegen.CollectionOneofProto;
+import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.ProtoParser;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
@@ -35,7 +36,7 @@ import javax.annotation.Nullable;
 public abstract class ResourceNameOneofConfig implements ResourceNameConfig {
 
   @Override
-  public abstract String getEntityName();
+  public abstract Name getEntityName();
 
   public abstract List<ResourceNameConfig> getResourceNameConfigs();
 
@@ -98,7 +99,8 @@ public abstract class ResourceNameOneofConfig implements ResourceNameConfig {
       return null;
     }
 
-    return new AutoValue_ResourceNameOneofConfig(oneofName, oneofName, configList, file);
+    return new AutoValue_ResourceNameOneofConfig(
+        oneofName, ResourceNameMessageConfig.entityNameToName(oneofName), configList, file);
   }
 
   @Nullable
@@ -162,7 +164,8 @@ public abstract class ResourceNameOneofConfig implements ResourceNameConfig {
       }
     }
 
-    return new AutoValue_ResourceNameOneofConfig(oneOfName, oneOfName, configList, file);
+    return new AutoValue_ResourceNameOneofConfig(
+        oneOfName, ResourceNameMessageConfig.entityNameToName(oneOfName), configList, file);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/SingleResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/SingleResourceNameConfig.java
@@ -103,7 +103,6 @@ public abstract class SingleResourceNameConfig implements ResourceNameConfig {
         .setAssignedProtoFile(file)
         .setEntityId(resource.getSymbol())
         .setEntityName(ResourceNameMessageConfig.entityNameToName(resource.getSymbol()))
-        .setCommonResourceName(null)
         .build();
   }
 

--- a/src/main/java/com/google/api/codegen/config/SingleResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/SingleResourceNameConfig.java
@@ -18,6 +18,7 @@ import com.google.api.Resource;
 import com.google.api.codegen.CollectionConfigProto;
 import com.google.api.codegen.CollectionLanguageOverridesProto;
 import com.google.api.codegen.common.TargetLanguage;
+import com.google.api.codegen.util.Name;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.pathtemplate.ValidationException;
 import com.google.api.tools.framework.model.Diag;
@@ -42,15 +43,24 @@ public abstract class SingleResourceNameConfig implements ResourceNameConfig {
       CollectionConfigProto collectionConfigProto,
       @Nullable ProtoFile file,
       TargetLanguage language) {
+    SingleResourceNameConfig.Builder builder = newBuilder();
     String namePattern = collectionConfigProto.getNamePattern();
-    PathTemplate nameTemplate;
-    try {
-      nameTemplate = PathTemplate.create(namePattern);
-    } catch (ValidationException e) {
-      diagCollector.addDiag(Diag.error(SimpleLocation.TOPLEVEL, e.getMessage()));
-      return null;
-    }
     String entityId = collectionConfigProto.getEntityName();
+    PathTemplate nameTemplate = null;
+    if (!Strings.isNullOrEmpty(namePattern)) {
+      try {
+        nameTemplate = PathTemplate.create(namePattern);
+      } catch (ValidationException e) {
+        diagCollector.addDiag(Diag.error(SimpleLocation.TOPLEVEL, e.getMessage()));
+        return null;
+      }
+    }
+
+    builder.setNamePattern(namePattern);
+    builder.setNameTemplate(nameTemplate);
+    builder.setEntityId(entityId);
+    builder.setAssignedProtoFile(file);
+
     String entityName = entityId;
     String commonResourceName = null;
     if (language != null) {
@@ -67,8 +77,10 @@ public abstract class SingleResourceNameConfig implements ResourceNameConfig {
         }
       }
     }
-    return new AutoValue_SingleResourceNameConfig(
-        namePattern, nameTemplate, entityId, entityName, commonResourceName, file);
+    builder.setCommonResourceName(commonResourceName);
+    builder.setEntityName(ResourceNameMessageConfig.entityNameToName(entityName));
+
+    return builder.build();
   }
 
   /**
@@ -85,8 +97,14 @@ public abstract class SingleResourceNameConfig implements ResourceNameConfig {
       return null;
     }
 
-    return new AutoValue_SingleResourceNameConfig(
-        pathTemplate, nameTemplate, resource.getSymbol(), resource.getSymbol(), null, file);
+    return newBuilder()
+        .setNamePattern(pathTemplate)
+        .setNameTemplate(nameTemplate)
+        .setAssignedProtoFile(file)
+        .setEntityId(resource.getSymbol())
+        .setEntityName(ResourceNameMessageConfig.entityNameToName(resource.getSymbol()))
+        .setCommonResourceName(null)
+        .build();
   }
 
   /** Returns the name pattern for the resource name config. */
@@ -101,7 +119,7 @@ public abstract class SingleResourceNameConfig implements ResourceNameConfig {
 
   /** Returns the name used as a basis for generating methods. */
   @Override
-  public abstract String getEntityName();
+  public abstract Name getEntityName();
 
   @Override
   @Nullable
@@ -114,5 +132,28 @@ public abstract class SingleResourceNameConfig implements ResourceNameConfig {
   @Override
   public ResourceNameType getResourceNameType() {
     return ResourceNameType.SINGLE;
+  }
+
+  public static SingleResourceNameConfig.Builder newBuilder() {
+    return new AutoValue_SingleResourceNameConfig.Builder();
+  }
+
+  public abstract Builder toBuilder();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setNamePattern(String val);
+
+    public abstract Builder setNameTemplate(PathTemplate val);
+
+    public abstract Builder setEntityId(String val);
+
+    public abstract Builder setEntityName(Name val);
+
+    public abstract Builder setCommonResourceName(String val);
+
+    public abstract Builder setAssignedProtoFile(ProtoFile val);
+
+    public abstract SingleResourceNameConfig build();
   }
 }

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/DiscoGapicParser.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/DiscoGapicParser.java
@@ -161,6 +161,6 @@ public class DiscoGapicParser {
 
   /** Returns the name for a ResourceName for the resource of the given method. */
   public static Name getResourceNameName(ResourceNameConfig resourceNameConfig) {
-    return Name.anyCamel(resourceNameConfig.getEntityName()).join("name");
+    return resourceNameConfig.getEntityName().join("name");
   }
 }

--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
@@ -33,6 +33,7 @@ import com.google.api.tools.framework.model.stages.Merged;
 import com.google.api.tools.framework.tools.ToolDriverBase;
 import com.google.api.tools.framework.tools.ToolOptions;
 import com.google.api.tools.framework.tools.ToolOptions.Option;
+import com.google.api.tools.framework.tools.ToolUtil;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -167,6 +168,7 @@ public class GapicGeneratorApp extends ToolDriverBase {
     GapicProductConfig productConfig =
         GapicProductConfig.create(model, configProto, protoPackage, clientPackage, language);
     if (productConfig == null) {
+      ToolUtil.reportDiags(model.getDiagReporter().getDiagCollector(), true);
       return;
     }
 

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -124,7 +124,7 @@ public class PathTemplateTransformer {
             .paramName(namer.getResourceParameterName(config))
             .propertyName(namer.getResourcePropertyName(config))
             .enumName(namer.getResourceEnumName(config))
-            .docName(config.getEntityName())
+            .docName(config.getEntityName().toLowerUnderscore())
             .index(index)
             .pattern(config.getNamePattern())
             .commonResourceName(config.getCommonResourceName());
@@ -152,7 +152,7 @@ public class PathTemplateTransformer {
             .paramName(namer.getResourceParameterName(config))
             .propertyName(namer.getResourcePropertyName(config))
             .enumName(namer.getResourceEnumName(config))
-            .docName(config.getEntityName())
+            .docName(config.getEntityName().toLowerUnderscore())
             .index(index)
             .children(generateResourceNames(context, config.getResourceNameConfigs()));
     return builder.build();
@@ -167,7 +167,7 @@ public class PathTemplateTransformer {
             .paramName(namer.getResourceParameterName(config))
             .propertyName(namer.getResourcePropertyName(config))
             .enumName(namer.getResourceEnumName(config))
-            .docName(config.getEntityName())
+            .docName(config.getEntityName().toLowerUnderscore())
             .index(index)
             .value(config.getFixedValue());
     return builder.build();
@@ -187,7 +187,7 @@ public class PathTemplateTransformer {
       FormatResourceFunctionView.Builder function =
           FormatResourceFunctionView.newBuilder()
               .resourceName(namer.getResourceTypeName(resourceNameConfig))
-              .entityName(resourceNameConfig.getEntityName())
+              .entityName(resourceNameConfig.getEntityName().toLowerUnderscore())
               .name(namer.getFormatFunctionName(interfaceConfig, resourceNameConfig))
               .pathTemplateName(namer.getPathTemplateName(interfaceConfig, resourceNameConfig))
               .pathTemplateGetterName(
@@ -224,7 +224,7 @@ public class PathTemplateTransformer {
       for (String var : resourceNameConfig.getNameTemplate().vars()) {
         ParseResourceFunctionView.Builder function =
             ParseResourceFunctionView.newBuilder()
-                .entityName(resourceNameConfig.getEntityName())
+                .entityName(resourceNameConfig.getEntityName().toLowerUnderscore())
                 .name(namer.getParseFunctionName(var, resourceNameConfig))
                 .pathTemplateName(namer.getPathTemplateName(interfaceConfig, resourceNameConfig))
                 .pathTemplateGetterName(

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -56,7 +56,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
  * A SurfaceNamer provides language-specific names for specific components of a view for a surface.
@@ -879,28 +878,20 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   protected Name getResourceTypeNameObject(ResourceNameConfig resourceNameConfig) {
-    String entityName = resourceNameConfig.getEntityName();
+    Name entityName = resourceNameConfig.getEntityName();
     ResourceNameType resourceNameType = resourceNameConfig.getResourceNameType();
-    // Proto annotations use UpperCamelCase for resource names,
-    // and GAPIC config uses lower_snake_case, so we have to support both formats.
-    Function<String, Name> formatNameFunc;
-    if (entityName.length() > 0 && Character.isUpperCase(entityName.charAt(0))) {
-      formatNameFunc = Name::upperCamel;
-    } else {
-      formatNameFunc = Name::anyLower;
-    }
     switch (resourceNameType) {
       case ANY:
         return getAnyResourceTypeName();
       case FIXED:
-        return Name.anyLower(entityName).join("name_fixed");
+        return entityName.join("name_fixed");
       case ONEOF:
         // Remove suffix "_oneof". This allows the collection oneof config to "share" an entity name
         // with a collection config.
-        entityName = StringUtil.removeSuffix(entityName, "_oneof");
-        return formatNameFunc.apply(entityName).join("name_oneof");
+        entityName = Name.from(StringUtil.removeSuffix(entityName.toLowerUnderscore(), "_oneof"));
+        return entityName.join("name_oneof");
       case SINGLE:
-        return formatNameFunc.apply(entityName).join("name");
+        return entityName.join("name");
       case NONE:
       default:
         throw new UnsupportedOperationException("unexpected entity name type");
@@ -1212,25 +1203,26 @@ public class SurfaceNamer extends NameFormatterDelegator {
    */
   public String getPathTemplateName(
       InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
-    return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
+    return inittedConstantName(resourceNameConfig.getEntityName().join("path").join("template"));
   }
 
   /** The name of a getter function to get a particular path template for the given collection. */
   public String getPathTemplateNameGetter(
       InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return publicMethodName(
-        Name.from("get", resourceNameConfig.getEntityName(), "name", "template"));
+        Name.from("get").join(resourceNameConfig.getEntityName()).join("name").join("template"));
   }
 
   /** The name of the path template resource, in human format. */
   public String getPathTemplateResourcePhraseName(SingleResourceNameConfig resourceNameConfig) {
-    return Name.from(resourceNameConfig.getEntityName()).toPhrase();
+    return resourceNameConfig.getEntityName().toPhrase();
   }
 
   /** The function name to format the entity for the given collection. */
   public String getFormatFunctionName(
       InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
-    return staticFunctionName(Name.anyLower("format", resourceNameConfig.getEntityName(), "name"));
+    return staticFunctionName(
+        Name.from("format").join(resourceNameConfig.getEntityName()).join("name"));
   }
 
   /**
@@ -1239,17 +1231,17 @@ public class SurfaceNamer extends NameFormatterDelegator {
    */
   public String getParseFunctionName(String var, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(
-        Name.from("parse", var, "from", resourceNameConfig.getEntityName(), "name"));
+        Name.from("parse", var, "from").join(resourceNameConfig.getEntityName()).join("name"));
   }
 
   /** The entity name for the given collection. */
   public String getEntityName(SingleResourceNameConfig resourceNameConfig) {
-    return localVarName(Name.from(resourceNameConfig.getEntityName()));
+    return localVarName(resourceNameConfig.getEntityName());
   }
 
   /** The parameter name for the entity for the given collection config. */
   public String getEntityNameParamName(SingleResourceNameConfig resourceNameConfig) {
-    return localVarName(Name.from(resourceNameConfig.getEntityName(), "name"));
+    return localVarName(resourceNameConfig.getEntityName().join("name"));
   }
 
   /////////////////////////////////////// Page Streaming ////////////////////////////////////////

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -248,7 +248,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   @Override
   public String getPathTemplateName(
       InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
-    return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "template"));
+    return inittedConstantName(resourceNameConfig.getEntityName().join("template"));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -52,7 +52,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
 
 /** The SurfaceNamer for Java. */
 public class JavaSurfaceNamer extends SurfaceNamer {
@@ -300,28 +299,20 @@ public class JavaSurfaceNamer extends SurfaceNamer {
 
   @Override
   protected Name getResourceTypeNameObject(ResourceNameConfig resourceNameConfig) {
-    String entityName = resourceNameConfig.getEntityName();
+    Name entityName = resourceNameConfig.getEntityName();
     ResourceNameType resourceNameType = resourceNameConfig.getResourceNameType();
-    // Proto annotations use UpperCamelCase for resource names,
-    // and GAPIC config uses lower_snake_case, so we have to support both formats.
-    Function<String, Name> formatNameFunc;
-    if (entityName.length() > 0 && Character.isUpperCase(entityName.charAt(0))) {
-      formatNameFunc = Name::upperCamel;
-    } else {
-      formatNameFunc = Name::anyLower;
-    }
     switch (resourceNameType) {
       case ANY:
         return getAnyResourceTypeName();
       case FIXED:
-        return formatNameFunc.apply(entityName).join("name_fixed");
+        return entityName.join("name_fixed");
       case ONEOF:
         // Remove suffix "_oneof". This allows the collection oneof config to "share" an entity name
         // with a collection config.
-        entityName = StringUtil.removeSuffix(entityName, "_oneof");
-        return formatNameFunc.apply(entityName).join("name");
+        entityName = Name.from(StringUtil.removeSuffix(entityName.toLowerUnderscore(), "_oneof"));
+        return entityName.join("name");
       case SINGLE:
-        return formatNameFunc.apply(entityName).join("name");
+        return entityName.join("name");
       case NONE:
       default:
         throw new UnsupportedOperationException("unexpected entity name type");

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -173,19 +173,23 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   @Override
   public String getPathTemplateName(
       InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
-    return publicFieldName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
+    return publicFieldName(resourceNameConfig.getEntityName().join(Name.from("path", "template")));
   }
 
   @Override
   public String getParseFunctionName(String var, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(
-        Name.from("match", var, "from", resourceNameConfig.getEntityName(), "name"));
+        Name.from("match")
+            .join(var)
+            .join("from")
+            .join(resourceNameConfig.getEntityName())
+            .join("name"));
   }
 
   @Override
   public String getFormatFunctionName(
       InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
-    return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
+    return staticFunctionName(resourceNameConfig.getEntityName().join("path"));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -98,13 +98,14 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   @Override
   public String getFormatFunctionName(
       InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
-    return publicMethodName(Name.from(resourceNameConfig.getEntityName(), "name"));
+    return publicMethodName(resourceNameConfig.getEntityName().join("name"));
   }
 
   @Override
   public String getPathTemplateName(
       InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
-    return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "name", "template"));
+    return inittedConstantName(
+        resourceNameConfig.getEntityName().join(Name.from("name", "template")));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -248,19 +248,19 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   public String getPathTemplateName(
       InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return "_"
-        + inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
+        + inittedConstantName(resourceNameConfig.getEntityName().join("path").join("template"));
   }
 
   @Override
   public String getFormatFunctionName(
       InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
-    return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
+    return staticFunctionName(resourceNameConfig.getEntityName().join("path"));
   }
 
   @Override
   public String getParseFunctionName(String var, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(
-        Name.from("match", var, "from", resourceNameConfig.getEntityName(), "name"));
+        Name.from("match", var, "from").join(resourceNameConfig.getEntityName()).join("name"));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -94,13 +94,13 @@ public class RubySurfaceNamer extends SurfaceNamer {
   @Override
   public String getFormatFunctionName(
       InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
-    return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
+    return staticFunctionName(resourceNameConfig.getEntityName().join("path"));
   }
 
   @Override
   public String getParseFunctionName(String var, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(
-        Name.from("match", var, "from", resourceNameConfig.getEntityName(), "name"));
+        Name.from("match", var, "from").join(resourceNameConfig.getEntityName()).join("name"));
   }
 
   @Override

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -363,7 +363,7 @@ message SampleInitAttribute {
   // should be accepted as a parameter, with the given name, to the sample function.
   string sample_argument_name = 2;
 
-  // If `read_file` is true, then during sample initialization, the value of this 
+  // If `read_file` is true, then during sample initialization, the value of this
   // attribute gets replaced by the contents of the local file with the given name.
   // This is only allowed when this parameter is a bytes field.
   // If this parameter is required or optional, the original value of this parameter
@@ -700,7 +700,7 @@ message OutputSpec {
     repeated OutputSpec body = 3;
 
     // The map over which to iterate.
-    // Exactly one of `map` and `collection` should be specified. 
+    // Exactly one of `map` and `collection` should be specified.
     string map = 4;
 
     // The iteration variable for key.


### PR DESCRIPTION
Methods that call ResourceNameConfig.getEntityName() pretty much immediately convert it to a Name anyways. 

By making it a `Name`, we can take care of parsing the CamelCasing/snake_casing in one place, during construction, rather than trying to convert a weird String entityName into a Name in many other places.

Also make SingleResourceNameConfig an AutoValue.Builder built object so we can alter it via `toBuilder()` later on.