### PR TITLE
Fix empty method signature bug

### DIFF
--- a/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
@@ -145,9 +145,6 @@ public abstract class FlatteningConfig {
     List<List<String>> methodSignatures =
         protoParser.getMethodSignatures(methodModel.getProtoMethod());
     for (List<String> signature : methodSignatures) {
-      if (signature.isEmpty()) {
-        break;
-      }
       FlatteningConfig groupConfig =
           FlatteningConfig.createFlatteningFromProtoFile(
               diagCollector,

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -116,12 +116,30 @@ import com.google.api.pathtemplate.PathTemplate;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.stub.LibraryServiceStub;
 import com.google.example.library.v1.stub.LibraryServiceStubSettings;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsClient;
+import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Empty;
 import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
 import com.google.tagger.v1.TaggerProto.AddTagRequest;
 import com.google.tagger.v1.TaggerProto.AddTagResponse;
 import java.io.Closeable;
@@ -559,6 +577,28 @@ public class LibraryServiceClient implements BackgroundResource {
    */
   public final UnaryCallable<GetShelfRequest, Shelf> getShelfCallable() {
     return stub.getShelfCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists shelves.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *
+   *   ListShelvesResponse response = libraryServiceClient.listShelves();
+   * }
+   * </code></pre>
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListShelvesResponse listShelves() {
+
+    ListShelvesRequest request =
+        ListShelvesRequest.newBuilder()
+
+        .build();
+    return listShelves(request);
   }
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
@@ -1571,6 +1611,54 @@ public class LibraryServiceClient implements BackgroundResource {
    */
   public final UnaryCallable<MoveBookRequest, Book> moveBookCallable() {
     return stub.moveBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *
+   *   for (String element : libraryServiceClient.listStrings().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListStringsPagedResponse listStrings() {
+    ListStringsRequest request =
+        ListStringsRequest.newBuilder()
+
+        .build();
+    return listStrings(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   String name = "";
+   *   for (String element : libraryServiceClient.listStrings(name).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param name
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListStringsPagedResponse listStrings(String name) {
+    ListStringsRequest request =
+        ListStringsRequest.newBuilder()
+        .setName(name)
+        .build();
+    return listStrings(request);
   }
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
@@ -2680,6 +2768,610 @@ public class LibraryServiceClient implements BackgroundResource {
    */
   public final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable() {
     return stub.getBigNothingCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test optional flattening parameters of all types
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *
+   *   TestOptionalRequiredFlatteningParamsResponse response = libraryServiceClient.testOptionalRequiredFlatteningParams();
+   * }
+   * </code></pre>
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final TestOptionalRequiredFlatteningParamsResponse testOptionalRequiredFlatteningParams() {
+
+    TestOptionalRequiredFlatteningParamsRequest request =
+        TestOptionalRequiredFlatteningParamsRequest.newBuilder()
+
+        .build();
+    return testOptionalRequiredFlatteningParams(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test optional flattening parameters of all types
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   int requiredSingularInt32 = 0;
+   *   long requiredSingularInt64 = 0L;
+   *   float requiredSingularFloat = 0.0F;
+   *   double requiredSingularDouble = 0.0;
+   *   boolean requiredSingularBool = false;
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   *   String requiredSingularString = "";
+   *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+   *   BookName requiredSingularResourceName = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName requiredSingularResourceNameOneof = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+   *   int requiredSingularFixed32 = 0;
+   *   long requiredSingularFixed64 = 0L;
+   *   List&lt;Integer&gt; requiredRepeatedInt32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedInt64 = new ArrayList&lt;&gt;();
+   *   List&lt;Float&gt; requiredRepeatedFloat = new ArrayList&lt;&gt;();
+   *   List&lt;Double&gt; requiredRepeatedDouble = new ArrayList&lt;&gt;();
+   *   List&lt;Boolean&gt; requiredRepeatedBool = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerEnum&gt; requiredRepeatedEnum = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; requiredRepeatedString = new ArrayList&lt;&gt;();
+   *   List&lt;ByteString&gt; requiredRepeatedBytes = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedRequiredRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedRequiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedRequiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
+   *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
+   *   Map&lt;Integer, String&gt; requiredMap = new HashMap&lt;&gt;();
+   *   int optionalSingularInt32 = 0;
+   *   long optionalSingularInt64 = 0L;
+   *   float optionalSingularFloat = 0.0F;
+   *   double optionalSingularDouble = 0.0;
+   *   boolean optionalSingularBool = false;
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   *   String optionalSingularString = "";
+   *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+   *   BookName optionalSingularResourceName = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName optionalSingularResourceNameOneof = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+   *   int optionalSingularFixed32 = 0;
+   *   long optionalSingularFixed64 = 0L;
+   *   List&lt;Integer&gt; optionalRepeatedInt32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; optionalRepeatedInt64 = new ArrayList&lt;&gt;();
+   *   List&lt;Float&gt; optionalRepeatedFloat = new ArrayList&lt;&gt;();
+   *   List&lt;Double&gt; optionalRepeatedDouble = new ArrayList&lt;&gt;();
+   *   List&lt;Boolean&gt; optionalRepeatedBool = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerEnum&gt; optionalRepeatedEnum = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; optionalRepeatedString = new ArrayList&lt;&gt;();
+   *   List&lt;ByteString&gt; optionalRepeatedBytes = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; optionalRepeatedMessage = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedOptionalRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedOptionalRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedOptionalRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
+   *   List&lt;Integer&gt; optionalRepeatedFixed32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; optionalRepeatedFixed64 = new ArrayList&lt;&gt;();
+   *   Map&lt;Integer, String&gt; optionalMap = new HashMap&lt;&gt;();
+   *   Any anyValue = Any.newBuilder().build();
+   *   Struct structValue = Struct.newBuilder().build();
+   *   Value valueValue = Value.newBuilder().build();
+   *   ListValue listValueValue = ListValue.newBuilder().build();
+   *   Timestamp timeValue = Timestamp.newBuilder().build();
+   *   Duration durationValue = Duration.newBuilder().build();
+   *   FieldMask fieldMaskValue = FieldMask.newBuilder().build();
+   *   Int32Value int32Value = Int32Value.newBuilder().build();
+   *   UInt32Value uint32Value = UInt32Value.newBuilder().build();
+   *   Int64Value int64Value = Int64Value.newBuilder().build();
+   *   UInt64Value uint64Value = UInt64Value.newBuilder().build();
+   *   FloatValue floatValue = FloatValue.newBuilder().build();
+   *   DoubleValue doubleValue = DoubleValue.newBuilder().build();
+   *   StringValue stringValue = StringValue.newBuilder().build();
+   *   BoolValue boolValue = BoolValue.newBuilder().build();
+   *   BytesValue bytesValue = BytesValue.newBuilder().build();
+   *   List&lt;Any&gt; repeatedAnyValue = new ArrayList&lt;&gt;();
+   *   List&lt;Struct&gt; repeatedStructValue = new ArrayList&lt;&gt;();
+   *   List&lt;Value&gt; repeatedValueValue = new ArrayList&lt;&gt;();
+   *   List&lt;ListValue&gt; repeatedListValueValue = new ArrayList&lt;&gt;();
+   *   List&lt;Timestamp&gt; repeatedTimeValue = new ArrayList&lt;&gt;();
+   *   List&lt;Duration&gt; repeatedDurationValue = new ArrayList&lt;&gt;();
+   *   List&lt;FieldMask&gt; repeatedFieldMaskValue = new ArrayList&lt;&gt;();
+   *   List&lt;Int32Value&gt; repeatedInt32Value = new ArrayList&lt;&gt;();
+   *   List&lt;UInt32Value&gt; repeatedUint32Value = new ArrayList&lt;&gt;();
+   *   List&lt;Int64Value&gt; repeatedInt64Value = new ArrayList&lt;&gt;();
+   *   List&lt;UInt64Value&gt; repeatedUint64Value = new ArrayList&lt;&gt;();
+   *   List&lt;FloatValue&gt; repeatedFloatValue = new ArrayList&lt;&gt;();
+   *   List&lt;DoubleValue&gt; repeatedDoubleValue = new ArrayList&lt;&gt;();
+   *   List&lt;StringValue&gt; repeatedStringValue = new ArrayList&lt;&gt;();
+   *   List&lt;BoolValue&gt; repeatedBoolValue = new ArrayList&lt;&gt;();
+   *   List&lt;BytesValue&gt; repeatedBytesValue = new ArrayList&lt;&gt;();
+   *   TestOptionalRequiredFlatteningParamsResponse response = libraryServiceClient.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName.toString(), requiredSingularResourceNameOneof.toString(), requiredSingularResourceNameCommon.toString(), requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, formattedRequiredRepeatedResourceName, formattedRequiredRepeatedResourceNameOneof, formattedRequiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName.toString(), optionalSingularResourceNameOneof.toString(), optionalSingularResourceNameCommon.toString(), optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, formattedOptionalRepeatedResourceName, formattedOptionalRepeatedResourceNameOneof, formattedOptionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap, anyValue, structValue, valueValue, listValueValue, timeValue, durationValue, fieldMaskValue, int32Value, uint32Value, int64Value, uint64Value, floatValue, doubleValue, stringValue, boolValue, bytesValue, repeatedAnyValue, repeatedStructValue, repeatedValueValue, repeatedListValueValue, repeatedTimeValue, repeatedDurationValue, repeatedFieldMaskValue, repeatedInt32Value, repeatedUint32Value, repeatedInt64Value, repeatedUint64Value, repeatedFloatValue, repeatedDoubleValue, repeatedStringValue, repeatedBoolValue, repeatedBytesValue);
+   * }
+   * </code></pre>
+   *
+   * @param requiredSingularInt32
+   * @param requiredSingularInt64
+   * @param requiredSingularFloat
+   * @param requiredSingularDouble
+   * @param requiredSingularBool
+   * @param requiredSingularEnum
+   * @param requiredSingularString
+   * @param requiredSingularBytes
+   * @param requiredSingularMessage
+   * @param requiredSingularResourceName
+   * @param requiredSingularResourceNameOneof
+   * @param requiredSingularResourceNameCommon
+   * @param requiredSingularFixed32
+   * @param requiredSingularFixed64
+   * @param requiredRepeatedInt32
+   * @param requiredRepeatedInt64
+   * @param requiredRepeatedFloat
+   * @param requiredRepeatedDouble
+   * @param requiredRepeatedBool
+   * @param requiredRepeatedEnum
+   * @param requiredRepeatedString
+   * @param requiredRepeatedBytes
+   * @param requiredRepeatedMessage
+   * @param requiredRepeatedResourceName
+   * @param requiredRepeatedResourceNameOneof
+   * @param requiredRepeatedResourceNameCommon
+   * @param requiredRepeatedFixed32
+   * @param requiredRepeatedFixed64
+   * @param requiredMap
+   * @param optionalSingularInt32
+   * @param optionalSingularInt64
+   * @param optionalSingularFloat
+   * @param optionalSingularDouble
+   * @param optionalSingularBool
+   * @param optionalSingularEnum
+   * @param optionalSingularString
+   * @param optionalSingularBytes
+   * @param optionalSingularMessage
+   * @param optionalSingularResourceName
+   * @param optionalSingularResourceNameOneof
+   * @param optionalSingularResourceNameCommon
+   * @param optionalSingularFixed32
+   * @param optionalSingularFixed64
+   * @param optionalRepeatedInt32
+   * @param optionalRepeatedInt64
+   * @param optionalRepeatedFloat
+   * @param optionalRepeatedDouble
+   * @param optionalRepeatedBool
+   * @param optionalRepeatedEnum
+   * @param optionalRepeatedString
+   * @param optionalRepeatedBytes
+   * @param optionalRepeatedMessage
+   * @param optionalRepeatedResourceName
+   * @param optionalRepeatedResourceNameOneof
+   * @param optionalRepeatedResourceNameCommon
+   * @param optionalRepeatedFixed32
+   * @param optionalRepeatedFixed64
+   * @param optionalMap
+   * @param anyValue
+   * @param structValue
+   * @param valueValue
+   * @param listValueValue
+   * @param timeValue
+   * @param durationValue
+   * @param fieldMaskValue
+   * @param int32Value
+   * @param uint32Value
+   * @param int64Value
+   * @param uint64Value
+   * @param floatValue
+   * @param doubleValue
+   * @param stringValue
+   * @param boolValue
+   * @param bytesValue
+   * @param repeatedAnyValue
+   * @param repeatedStructValue
+   * @param repeatedValueValue
+   * @param repeatedListValueValue
+   * @param repeatedTimeValue
+   * @param repeatedDurationValue
+   * @param repeatedFieldMaskValue
+   * @param repeatedInt32Value
+   * @param repeatedUint32Value
+   * @param repeatedInt64Value
+   * @param repeatedUint64Value
+   * @param repeatedFloatValue
+   * @param repeatedDoubleValue
+   * @param repeatedStringValue
+   * @param repeatedBoolValue
+   * @param repeatedBytesValue
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final TestOptionalRequiredFlatteningParamsResponse testOptionalRequiredFlatteningParams(int requiredSingularInt32, long requiredSingularInt64, float requiredSingularFloat, double requiredSingularDouble, boolean requiredSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum, String requiredSingularString, ByteString requiredSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage, String requiredSingularResourceName, String requiredSingularResourceNameOneof, String requiredSingularResourceNameCommon, int requiredSingularFixed32, long requiredSingularFixed64, List<Integer> requiredRepeatedInt32, List<Long> requiredRepeatedInt64, List<Float> requiredRepeatedFloat, List<Double> requiredRepeatedDouble, List<Boolean> requiredRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum, List<String> requiredRepeatedString, List<ByteString> requiredRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage, List<String> requiredRepeatedResourceName, List<String> requiredRepeatedResourceNameOneof, List<String> requiredRepeatedResourceNameCommon, List<Integer> requiredRepeatedFixed32, List<Long> requiredRepeatedFixed64, Map<Integer, String> requiredMap, int optionalSingularInt32, long optionalSingularInt64, float optionalSingularFloat, double optionalSingularDouble, boolean optionalSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum, String optionalSingularString, ByteString optionalSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage, String optionalSingularResourceName, String optionalSingularResourceNameOneof, String optionalSingularResourceNameCommon, int optionalSingularFixed32, long optionalSingularFixed64, List<Integer> optionalRepeatedInt32, List<Long> optionalRepeatedInt64, List<Float> optionalRepeatedFloat, List<Double> optionalRepeatedDouble, List<Boolean> optionalRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum, List<String> optionalRepeatedString, List<ByteString> optionalRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage, List<String> optionalRepeatedResourceName, List<String> optionalRepeatedResourceNameOneof, List<String> optionalRepeatedResourceNameCommon, List<Integer> optionalRepeatedFixed32, List<Long> optionalRepeatedFixed64, Map<Integer, String> optionalMap, Any anyValue, Struct structValue, Value valueValue, ListValue listValueValue, Timestamp timeValue, Duration durationValue, FieldMask fieldMaskValue, Int32Value int32Value, UInt32Value uint32Value, Int64Value int64Value, UInt64Value uint64Value, FloatValue floatValue, DoubleValue doubleValue, StringValue stringValue, BoolValue boolValue, BytesValue bytesValue, List<Any> repeatedAnyValue, List<Struct> repeatedStructValue, List<Value> repeatedValueValue, List<ListValue> repeatedListValueValue, List<Timestamp> repeatedTimeValue, List<Duration> repeatedDurationValue, List<FieldMask> repeatedFieldMaskValue, List<Int32Value> repeatedInt32Value, List<UInt32Value> repeatedUint32Value, List<Int64Value> repeatedInt64Value, List<UInt64Value> repeatedUint64Value, List<FloatValue> repeatedFloatValue, List<DoubleValue> repeatedDoubleValue, List<StringValue> repeatedStringValue, List<BoolValue> repeatedBoolValue, List<BytesValue> repeatedBytesValue) {
+
+    TestOptionalRequiredFlatteningParamsRequest request =
+        TestOptionalRequiredFlatteningParamsRequest.newBuilder()
+        .setRequiredSingularInt32(requiredSingularInt32)
+        .setRequiredSingularInt64(requiredSingularInt64)
+        .setRequiredSingularFloat(requiredSingularFloat)
+        .setRequiredSingularDouble(requiredSingularDouble)
+        .setRequiredSingularBool(requiredSingularBool)
+        .setRequiredSingularEnum(requiredSingularEnum)
+        .setRequiredSingularString(requiredSingularString)
+        .setRequiredSingularBytes(requiredSingularBytes)
+        .setRequiredSingularMessage(requiredSingularMessage)
+        .setRequiredSingularResourceName(requiredSingularResourceName)
+        .setRequiredSingularResourceNameOneof(requiredSingularResourceNameOneof)
+        .setRequiredSingularResourceNameCommon(requiredSingularResourceNameCommon)
+        .setRequiredSingularFixed32(requiredSingularFixed32)
+        .setRequiredSingularFixed64(requiredSingularFixed64)
+        .addAllRequiredRepeatedInt32(requiredRepeatedInt32)
+        .addAllRequiredRepeatedInt64(requiredRepeatedInt64)
+        .addAllRequiredRepeatedFloat(requiredRepeatedFloat)
+        .addAllRequiredRepeatedDouble(requiredRepeatedDouble)
+        .addAllRequiredRepeatedBool(requiredRepeatedBool)
+        .addAllRequiredRepeatedEnum(requiredRepeatedEnum)
+        .addAllRequiredRepeatedString(requiredRepeatedString)
+        .addAllRequiredRepeatedBytes(requiredRepeatedBytes)
+        .addAllRequiredRepeatedMessage(requiredRepeatedMessage)
+        .addAllRequiredRepeatedResourceName(requiredRepeatedResourceName)
+        .addAllRequiredRepeatedResourceNameOneof(requiredRepeatedResourceNameOneof)
+        .addAllRequiredRepeatedResourceNameCommon(requiredRepeatedResourceNameCommon)
+        .addAllRequiredRepeatedFixed32(requiredRepeatedFixed32)
+        .addAllRequiredRepeatedFixed64(requiredRepeatedFixed64)
+        .putAllRequiredMap(requiredMap)
+        .setOptionalSingularInt32(optionalSingularInt32)
+        .setOptionalSingularInt64(optionalSingularInt64)
+        .setOptionalSingularFloat(optionalSingularFloat)
+        .setOptionalSingularDouble(optionalSingularDouble)
+        .setOptionalSingularBool(optionalSingularBool)
+        .setOptionalSingularEnum(optionalSingularEnum)
+        .setOptionalSingularString(optionalSingularString)
+        .setOptionalSingularBytes(optionalSingularBytes)
+        .setOptionalSingularMessage(optionalSingularMessage)
+        .setOptionalSingularResourceName(optionalSingularResourceName)
+        .setOptionalSingularResourceNameOneof(optionalSingularResourceNameOneof)
+        .setOptionalSingularResourceNameCommon(optionalSingularResourceNameCommon)
+        .setOptionalSingularFixed32(optionalSingularFixed32)
+        .setOptionalSingularFixed64(optionalSingularFixed64)
+        .addAllOptionalRepeatedInt32(optionalRepeatedInt32)
+        .addAllOptionalRepeatedInt64(optionalRepeatedInt64)
+        .addAllOptionalRepeatedFloat(optionalRepeatedFloat)
+        .addAllOptionalRepeatedDouble(optionalRepeatedDouble)
+        .addAllOptionalRepeatedBool(optionalRepeatedBool)
+        .addAllOptionalRepeatedEnum(optionalRepeatedEnum)
+        .addAllOptionalRepeatedString(optionalRepeatedString)
+        .addAllOptionalRepeatedBytes(optionalRepeatedBytes)
+        .addAllOptionalRepeatedMessage(optionalRepeatedMessage)
+        .addAllOptionalRepeatedResourceName(optionalRepeatedResourceName)
+        .addAllOptionalRepeatedResourceNameOneof(optionalRepeatedResourceNameOneof)
+        .addAllOptionalRepeatedResourceNameCommon(optionalRepeatedResourceNameCommon)
+        .addAllOptionalRepeatedFixed32(optionalRepeatedFixed32)
+        .addAllOptionalRepeatedFixed64(optionalRepeatedFixed64)
+        .putAllOptionalMap(optionalMap)
+        .setAnyValue(anyValue)
+        .setStructValue(structValue)
+        .setValueValue(valueValue)
+        .setListValueValue(listValueValue)
+        .setTimeValue(timeValue)
+        .setDurationValue(durationValue)
+        .setFieldMaskValue(fieldMaskValue)
+        .setInt32Value(int32Value)
+        .setUint32Value(uint32Value)
+        .setInt64Value(int64Value)
+        .setUint64Value(uint64Value)
+        .setFloatValue(floatValue)
+        .setDoubleValue(doubleValue)
+        .setStringValue(stringValue)
+        .setBoolValue(boolValue)
+        .setBytesValue(bytesValue)
+        .addAllRepeatedAnyValue(repeatedAnyValue)
+        .addAllRepeatedStructValue(repeatedStructValue)
+        .addAllRepeatedValueValue(repeatedValueValue)
+        .addAllRepeatedListValueValue(repeatedListValueValue)
+        .addAllRepeatedTimeValue(repeatedTimeValue)
+        .addAllRepeatedDurationValue(repeatedDurationValue)
+        .addAllRepeatedFieldMaskValue(repeatedFieldMaskValue)
+        .addAllRepeatedInt32Value(repeatedInt32Value)
+        .addAllRepeatedUint32Value(repeatedUint32Value)
+        .addAllRepeatedInt64Value(repeatedInt64Value)
+        .addAllRepeatedUint64Value(repeatedUint64Value)
+        .addAllRepeatedFloatValue(repeatedFloatValue)
+        .addAllRepeatedDoubleValue(repeatedDoubleValue)
+        .addAllRepeatedStringValue(repeatedStringValue)
+        .addAllRepeatedBoolValue(repeatedBoolValue)
+        .addAllRepeatedBytesValue(repeatedBytesValue)
+        .build();
+    return testOptionalRequiredFlatteningParams(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test optional flattening parameters of all types
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   int requiredSingularInt32 = 0;
+   *   long requiredSingularInt64 = 0L;
+   *   float requiredSingularFloat = 0.0F;
+   *   double requiredSingularDouble = 0.0;
+   *   boolean requiredSingularBool = false;
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   *   String requiredSingularString = "";
+   *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+   *   String formattedRequiredSingularResourceName = BookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedRequiredSingularResourceNameOneof = BookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedRequiredSingularResourceNameCommon = ProjectName.format("[PROJECT]");
+   *   int requiredSingularFixed32 = 0;
+   *   long requiredSingularFixed64 = 0L;
+   *   List&lt;Integer&gt; requiredRepeatedInt32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedInt64 = new ArrayList&lt;&gt;();
+   *   List&lt;Float&gt; requiredRepeatedFloat = new ArrayList&lt;&gt;();
+   *   List&lt;Double&gt; requiredRepeatedDouble = new ArrayList&lt;&gt;();
+   *   List&lt;Boolean&gt; requiredRepeatedBool = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerEnum&gt; requiredRepeatedEnum = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; requiredRepeatedString = new ArrayList&lt;&gt;();
+   *   List&lt;ByteString&gt; requiredRepeatedBytes = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedRequiredRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedRequiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedRequiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
+   *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
+   *   Map&lt;Integer, String&gt; requiredMap = new HashMap&lt;&gt;();
+   *   int optionalSingularInt32 = 0;
+   *   long optionalSingularInt64 = 0L;
+   *   float optionalSingularFloat = 0.0F;
+   *   double optionalSingularDouble = 0.0;
+   *   boolean optionalSingularBool = false;
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   *   String optionalSingularString = "";
+   *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
+   *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+   *   String formattedOptionalSingularResourceName = BookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedOptionalSingularResourceNameOneof = BookName.format("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedOptionalSingularResourceNameCommon = ProjectName.format("[PROJECT]");
+   *   int optionalSingularFixed32 = 0;
+   *   long optionalSingularFixed64 = 0L;
+   *   List&lt;Integer&gt; optionalRepeatedInt32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; optionalRepeatedInt64 = new ArrayList&lt;&gt;();
+   *   List&lt;Float&gt; optionalRepeatedFloat = new ArrayList&lt;&gt;();
+   *   List&lt;Double&gt; optionalRepeatedDouble = new ArrayList&lt;&gt;();
+   *   List&lt;Boolean&gt; optionalRepeatedBool = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerEnum&gt; optionalRepeatedEnum = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; optionalRepeatedString = new ArrayList&lt;&gt;();
+   *   List&lt;ByteString&gt; optionalRepeatedBytes = new ArrayList&lt;&gt;();
+   *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; optionalRepeatedMessage = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedOptionalRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedOptionalRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;String&gt; formattedOptionalRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
+   *   List&lt;Integer&gt; optionalRepeatedFixed32 = new ArrayList&lt;&gt;();
+   *   List&lt;Long&gt; optionalRepeatedFixed64 = new ArrayList&lt;&gt;();
+   *   Map&lt;Integer, String&gt; optionalMap = new HashMap&lt;&gt;();
+   *   Any anyValue = Any.newBuilder().build();
+   *   Struct structValue = Struct.newBuilder().build();
+   *   Value valueValue = Value.newBuilder().build();
+   *   ListValue listValueValue = ListValue.newBuilder().build();
+   *   Timestamp timeValue = Timestamp.newBuilder().build();
+   *   Duration durationValue = Duration.newBuilder().build();
+   *   FieldMask fieldMaskValue = FieldMask.newBuilder().build();
+   *   Int32Value int32Value = Int32Value.newBuilder().build();
+   *   UInt32Value uint32Value = UInt32Value.newBuilder().build();
+   *   Int64Value int64Value = Int64Value.newBuilder().build();
+   *   UInt64Value uint64Value = UInt64Value.newBuilder().build();
+   *   FloatValue floatValue = FloatValue.newBuilder().build();
+   *   DoubleValue doubleValue = DoubleValue.newBuilder().build();
+   *   StringValue stringValue = StringValue.newBuilder().build();
+   *   BoolValue boolValue = BoolValue.newBuilder().build();
+   *   BytesValue bytesValue = BytesValue.newBuilder().build();
+   *   List&lt;Any&gt; repeatedAnyValue = new ArrayList&lt;&gt;();
+   *   List&lt;Struct&gt; repeatedStructValue = new ArrayList&lt;&gt;();
+   *   List&lt;Value&gt; repeatedValueValue = new ArrayList&lt;&gt;();
+   *   List&lt;ListValue&gt; repeatedListValueValue = new ArrayList&lt;&gt;();
+   *   List&lt;Timestamp&gt; repeatedTimeValue = new ArrayList&lt;&gt;();
+   *   List&lt;Duration&gt; repeatedDurationValue = new ArrayList&lt;&gt;();
+   *   List&lt;FieldMask&gt; repeatedFieldMaskValue = new ArrayList&lt;&gt;();
+   *   List&lt;Int32Value&gt; repeatedInt32Value = new ArrayList&lt;&gt;();
+   *   List&lt;UInt32Value&gt; repeatedUint32Value = new ArrayList&lt;&gt;();
+   *   List&lt;Int64Value&gt; repeatedInt64Value = new ArrayList&lt;&gt;();
+   *   List&lt;UInt64Value&gt; repeatedUint64Value = new ArrayList&lt;&gt;();
+   *   List&lt;FloatValue&gt; repeatedFloatValue = new ArrayList&lt;&gt;();
+   *   List&lt;DoubleValue&gt; repeatedDoubleValue = new ArrayList&lt;&gt;();
+   *   List&lt;StringValue&gt; repeatedStringValue = new ArrayList&lt;&gt;();
+   *   List&lt;BoolValue&gt; repeatedBoolValue = new ArrayList&lt;&gt;();
+   *   List&lt;BytesValue&gt; repeatedBytesValue = new ArrayList&lt;&gt;();
+   *   TestOptionalRequiredFlatteningParamsResponse response = libraryServiceClient.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, formattedRequiredSingularResourceName, formattedRequiredSingularResourceNameOneof, formattedRequiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, formattedRequiredRepeatedResourceName, formattedRequiredRepeatedResourceNameOneof, formattedRequiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, formattedOptionalSingularResourceName, formattedOptionalSingularResourceNameOneof, formattedOptionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, formattedOptionalRepeatedResourceName, formattedOptionalRepeatedResourceNameOneof, formattedOptionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap, anyValue, structValue, valueValue, listValueValue, timeValue, durationValue, fieldMaskValue, int32Value, uint32Value, int64Value, uint64Value, floatValue, doubleValue, stringValue, boolValue, bytesValue, repeatedAnyValue, repeatedStructValue, repeatedValueValue, repeatedListValueValue, repeatedTimeValue, repeatedDurationValue, repeatedFieldMaskValue, repeatedInt32Value, repeatedUint32Value, repeatedInt64Value, repeatedUint64Value, repeatedFloatValue, repeatedDoubleValue, repeatedStringValue, repeatedBoolValue, repeatedBytesValue);
+   * }
+   * </code></pre>
+   *
+   * @param requiredSingularInt32
+   * @param requiredSingularInt64
+   * @param requiredSingularFloat
+   * @param requiredSingularDouble
+   * @param requiredSingularBool
+   * @param requiredSingularEnum
+   * @param requiredSingularString
+   * @param requiredSingularBytes
+   * @param requiredSingularMessage
+   * @param requiredSingularResourceName
+   * @param requiredSingularResourceNameOneof
+   * @param requiredSingularResourceNameCommon
+   * @param requiredSingularFixed32
+   * @param requiredSingularFixed64
+   * @param requiredRepeatedInt32
+   * @param requiredRepeatedInt64
+   * @param requiredRepeatedFloat
+   * @param requiredRepeatedDouble
+   * @param requiredRepeatedBool
+   * @param requiredRepeatedEnum
+   * @param requiredRepeatedString
+   * @param requiredRepeatedBytes
+   * @param requiredRepeatedMessage
+   * @param requiredRepeatedResourceName
+   * @param requiredRepeatedResourceNameOneof
+   * @param requiredRepeatedResourceNameCommon
+   * @param requiredRepeatedFixed32
+   * @param requiredRepeatedFixed64
+   * @param requiredMap
+   * @param optionalSingularInt32
+   * @param optionalSingularInt64
+   * @param optionalSingularFloat
+   * @param optionalSingularDouble
+   * @param optionalSingularBool
+   * @param optionalSingularEnum
+   * @param optionalSingularString
+   * @param optionalSingularBytes
+   * @param optionalSingularMessage
+   * @param optionalSingularResourceName
+   * @param optionalSingularResourceNameOneof
+   * @param optionalSingularResourceNameCommon
+   * @param optionalSingularFixed32
+   * @param optionalSingularFixed64
+   * @param optionalRepeatedInt32
+   * @param optionalRepeatedInt64
+   * @param optionalRepeatedFloat
+   * @param optionalRepeatedDouble
+   * @param optionalRepeatedBool
+   * @param optionalRepeatedEnum
+   * @param optionalRepeatedString
+   * @param optionalRepeatedBytes
+   * @param optionalRepeatedMessage
+   * @param optionalRepeatedResourceName
+   * @param optionalRepeatedResourceNameOneof
+   * @param optionalRepeatedResourceNameCommon
+   * @param optionalRepeatedFixed32
+   * @param optionalRepeatedFixed64
+   * @param optionalMap
+   * @param anyValue
+   * @param structValue
+   * @param valueValue
+   * @param listValueValue
+   * @param timeValue
+   * @param durationValue
+   * @param fieldMaskValue
+   * @param int32Value
+   * @param uint32Value
+   * @param int64Value
+   * @param uint64Value
+   * @param floatValue
+   * @param doubleValue
+   * @param stringValue
+   * @param boolValue
+   * @param bytesValue
+   * @param repeatedAnyValue
+   * @param repeatedStructValue
+   * @param repeatedValueValue
+   * @param repeatedListValueValue
+   * @param repeatedTimeValue
+   * @param repeatedDurationValue
+   * @param repeatedFieldMaskValue
+   * @param repeatedInt32Value
+   * @param repeatedUint32Value
+   * @param repeatedInt64Value
+   * @param repeatedUint64Value
+   * @param repeatedFloatValue
+   * @param repeatedDoubleValue
+   * @param repeatedStringValue
+   * @param repeatedBoolValue
+   * @param repeatedBytesValue
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final TestOptionalRequiredFlatteningParamsResponse testOptionalRequiredFlatteningParams(int requiredSingularInt32, long requiredSingularInt64, float requiredSingularFloat, double requiredSingularDouble, boolean requiredSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum, String requiredSingularString, ByteString requiredSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage, String requiredSingularResourceName, String requiredSingularResourceNameOneof, String requiredSingularResourceNameCommon, int requiredSingularFixed32, long requiredSingularFixed64, List<Integer> requiredRepeatedInt32, List<Long> requiredRepeatedInt64, List<Float> requiredRepeatedFloat, List<Double> requiredRepeatedDouble, List<Boolean> requiredRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum, List<String> requiredRepeatedString, List<ByteString> requiredRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage, List<String> requiredRepeatedResourceName, List<String> requiredRepeatedResourceNameOneof, List<String> requiredRepeatedResourceNameCommon, List<Integer> requiredRepeatedFixed32, List<Long> requiredRepeatedFixed64, Map<Integer, String> requiredMap, int optionalSingularInt32, long optionalSingularInt64, float optionalSingularFloat, double optionalSingularDouble, boolean optionalSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum, String optionalSingularString, ByteString optionalSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage, String optionalSingularResourceName, String optionalSingularResourceNameOneof, String optionalSingularResourceNameCommon, int optionalSingularFixed32, long optionalSingularFixed64, List<Integer> optionalRepeatedInt32, List<Long> optionalRepeatedInt64, List<Float> optionalRepeatedFloat, List<Double> optionalRepeatedDouble, List<Boolean> optionalRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum, List<String> optionalRepeatedString, List<ByteString> optionalRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage, List<String> optionalRepeatedResourceName, List<String> optionalRepeatedResourceNameOneof, List<String> optionalRepeatedResourceNameCommon, List<Integer> optionalRepeatedFixed32, List<Long> optionalRepeatedFixed64, Map<Integer, String> optionalMap, Any anyValue, Struct structValue, Value valueValue, ListValue listValueValue, Timestamp timeValue, Duration durationValue, FieldMask fieldMaskValue, Int32Value int32Value, UInt32Value uint32Value, Int64Value int64Value, UInt64Value uint64Value, FloatValue floatValue, DoubleValue doubleValue, StringValue stringValue, BoolValue boolValue, BytesValue bytesValue, List<Any> repeatedAnyValue, List<Struct> repeatedStructValue, List<Value> repeatedValueValue, List<ListValue> repeatedListValueValue, List<Timestamp> repeatedTimeValue, List<Duration> repeatedDurationValue, List<FieldMask> repeatedFieldMaskValue, List<Int32Value> repeatedInt32Value, List<UInt32Value> repeatedUint32Value, List<Int64Value> repeatedInt64Value, List<UInt64Value> repeatedUint64Value, List<FloatValue> repeatedFloatValue, List<DoubleValue> repeatedDoubleValue, List<StringValue> repeatedStringValue, List<BoolValue> repeatedBoolValue, List<BytesValue> repeatedBytesValue) {
+
+    TestOptionalRequiredFlatteningParamsRequest request =
+        TestOptionalRequiredFlatteningParamsRequest.newBuilder()
+        .setRequiredSingularInt32(requiredSingularInt32)
+        .setRequiredSingularInt64(requiredSingularInt64)
+        .setRequiredSingularFloat(requiredSingularFloat)
+        .setRequiredSingularDouble(requiredSingularDouble)
+        .setRequiredSingularBool(requiredSingularBool)
+        .setRequiredSingularEnum(requiredSingularEnum)
+        .setRequiredSingularString(requiredSingularString)
+        .setRequiredSingularBytes(requiredSingularBytes)
+        .setRequiredSingularMessage(requiredSingularMessage)
+        .setRequiredSingularResourceName(requiredSingularResourceName)
+        .setRequiredSingularResourceNameOneof(requiredSingularResourceNameOneof)
+        .setRequiredSingularResourceNameCommon(requiredSingularResourceNameCommon)
+        .setRequiredSingularFixed32(requiredSingularFixed32)
+        .setRequiredSingularFixed64(requiredSingularFixed64)
+        .addAllRequiredRepeatedInt32(requiredRepeatedInt32)
+        .addAllRequiredRepeatedInt64(requiredRepeatedInt64)
+        .addAllRequiredRepeatedFloat(requiredRepeatedFloat)
+        .addAllRequiredRepeatedDouble(requiredRepeatedDouble)
+        .addAllRequiredRepeatedBool(requiredRepeatedBool)
+        .addAllRequiredRepeatedEnum(requiredRepeatedEnum)
+        .addAllRequiredRepeatedString(requiredRepeatedString)
+        .addAllRequiredRepeatedBytes(requiredRepeatedBytes)
+        .addAllRequiredRepeatedMessage(requiredRepeatedMessage)
+        .addAllRequiredRepeatedResourceName(requiredRepeatedResourceName)
+        .addAllRequiredRepeatedResourceNameOneof(requiredRepeatedResourceNameOneof)
+        .addAllRequiredRepeatedResourceNameCommon(requiredRepeatedResourceNameCommon)
+        .addAllRequiredRepeatedFixed32(requiredRepeatedFixed32)
+        .addAllRequiredRepeatedFixed64(requiredRepeatedFixed64)
+        .putAllRequiredMap(requiredMap)
+        .setOptionalSingularInt32(optionalSingularInt32)
+        .setOptionalSingularInt64(optionalSingularInt64)
+        .setOptionalSingularFloat(optionalSingularFloat)
+        .setOptionalSingularDouble(optionalSingularDouble)
+        .setOptionalSingularBool(optionalSingularBool)
+        .setOptionalSingularEnum(optionalSingularEnum)
+        .setOptionalSingularString(optionalSingularString)
+        .setOptionalSingularBytes(optionalSingularBytes)
+        .setOptionalSingularMessage(optionalSingularMessage)
+        .setOptionalSingularResourceName(optionalSingularResourceName)
+        .setOptionalSingularResourceNameOneof(optionalSingularResourceNameOneof)
+        .setOptionalSingularResourceNameCommon(optionalSingularResourceNameCommon)
+        .setOptionalSingularFixed32(optionalSingularFixed32)
+        .setOptionalSingularFixed64(optionalSingularFixed64)
+        .addAllOptionalRepeatedInt32(optionalRepeatedInt32)
+        .addAllOptionalRepeatedInt64(optionalRepeatedInt64)
+        .addAllOptionalRepeatedFloat(optionalRepeatedFloat)
+        .addAllOptionalRepeatedDouble(optionalRepeatedDouble)
+        .addAllOptionalRepeatedBool(optionalRepeatedBool)
+        .addAllOptionalRepeatedEnum(optionalRepeatedEnum)
+        .addAllOptionalRepeatedString(optionalRepeatedString)
+        .addAllOptionalRepeatedBytes(optionalRepeatedBytes)
+        .addAllOptionalRepeatedMessage(optionalRepeatedMessage)
+        .addAllOptionalRepeatedResourceName(optionalRepeatedResourceName)
+        .addAllOptionalRepeatedResourceNameOneof(optionalRepeatedResourceNameOneof)
+        .addAllOptionalRepeatedResourceNameCommon(optionalRepeatedResourceNameCommon)
+        .addAllOptionalRepeatedFixed32(optionalRepeatedFixed32)
+        .addAllOptionalRepeatedFixed64(optionalRepeatedFixed64)
+        .putAllOptionalMap(optionalMap)
+        .setAnyValue(anyValue)
+        .setStructValue(structValue)
+        .setValueValue(valueValue)
+        .setListValueValue(listValueValue)
+        .setTimeValue(timeValue)
+        .setDurationValue(durationValue)
+        .setFieldMaskValue(fieldMaskValue)
+        .setInt32Value(int32Value)
+        .setUint32Value(uint32Value)
+        .setInt64Value(int64Value)
+        .setUint64Value(uint64Value)
+        .setFloatValue(floatValue)
+        .setDoubleValue(doubleValue)
+        .setStringValue(stringValue)
+        .setBoolValue(boolValue)
+        .setBytesValue(bytesValue)
+        .addAllRepeatedAnyValue(repeatedAnyValue)
+        .addAllRepeatedStructValue(repeatedStructValue)
+        .addAllRepeatedValueValue(repeatedValueValue)
+        .addAllRepeatedListValueValue(repeatedListValueValue)
+        .addAllRepeatedTimeValue(repeatedTimeValue)
+        .addAllRepeatedDurationValue(repeatedDurationValue)
+        .addAllRepeatedFieldMaskValue(repeatedFieldMaskValue)
+        .addAllRepeatedInt32Value(repeatedInt32Value)
+        .addAllRepeatedUint32Value(repeatedUint32Value)
+        .addAllRepeatedInt64Value(repeatedInt64Value)
+        .addAllRepeatedUint64Value(repeatedUint64Value)
+        .addAllRepeatedFloatValue(repeatedFloatValue)
+        .addAllRepeatedDoubleValue(repeatedDoubleValue)
+        .addAllRepeatedStringValue(repeatedStringValue)
+        .addAllRepeatedBoolValue(repeatedBoolValue)
+        .addAllRepeatedBytesValue(repeatedBytesValue)
+        .build();
+    return testOptionalRequiredFlatteningParams(request);
   }
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
@@ -4003,14 +4695,32 @@ import com.google.example.library.v1.StreamBooksRequest;
 import com.google.example.library.v1.StreamShelvesRequest;
 import com.google.example.library.v1.StreamShelvesResponse;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.GrpcOperationsStub;
 import com.google.longrunning.stub.OperationsStub;
+import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Empty;
 import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
 import com.google.tagger.v1.TaggerProto.AddTagRequest;
 import com.google.tagger.v1.TaggerProto.AddTagResponse;
 import io.grpc.MethodDescriptor;
@@ -4163,13 +4873,31 @@ import com.google.example.library.v1.StreamBooksRequest;
 import com.google.example.library.v1.StreamShelvesRequest;
 import com.google.example.library.v1.StreamShelvesResponse;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.GrpcOperationsStub;
+import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Empty;
 import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
 import com.google.tagger.v1.TaggerProto.AddTagRequest;
 import com.google.tagger.v1.TaggerProto.AddTagResponse;
 import io.grpc.MethodDescriptor;
@@ -5036,13 +5764,31 @@ import com.google.example.library.v1.StreamBooksRequest;
 import com.google.example.library.v1.StreamShelvesRequest;
 import com.google.example.library.v1.StreamShelvesResponse;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
+import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Empty;
 import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
 import com.google.tagger.v1.TaggerProto.AddTagRequest;
 import com.google.tagger.v1.TaggerProto.AddTagResponse;
 import java.util.List;
@@ -6533,12 +7279,29 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.common.collect.Lists;
 import static com.google.example.library.v1.LibraryServiceClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryServiceClient.ListBooksPagedResponse;
+import static com.google.example.library.v1.LibraryServiceClient.ListStringsPagedResponse;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.longrunning.Operation;
 import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Empty;
 import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -6778,6 +7541,47 @@ public class LibraryServiceClientTest {
       com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
 
       client.getShelf(name, message, stringBuilder);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listShelvesTest() {
+    String nextPageToken = "nextPageToken-1530815211";
+    ListShelvesResponse expectedResponse = ListShelvesResponse.newBuilder()
+      .setNextPageToken(nextPageToken)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+
+
+    ListShelvesResponse actualResponse =
+        client.listShelves();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListShelvesRequest actualRequest = (ListShelvesRequest)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listShelvesExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+
+
+      client.listShelves();
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception
@@ -7260,6 +8064,99 @@ public class LibraryServiceClientTest {
       ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
 
       client.moveBook(name, otherShelfName);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listStringsTest() {
+    String nextPageToken = "";
+    String stringsElement = "stringsElement474465855";
+    List<String> strings = Arrays.asList(stringsElement);
+    ListStringsResponse expectedResponse = ListStringsResponse.newBuilder()
+      .setNextPageToken(nextPageToken)
+      .addAllStrings(strings)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+
+
+    ListStringsPagedResponse pagedListResponse = client.listStrings();
+
+    List<String> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getStringsList().get(0), resources.get(0));
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListStringsRequest actualRequest = (ListStringsRequest)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listStringsExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+
+
+      client.listStrings();
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listStringsTest2() {
+    String nextPageToken = "";
+    String stringsElement = "stringsElement474465855";
+    List<String> strings = Arrays.asList(stringsElement);
+    ListStringsResponse expectedResponse = ListStringsResponse.newBuilder()
+      .setNextPageToken(nextPageToken)
+      .addAllStrings(strings)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String name = "name3373707";
+
+    ListStringsPagedResponse pagedListResponse = client.listStrings(name);
+
+    List<String> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getStringsList().get(0), resources.get(0));
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListStringsRequest actualRequest = (ListStringsRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, actualRequest.getName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void listStringsExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String name = "name3373707";
+
+      client.listStrings(name);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception
@@ -7816,6 +8713,350 @@ public class LibraryServiceClientTest {
     }
   }
 
+
+  @Test
+  @SuppressWarnings("all")
+  public void testOptionalRequiredFlatteningParamsTest() {
+    TestOptionalRequiredFlatteningParamsResponse expectedResponse = TestOptionalRequiredFlatteningParamsResponse.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+
+
+    TestOptionalRequiredFlatteningParamsResponse actualResponse =
+        client.testOptionalRequiredFlatteningParams();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    TestOptionalRequiredFlatteningParamsRequest actualRequest = (TestOptionalRequiredFlatteningParamsRequest)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void testOptionalRequiredFlatteningParamsExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+
+
+      client.testOptionalRequiredFlatteningParams();
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void testOptionalRequiredFlatteningParamsTest2() {
+    TestOptionalRequiredFlatteningParamsResponse expectedResponse = TestOptionalRequiredFlatteningParamsResponse.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    int requiredSingularInt32 = 72313594;
+    long requiredSingularInt64 = 72313499L;
+    float requiredSingularFloat = -7514705.0F;
+    double requiredSingularDouble = 1.9111005E8;
+    boolean requiredSingularBool = true;
+    TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+    String requiredSingularString = "requiredSingularString-1949894503";
+    ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
+    TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+    BookName requiredSingularResourceName = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName requiredSingularResourceNameOneof = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+    int requiredSingularFixed32 = 720656715;
+    long requiredSingularFixed64 = 720656810;
+    List<Integer> requiredRepeatedInt32 = new ArrayList<>();
+    List<Long> requiredRepeatedInt64 = new ArrayList<>();
+    List<Float> requiredRepeatedFloat = new ArrayList<>();
+    List<Double> requiredRepeatedDouble = new ArrayList<>();
+    List<Boolean> requiredRepeatedBool = new ArrayList<>();
+    List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum = new ArrayList<>();
+    List<String> requiredRepeatedString = new ArrayList<>();
+    List<ByteString> requiredRepeatedBytes = new ArrayList<>();
+    List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage = new ArrayList<>();
+    List<String> formattedRequiredRepeatedResourceName = new ArrayList<>();
+    List<String> formattedRequiredRepeatedResourceNameOneof = new ArrayList<>();
+    List<String> formattedRequiredRepeatedResourceNameCommon = new ArrayList<>();
+    List<Integer> requiredRepeatedFixed32 = new ArrayList<>();
+    List<Long> requiredRepeatedFixed64 = new ArrayList<>();
+    Map<Integer, String> requiredMap = new HashMap<>();
+    int optionalSingularInt32 = 1196565723;
+    long optionalSingularInt64 = 1196565628L;
+    float optionalSingularFloat = -1.19939918E8F;
+    double optionalSingularDouble = 1.41902287E8;
+    boolean optionalSingularBool = false;
+    TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+    String optionalSingularString = "optionalSingularString1852995162";
+    ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
+    TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+    BookName optionalSingularResourceName = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName optionalSingularResourceNameOneof = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+    int optionalSingularFixed32 = 1648847958;
+    long optionalSingularFixed64 = 1648847863;
+    List<Integer> optionalRepeatedInt32 = new ArrayList<>();
+    List<Long> optionalRepeatedInt64 = new ArrayList<>();
+    List<Float> optionalRepeatedFloat = new ArrayList<>();
+    List<Double> optionalRepeatedDouble = new ArrayList<>();
+    List<Boolean> optionalRepeatedBool = new ArrayList<>();
+    List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum = new ArrayList<>();
+    List<String> optionalRepeatedString = new ArrayList<>();
+    List<ByteString> optionalRepeatedBytes = new ArrayList<>();
+    List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage = new ArrayList<>();
+    List<String> formattedOptionalRepeatedResourceName = new ArrayList<>();
+    List<String> formattedOptionalRepeatedResourceNameOneof = new ArrayList<>();
+    List<String> formattedOptionalRepeatedResourceNameCommon = new ArrayList<>();
+    List<Integer> optionalRepeatedFixed32 = new ArrayList<>();
+    List<Long> optionalRepeatedFixed64 = new ArrayList<>();
+    Map<Integer, String> optionalMap = new HashMap<>();
+    Any anyValue = Any.newBuilder().build();
+    Struct structValue = Struct.newBuilder().build();
+    Value valueValue = Value.newBuilder().build();
+    ListValue listValueValue = ListValue.newBuilder().build();
+    Timestamp timeValue = Timestamp.newBuilder().build();
+    Duration durationValue = Duration.newBuilder().build();
+    FieldMask fieldMaskValue = FieldMask.newBuilder().build();
+    Int32Value int32Value = Int32Value.newBuilder().build();
+    UInt32Value uint32Value = UInt32Value.newBuilder().build();
+    Int64Value int64Value = Int64Value.newBuilder().build();
+    UInt64Value uint64Value = UInt64Value.newBuilder().build();
+    FloatValue floatValue = FloatValue.newBuilder().build();
+    DoubleValue doubleValue = DoubleValue.newBuilder().build();
+    StringValue stringValue = StringValue.newBuilder().build();
+    BoolValue boolValue = BoolValue.newBuilder().build();
+    BytesValue bytesValue = BytesValue.newBuilder().build();
+    List<Any> repeatedAnyValue = new ArrayList<>();
+    List<Struct> repeatedStructValue = new ArrayList<>();
+    List<Value> repeatedValueValue = new ArrayList<>();
+    List<ListValue> repeatedListValueValue = new ArrayList<>();
+    List<Timestamp> repeatedTimeValue = new ArrayList<>();
+    List<Duration> repeatedDurationValue = new ArrayList<>();
+    List<FieldMask> repeatedFieldMaskValue = new ArrayList<>();
+    List<Int32Value> repeatedInt32Value = new ArrayList<>();
+    List<UInt32Value> repeatedUint32Value = new ArrayList<>();
+    List<Int64Value> repeatedInt64Value = new ArrayList<>();
+    List<UInt64Value> repeatedUint64Value = new ArrayList<>();
+    List<FloatValue> repeatedFloatValue = new ArrayList<>();
+    List<DoubleValue> repeatedDoubleValue = new ArrayList<>();
+    List<StringValue> repeatedStringValue = new ArrayList<>();
+    List<BoolValue> repeatedBoolValue = new ArrayList<>();
+    List<BytesValue> repeatedBytesValue = new ArrayList<>();
+
+    TestOptionalRequiredFlatteningParamsResponse actualResponse =
+        client.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, formattedRequiredRepeatedResourceName, formattedRequiredRepeatedResourceNameOneof, formattedRequiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, formattedOptionalRepeatedResourceName, formattedOptionalRepeatedResourceNameOneof, formattedOptionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap, anyValue, structValue, valueValue, listValueValue, timeValue, durationValue, fieldMaskValue, int32Value, uint32Value, int64Value, uint64Value, floatValue, doubleValue, stringValue, boolValue, bytesValue, repeatedAnyValue, repeatedStructValue, repeatedValueValue, repeatedListValueValue, repeatedTimeValue, repeatedDurationValue, repeatedFieldMaskValue, repeatedInt32Value, repeatedUint32Value, repeatedInt64Value, repeatedUint64Value, repeatedFloatValue, repeatedDoubleValue, repeatedStringValue, repeatedBoolValue, repeatedBytesValue);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    TestOptionalRequiredFlatteningParamsRequest actualRequest = (TestOptionalRequiredFlatteningParamsRequest)actualRequests.get(0);
+
+    Assert.assertEquals(requiredSingularInt32, actualRequest.getRequiredSingularInt32());
+    Assert.assertEquals(requiredSingularInt64, actualRequest.getRequiredSingularInt64());
+    Assert.assertEquals(requiredSingularFloat, actualRequest.getRequiredSingularFloat());
+    Assert.assertEquals(requiredSingularDouble, actualRequest.getRequiredSingularDouble());
+    Assert.assertEquals(requiredSingularBool, actualRequest.getRequiredSingularBool());
+    Assert.assertEquals(requiredSingularEnum, actualRequest.getRequiredSingularEnum());
+    Assert.assertEquals(requiredSingularString, actualRequest.getRequiredSingularString());
+    Assert.assertEquals(requiredSingularBytes, actualRequest.getRequiredSingularBytes());
+    Assert.assertEquals(requiredSingularMessage, actualRequest.getRequiredSingularMessage());
+    Assert.assertEquals(requiredSingularResourceName, actualRequest.getRequiredSingularResourceName());
+    Assert.assertEquals(requiredSingularResourceNameOneof, actualRequest.getRequiredSingularResourceNameOneof());
+    Assert.assertEquals(requiredSingularResourceNameCommon, actualRequest.getRequiredSingularResourceNameCommon());
+    Assert.assertEquals(requiredSingularFixed32, actualRequest.getRequiredSingularFixed32());
+    Assert.assertEquals(requiredSingularFixed64, actualRequest.getRequiredSingularFixed64());
+    Assert.assertEquals(requiredRepeatedInt32, actualRequest.getRequiredRepeatedInt32List());
+    Assert.assertEquals(requiredRepeatedInt64, actualRequest.getRequiredRepeatedInt64List());
+    Assert.assertEquals(requiredRepeatedFloat, actualRequest.getRequiredRepeatedFloatList());
+    Assert.assertEquals(requiredRepeatedDouble, actualRequest.getRequiredRepeatedDoubleList());
+    Assert.assertEquals(requiredRepeatedBool, actualRequest.getRequiredRepeatedBoolList());
+    Assert.assertEquals(requiredRepeatedEnum, actualRequest.getRequiredRepeatedEnumList());
+    Assert.assertEquals(requiredRepeatedString, actualRequest.getRequiredRepeatedStringList());
+    Assert.assertEquals(requiredRepeatedBytes, actualRequest.getRequiredRepeatedBytesList());
+    Assert.assertEquals(requiredRepeatedMessage, actualRequest.getRequiredRepeatedMessageList());
+    Assert.assertEquals(formattedRequiredRepeatedResourceName, actualRequest.getRequiredRepeatedResourceNameList());
+    Assert.assertEquals(formattedRequiredRepeatedResourceNameOneof, actualRequest.getRequiredRepeatedResourceNameOneofList());
+    Assert.assertEquals(formattedRequiredRepeatedResourceNameCommon, actualRequest.getRequiredRepeatedResourceNameCommonList());
+    Assert.assertEquals(requiredRepeatedFixed32, actualRequest.getRequiredRepeatedFixed32List());
+    Assert.assertEquals(requiredRepeatedFixed64, actualRequest.getRequiredRepeatedFixed64List());
+    Assert.assertEquals(requiredMap, actualRequest.getRequiredMapMap());
+    Assert.assertEquals(optionalSingularInt32, actualRequest.getOptionalSingularInt32());
+    Assert.assertEquals(optionalSingularInt64, actualRequest.getOptionalSingularInt64());
+    Assert.assertEquals(optionalSingularFloat, actualRequest.getOptionalSingularFloat());
+    Assert.assertEquals(optionalSingularDouble, actualRequest.getOptionalSingularDouble());
+    Assert.assertEquals(optionalSingularBool, actualRequest.getOptionalSingularBool());
+    Assert.assertEquals(optionalSingularEnum, actualRequest.getOptionalSingularEnum());
+    Assert.assertEquals(optionalSingularString, actualRequest.getOptionalSingularString());
+    Assert.assertEquals(optionalSingularBytes, actualRequest.getOptionalSingularBytes());
+    Assert.assertEquals(optionalSingularMessage, actualRequest.getOptionalSingularMessage());
+    Assert.assertEquals(optionalSingularResourceName, actualRequest.getOptionalSingularResourceName());
+    Assert.assertEquals(optionalSingularResourceNameOneof, actualRequest.getOptionalSingularResourceNameOneof());
+    Assert.assertEquals(optionalSingularResourceNameCommon, actualRequest.getOptionalSingularResourceNameCommon());
+    Assert.assertEquals(optionalSingularFixed32, actualRequest.getOptionalSingularFixed32());
+    Assert.assertEquals(optionalSingularFixed64, actualRequest.getOptionalSingularFixed64());
+    Assert.assertEquals(optionalRepeatedInt32, actualRequest.getOptionalRepeatedInt32List());
+    Assert.assertEquals(optionalRepeatedInt64, actualRequest.getOptionalRepeatedInt64List());
+    Assert.assertEquals(optionalRepeatedFloat, actualRequest.getOptionalRepeatedFloatList());
+    Assert.assertEquals(optionalRepeatedDouble, actualRequest.getOptionalRepeatedDoubleList());
+    Assert.assertEquals(optionalRepeatedBool, actualRequest.getOptionalRepeatedBoolList());
+    Assert.assertEquals(optionalRepeatedEnum, actualRequest.getOptionalRepeatedEnumList());
+    Assert.assertEquals(optionalRepeatedString, actualRequest.getOptionalRepeatedStringList());
+    Assert.assertEquals(optionalRepeatedBytes, actualRequest.getOptionalRepeatedBytesList());
+    Assert.assertEquals(optionalRepeatedMessage, actualRequest.getOptionalRepeatedMessageList());
+    Assert.assertEquals(formattedOptionalRepeatedResourceName, actualRequest.getOptionalRepeatedResourceNameList());
+    Assert.assertEquals(formattedOptionalRepeatedResourceNameOneof, actualRequest.getOptionalRepeatedResourceNameOneofList());
+    Assert.assertEquals(formattedOptionalRepeatedResourceNameCommon, actualRequest.getOptionalRepeatedResourceNameCommonList());
+    Assert.assertEquals(optionalRepeatedFixed32, actualRequest.getOptionalRepeatedFixed32List());
+    Assert.assertEquals(optionalRepeatedFixed64, actualRequest.getOptionalRepeatedFixed64List());
+    Assert.assertEquals(optionalMap, actualRequest.getOptionalMapMap());
+    Assert.assertEquals(anyValue, actualRequest.getAnyValue());
+    Assert.assertEquals(structValue, actualRequest.getStructValue());
+    Assert.assertEquals(valueValue, actualRequest.getValueValue());
+    Assert.assertEquals(listValueValue, actualRequest.getListValueValue());
+    Assert.assertEquals(timeValue, actualRequest.getTimeValue());
+    Assert.assertEquals(durationValue, actualRequest.getDurationValue());
+    Assert.assertEquals(fieldMaskValue, actualRequest.getFieldMaskValue());
+    Assert.assertEquals(int32Value, actualRequest.getInt32Value());
+    Assert.assertEquals(uint32Value, actualRequest.getUint32Value());
+    Assert.assertEquals(int64Value, actualRequest.getInt64Value());
+    Assert.assertEquals(uint64Value, actualRequest.getUint64Value());
+    Assert.assertEquals(floatValue, actualRequest.getFloatValue());
+    Assert.assertEquals(doubleValue, actualRequest.getDoubleValue());
+    Assert.assertEquals(stringValue, actualRequest.getStringValue());
+    Assert.assertEquals(boolValue, actualRequest.getBoolValue());
+    Assert.assertEquals(bytesValue, actualRequest.getBytesValue());
+    Assert.assertEquals(repeatedAnyValue, actualRequest.getRepeatedAnyValueList());
+    Assert.assertEquals(repeatedStructValue, actualRequest.getRepeatedStructValueList());
+    Assert.assertEquals(repeatedValueValue, actualRequest.getRepeatedValueValueList());
+    Assert.assertEquals(repeatedListValueValue, actualRequest.getRepeatedListValueValueList());
+    Assert.assertEquals(repeatedTimeValue, actualRequest.getRepeatedTimeValueList());
+    Assert.assertEquals(repeatedDurationValue, actualRequest.getRepeatedDurationValueList());
+    Assert.assertEquals(repeatedFieldMaskValue, actualRequest.getRepeatedFieldMaskValueList());
+    Assert.assertEquals(repeatedInt32Value, actualRequest.getRepeatedInt32ValueList());
+    Assert.assertEquals(repeatedUint32Value, actualRequest.getRepeatedUint32ValueList());
+    Assert.assertEquals(repeatedInt64Value, actualRequest.getRepeatedInt64ValueList());
+    Assert.assertEquals(repeatedUint64Value, actualRequest.getRepeatedUint64ValueList());
+    Assert.assertEquals(repeatedFloatValue, actualRequest.getRepeatedFloatValueList());
+    Assert.assertEquals(repeatedDoubleValue, actualRequest.getRepeatedDoubleValueList());
+    Assert.assertEquals(repeatedStringValue, actualRequest.getRepeatedStringValueList());
+    Assert.assertEquals(repeatedBoolValue, actualRequest.getRepeatedBoolValueList());
+    Assert.assertEquals(repeatedBytesValue, actualRequest.getRepeatedBytesValueList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void testOptionalRequiredFlatteningParamsExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      int requiredSingularInt32 = 72313594;
+      long requiredSingularInt64 = 72313499L;
+      float requiredSingularFloat = -7514705.0F;
+      double requiredSingularDouble = 1.9111005E8;
+      boolean requiredSingularBool = true;
+      TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+      String requiredSingularString = "requiredSingularString-1949894503";
+      ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
+      TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+      BookName requiredSingularResourceName = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+      BookName requiredSingularResourceNameOneof = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+      int requiredSingularFixed32 = 720656715;
+      long requiredSingularFixed64 = 720656810;
+      List<Integer> requiredRepeatedInt32 = new ArrayList<>();
+      List<Long> requiredRepeatedInt64 = new ArrayList<>();
+      List<Float> requiredRepeatedFloat = new ArrayList<>();
+      List<Double> requiredRepeatedDouble = new ArrayList<>();
+      List<Boolean> requiredRepeatedBool = new ArrayList<>();
+      List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum = new ArrayList<>();
+      List<String> requiredRepeatedString = new ArrayList<>();
+      List<ByteString> requiredRepeatedBytes = new ArrayList<>();
+      List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage = new ArrayList<>();
+      List<String> formattedRequiredRepeatedResourceName = new ArrayList<>();
+      List<String> formattedRequiredRepeatedResourceNameOneof = new ArrayList<>();
+      List<String> formattedRequiredRepeatedResourceNameCommon = new ArrayList<>();
+      List<Integer> requiredRepeatedFixed32 = new ArrayList<>();
+      List<Long> requiredRepeatedFixed64 = new ArrayList<>();
+      Map<Integer, String> requiredMap = new HashMap<>();
+      int optionalSingularInt32 = 1196565723;
+      long optionalSingularInt64 = 1196565628L;
+      float optionalSingularFloat = -1.19939918E8F;
+      double optionalSingularDouble = 1.41902287E8;
+      boolean optionalSingularBool = false;
+      TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+      String optionalSingularString = "optionalSingularString1852995162";
+      ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
+      TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+      BookName optionalSingularResourceName = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+      BookName optionalSingularResourceNameOneof = BookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+      int optionalSingularFixed32 = 1648847958;
+      long optionalSingularFixed64 = 1648847863;
+      List<Integer> optionalRepeatedInt32 = new ArrayList<>();
+      List<Long> optionalRepeatedInt64 = new ArrayList<>();
+      List<Float> optionalRepeatedFloat = new ArrayList<>();
+      List<Double> optionalRepeatedDouble = new ArrayList<>();
+      List<Boolean> optionalRepeatedBool = new ArrayList<>();
+      List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum = new ArrayList<>();
+      List<String> optionalRepeatedString = new ArrayList<>();
+      List<ByteString> optionalRepeatedBytes = new ArrayList<>();
+      List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage = new ArrayList<>();
+      List<String> formattedOptionalRepeatedResourceName = new ArrayList<>();
+      List<String> formattedOptionalRepeatedResourceNameOneof = new ArrayList<>();
+      List<String> formattedOptionalRepeatedResourceNameCommon = new ArrayList<>();
+      List<Integer> optionalRepeatedFixed32 = new ArrayList<>();
+      List<Long> optionalRepeatedFixed64 = new ArrayList<>();
+      Map<Integer, String> optionalMap = new HashMap<>();
+      Any anyValue = Any.newBuilder().build();
+      Struct structValue = Struct.newBuilder().build();
+      Value valueValue = Value.newBuilder().build();
+      ListValue listValueValue = ListValue.newBuilder().build();
+      Timestamp timeValue = Timestamp.newBuilder().build();
+      Duration durationValue = Duration.newBuilder().build();
+      FieldMask fieldMaskValue = FieldMask.newBuilder().build();
+      Int32Value int32Value = Int32Value.newBuilder().build();
+      UInt32Value uint32Value = UInt32Value.newBuilder().build();
+      Int64Value int64Value = Int64Value.newBuilder().build();
+      UInt64Value uint64Value = UInt64Value.newBuilder().build();
+      FloatValue floatValue = FloatValue.newBuilder().build();
+      DoubleValue doubleValue = DoubleValue.newBuilder().build();
+      StringValue stringValue = StringValue.newBuilder().build();
+      BoolValue boolValue = BoolValue.newBuilder().build();
+      BytesValue bytesValue = BytesValue.newBuilder().build();
+      List<Any> repeatedAnyValue = new ArrayList<>();
+      List<Struct> repeatedStructValue = new ArrayList<>();
+      List<Value> repeatedValueValue = new ArrayList<>();
+      List<ListValue> repeatedListValueValue = new ArrayList<>();
+      List<Timestamp> repeatedTimeValue = new ArrayList<>();
+      List<Duration> repeatedDurationValue = new ArrayList<>();
+      List<FieldMask> repeatedFieldMaskValue = new ArrayList<>();
+      List<Int32Value> repeatedInt32Value = new ArrayList<>();
+      List<UInt32Value> repeatedUint32Value = new ArrayList<>();
+      List<Int64Value> repeatedInt64Value = new ArrayList<>();
+      List<UInt64Value> repeatedUint64Value = new ArrayList<>();
+      List<FloatValue> repeatedFloatValue = new ArrayList<>();
+      List<DoubleValue> repeatedDoubleValue = new ArrayList<>();
+      List<StringValue> repeatedStringValue = new ArrayList<>();
+      List<BoolValue> repeatedBoolValue = new ArrayList<>();
+      List<BytesValue> repeatedBytesValue = new ArrayList<>();
+
+      client.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, formattedRequiredRepeatedResourceName, formattedRequiredRepeatedResourceNameOneof, formattedRequiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, formattedOptionalRepeatedResourceName, formattedOptionalRepeatedResourceNameOneof, formattedOptionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap, anyValue, structValue, valueValue, listValueValue, timeValue, durationValue, fieldMaskValue, int32Value, uint32Value, int64Value, uint64Value, floatValue, doubleValue, stringValue, boolValue, bytesValue, repeatedAnyValue, repeatedStructValue, repeatedValueValue, repeatedListValueValue, repeatedTimeValue, repeatedDurationValue, repeatedFieldMaskValue, repeatedInt32Value, repeatedUint32Value, repeatedInt64Value, repeatedUint64Value, repeatedFloatValue, repeatedDoubleValue, repeatedStringValue, repeatedBoolValue, repeatedBytesValue);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
 
 }
 ============== file: src/test/java/com/google/example/library/v1/MockLibraryService.java ==============


### PR DESCRIPTION
There was a bug where if an empty method signature was detected, we would immediately stop processing `method_signature`s. However, empty method signatures are valid, and we should treat them as any other.

([ProtoParserTest.java](https://github.com/googleapis/gapic-generator/blob/2c7caffd5dc6a813a51640e60944fa2d02326486/src/test/java/com/google/api/codegen/util/ProtoParserTest.java#L315) already verifies that we can tell the difference between an empty method signature and the absence of any method signatures).