### PR TITLE
Refactor gapic method config

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -231,18 +231,33 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
     for (Entry<Method, MethodConfigProto> methodEntry : methodsToGenerate.entrySet()) {
       MethodConfigProto methodConfigProto = methodEntry.getValue();
       Method method = methodEntry.getKey();
-      GapicMethodConfig methodConfig =
-          GapicMethodConfig.createMethodConfig(
-              diagCollector,
-              language,
-              defaultPackageName,
-              methodConfigProto,
-              method,
-              messageConfigs,
-              resourceNameConfigs,
-              retryCodesConfig,
-              retryParamsConfigNames,
-              protoParser);
+      GapicMethodConfig methodConfig;
+      if (protoParser.isProtoAnnotationsEnabled()) {
+        methodConfig =
+            GapicMethodConfig.createGapicMethodConfigFromProto(
+                diagCollector,
+                language,
+                defaultPackageName,
+                methodConfigProto,
+                method,
+                messageConfigs,
+                resourceNameConfigs,
+                retryCodesConfig,
+                retryParamsConfigNames,
+                protoParser);
+      } else {
+        methodConfig =
+            GapicMethodConfig.createGapicMethodConfigFromGapicYaml(
+                diagCollector,
+                language,
+                defaultPackageName,
+                methodConfigProto,
+                method,
+                messageConfigs,
+                resourceNameConfigs,
+                retryCodesConfig,
+                retryParamsConfigNames);
+      }
       if (methodConfig == null) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -176,53 +176,53 @@ public abstract class GapicMethodConfig extends MethodConfig {
 
     GapicMethodConfig.Builder builder =
         createCommonMethodConfig(
-            diagCollector,
-            language,
-            defaultPackageName,
-            methodConfigProto,
-            method,
-            methodModel,
-            messageConfigs,
-            resourceNameConfigs,
-            retryCodesConfig,
-            retryParamsConfigNames)
-        .setPageStreaming(
-            PageStreamingConfig.createPageStreamingConfig(
                 diagCollector,
+                language,
                 defaultPackageName,
-                methodModel,
-                messageConfigs,
-                resourceNameConfigs,
-                protoParser))
-        .setFlatteningConfigs(
-            FlatteningConfig.createFlatteningConfigs(
-                diagCollector,
-                messageConfigs,
-                resourceNameConfigs,
                 methodConfigProto,
+                method,
                 methodModel,
-                protoParser))
-        .setFieldNamePatterns(fieldNamePatterns)
-        .setRequiredFieldConfigs(
-            createFieldNameConfigs(
-                diagCollector,
                 messageConfigs,
-                defaultResourceNameTreatment,
-                fieldNamePatterns,
                 resourceNameConfigs,
-                getRequiredFields(diagCollector, methodModel, requiredFields)))
-        .setOptionalFieldConfigs(
-            createFieldNameConfigs(
-                diagCollector,
-                messageConfigs,
-                defaultResourceNameTreatment,
-                fieldNamePatterns,
-                resourceNameConfigs,
-                getOptionalFields(methodModel, requiredFields)))
-        .setLroConfig(
-            LongRunningConfig.createLongRunningConfig(
-                method, diagCollector, methodConfigProto.getLongRunning(), protoParser))
-        .setDefaultResourceNameTreatment(defaultResourceNameTreatment);
+                retryCodesConfig,
+                retryParamsConfigNames)
+            .setPageStreaming(
+                PageStreamingConfig.createPageStreamingConfig(
+                    diagCollector,
+                    defaultPackageName,
+                    methodModel,
+                    messageConfigs,
+                    resourceNameConfigs,
+                    protoParser))
+            .setFlatteningConfigs(
+                FlatteningConfig.createFlatteningConfigs(
+                    diagCollector,
+                    messageConfigs,
+                    resourceNameConfigs,
+                    methodConfigProto,
+                    methodModel,
+                    protoParser))
+            .setFieldNamePatterns(fieldNamePatterns)
+            .setRequiredFieldConfigs(
+                createFieldNameConfigs(
+                    diagCollector,
+                    messageConfigs,
+                    defaultResourceNameTreatment,
+                    fieldNamePatterns,
+                    resourceNameConfigs,
+                    getRequiredFields(diagCollector, methodModel, requiredFields)))
+            .setOptionalFieldConfigs(
+                createFieldNameConfigs(
+                    diagCollector,
+                    messageConfigs,
+                    defaultResourceNameTreatment,
+                    fieldNamePatterns,
+                    resourceNameConfigs,
+                    getOptionalFields(methodModel, requiredFields)))
+            .setLroConfig(
+                LongRunningConfig.createLongRunningConfig(
+                    method, diagCollector, methodConfigProto.getLongRunning(), protoParser))
+            .setDefaultResourceNameTreatment(defaultResourceNameTreatment);
 
     if (diagCollector.getErrorCount() - previousErrors > 0) {
       return null;
@@ -253,43 +253,51 @@ public abstract class GapicMethodConfig extends MethodConfig {
 
     GapicMethodConfig.Builder builder =
         createCommonMethodConfig(
-            diagCollector,
-            language,
-            defaultPackageName,
-            methodConfigProto,
-            method,
-            methodModel,
-            messageConfigs,
-            resourceNameConfigs,
-            retryCodesConfig,
-            retryParamsConfigNames)
-        .setPageStreaming(
-            PageStreamingConfig.createPageStreamingConfig(
-                diagCollector, methodModel, methodConfigProto, messageConfigs, resourceNameConfigs))
-        .setFlatteningConfigs(
-            FlatteningConfig.createFlatteningConfigs(
-                diagCollector, messageConfigs, resourceNameConfigs, methodConfigProto, methodModel))
-        .setFieldNamePatterns(fieldNamePatterns)
-        .setRequiredFieldConfigs(
-            createFieldNameConfigs(
                 diagCollector,
+                language,
+                defaultPackageName,
+                methodConfigProto,
+                method,
+                methodModel,
                 messageConfigs,
-                defaultResourceNameTreatment,
-                fieldNamePatterns,
                 resourceNameConfigs,
-                getRequiredFields(diagCollector, methodModel, requiredFields)))
-        .setOptionalFieldConfigs(
-            createFieldNameConfigs(
-                diagCollector,
-                messageConfigs,
-                defaultResourceNameTreatment,
-                fieldNamePatterns,
-                resourceNameConfigs,
-                getOptionalFields(methodModel, requiredFields)))
-        .setLroConfig(
-            LongRunningConfig.createLongRunningConfigFromGapicConfigOnly(
-                method.getModel(), diagCollector, methodConfigProto.getLongRunning()))
-        .setDefaultResourceNameTreatment(defaultResourceNameTreatment);
+                retryCodesConfig,
+                retryParamsConfigNames)
+            .setPageStreaming(
+                PageStreamingConfig.createPageStreamingConfig(
+                    diagCollector,
+                    methodModel,
+                    methodConfigProto,
+                    messageConfigs,
+                    resourceNameConfigs))
+            .setFlatteningConfigs(
+                FlatteningConfig.createFlatteningConfigs(
+                    diagCollector,
+                    messageConfigs,
+                    resourceNameConfigs,
+                    methodConfigProto,
+                    methodModel))
+            .setFieldNamePatterns(fieldNamePatterns)
+            .setRequiredFieldConfigs(
+                createFieldNameConfigs(
+                    diagCollector,
+                    messageConfigs,
+                    defaultResourceNameTreatment,
+                    fieldNamePatterns,
+                    resourceNameConfigs,
+                    getRequiredFields(diagCollector, methodModel, requiredFields)))
+            .setOptionalFieldConfigs(
+                createFieldNameConfigs(
+                    diagCollector,
+                    messageConfigs,
+                    defaultResourceNameTreatment,
+                    fieldNamePatterns,
+                    resourceNameConfigs,
+                    getOptionalFields(methodModel, requiredFields)))
+            .setLroConfig(
+                LongRunningConfig.createLongRunningConfigFromGapicConfigOnly(
+                    method.getModel(), diagCollector, methodConfigProto.getLongRunning()))
+            .setDefaultResourceNameTreatment(defaultResourceNameTreatment);
 
     if (diagCollector.getErrorCount() - previousErrors > 0) {
       return null;

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -64,7 +64,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
    * collector.
    */
   @Nullable
-  private static GapicMethodConfig.Builder createMethodConfig(
+  private static GapicMethodConfig.Builder createCommonMethodConfig(
       DiagCollector diagCollector,
       TargetLanguage language,
       String defaultPackageName,
@@ -169,9 +169,13 @@ public abstract class GapicMethodConfig extends MethodConfig {
     int previousErrors = diagCollector.getErrorCount();
 
     ProtoMethodModel methodModel = new ProtoMethodModel(method);
+    ImmutableMap<String, String> fieldNamePatterns = protoParser.getFieldNamePatterns(method);
+    List<String> requiredFields = protoParser.getRequiredFields(method);
+    ResourceNameTreatment defaultResourceNameTreatment =
+        defaultResourceNameTreatmentFromProto(method, protoParser, defaultPackageName);
 
     GapicMethodConfig.Builder builder =
-        createMethodConfig(
+        createCommonMethodConfig(
             diagCollector,
             language,
             defaultPackageName,
@@ -181,14 +185,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
             messageConfigs,
             resourceNameConfigs,
             retryCodesConfig,
-            retryParamsConfigNames);
-
-    ImmutableMap<String, String> fieldNamePatterns = protoParser.getFieldNamePatterns(method);
-    List<String> requiredFields = protoParser.getRequiredFields(method);
-    ResourceNameTreatment defaultResourceNameTreatment =
-        defaultResourceNameTreatmentFromProto(method, protoParser, defaultPackageName);
-
-    builder
+            retryParamsConfigNames)
         .setPageStreaming(
             PageStreamingConfig.createPageStreamingConfig(
                 diagCollector,
@@ -248,9 +245,14 @@ public abstract class GapicMethodConfig extends MethodConfig {
     int previousErrors = diagCollector.getErrorCount();
 
     ProtoMethodModel methodModel = new ProtoMethodModel(method);
+    List<String> requiredFields = methodConfigProto.getRequiredFieldsList();
+    ImmutableMap<String, String> fieldNamePatterns =
+        ImmutableMap.copyOf(methodConfigProto.getFieldNamePatterns());
+    ResourceNameTreatment defaultResourceNameTreatment =
+        methodConfigProto.getResourceNameTreatment();
 
     GapicMethodConfig.Builder builder =
-        createMethodConfig(
+        createCommonMethodConfig(
             diagCollector,
             language,
             defaultPackageName,
@@ -260,15 +262,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
             messageConfigs,
             resourceNameConfigs,
             retryCodesConfig,
-            retryParamsConfigNames);
-
-    List<String> requiredFields = methodConfigProto.getRequiredFieldsList();
-    ImmutableMap<String, String> fieldNamePatterns =
-        ImmutableMap.copyOf(methodConfigProto.getFieldNamePatterns());
-    ResourceNameTreatment defaultResourceNameTreatment =
-        methodConfigProto.getResourceNameTreatment();
-
-    builder
+            retryParamsConfigNames)
         .setPageStreaming(
             PageStreamingConfig.createPageStreamingConfig(
                 diagCollector, methodModel, methodConfigProto, messageConfigs, resourceNameConfigs))

--- a/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
@@ -206,11 +206,8 @@ public abstract class PageStreamingConfig {
       resourcesFieldConfig = null;
     } else {
       ResourceNameTreatment resourceNameTreatment =
-          GapicMethodConfig.defaultResourceNameTreatment(
-              MethodConfigProto.getDefaultInstance(),
-              method.getProtoMethod(),
-              protoParser,
-              defaultPackageName);
+          GapicMethodConfig.defaultResourceNameTreatmentFromProto(
+              method.getProtoMethod(), protoParser, defaultPackageName);
       resourcesFieldConfig =
           FieldConfig.createMessageFieldConfig(
               messageConfigs, resourceNameConfigs, resourcesField, resourceNameTreatment);

--- a/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
@@ -451,26 +451,14 @@ public class ResourceNameMessageConfigsTest {
 
     Mockito.doReturn("Book").when(protoParser).getResourceReference(bookName);
 
-    MethodConfigProto noConfig = MethodConfigProto.getDefaultInstance();
-
     ResourceNameTreatment noTreatment =
-        GapicMethodConfig.defaultResourceNameTreatment(
-            noConfig, createShelvesMethod, protoParser, DEFAULT_PACKAGE);
+        GapicMethodConfig.defaultResourceNameTreatmentFromProto(
+            createShelvesMethod, protoParser, DEFAULT_PACKAGE);
     assertThat(noTreatment).isEqualTo(ResourceNameTreatment.UNSET_TREATMENT);
 
-    MethodConfigProto staticTypesMethodConfig =
-        MethodConfigProto.newBuilder()
-            .setResourceNameTreatment(ResourceNameTreatment.STATIC_TYPES)
-            .build();
-
-    ResourceNameTreatment resourceNameTreatment =
-        GapicMethodConfig.defaultResourceNameTreatment(
-            staticTypesMethodConfig, createShelvesMethod, protoParser, DEFAULT_PACKAGE);
-    assertThat(resourceNameTreatment).isEqualTo(ResourceNameTreatment.STATIC_TYPES);
-
     ResourceNameTreatment noConfigWithAnnotatedResourceReferenceTreatment =
-        GapicMethodConfig.defaultResourceNameTreatment(
-            noConfig, insertBook, protoParser, DEFAULT_PACKAGE);
+        GapicMethodConfig.defaultResourceNameTreatmentFromProto(
+            insertBook, protoParser, DEFAULT_PACKAGE);
     assertThat(noConfigWithAnnotatedResourceReferenceTreatment)
         .isEqualTo(ResourceNameTreatment.STATIC_TYPES);
 


### PR DESCRIPTION
- Convert GapicMethodConfig to use an AutoValue Builder
- Create two GapicMethodConfig create methods: 1 for proto annotation parsing, one without

Please let me know what you think of this change - is it an improvement? Or just churn but not really better.