### PR TITLE
Fix missing default retries

### DIFF
--- a/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
@@ -71,8 +71,7 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
       ResourceNameMessageConfigs messageConfigs,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs) {
 
-    RetryCodesConfig retryCodesConfig =
-        RetryCodesConfig.create(model.getDiagCollector(), interfaceConfigProto);
+    RetryCodesConfig retryCodesConfig = RetryCodesConfig.create(interfaceConfigProto);
     ImmutableMap<String, RetryParamsDefinitionProto> retrySettingsDefinition =
         RetryDefinitionsTransformer.createRetrySettingsDefinition(interfaceConfigProto);
 

--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -119,7 +119,6 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
 
     RetryCodesConfig retryCodesConfig =
         RetryCodesConfig.create(
-            diagCollector,
             interfaceConfigProto,
             new ArrayList<>(interfaceInput.getMethodsToGenerate().keySet()),
             protoParser);

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -47,6 +47,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.Api;
 import com.google.protobuf.DescriptorProtos;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -47,7 +47,6 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.Api;
 import com.google.protobuf.DescriptorProtos;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
@@ -1087,6 +1087,9 @@ public class DecrementerServiceStubSettings extends StubSettings<DecrementerServ
     static {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
+          "idempotent",
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+      definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
       RETRYABLE_CODE_DEFINITIONS = definitions.build();
@@ -1877,6 +1880,9 @@ public class IncrementerServiceStubSettings extends StubSettings<IncrementerServ
 
     static {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
+      definitions.put(
+          "idempotent",
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -960,6 +960,9 @@ public class NoTemplatesApiServiceStubSettings extends StubSettings<NoTemplatesA
     static {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
+          "idempotent",
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+      definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
       RETRYABLE_CODE_DEFINITIONS = definitions.build();

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -392,6 +392,10 @@ module.exports = DecrementerServiceClient;
   "interfaces": {
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {
@@ -710,6 +714,10 @@ module.exports = IncrementerServiceClient;
   "interfaces": {
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -387,6 +387,10 @@ module.exports = NoTemplatesApiServiceClient;
   "interfaces": {
     "google.cloud.example.v1.NoTemplatesAPIService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
@@ -282,6 +282,10 @@ class NoTemplatesApiServiceClient extends NoTemplatesApiServiceGapicClient
   "interfaces": {
     "google.cloud.example.v1.NoTemplatesAPIService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1073,10 +1073,6 @@ config = {
   "interfaces": {
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
-        "idempotent": [
-          "DEADLINE_EXCEEDED",
-          "UNAVAILABLE"
-        ],
         "non_idempotent": []
       },
       "retry_params": {
@@ -1311,10 +1307,6 @@ config = {
   "interfaces": {
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
-        "idempotent": [
-          "DEADLINE_EXCEEDED",
-          "UNAVAILABLE"
-        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -279,11 +279,11 @@ Next Steps
    API to see other available methods on the client.
 -  Read the `Google Example API Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository?s main README`_ to see the full list of Cloud
+-  View this `repository’s main README`_ to see the full list of Cloud
    APIs that we cover.
 
 .. _Google Example API Product documentation:  https://cloud.google.com/multiple_services
-.. _repository?s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
 ============== file: docs/conf.py ==============
 # -*- coding: utf-8 -*-
 #
@@ -720,11 +720,11 @@ Next Steps
    API to see other available methods on the client.
 -  Read the `Google Example API Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository?s main README`_ to see the full list of Cloud
+-  View this `repository’s main README`_ to see the full list of Cloud
    APIs that we cover.
 
 .. _Google Example API Product documentation:  https://cloud.google.com/multiple_services
-.. _repository?s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
 
 Api Reference
 -------------

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -279,11 +279,11 @@ Next Steps
    API to see other available methods on the client.
 -  Read the `Google Example API Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository’s main README`_ to see the full list of Cloud
+-  View this `repository?s main README`_ to see the full list of Cloud
    APIs that we cover.
 
 .. _Google Example API Product documentation:  https://cloud.google.com/multiple_services
-.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _repository?s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
 ============== file: docs/conf.py ==============
 # -*- coding: utf-8 -*-
 #
@@ -720,11 +720,11 @@ Next Steps
    API to see other available methods on the client.
 -  Read the `Google Example API Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository’s main README`_ to see the full list of Cloud
+-  View this `repository?s main README`_ to see the full list of Cloud
    APIs that we cover.
 
 .. _Google Example API Product documentation:  https://cloud.google.com/multiple_services
-.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _repository?s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
 
 Api Reference
 -------------
@@ -1073,6 +1073,10 @@ config = {
   "interfaces": {
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {
@@ -1307,6 +1311,10 @@ config = {
   "interfaces": {
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1073,6 +1073,10 @@ config = {
   "interfaces": {
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {
@@ -1307,6 +1311,10 @@ config = {
   "interfaces": {
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1012,6 +1012,10 @@ config = {
   "interfaces": {
     "google.cloud.example.v1.NoTemplatesAPIService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -279,11 +279,11 @@ Next Steps
    API to see other available methods on the client.
 -  Read the `Google Fake API Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository?s main README`_ to see the full list of Cloud
+-  View this `repository’s main README`_ to see the full list of Cloud
    APIs that we cover.
 
 .. _Google Fake API Product documentation:  https://cloud.google.com/library
-.. _repository?s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
 ============== file: docs/conf.py ==============
 # -*- coding: utf-8 -*-
 #
@@ -720,11 +720,11 @@ Next Steps
    API to see other available methods on the client.
 -  Read the `Google Fake API Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository?s main README`_ to see the full list of Cloud
+-  View this `repository’s main README`_ to see the full list of Cloud
    APIs that we cover.
 
 .. _Google Fake API Product documentation:  https://cloud.google.com/library
-.. _repository?s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
 
 Api Reference
 -------------

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -279,11 +279,11 @@ Next Steps
    API to see other available methods on the client.
 -  Read the `Google Fake API Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository’s main README`_ to see the full list of Cloud
+-  View this `repository?s main README`_ to see the full list of Cloud
    APIs that we cover.
 
 .. _Google Fake API Product documentation:  https://cloud.google.com/library
-.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _repository?s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
 ============== file: docs/conf.py ==============
 # -*- coding: utf-8 -*-
 #
@@ -720,11 +720,11 @@ Next Steps
    API to see other available methods on the client.
 -  Read the `Google Fake API Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository’s main README`_ to see the full list of Cloud
+-  View this `repository?s main README`_ to see the full list of Cloud
    APIs that we cover.
 
 .. _Google Fake API Product documentation:  https://cloud.google.com/library
-.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _repository?s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
 
 Api Reference
 -------------
@@ -1012,6 +1012,10 @@ config = {
   "interfaces": {
     "google.cloud.example.v1.NoTemplatesAPIService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1012,10 +1012,6 @@ config = {
   "interfaces": {
     "google.cloud.example.v1.NoTemplatesAPIService": {
       "retry_codes": {
-        "idempotent": [
-          "DEADLINE_EXCEEDED",
-          "UNAVAILABLE"
-        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
@@ -326,7 +326,7 @@ end
 This library is supported on Ruby 2.3+.
 
 Google provides official support for Ruby versions that are actively supported
-by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+by Ruby Core?that is, Ruby versions that are either in normal maintenance or
 in security maintenance, and not end of life. Currently, this means Ruby 2.3
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
@@ -1146,6 +1146,10 @@ end
   "interfaces": {
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {
@@ -1425,6 +1429,10 @@ end
   "interfaces": {
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
@@ -326,7 +326,7 @@ end
 This library is supported on Ruby 2.3+.
 
 Google provides official support for Ruby versions that are actively supported
-by Ruby Core?that is, Ruby versions that are either in normal maintenance or
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
 in security maintenance, and not end of life. Currently, this means Ruby 2.3
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
@@ -1146,10 +1146,6 @@ end
   "interfaces": {
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
-        "idempotent": [
-          "DEADLINE_EXCEEDED",
-          "UNAVAILABLE"
-        ],
         "non_idempotent": []
       },
       "retry_params": {
@@ -1429,10 +1425,6 @@ end
   "interfaces": {
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
-        "idempotent": [
-          "DEADLINE_EXCEEDED",
-          "UNAVAILABLE"
-        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
@@ -1146,6 +1146,10 @@ end
   "interfaces": {
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {
@@ -1425,6 +1429,10 @@ end
   "interfaces": {
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -8279,6 +8279,9 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
     static {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
+          "idempotent",
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+      definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
       RETRYABLE_CODE_DEFINITIONS = definitions.build();

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -5143,6 +5143,10 @@ end
   "interfaces": {
     "google.example.library.v1.MyProto": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -325,7 +325,7 @@ end
 This library is supported on Ruby 2.3+.
 
 Google provides official support for Ruby versions that are actively supported
-by Ruby Core?that is, Ruby versions that are either in normal maintenance or
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
 in security maintenance, and not end of life. Currently, this means Ruby 2.3
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
@@ -5143,10 +5143,6 @@ end
   "interfaces": {
     "google.example.library.v1.MyProto": {
       "retry_codes": {
-        "idempotent": [
-          "DEADLINE_EXCEEDED",
-          "UNAVAILABLE"
-        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -325,7 +325,7 @@ end
 This library is supported on Ruby 2.3+.
 
 Google provides official support for Ruby versions that are actively supported
-by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+by Ruby Core?that is, Ruby versions that are either in normal maintenance or
 in security maintenance, and not end of life. Currently, this means Ruby 2.3
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
@@ -5143,6 +5143,10 @@ end
   "interfaces": {
     "google.example.library.v1.MyProto": {
       "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/transformer/RetryDefinitionsTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/RetryDefinitionsTransformerTest.java
@@ -99,8 +99,7 @@ public class RetryDefinitionsTransformerTest {
     DiagCollector diagCollector = new BoundedDiagCollector();
 
     RetryCodesConfig retryCodesConfig =
-        RetryCodesConfig.create(
-            diagCollector, interfaceConfigProto, apiInterface.getMethods(), protoParser);
+        RetryCodesConfig.create(interfaceConfigProto, apiInterface.getMethods(), protoParser);
 
     Map<String, ImmutableList<String>> retryCodesDef = retryCodesConfig.getRetryCodesDefinition();
     Map<String, String> retryCodesMap = retryCodesConfig.getMethodRetryNames();
@@ -154,11 +153,8 @@ public class RetryDefinitionsTransformerTest {
             .addMethods(MethodConfigProto.newBuilder().setName(PERMISSION_DENIED_METHOD_NAME))
             .build();
 
-    DiagCollector diagCollector = new BoundedDiagCollector();
-
     RetryCodesConfig retryCodesConfig =
-        RetryCodesConfig.create(
-            diagCollector, bareBonesConfigProto, apiInterface.getMethods(), protoParser);
+        RetryCodesConfig.create(bareBonesConfigProto, apiInterface.getMethods(), protoParser);
 
     Map<String, ImmutableList<String>> retryCodesDef = retryCodesConfig.getRetryCodesDefinition();
     Map<String, String> retryCodesMap = retryCodesConfig.getMethodRetryNames();


### PR DESCRIPTION
- Always add default retry codes for idempotent and non-idempotent cases, so that when these codes are not present in the gapic config they will still be present and usable.
- Minor refactoring to reduce code re-use.