### PR TITLE
Bring back timeout millis in GAPIC config v2

### DIFF
--- a/src/main/proto/com/google/api/codegen/v2/config_v2.proto
+++ b/src/main/proto/com/google/api/codegen/v2/config_v2.proto
@@ -165,7 +165,7 @@ message MethodConfigProto {
   // The fully qualified name of the method.
   string name = 1;
 
-  reserved 2, 3, 7, 8, 9, 11, 14, 15;
+  reserved 2, 3, 7, 8, 9, 14, 15;
 
   // Specifies the configuration for gRPC-streaming responses.
   // Note that this is for configuring paged gRPC-streaming responses.
@@ -179,6 +179,10 @@ message MethodConfigProto {
   // Specifies the configuration for retry/backoff parameters.
   // The name must be defined in InterfaceConfigProto::retry_params_def.
   string retry_params_name = 5;
+
+  // Specifies the default timeout for a non-retrying call. If the call is
+  // retrying, refer to `retry_params_name` instead.
+  uint64 timeout_millis = 11; // UNSUPPORTED in Java, C#, PHP, Go.
 
   // Specifies the configuration for batching.
   BatchingConfigProto batching = 6;


### PR DESCRIPTION
Because https://github.com/googleapis/gapic-generator/pull/2707