### PR TITLE
go: fix ignored page token bug in iterator

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -270,6 +270,7 @@
         }
         it.pageInfo, it.nextFunc = iterator.NewPageInfo(fetch, it.bufLen, it.takeBuf)
         it.pageInfo.MaxSize = int(req.PageSize)
+        it.pageInfo.Token = req.PageToken
         return it
     }
 @end

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -456,6 +456,7 @@ func (c *LibClient) ListShelves(ctx context.Context, req *librarypb.ListShelvesR
     }
     it.pageInfo, it.nextFunc = iterator.NewPageInfo(fetch, it.bufLen, it.takeBuf)
     it.pageInfo.MaxSize = int(req.PageSize)
+    it.pageInfo.Token = req.PageToken
     return it
 }
 
@@ -577,6 +578,7 @@ func (c *LibClient) ListBooks(ctx context.Context, req *librarypb.ListBooksReque
     }
     it.pageInfo, it.nextFunc = iterator.NewPageInfo(fetch, it.bufLen, it.takeBuf)
     it.pageInfo.MaxSize = int(req.PageSize)
+    it.pageInfo.Token = req.PageToken
     return it
 }
 
@@ -661,6 +663,7 @@ func (c *LibClient) ListStrings(ctx context.Context, req *librarypb.ListStringsR
     }
     it.pageInfo, it.nextFunc = iterator.NewPageInfo(fetch, it.bufLen, it.takeBuf)
     it.pageInfo.MaxSize = int(req.PageSize)
+    it.pageInfo.Token = req.PageToken
     return it
 }
 
@@ -841,6 +844,7 @@ func (c *LibClient) FindRelatedBooks(ctx context.Context, req *librarypb.FindRel
     }
     it.pageInfo, it.nextFunc = iterator.NewPageInfo(fetch, it.bufLen, it.takeBuf)
     it.pageInfo.MaxSize = int(req.PageSize)
+    it.pageInfo.Token = req.PageToken
     return it
 }
 


### PR DESCRIPTION
A mirror of the fix submitted in [gapic-generator-go#128](https://github.com/googleapis/gapic-generator-go/pull/128), the `PageToken` was not being respected at iterator creation. It was being ignored entirely if supplied when creating a new iterator.

added @jadekler for approval of changes to generated output. This is technically a bug in all Go GAPICs today. We will need to regen once the change is released.