### PR TITLE
Really alphabetize the SingleResourceNameConfigs

### DIFF
--- a/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
@@ -106,7 +106,7 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
       }
     }
 
-    ImmutableList.Builder<SingleResourceNameConfig> resourcesBuilder = ImmutableList.builder();
+    ImmutableSet.Builder<SingleResourceNameConfig> resourcesBuilder = ImmutableSet.builder();
     for (CollectionConfigProto collectionConfigProto : interfaceConfigProto.getCollectionsList()) {
       String entityName = collectionConfigProto.getEntityName();
       ResourceNameConfig resourceName = resourceNameConfigs.get(entityName);
@@ -123,7 +123,7 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
       }
       resourcesBuilder.add((SingleResourceNameConfig) resourceName);
     }
-    ImmutableList<SingleResourceNameConfig> singleResourceNames = resourcesBuilder.build();
+    ImmutableSet<SingleResourceNameConfig> singleResourceNames = resourcesBuilder.build();
 
     ImmutableMap.Builder<MethodConfig, SingleResourceNameConfig> methodToSingleResourceNameMap =
         ImmutableMap.builder();
@@ -322,5 +322,5 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
   abstract ImmutableMap<String, ? extends MethodConfig> getMethodConfigMap();
 
   @Override
-  public abstract ImmutableList<SingleResourceNameConfig> getSingleResourceNameConfigs();
+  public abstract ImmutableSet<SingleResourceNameConfig> getSingleResourceNameConfigs();
 }

--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,7 +80,7 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
   public abstract ImmutableList<String> getRequiredConstructorParams();
 
   @Override
-  public abstract ImmutableList<SingleResourceNameConfig> getSingleResourceNameConfigs();
+  public abstract ImmutableSet<SingleResourceNameConfig> getSingleResourceNameConfigs();
 
   @Override
   public abstract String getManualDoc();
@@ -164,7 +163,7 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
       }
     }
 
-    List<SingleResourceNameConfig> resourcesBuilder = new ArrayList<>();
+    ImmutableSet.Builder<SingleResourceNameConfig> resourcesBuilder = ImmutableSet.builder();
     if (protoParser.isProtoAnnotationsEnabled()) {
       resourceNameConfigs
           .values()
@@ -192,9 +191,7 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
         resourcesBuilder.add((SingleResourceNameConfig) resourceName);
       }
     }
-    ImmutableList<SingleResourceNameConfig> singleResourceNames =
-        ImmutableList.sortedCopyOf(
-            Comparator.comparing(ResourceNameConfig::getEntityId), resourcesBuilder);
+    ImmutableSet<SingleResourceNameConfig> singleResourceNames = resourcesBuilder.build();
 
     String manualDoc =
         Strings.nullToEmpty(

--- a/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
@@ -17,6 +17,7 @@ package com.google.api.codegen.config;
 import com.google.api.codegen.RetryParamsDefinitionProto;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -62,7 +63,7 @@ public interface InterfaceConfig {
 
   boolean hasReroutedInterfaceMethods();
 
-  ImmutableList<SingleResourceNameConfig> getSingleResourceNameConfigs();
+  ImmutableSet<SingleResourceNameConfig> getSingleResourceNameConfigs();
 
   @Nullable
   String getInterfaceNameOverride();

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -35,6 +35,7 @@ import com.google.api.codegen.viewmodel.ResourceNameSingleView;
 import com.google.api.codegen.viewmodel.ResourceNameView;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -64,10 +65,9 @@ public class PathTemplateTransformer {
       InterfaceContext context) {
     InterfaceConfig interfaceConfig = context.getInterfaceConfig();
     Set<String> foundSet = new HashSet<>();
-    ImmutableList.Builder<SingleResourceNameConfig> resourceNameConfigsBuilder =
-        ImmutableList.builder();
+    List<SingleResourceNameConfig> resourceNameConfigs = new ArrayList<>();
     for (SingleResourceNameConfig config : interfaceConfig.getSingleResourceNameConfigs()) {
-      resourceNameConfigsBuilder.add(config);
+      resourceNameConfigs.add(config);
       foundSet.add(config.getEntityId());
     }
     for (MethodConfig methodConfig : interfaceConfig.getMethodConfigs()) {
@@ -76,12 +76,13 @@ public class PathTemplateTransformer {
         SingleResourceNameConfig resourceNameConfig =
             methodContext.getSingleResourceNameConfig(fieldNamePattern);
         if (resourceNameConfig != null && !foundSet.contains(resourceNameConfig.getEntityId())) {
-          resourceNameConfigsBuilder.add(resourceNameConfig);
+          resourceNameConfigs.add(resourceNameConfig);
           foundSet.add(resourceNameConfig.getEntityId());
         }
       }
     }
-    return resourceNameConfigsBuilder.build();
+    return ImmutableList.sortedCopyOf(
+        Comparator.comparing(ResourceNameConfig::getEntityId), resourceNameConfigs);
   }
 
   public List<ResourceNameView> generateResourceNames(GapicInterfaceContext context) {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -2912,6 +2912,9 @@ public class LibraryClient implements BackgroundResource {
   private final LibraryServiceStub stub;
   private final OperationsClient operationsClient;
 
+  private static final PathTemplate ARCHIVED_BOOK_PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("archives/{archive_path}/books/{book_id=**}");
+
   private static final PathTemplate SHELF_BOOK_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}/books/{book_id}");
 
@@ -2921,8 +2924,18 @@ public class LibraryClient implements BackgroundResource {
   private static final PathTemplate SHELF_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}");
 
-  private static final PathTemplate ARCHIVED_BOOK_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("archives/{archive_path}/books/{book_id=**}");
+  /**
+   * Formats a string containing the fully-qualified path to represent
+   * a archived_book resource.
+   *
+   * @deprecated Use the {@link ArchivedBookName} class instead.
+   */
+  @Deprecated
+  public static final String formatArchivedBookName(String archivePath, String bookId) {
+    return ARCHIVED_BOOK_PATH_TEMPLATE.instantiate(
+        "archive_path", archivePath,
+        "book_id", bookId);
+  }
 
   /**
    * Formats a string containing the fully-qualified path to represent
@@ -2962,16 +2975,25 @@ public class LibraryClient implements BackgroundResource {
   }
 
   /**
-   * Formats a string containing the fully-qualified path to represent
-   * a archived_book resource.
+   * Parses the archive_path from the given fully-qualified path which
+   * represents a archived_book resource.
    *
    * @deprecated Use the {@link ArchivedBookName} class instead.
    */
   @Deprecated
-  public static final String formatArchivedBookName(String archivePath, String bookId) {
-    return ARCHIVED_BOOK_PATH_TEMPLATE.instantiate(
-        "archive_path", archivePath,
-        "book_id", bookId);
+  public static final String parseArchivePathFromArchivedBookName(String archivedBookName) {
+    return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("archive_path");
+  }
+
+  /**
+   * Parses the book_id from the given fully-qualified path which
+   * represents a archived_book resource.
+   *
+   * @deprecated Use the {@link ArchivedBookName} class instead.
+   */
+  @Deprecated
+  public static final String parseBookIdFromArchivedBookName(String archivedBookName) {
+    return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("book_id");
   }
 
   /**
@@ -3016,28 +3038,6 @@ public class LibraryClient implements BackgroundResource {
   @Deprecated
   public static final String parseShelfIdFromShelfName(String shelfName) {
     return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf_id");
-  }
-
-  /**
-   * Parses the archive_path from the given fully-qualified path which
-   * represents a archived_book resource.
-   *
-   * @deprecated Use the {@link ArchivedBookName} class instead.
-   */
-  @Deprecated
-  public static final String parseArchivePathFromArchivedBookName(String archivedBookName) {
-    return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("archive_path");
-  }
-
-  /**
-   * Parses the book_id from the given fully-qualified path which
-   * represents a archived_book resource.
-   *
-   * @deprecated Use the {@link ArchivedBookName} class instead.
-   */
-  @Deprecated
-  public static final String parseBookIdFromArchivedBookName(String archivedBookName) {
-    return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("book_id");
   }
 
   /**

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -4054,6 +4054,9 @@ class LibraryServiceClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
+      archivedBookPathTemplate: new gax.PathTemplate(
+        'archives/{archive_path}/books/{book_id=**}'
+      ),
       bookPathTemplate: new gax.PathTemplate(
         'shelves/{shelf_id}/books/{book_id}'
       ),
@@ -4062,9 +4065,6 @@ class LibraryServiceClient {
       ),
       shelfPathTemplate: new gax.PathTemplate(
         'shelves/{shelf_id}'
-      ),
-      archivedBookPathTemplate: new gax.PathTemplate(
-        'archives/{archive_path}/books/{book_id=**}'
       ),
     };
 
@@ -6517,6 +6517,20 @@ class LibraryServiceClient {
   // --------------------
 
   /**
+   * Return a fully-qualified archived_book resource name string.
+   *
+   * @param {String} archivePath
+   * @param {String} bookId
+   * @returns {String}
+   */
+  archivedBookPath(archivePath, bookId) {
+    return this._pathTemplates.archivedBookPathTemplate.render({
+      archive_path: archivePath,
+      book_id: bookId,
+    });
+  }
+
+  /**
    * Return a fully-qualified book resource name string.
    *
    * @param {String} shelfId
@@ -6555,17 +6569,29 @@ class LibraryServiceClient {
   }
 
   /**
-   * Return a fully-qualified archived_book resource name string.
+   * Parse the archivedBookName from a archived_book resource.
    *
-   * @param {String} archivePath
-   * @param {String} bookId
-   * @returns {String}
+   * @param {String} archivedBookName
+   *   A fully-qualified path representing a archived_book resources.
+   * @returns {String} - A string representing the archive_path.
    */
-  archivedBookPath(archivePath, bookId) {
-    return this._pathTemplates.archivedBookPathTemplate.render({
-      archive_path: archivePath,
-      book_id: bookId,
-    });
+  matchArchivePathFromArchivedBookName(archivedBookName) {
+    return this._pathTemplates.archivedBookPathTemplate
+      .match(archivedBookName)
+      .archive_path;
+  }
+
+  /**
+   * Parse the archivedBookName from a archived_book resource.
+   *
+   * @param {String} archivedBookName
+   *   A fully-qualified path representing a archived_book resources.
+   * @returns {String} - A string representing the book_id.
+   */
+  matchBookIdFromArchivedBookName(archivedBookName) {
+    return this._pathTemplates.archivedBookPathTemplate
+      .match(archivedBookName)
+      .book_id;
   }
 
   /**
@@ -6618,32 +6644,6 @@ class LibraryServiceClient {
     return this._pathTemplates.shelfPathTemplate
       .match(shelfName)
       .shelf_id;
-  }
-
-  /**
-   * Parse the archivedBookName from a archived_book resource.
-   *
-   * @param {String} archivedBookName
-   *   A fully-qualified path representing a archived_book resources.
-   * @returns {String} - A string representing the archive_path.
-   */
-  matchArchivePathFromArchivedBookName(archivedBookName) {
-    return this._pathTemplates.archivedBookPathTemplate
-      .match(archivedBookName)
-      .archive_path;
-  }
-
-  /**
-   * Parse the archivedBookName from a archived_book resource.
-   *
-   * @param {String} archivedBookName
-   *   A fully-qualified path representing a archived_book resources.
-   * @returns {String} - A string representing the book_id.
-   */
-  matchBookIdFromArchivedBookName(archivedBookName) {
-    return this._pathTemplates.archivedBookPathTemplate
-      .match(archivedBookName)
-      .book_id;
   }
 }
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -194,10 +194,10 @@ class LibraryServiceGapicClient
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/library',
     ];
+    private static $archivedBookNameTemplate;
     private static $bookNameTemplate;
     private static $projectNameTemplate;
     private static $shelfNameTemplate;
-    private static $archivedBookNameTemplate;
     private static $pathTemplateMap;
 
     private $operationsClient;
@@ -218,6 +218,15 @@ class LibraryServiceGapicClient
                 ]
             ]
         ];
+    }
+
+    private static function getArchivedBookNameTemplate()
+    {
+        if (self::$archivedBookNameTemplate == null) {
+            self::$archivedBookNameTemplate = new PathTemplate('archives/{archive_path}/books/{book_id=**}');
+        }
+
+        return self::$archivedBookNameTemplate;
     }
 
     private static function getBookNameTemplate()
@@ -247,28 +256,36 @@ class LibraryServiceGapicClient
         return self::$shelfNameTemplate;
     }
 
-    private static function getArchivedBookNameTemplate()
-    {
-        if (self::$archivedBookNameTemplate == null) {
-            self::$archivedBookNameTemplate = new PathTemplate('archives/{archive_path}/books/{book_id=**}');
-        }
-
-        return self::$archivedBookNameTemplate;
-    }
-
 
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'archivedBook' => self::getArchivedBookNameTemplate(),
                 'book' => self::getBookNameTemplate(),
                 'project' => self::getProjectNameTemplate(),
                 'shelf' => self::getShelfNameTemplate(),
-                'archivedBook' => self::getArchivedBookNameTemplate(),
             ];
         }
         return self::$pathTemplateMap;
     }
+    /**
+     * Formats a string containing the fully-qualified path to represent
+     * a archived_book resource.
+     *
+     * @param string $archivePath
+     * @param string $bookId
+     * @return string The formatted archived_book resource.
+     * @experimental
+     */
+    public static function archivedBookName($archivePath, $bookId)
+    {
+        return self::getArchivedBookNameTemplate()->render([
+            'archive_path' => $archivePath,
+            'book_id' => $bookId,
+        ]);
+    }
+
     /**
      * Formats a string containing the fully-qualified path to represent
      * a book resource.
@@ -317,30 +334,13 @@ class LibraryServiceGapicClient
     }
 
     /**
-     * Formats a string containing the fully-qualified path to represent
-     * a archived_book resource.
-     *
-     * @param string $archivePath
-     * @param string $bookId
-     * @return string The formatted archived_book resource.
-     * @experimental
-     */
-    public static function archivedBookName($archivePath, $bookId)
-    {
-        return self::getArchivedBookNameTemplate()->render([
-            'archive_path' => $archivePath,
-            'book_id' => $bookId,
-        ]);
-    }
-
-    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - archivedBook: archives/{archive_path}/books/{book_id=**}
      * - book: shelves/{shelf_id}/books/{book_id}
      * - project: projects/{project}
      * - shelf: shelves/{shelf_id}
-     * - archivedBook: archives/{archive_path}/books/{book_id=**}
      *
      * The optional $template argument can be supplied to specify a particular pattern, and must
      * match one of the templates listed above. If no $template argument is provided, or if the

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -1145,6 +1145,15 @@ class LibraryServiceClient(object):
 
 
     @classmethod
+    def archived_book_path(cls, archive_path, book_id):
+        """Return a fully-qualified archived_book string."""
+        return google.api_core.path_template.expand(
+            'archives/{archive_path}/books/{book_id=**}',
+            archive_path=archive_path,
+            book_id=book_id,
+        )
+
+    @classmethod
     def book_path(cls, shelf_id, book_id):
         """Return a fully-qualified book string."""
         return google.api_core.path_template.expand(
@@ -1167,15 +1176,6 @@ class LibraryServiceClient(object):
         return google.api_core.path_template.expand(
             'shelves/{shelf_id}',
             shelf_id=shelf_id,
-        )
-
-    @classmethod
-    def archived_book_path(cls, archive_path, book_id):
-        """Return a fully-qualified archived_book string."""
-        return google.api_core.path_template.expand(
-            'archives/{archive_path}/books/{book_id=**}',
-            archive_path=archive_path,
-            book_id=book_id,
         )
 
     def __init__(self, transport=None, channel=None, credentials=None,

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -2916,6 +2916,12 @@ module Library
         self::GRPC_INTERCEPTORS = LibraryServiceClient::GRPC_INTERCEPTORS
       end
 
+      ARCHIVED_BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+        "archives/{archive_path}/books/{book_id=**}"
+      )
+
+      private_constant :ARCHIVED_BOOK_PATH_TEMPLATE
+
       BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
         "shelves/{shelf_id}/books/{book_id}"
       )
@@ -2934,11 +2940,16 @@ module Library
 
       private_constant :SHELF_PATH_TEMPLATE
 
-      ARCHIVED_BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "archives/{archive_path}/books/{book_id=**}"
-      )
-
-      private_constant :ARCHIVED_BOOK_PATH_TEMPLATE
+      # Returns a fully-qualified archived_book resource name string.
+      # @param archive_path [String]
+      # @param book_id [String]
+      # @return [String]
+      def self.archived_book_path archive_path, book_id
+        ARCHIVED_BOOK_PATH_TEMPLATE.render(
+          :"archive_path" => archive_path,
+          :"book_id" => book_id
+        )
+      end
 
       # Returns a fully-qualified book resource name string.
       # @param shelf_id [String]
@@ -2966,17 +2977,6 @@ module Library
       def self.shelf_path shelf_id
         SHELF_PATH_TEMPLATE.render(
           :"shelf_id" => shelf_id
-        )
-      end
-
-      # Returns a fully-qualified archived_book resource name string.
-      # @param archive_path [String]
-      # @param book_id [String]
-      # @return [String]
-      def self.archived_book_path archive_path, book_id
-        ARCHIVED_BOOK_PATH_TEMPLATE.render(
-          :"archive_path" => archive_path,
-          :"book_id" => book_id
         )
       end
 


### PR DESCRIPTION
Emphasize that InterfaceConfig.getSingleResourceNameConfigs is an unordered collection, and that it's up to the transformers to order the configs as they see fit.

This reduces the diff between a GAPIC config v2 -generated client and one generated with GAPIC config v1.