### PR TITLE
Split proto parsing in GapicMethodConfig

### DIFF
--- a/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,14 +46,13 @@ public abstract class FlatteningConfig {
    * Returns a map of a string representing a list of the fields in a flattening, to the flattening
    * config created from a method in the gapic config.
    */
-  private static Map<String, FlatteningConfig> createFlatteningsFromGapicConfig(
+  private static void insertFlatteningsFromGapicConfig(
       DiagCollector diagCollector,
       ResourceNameMessageConfigs messageConfigs,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs,
       MethodConfigProto methodConfigProto,
-      MethodModel methodModel) {
-
-    Map<String, FlatteningConfig> flatteningConfigs = new LinkedHashMap<>();
+      MethodModel methodModel,
+      ImmutableMap.Builder<String, FlatteningConfig> flatteningConfigs) {
 
     for (FlatteningGroupProto flatteningGroup : methodConfigProto.getFlattening().getGroupsList()) {
       FlatteningConfig groupConfig =
@@ -69,11 +67,6 @@ public abstract class FlatteningConfig {
         flatteningConfigs.put(flatteningConfigToString(groupConfig), groupConfig);
       }
     }
-    if (diagCollector.hasErrors()) {
-      return null;
-    }
-
-    return flatteningConfigs;
   }
 
   static ImmutableList<FlatteningConfig> createFlatteningConfigs(
@@ -81,14 +74,19 @@ public abstract class FlatteningConfig {
       ResourceNameMessageConfigs messageConfigs,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs,
       MethodConfigProto methodConfigProto,
-      DiscoveryMethodModel methodModel) {
-    Map<String, FlatteningConfig> flatteningConfigMap =
-        createFlatteningsFromGapicConfig(
-            diagCollector, messageConfigs, resourceNameConfigs, methodConfigProto, methodModel);
-    if (flatteningConfigMap == null) {
+      MethodModel methodModel) {
+    ImmutableMap.Builder<String, FlatteningConfig> flatteningConfigs = ImmutableMap.builder();
+    insertFlatteningsFromGapicConfig(
+        diagCollector,
+        messageConfigs,
+        resourceNameConfigs,
+        methodConfigProto,
+        methodModel,
+        flatteningConfigs);
+    if (diagCollector.hasErrors()) {
       return null;
     }
-    return ImmutableList.copyOf(flatteningConfigMap.values());
+    return ImmutableList.copyOf(flatteningConfigs.build().values());
   }
 
   @VisibleForTesting
@@ -101,45 +99,40 @@ public abstract class FlatteningConfig {
       ProtoMethodModel methodModel,
       ProtoParser protoParser) {
 
-    Map<String, FlatteningConfig> flatteningConfigsFromGapicConfig =
-        createFlatteningsFromGapicConfig(
-            diagCollector, messageConfigs, resourceNameConfigs, methodConfigProto, methodModel);
-    if (flatteningConfigsFromGapicConfig == null) {
+    ImmutableMap.Builder<String, FlatteningConfig> flatteningConfigs = ImmutableMap.builder();
+
+    insertFlatteningsFromGapicConfig(
+        diagCollector,
+        messageConfigs,
+        resourceNameConfigs,
+        methodConfigProto,
+        methodModel,
+        flatteningConfigs);
+    insertFlatteningConfigsFromProtoFile(
+        diagCollector,
+        messageConfigs,
+        resourceNameConfigs,
+        methodModel,
+        protoParser,
+        flatteningConfigs);
+
+    if (diagCollector.hasErrors()) {
       return null;
     }
-
-    // Get flattenings from protofile annotations
-    Map<String, FlatteningConfig> flatteningConfigsFromProtoFile =
-        createFlatteningConfigsFromProtoFile(
-            diagCollector, messageConfigs, resourceNameConfigs, methodModel, protoParser);
-    if (flatteningConfigsFromProtoFile == null) {
-      return null;
-    }
-
-    // Enforce unique flattening configs, in case proto annotations overlaps with configProto
-    // flattening.
-    Map<String, FlatteningConfig> flatteningConfigs = new LinkedHashMap<>();
-
-    // Let flattenings from GAPIC config override flattenings from proto annotations.
-    flatteningConfigs.putAll(flatteningConfigsFromProtoFile);
-    flatteningConfigs.putAll(flatteningConfigsFromGapicConfig);
-
-    return ImmutableList.copyOf(flatteningConfigs.values());
+    return ImmutableList.copyOf(flatteningConfigs.build().values());
   }
 
   /**
    * Returns a map of a string representing a list of the fields in a flattening, to the flattening
    * config created from a method from the proto file.
    */
-  @Nullable
-  private static Map<String, FlatteningConfig> createFlatteningConfigsFromProtoFile(
+  private static void insertFlatteningConfigsFromProtoFile(
       DiagCollector diagCollector,
       ResourceNameMessageConfigs messageConfigs,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs,
       ProtoMethodModel methodModel,
-      ProtoParser protoParser) {
-
-    Map<String, FlatteningConfig> flatteningConfigs = new LinkedHashMap<>();
+      ProtoParser protoParser,
+      ImmutableMap.Builder<String, FlatteningConfig> flatteningConfigs) {
 
     // Get flattenings from protofile annotations, let these override flattenings from GAPIC config.
     List<List<String>> methodSignatures =
@@ -158,10 +151,6 @@ public abstract class FlatteningConfig {
         flatteningConfigs.put(flatteningConfigToString(groupConfig), groupConfig);
       }
     }
-    if (diagCollector.hasErrors()) {
-      return null;
-    }
-    return flatteningConfigs;
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
@@ -43,8 +43,8 @@ public abstract class FlatteningConfig {
   public abstract ImmutableMap<String, FieldConfig> getFlattenedFieldConfigs();
 
   /**
-   * Returns a map of a string representing a list of the fields in a flattening, to the flattening
-   * config created from a method in the gapic config.
+   * Appends to a map of a string representing a list of the fields in a flattening, to the
+   * flattening config created from a method in the gapic config.
    */
   private static void insertFlatteningsFromGapicConfig(
       DiagCollector diagCollector,
@@ -123,7 +123,7 @@ public abstract class FlatteningConfig {
   }
 
   /**
-   * Returns a map of a string representing a list of the fields in a flattening, to the flattening
+   * Appends to map of a string representing a list of the fields in a flattening, to the flattening
    * config created from a method from the proto file.
    */
   private static void insertFlatteningConfigsFromProtoFile(
@@ -133,7 +133,6 @@ public abstract class FlatteningConfig {
       ProtoMethodModel methodModel,
       ProtoParser protoParser,
       ImmutableMap.Builder<String, FlatteningConfig> flatteningConfigs) {
-
     // Get flattenings from protofile annotations, let these override flattenings from GAPIC config.
     List<List<String>> methodSignatures =
         protoParser.getMethodSignatures(methodModel.getProtoMethod());
@@ -147,7 +146,6 @@ public abstract class FlatteningConfig {
               methodModel,
               protoParser);
       if (groupConfig != null) {
-
         flatteningConfigs.put(flatteningConfigToString(groupConfig), groupConfig);
       }
     }

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -217,7 +217,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
               method, diagCollector, methodConfigProto.getLongRunning(), protoParser);
     } else {
       longRunningConfig =
-          LongRunningConfig.createLongRunningConfigFromGapicConfig(
+          LongRunningConfig.createLongRunningConfigFromGapicConfigOnly(
               method.getModel(), diagCollector, methodConfigProto.getLongRunning());
     }
 

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -107,14 +107,21 @@ public abstract class GapicMethodConfig extends MethodConfig {
       }
     }
 
-    ImmutableList<FlatteningConfig> flattening =
-        FlatteningConfig.createFlatteningConfigs(
-            diagCollector,
-            messageConfigs,
-            resourceNameConfigs,
-            methodConfigProto,
-            methodModel,
-            protoParser);
+    ImmutableList<FlatteningConfig> flattening;
+    if (protoParser.isProtoAnnotationsEnabled()) {
+      flattening =
+          FlatteningConfig.createFlatteningConfigs(
+              diagCollector,
+              messageConfigs,
+              resourceNameConfigs,
+              methodConfigProto,
+              methodModel,
+              protoParser);
+    } else {
+      flattening =
+          FlatteningConfig.createFlatteningConfigs(
+              diagCollector, messageConfigs, resourceNameConfigs, methodConfigProto, methodModel);
+    }
 
     BatchingConfig batching = null;
     if (!BatchingConfigProto.getDefaultInstance().equals(methodConfigProto.getBatching())) {

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -79,15 +79,21 @@ public abstract class GapicMethodConfig extends MethodConfig {
     int previousErrors = diagCollector.getErrorCount();
     ProtoMethodModel methodModel = new ProtoMethodModel(method);
 
-    PageStreamingConfig pageStreaming =
-        PageStreamingConfig.createPageStreamingConfig(
-            diagCollector,
-            defaultPackageName,
-            methodModel,
-            methodConfigProto,
-            messageConfigs,
-            resourceNameConfigs,
-            protoParser);
+    PageStreamingConfig pageStreaming;
+    if (protoParser.isProtoAnnotationsEnabled()) {
+      pageStreaming =
+          PageStreamingConfig.createPageStreamingConfig(
+              diagCollector,
+              defaultPackageName,
+              methodModel,
+              messageConfigs,
+              resourceNameConfigs,
+              protoParser);
+    } else {
+      pageStreaming =
+          PageStreamingConfig.createPageStreamingConfig(
+              diagCollector, methodModel, methodConfigProto, messageConfigs, resourceNameConfigs);
+    }
 
     GrpcStreamingConfig grpcStreaming = null;
     if (isGrpcStreamingMethod(methodModel)) {

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -210,9 +210,16 @@ public abstract class GapicMethodConfig extends MethodConfig {
       }
     }
 
-    LongRunningConfig longRunningConfig =
-        LongRunningConfig.createLongRunningConfig(
-            method, diagCollector, methodConfigProto.getLongRunning(), protoParser);
+    LongRunningConfig longRunningConfig;
+    if (protoParser.isProtoAnnotationsEnabled()) {
+      longRunningConfig =
+          LongRunningConfig.createLongRunningConfig(
+              method, diagCollector, methodConfigProto.getLongRunning(), protoParser);
+    } else {
+      longRunningConfig =
+          LongRunningConfig.createLongRunningConfigFromGapicConfig(
+              method.getModel(), diagCollector, methodConfigProto.getLongRunning());
+    }
 
     List<String> headerRequestParams = findHeaderRequestParams(method);
 

--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -58,26 +58,6 @@ public abstract class LongRunningConfig {
   /** Returns total polling timeout. */
   public abstract Duration getTotalPollTimeout();
 
-  @Nullable
-  static LongRunningConfig createLongRunningConfig(
-      Method method,
-      DiagCollector diagCollector,
-      LongRunningConfigProto longRunningConfigProto,
-      ProtoParser protoParser) {
-    LongRunningConfig longRunningConfig =
-        createLongRunningConfigFromProtoFile(
-            method, diagCollector, longRunningConfigProto, protoParser);
-    if (longRunningConfig != null) {
-      return longRunningConfig;
-    }
-
-    if (!LongRunningConfigProto.getDefaultInstance().equals(longRunningConfigProto)) {
-      return LongRunningConfig.createLongRunningConfigFromGapicConfig(
-          method.getModel(), diagCollector, longRunningConfigProto);
-    }
-    return null;
-  }
-
   private static String qualifyLroTypeName(
       String typeName, Method method, ProtoParser protoParser) {
     if (!typeName.contains(".")) {
@@ -91,7 +71,7 @@ public abstract class LongRunningConfig {
    * long running config from GAPIC config, use the GAPIC config's timeout values.
    */
   @Nullable
-  private static LongRunningConfig createLongRunningConfigFromProtoFile(
+  static LongRunningConfig createLongRunningConfig(
       Method method,
       DiagCollector diagCollector,
       LongRunningConfigProto longRunningConfigProto,
@@ -168,7 +148,7 @@ public abstract class LongRunningConfig {
 
   /** Creates an instance of LongRunningConfig based on LongRunningConfigProto. */
   @Nullable
-  private static LongRunningConfig createLongRunningConfigFromGapicConfig(
+  static LongRunningConfig createLongRunningConfigFromGapicConfig(
       Model model, DiagCollector diagCollector, LongRunningConfigProto longRunningConfigProto) {
 
     int preexistingErrors = diagCollector.getErrorCount();

--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -93,7 +93,7 @@ public abstract class LongRunningConfig {
     if (responseTypeName.equals(longRunningConfigProto.getReturnType())
         && metadataTypeName.equals(longRunningConfigProto.getMetadataType())) {
       // GAPIC config refers to the same Long running config; so use its retry settings.
-      return LongRunningConfig.createLongRunningConfigFromGapicConfig(
+      return LongRunningConfig.createLongRunningConfigFromGapicConfigOnly(
           method.getModel(), diagCollector, longRunningConfigProto);
     }
 
@@ -148,8 +148,11 @@ public abstract class LongRunningConfig {
 
   /** Creates an instance of LongRunningConfig based on LongRunningConfigProto. */
   @Nullable
-  static LongRunningConfig createLongRunningConfigFromGapicConfig(
+  static LongRunningConfig createLongRunningConfigFromGapicConfigOnly(
       Model model, DiagCollector diagCollector, LongRunningConfigProto longRunningConfigProto) {
+    if (LongRunningConfigProto.getDefaultInstance().equals(longRunningConfigProto)) {
+      return null;
+    }
 
     int preexistingErrors = diagCollector.getErrorCount();
 

--- a/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
@@ -227,39 +227,45 @@ public abstract class PageStreamingConfig {
       DiagCollector diagCollector,
       String defaultPackageName,
       ProtoMethodModel methodModel,
-      @Nonnull MethodConfigProto methodConfigProto,
       ResourceNameMessageConfigs messageConfigs,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs,
       ProtoParser protoParser) {
-    if (protoParser.isProtoAnnotationsEnabled()) {
-      // Toggle pagination based on presence of paging params.
-      // See https://cloud.google.com/apis/design/design_patterns for API pagination pattern.
-      ProtoField tokenField = methodModel.getInputField(ProtoPagingParameters.nameForPageToken());
-      ProtoField pageSizeField = methodModel.getInputField(ProtoPagingParameters.nameForPageSize());
-      ProtoField responseTokenField =
-          methodModel.getOutputField(ProtoPagingParameters.nameForNextPageToken());
-      if (tokenField != null && responseTokenField != null && pageSizeField != null) {
-        PagingFields pagingFields =
-            PagingFields.newBuilder()
-                .setResponseTokenField(responseTokenField)
-                .setRequestTokenField(tokenField)
-                .setPageSizeField(pageSizeField)
-                .build();
-        return PageStreamingConfig.createPageStreamingFromProtoFile(
-            diagCollector,
-            messageConfigs,
-            resourceNameConfigs,
-            methodModel,
-            pagingFields,
-            protoParser,
-            defaultPackageName);
-      }
-    } else {
-      if (!PageStreamingConfigProto.getDefaultInstance()
-          .equals(methodConfigProto.getPageStreaming())) {
-        return PageStreamingConfig.createPageStreamingFromGapicConfig(
-            diagCollector, messageConfigs, resourceNameConfigs, methodConfigProto, methodModel);
-      }
+    // Toggle pagination based on presence of paging params.
+    // See https://cloud.google.com/apis/design/design_patterns for API pagination pattern.
+    ProtoField tokenField = methodModel.getInputField(ProtoPagingParameters.nameForPageToken());
+    ProtoField pageSizeField = methodModel.getInputField(ProtoPagingParameters.nameForPageSize());
+    ProtoField responseTokenField =
+        methodModel.getOutputField(ProtoPagingParameters.nameForNextPageToken());
+    if (tokenField != null && responseTokenField != null && pageSizeField != null) {
+      PagingFields pagingFields =
+          PagingFields.newBuilder()
+              .setResponseTokenField(responseTokenField)
+              .setRequestTokenField(tokenField)
+              .setPageSizeField(pageSizeField)
+              .build();
+      return PageStreamingConfig.createPageStreamingFromProtoFile(
+          diagCollector,
+          messageConfigs,
+          resourceNameConfigs,
+          methodModel,
+          pagingFields,
+          protoParser,
+          defaultPackageName);
+    }
+    return null;
+  }
+
+  /** package-private for use by {@link GapicMethodConfig}. */
+  static PageStreamingConfig createPageStreamingConfig(
+      DiagCollector diagCollector,
+      ProtoMethodModel methodModel,
+      @Nonnull MethodConfigProto methodConfigProto,
+      ResourceNameMessageConfigs messageConfigs,
+      ImmutableMap<String, ResourceNameConfig> resourceNameConfigs) {
+    if (!PageStreamingConfigProto.getDefaultInstance()
+        .equals(methodConfigProto.getPageStreaming())) {
+      return PageStreamingConfig.createPageStreamingFromGapicConfig(
+          diagCollector, messageConfigs, resourceNameConfigs, methodConfigProto, methodModel);
     }
     return null;
   }

--- a/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/LongRunningConfigTest.java
@@ -137,8 +137,8 @@ public class LongRunningConfigTest {
     // simpleMethod has no LRO proto annotations.
     // lroConfigProtoWithPollSettings contains LRO settings.
     LongRunningConfig longRunningConfig =
-        LongRunningConfig.createLongRunningConfig(
-            simpleMethod, diagCollector, lroConfigProtoWithPollSettings, protoParser);
+        LongRunningConfig.createLongRunningConfigFromGapicConfigOnly(
+            simpleMethod.getModel(), diagCollector, lroConfigProtoWithPollSettings);
 
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
     assertThat(longRunningConfig).isNotNull();


### PR DESCRIPTION
- Fixes parsing for flattenings
- Fixes parsing for LRO
- Pushes `if (protoParser.isProtoAnnotationsEnabled())` logic into GapicMethodConfig for page streaming

The intention of pushing the `if (protoParser.isProtoAnnotationsEnabled())` up into GapicMethodConfig is to enable a followup that gathers the many `if (protoParser.isProtoAnnotationsEnabled())` statements in GapicMethodConfig into a single statement. This will involve a reordering in GapicMethodConfig but no semantic changes, but hopefully will improve clarify about when proto parsing is active.