### PR TITLE
Update artman docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,7 +415,7 @@ jobs:
           path: reports/gapic-generator
   generate-clients:
     docker:
-      - image: googleapis/artman:0.16.21
+      - image: googleapis/artman:0.16.25
     working_directory: /tmp/
     environment:
       <<: *anchor_artman_vars
@@ -744,7 +744,7 @@ jobs:
     environment:
       ARTMAN_USER_CONFIG: /tmp/workspace/gapic-generator/.circleci/artman_config.yaml
     docker:
-      - image: googleapis/artman:0.16.21
+      - image: googleapis/artman:0.16.25
     steps:
       - attach_workspace:
           at: workspace


### PR DESCRIPTION
The updated pubsub_gapic.yaml only works with artman v0.16.25+

Fixes CircleCI build.