### PR TITLE
Package-qualify resource references

### DIFF
--- a/src/main/java/com/google/api/codegen/util/ProtoParser.java
+++ b/src/main/java/com/google/api/codegen/util/ProtoParser.java
@@ -55,7 +55,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.StringUtils;
 
 // Utils for parsing possibly-annotated protobuf API IDL.
 public class ProtoParser {
@@ -165,8 +164,11 @@ public class ProtoParser {
       Map<ResourceSet, ProtoFile> allResourceSets) {
     String resourceName = getResourceReference(field);
     if (!Strings.isNullOrEmpty(resourceName)) {
-      String fullyQualifiedResourceName =
-          StringUtils.prependIfMissing(resourceName, getProtoPackage(field.getFile()) + ".");
+      String fullyQualifiedResourceName = resourceName;
+      if (!resourceName.contains(".")) {
+        fullyQualifiedResourceName =
+            String.format("%s.%s", getProtoPackage(field.getFile()), resourceName);
+      }
 
       // Look in the given Resource and ResourceSet collections.
       for (Resource resource : allResources.keySet()) {

--- a/src/main/java/com/google/api/codegen/util/ProtoParser.java
+++ b/src/main/java/com/google/api/codegen/util/ProtoParser.java
@@ -55,6 +55,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 
 // Utils for parsing possibly-annotated protobuf API IDL.
 public class ProtoParser {
@@ -164,19 +165,23 @@ public class ProtoParser {
       Map<ResourceSet, ProtoFile> allResourceSets) {
     String resourceName = getResourceReference(field);
     if (!Strings.isNullOrEmpty(resourceName)) {
+      String fullyQualifiedResourceName =
+          StringUtils.prependIfMissing(resourceName, getProtoPackage(field.getFile()) + ".");
 
       // Look in the given Resource and ResourceSet collections.
       for (Resource resource : allResources.keySet()) {
         ProtoFile protoFile = allResources.get(resource);
-        if (getResourceFullName(resource, protoFile).equals(resourceName)
-            || field.getFile().equals(protoFile) && resource.getSymbol().equals(resourceName)) {
+        if (getResourceFullName(resource, protoFile).equals(fullyQualifiedResourceName)
+            || field.getFile().equals(protoFile)
+                && resource.getSymbol().equals(fullyQualifiedResourceName)) {
           return resource.getSymbol();
         }
       }
       for (ResourceSet resourceSet : allResourceSets.keySet()) {
         ProtoFile protoFile = allResourceSets.get(resourceSet);
-        if (getResourceSetFullName(resourceSet, protoFile).equals(resourceName)
-            || field.getFile().equals(protoFile) && resourceSet.getSymbol().equals(resourceName)) {
+        if (getResourceSetFullName(resourceSet, protoFile).equals(fullyQualifiedResourceName)
+            || field.getFile().equals(protoFile)
+                && resourceSet.getSymbol().equals(fullyQualifiedResourceName)) {
           return resourceSet.getSymbol();
         }
       }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -8254,12 +8254,12 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    String name2 = "name2-1052831874";
+    BookOneOfName name2 = DeletedBookName.of();
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
     BookFromAnywhere expectedResponse = BookFromAnywhere.newBuilder()
-      .setName(name2)
+      .setName(name2.toString())
       .setAuthor(author)
       .setTitle(title)
       .setRead(read)
@@ -8305,12 +8305,12 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    String name2 = "name2-1052831874";
+    BookOneOfName name2 = DeletedBookName.of();
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
     BookFromAnywhere expectedResponse = BookFromAnywhere.newBuilder()
-      .setName(name2)
+      .setName(name2.toString())
       .setAuthor(author)
       .setTitle(title)
       .setRead(read)

--- a/src/test/java/com/google/api/codegen/testsrc/common/book_from_anywhere.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/book_from_anywhere.proto
@@ -18,7 +18,7 @@ message BookFromAnywhere {
   // Book names have the form `bookShelves/{shelf_id}/books/{book_id}` or
   // `archives/{archive_id}/books/{book_id}`.
   string name = 1 [
-    (google.api.resource_reference) = "BookOneof"];
+    (google.api.resource_reference) = "BookOneOf"];
 
   // The name of the book author.
   string author = 2;

--- a/src/test/java/com/google/api/codegen/testsrc/common/book_from_anywhere.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/book_from_anywhere.proto
@@ -5,17 +5,21 @@ syntax = "proto3";
 
 package google.example.library.v1;
 
+import "google/api/resource.proto";
+
 option go_package = "google.golang.org/genproto/googleapis/example/library/v1;library";
 option java_multiple_files = true;
 option java_outer_classname = "BookFromAnywhereProto";
 option java_package = "com.google.example.library.v1";
+
 
 // A single book in the archives or library.
 message BookFromAnywhere {
   // The resource name of the book.
   // Book names have the form `bookShelves/{shelf_id}/books/{book_id}` or
   // `archives/{archive_id}/books/{book_id}`.
-  string name = 1;
+  string name = 1 [
+    (google.api.resource_reference) = "BookOneof"];
 
   // The name of the book author.
   string author = 2;

--- a/src/test/java/com/google/api/codegen/testsrc/common/book_from_anywhere.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/book_from_anywhere.proto
@@ -12,7 +12,6 @@ option java_multiple_files = true;
 option java_outer_classname = "BookFromAnywhereProto";
 option java_package = "com.google.example.library.v1";
 
-
 // A single book in the archives or library.
 message BookFromAnywhere {
   // The resource name of the book.

--- a/src/test/java/com/google/api/codegen/util/ProtoParserTest.java
+++ b/src/test/java/com/google/api/codegen/util/ProtoParserTest.java
@@ -47,6 +47,7 @@ public class ProtoParserTest {
   private static Model model;
   private static TestDataLocator testDataLocator;
   private static ProtoFile libraryProtoFile;
+  private static ProtoFile bookFromAnywhereProtoFile;
   private static Field shelfNameField;
   private static Interface libraryService;
   private static Method deleteShelfMethod;
@@ -76,6 +77,14 @@ public class ProtoParserTest {
             .getFiles()
             .stream()
             .filter(f -> f.getSimpleName().equals("library.proto"))
+            .findFirst()
+            .get();
+
+    bookFromAnywhereProtoFile =
+        model
+            .getFiles()
+            .stream()
+            .filter(f -> f.getSimpleName().equals("book_from_anywhere.proto"))
             .findFirst()
             .get();
 
@@ -222,6 +231,25 @@ public class ProtoParserTest {
             .findFirst()
             .get();
     assertThat(protoParser.getResourceReferenceName(nameField, resourceDefs, resourceSetDefs))
+        .isEqualTo("BookOneOf");
+
+    MessageType bookFromAnywhere =
+        bookFromAnywhereProtoFile
+            .getMessages()
+            .stream()
+            .filter(m -> m.getSimpleName().equals("BookFromAnywhere"))
+            .findFirst()
+            .get();
+    Field bookFromAnywhereNameField =
+        bookFromAnywhere
+            .getFields()
+            .stream()
+            .filter(f -> f.getSimpleName().equals("name"))
+            .findFirst()
+            .get();
+    assertThat(
+            protoParser.getResourceReferenceName(
+                bookFromAnywhereNameField, resourceDefs, resourceSetDefs))
         .isEqualTo("BookOneOf");
 
     Field altBookNameField =


### PR DESCRIPTION
When searching for a resource definition by its package-qualified resource name, use a package-qualified resource reference too.