### PR TITLE
Alphabetize SingleResourceNameConfigs

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -164,7 +164,7 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
       }
     }
 
-    ImmutableList.Builder<SingleResourceNameConfig> resourcesBuilder = ImmutableList.builder();
+    List<SingleResourceNameConfig> resourcesBuilder = new ArrayList<>();
     if (protoParser.isProtoAnnotationsEnabled()) {
       resourceNameConfigs
           .values()
@@ -194,7 +194,7 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
     }
     ImmutableList<SingleResourceNameConfig> singleResourceNames =
         ImmutableList.sortedCopyOf(
-            Comparator.comparing(ResourceNameConfig::getEntityId), resourcesBuilder.build());
+            Comparator.comparing(ResourceNameConfig::getEntityId), resourcesBuilder);
 
     String manualDoc =
         Strings.nullToEmpty(

--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -163,7 +164,8 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
       }
     }
 
-    ImmutableList.Builder<SingleResourceNameConfig> resourcesBuilder = ImmutableList.builder();
+    List<SingleResourceNameConfig> resourcesBuilder = new ArrayList<>();
+
     for (CollectionConfigProto collectionConfigProto : interfaceConfigProto.getCollectionsList()) {
       String entityName = collectionConfigProto.getEntityName();
       ResourceNameConfig resourceName = resourceNameConfigs.get(entityName);
@@ -178,7 +180,9 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
       }
       resourcesBuilder.add((SingleResourceNameConfig) resourceName);
     }
-    ImmutableList<SingleResourceNameConfig> singleResourceNames = resourcesBuilder.build();
+    ImmutableList<SingleResourceNameConfig> singleResourceNames =
+        ImmutableList.sortedCopyOf(
+            Comparator.comparing(ResourceNameConfig::getEntityId), resourcesBuilder);
 
     String manualDoc =
         Strings.nullToEmpty(

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -2868,29 +2868,17 @@ public class LibraryClient implements BackgroundResource {
   private final LibraryServiceStub stub;
   private final OperationsClient operationsClient;
 
-  private static final PathTemplate SHELF_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}");
-
   private static final PathTemplate SHELF_BOOK_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}/books/{book_id}");
 
   private static final PathTemplate PROJECT_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("projects/{project}");
 
+  private static final PathTemplate SHELF_PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}");
+
   private static final PathTemplate ARCHIVED_BOOK_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("archives/{archive_path}/books/{book_id=**}");
-
-  /**
-   * Formats a string containing the fully-qualified path to represent
-   * a shelf resource.
-   *
-   * @deprecated Use the {@link ShelfName} class instead.
-   */
-  @Deprecated
-  public static final String formatShelfName(String shelfId) {
-    return SHELF_PATH_TEMPLATE.instantiate(
-        "shelf_id", shelfId);
-  }
 
   /**
    * Formats a string containing the fully-qualified path to represent
@@ -2919,6 +2907,18 @@ public class LibraryClient implements BackgroundResource {
 
   /**
    * Formats a string containing the fully-qualified path to represent
+   * a shelf resource.
+   *
+   * @deprecated Use the {@link ShelfName} class instead.
+   */
+  @Deprecated
+  public static final String formatShelfName(String shelfId) {
+    return SHELF_PATH_TEMPLATE.instantiate(
+        "shelf_id", shelfId);
+  }
+
+  /**
+   * Formats a string containing the fully-qualified path to represent
    * a archived_book resource.
    *
    * @deprecated Use the {@link ArchivedBookName} class instead.
@@ -2928,17 +2928,6 @@ public class LibraryClient implements BackgroundResource {
     return ARCHIVED_BOOK_PATH_TEMPLATE.instantiate(
         "archive_path", archivePath,
         "book_id", bookId);
-  }
-
-  /**
-   * Parses the shelf_id from the given fully-qualified path which
-   * represents a shelf resource.
-   *
-   * @deprecated Use the {@link ShelfName} class instead.
-   */
-  @Deprecated
-  public static final String parseShelfIdFromShelfName(String shelfName) {
-    return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf_id");
   }
 
   /**
@@ -2972,6 +2961,17 @@ public class LibraryClient implements BackgroundResource {
   @Deprecated
   public static final String parseProjectFromProjectName(String projectName) {
     return PROJECT_PATH_TEMPLATE.parse(projectName).get("project");
+  }
+
+  /**
+   * Parses the shelf_id from the given fully-qualified path which
+   * represents a shelf resource.
+   *
+   * @deprecated Use the {@link ShelfName} class instead.
+   */
+  @Deprecated
+  public static final String parseShelfIdFromShelfName(String shelfName) {
+    return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf_id");
   }
 
   /**

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -3967,14 +3967,14 @@ class LibraryServiceClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      shelfPathTemplate: new gax.PathTemplate(
-        'shelves/{shelf_id}'
-      ),
       bookPathTemplate: new gax.PathTemplate(
         'shelves/{shelf_id}/books/{book_id}'
       ),
       projectPathTemplate: new gax.PathTemplate(
         'projects/{project}'
+      ),
+      shelfPathTemplate: new gax.PathTemplate(
+        'shelves/{shelf_id}'
       ),
       archivedBookPathTemplate: new gax.PathTemplate(
         'archives/{archive_path}/books/{book_id=**}'
@@ -6430,18 +6430,6 @@ class LibraryServiceClient {
   // --------------------
 
   /**
-   * Return a fully-qualified shelf resource name string.
-   *
-   * @param {String} shelfId
-   * @returns {String}
-   */
-  shelfPath(shelfId) {
-    return this._pathTemplates.shelfPathTemplate.render({
-      shelf_id: shelfId,
-    });
-  }
-
-  /**
    * Return a fully-qualified book resource name string.
    *
    * @param {String} shelfId
@@ -6468,6 +6456,18 @@ class LibraryServiceClient {
   }
 
   /**
+   * Return a fully-qualified shelf resource name string.
+   *
+   * @param {String} shelfId
+   * @returns {String}
+   */
+  shelfPath(shelfId) {
+    return this._pathTemplates.shelfPathTemplate.render({
+      shelf_id: shelfId,
+    });
+  }
+
+  /**
    * Return a fully-qualified archived_book resource name string.
    *
    * @param {String} archivePath
@@ -6479,19 +6479,6 @@ class LibraryServiceClient {
       archive_path: archivePath,
       book_id: bookId,
     });
-  }
-
-  /**
-   * Parse the shelfName from a shelf resource.
-   *
-   * @param {String} shelfName
-   *   A fully-qualified path representing a shelf resources.
-   * @returns {String} - A string representing the shelf_id.
-   */
-  matchShelfIdFromShelfName(shelfName) {
-    return this._pathTemplates.shelfPathTemplate
-      .match(shelfName)
-      .shelf_id;
   }
 
   /**
@@ -6531,6 +6518,19 @@ class LibraryServiceClient {
     return this._pathTemplates.projectPathTemplate
       .match(projectName)
       .project;
+  }
+
+  /**
+   * Parse the shelfName from a shelf resource.
+   *
+   * @param {String} shelfName
+   *   A fully-qualified path representing a shelf resources.
+   * @returns {String} - A string representing the shelf_id.
+   */
+  matchShelfIdFromShelfName(shelfName) {
+    return this._pathTemplates.shelfPathTemplate
+      .match(shelfName)
+      .shelf_id;
   }
 
   /**

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -194,9 +194,9 @@ class LibraryServiceGapicClient
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/library',
     ];
-    private static $shelfNameTemplate;
     private static $bookNameTemplate;
     private static $projectNameTemplate;
+    private static $shelfNameTemplate;
     private static $archivedBookNameTemplate;
     private static $pathTemplateMap;
 
@@ -220,15 +220,6 @@ class LibraryServiceGapicClient
         ];
     }
 
-    private static function getShelfNameTemplate()
-    {
-        if (self::$shelfNameTemplate == null) {
-            self::$shelfNameTemplate = new PathTemplate('shelves/{shelf_id}');
-        }
-
-        return self::$shelfNameTemplate;
-    }
-
     private static function getBookNameTemplate()
     {
         if (self::$bookNameTemplate == null) {
@@ -247,6 +238,15 @@ class LibraryServiceGapicClient
         return self::$projectNameTemplate;
     }
 
+    private static function getShelfNameTemplate()
+    {
+        if (self::$shelfNameTemplate == null) {
+            self::$shelfNameTemplate = new PathTemplate('shelves/{shelf_id}');
+        }
+
+        return self::$shelfNameTemplate;
+    }
+
     private static function getArchivedBookNameTemplate()
     {
         if (self::$archivedBookNameTemplate == null) {
@@ -261,29 +261,14 @@ class LibraryServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
-                'shelf' => self::getShelfNameTemplate(),
                 'book' => self::getBookNameTemplate(),
                 'project' => self::getProjectNameTemplate(),
+                'shelf' => self::getShelfNameTemplate(),
                 'archivedBook' => self::getArchivedBookNameTemplate(),
             ];
         }
         return self::$pathTemplateMap;
     }
-    /**
-     * Formats a string containing the fully-qualified path to represent
-     * a shelf resource.
-     *
-     * @param string $shelfId
-     * @return string The formatted shelf resource.
-     * @experimental
-     */
-    public static function shelfName($shelfId)
-    {
-        return self::getShelfNameTemplate()->render([
-            'shelf_id' => $shelfId,
-        ]);
-    }
-
     /**
      * Formats a string containing the fully-qualified path to represent
      * a book resource.
@@ -318,6 +303,21 @@ class LibraryServiceGapicClient
 
     /**
      * Formats a string containing the fully-qualified path to represent
+     * a shelf resource.
+     *
+     * @param string $shelfId
+     * @return string The formatted shelf resource.
+     * @experimental
+     */
+    public static function shelfName($shelfId)
+    {
+        return self::getShelfNameTemplate()->render([
+            'shelf_id' => $shelfId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent
      * a archived_book resource.
      *
      * @param string $archivePath
@@ -337,9 +337,9 @@ class LibraryServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
-     * - shelf: shelves/{shelf_id}
      * - book: shelves/{shelf_id}/books/{book_id}
      * - project: projects/{project}
+     * - shelf: shelves/{shelf_id}
      * - archivedBook: archives/{archive_path}/books/{book_id=**}
      *
      * The optional $template argument can be supplied to specify a particular pattern, and must

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -1145,14 +1145,6 @@ class LibraryServiceClient(object):
 
 
     @classmethod
-    def shelf_path(cls, shelf_id):
-        """Return a fully-qualified shelf string."""
-        return google.api_core.path_template.expand(
-            'shelves/{shelf_id}',
-            shelf_id=shelf_id,
-        )
-
-    @classmethod
     def book_path(cls, shelf_id, book_id):
         """Return a fully-qualified book string."""
         return google.api_core.path_template.expand(
@@ -1167,6 +1159,14 @@ class LibraryServiceClient(object):
         return google.api_core.path_template.expand(
             'projects/{project}',
             project=project,
+        )
+
+    @classmethod
+    def shelf_path(cls, shelf_id):
+        """Return a fully-qualified shelf string."""
+        return google.api_core.path_template.expand(
+            'shelves/{shelf_id}',
+            shelf_id=shelf_id,
         )
 
     @classmethod

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -2916,12 +2916,6 @@ module Library
         self::GRPC_INTERCEPTORS = LibraryServiceClient::GRPC_INTERCEPTORS
       end
 
-      SHELF_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "shelves/{shelf_id}"
-      )
-
-      private_constant :SHELF_PATH_TEMPLATE
-
       BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
         "shelves/{shelf_id}/books/{book_id}"
       )
@@ -2934,20 +2928,17 @@ module Library
 
       private_constant :PROJECT_PATH_TEMPLATE
 
+      SHELF_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+        "shelves/{shelf_id}"
+      )
+
+      private_constant :SHELF_PATH_TEMPLATE
+
       ARCHIVED_BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
         "archives/{archive_path}/books/{book_id=**}"
       )
 
       private_constant :ARCHIVED_BOOK_PATH_TEMPLATE
-
-      # Returns a fully-qualified shelf resource name string.
-      # @param shelf_id [String]
-      # @return [String]
-      def self.shelf_path shelf_id
-        SHELF_PATH_TEMPLATE.render(
-          :"shelf_id" => shelf_id
-        )
-      end
 
       # Returns a fully-qualified book resource name string.
       # @param shelf_id [String]
@@ -2966,6 +2957,15 @@ module Library
       def self.project_path project
         PROJECT_PATH_TEMPLATE.render(
           :"project" => project
+        )
+      end
+
+      # Returns a fully-qualified shelf resource name string.
+      # @param shelf_id [String]
+      # @return [String]
+      def self.shelf_path shelf_id
+        SHELF_PATH_TEMPLATE.render(
+          :"shelf_id" => shelf_id
         )
       end
 


### PR DESCRIPTION
In order to reduce churn during the config party, we should alphabetize all single resource name entities. Alphabetizing creates a deterministic, simple ordering for clients generated without a GAPIC config.