### PR TITLE
SampleGen: sample package for Node.js

### DIFF
--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorFactory.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorFactory.java
@@ -55,6 +55,7 @@ import com.google.api.codegen.transformer.nodejs.NodeJSGapicSurfaceDocTransforme
 import com.google.api.codegen.transformer.nodejs.NodeJSGapicSurfaceTestTransformer;
 import com.google.api.codegen.transformer.nodejs.NodeJSGapicSurfaceTransformer;
 import com.google.api.codegen.transformer.nodejs.NodeJSPackageMetadataTransformer;
+import com.google.api.codegen.transformer.nodejs.NodeJSSamplePackageMetadataTransformer;
 import com.google.api.codegen.transformer.php.PhpGapicSamplesTransformer;
 import com.google.api.codegen.transformer.php.PhpGapicSurfaceTestTransformer;
 import com.google.api.codegen.transformer.php.PhpGapicSurfaceTransformer;
@@ -314,7 +315,16 @@ public class GapicGeneratorFactory {
                   .setModelToViewTransformer(
                       new NodeJSGapicSamplesTransformer(nodeJSPathMapper, packageConfig))
                   .build();
+          CodeGenerator sampleMetadataGenerator =
+              GapicGenerator.newBuilder()
+                  .setModel(model)
+                  .setProductConfig(productConfig)
+                  .setSnippetSetRunner(new CommonSnippetSetRunner(new CommonRenderingUtil()))
+                  .setModelToViewTransformer(
+                      new NodeJSSamplePackageMetadataTransformer(packageConfig))
+                  .build();
           generators.add(sampleGenerator);
+          generators.add(sampleMetadataGenerator);
         }
 
         CodeGenerator messageGenerator =

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSCodePathMapper.java
@@ -19,24 +19,33 @@ import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.util.VersionMatcher;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.List;
 
 public class NodeJSCodePathMapper implements GapicCodePathMapper {
   @Override
   public String getOutputPath(String elementFullName, ProductConfig config) {
-    return getOutputPath(elementFullName, config, null);
+    ArrayList<String> dirs = new ArrayList<>();
+    dirs.add("src");
+    String apiVersion = getVersion(elementFullName);
+    if (!apiVersion.isEmpty()) {
+      dirs.add(apiVersion);
+    }
+    return Joiner.on("/").join(dirs);
   }
 
   @Override
   public String getSamplesOutputPath(String elementFullName, ProductConfig config, String method) {
-    return getOutputPath(elementFullName, config, method);
+    ArrayList<String> dirs = new ArrayList<>();
+    dirs.add("samples");
+    String apiVersion = getVersion(elementFullName);
+    if (!apiVersion.isEmpty()) {
+      dirs.add(apiVersion);
+    }
+    return Joiner.on("/").join(dirs);
   }
 
-  private String getOutputPath(String elementFullName, ProductConfig config, String methodSample) {
-    boolean haveSample = !Strings.isNullOrEmpty(methodSample);
-
+  private String getVersion(String elementFullName) {
     String apiVersion = "";
     List<String> packages = Splitter.on(".").splitToList(elementFullName);
     for (String p : packages) {
@@ -44,18 +53,6 @@ public class NodeJSCodePathMapper implements GapicCodePathMapper {
         apiVersion = p;
       }
     }
-
-    ArrayList<String> dirs = new ArrayList<>();
-    dirs.add("src");
-
-    if (haveSample) {
-      dirs.add(SAMPLES_DIRECTORY);
-    }
-
-    if (!apiVersion.isEmpty()) {
-      dirs.add(apiVersion);
-    }
-
-    return Joiner.on("/").join(dirs);
+    return apiVersion;
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSamplePackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSamplePackageMetadataTransformer.java
@@ -1,0 +1,100 @@
+/* Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer.nodejs;
+
+import com.google.api.codegen.common.TargetLanguage;
+import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.PackageMetadataConfig;
+import com.google.api.codegen.config.ProtoApiModel;
+import com.google.api.codegen.config.VersionBound;
+import com.google.api.codegen.transformer.ModelToViewTransformer;
+import com.google.api.codegen.transformer.PackageMetadataTransformer;
+import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.api.codegen.viewmodel.metadata.PackageDependencyView;
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.List;
+
+/** Responsible for producing package metadata for standalone samples in Node.js. */
+public class NodeJSSamplePackageMetadataTransformer
+    implements ModelToViewTransformer<ProtoApiModel> {
+
+  private static final String TEMPLATE_FILE = "nodejs/sample_package.json.snip";
+  private static final PackageMetadataTransformer metadataTransformer =
+      new PackageMetadataTransformer();
+
+  private final PackageMetadataConfig packageConfig;
+
+  public NodeJSSamplePackageMetadataTransformer(PackageMetadataConfig packageConfig) {
+    this.packageConfig = packageConfig;
+  }
+
+  @Override
+  public List<String> getTemplateFileNames() {
+    return Collections.singletonList(TEMPLATE_FILE);
+  }
+
+  @Override
+  public List<ViewModel> transform(ProtoApiModel model, GapicProductConfig productConfig) {
+    boolean shouldGenerateSamplePackages =
+        productConfig
+            .getInterfaceConfigMap()
+            .values()
+            .stream()
+            .flatMap(config -> config.getMethodConfigs().stream())
+            .anyMatch(config -> config.getSampleSpec().isConfigured());
+    if (!shouldGenerateSamplePackages) {
+      return Collections.emptyList();
+    }
+
+    NodeJSPackageMetadataNamer gapicPackageNamer =
+        new NodeJSPackageMetadataNamer(
+            productConfig.getPackageName(), productConfig.getDomainLayerLocation());
+    String outputPath = "samples/package.json";
+    ViewModel metadataView =
+        metadataTransformer
+            .generateMetadataView(
+                gapicPackageNamer,
+                packageConfig,
+                model,
+                TEMPLATE_FILE,
+                outputPath,
+                TargetLanguage.NODEJS)
+            .identifier(samplePackageIdentifier(productConfig))
+            .hasMultipleServices(model.hasMultipleServices())
+            .additionalDependencies(additionalDependencies(gapicPackageNamer))
+            .build();
+    return Collections.singletonList(metadataView);
+  }
+
+  private String samplePackageIdentifier(GapicProductConfig productConfig) {
+    String packageName = productConfig.getPackageName();
+    int firstDotIndex = packageName.indexOf(".");
+    return "nodejs-docs-samples"
+        + (firstDotIndex == -1 ? packageName : packageName.substring(0, firstDotIndex));
+  }
+
+  private List<PackageDependencyView> additionalDependencies(
+      NodeJSPackageMetadataNamer gapicPackageNamer) {
+    PackageDependencyView yargsDep =
+        PackageDependencyView.create(
+            "yargs", packageConfig.commonsCliVersionBound(TargetLanguage.NODEJS));
+    System.out.println(yargsDep);
+    PackageDependencyView gapicDep =
+        PackageDependencyView.create(
+            gapicPackageNamer.getMetadataIdentifier(), VersionBound.create("file:..", "file:.."));
+    return ImmutableList.of(yargsDep, gapicDep);
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSamplePackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSamplePackageMetadataTransformer.java
@@ -91,7 +91,6 @@ public class NodeJSSamplePackageMetadataTransformer
     PackageDependencyView yargsDep =
         PackageDependencyView.create(
             "yargs", packageConfig.commonsCliVersionBound(TargetLanguage.NODEJS));
-    System.out.println(yargsDep);
     PackageDependencyView gapicDep =
         PackageDependencyView.create(
             gapicPackageNamer.getMetadataIdentifier(), VersionBound.create("file:..", "file:.."));

--- a/src/main/resources/com/google/api/codegen/nodejs/sample_package.json.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/sample_package.json.snip
@@ -1,0 +1,23 @@
+@snippet generate(metadata)
+  {
+    "name": "{@metadata.identifier}",
+    "private": true,
+    "license": "{@metadata.licenseName}",
+    "author": "{@metadata.author}",
+    "files": [
+      "*.js"
+    ],
+    "dependencies": {
+      @join packageDep : metadata.additionalDependencies on ",".add(BREAK)
+        @if packageDep.versionBound.lower == packageDep.versionBound.upper
+          "{@packageDep.name}": "{@packageDep.versionBound.lower}"
+        @else
+          "{@packageDep.name}": "^{@packageDep.versionBound.lower}"
+        @end
+      @end
+    },
+    "engines": {
+      "node": ">=6.0.0"
+    }
+  }
+@end

--- a/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
+++ b/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
@@ -109,3 +109,7 @@ api_common_version:
 commons_cli_version:
   java:
     lower: '1.4'
+  nodejs:
+    name_override: yargs
+    lower: '13.1.0'
+    upper: '13.2.2'

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -107,6 +107,1288 @@ $ npm install --save @google-cloud/library
   }
 }
 
+============== file: samples/package.json ==============
+{
+  "name": "nodejs-docs-sampleslibrary",
+  "private": true,
+  "license": "Apache-2.0",
+  "author": "Google LLC",
+  "files": [
+    "*.js"
+  ],
+  "dependencies": {
+    "yargs": "^13.1.0",
+    "@google-cloud/library": "file:.."
+  },
+  "engines": {
+    "node": ">=6.0.0"
+  }
+}
+============== file: samples/v1/babble_about_book_request_streaming_client_empty_response_type_with_response_handling.js ==============
+// DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_with_response_handling")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test response handling for methods that return empty */
+function sampleBabbleAboutBook() {
+  const client = new library.LibraryServiceClient();
+  const stream = client.babbleAboutBook((err, response) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    // No one replied
+    console.log(`No one replied.`);
+  });
+  const request = {};
+  // Write request objects.
+  stream.write(request);
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleBabbleAboutBook();
+============== file: samples/v1/babble_about_book_request_streaming_client_empty_response_type_without_response_handling.js ==============
+// DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_without_response_handling")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleBabbleAboutBook() {
+  const client = new library.LibraryServiceClient();
+  const stream = client.babbleAboutBook((err, response) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+  });
+  const request = {};
+  // Write request objects.
+  stream.write(request);
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleBabbleAboutBook();
+============== file: samples/v1/delete_shelf_request_empty_response_type_with_response_handling.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_with_response_handling")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test response handling for methods that return empty */
+function sampleDeleteShelf() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.shelfPath('[SHELF_ID]');
+  client.deleteShelf({name: formattedName}).catch(err => {
+    console.error(err);
+  });
+  // Shelf deleted
+  console.log(`Shelf deleted.`);
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleDeleteShelf();
+============== file: samples/v1/delete_shelf_request_empty_response_type_without_response_handling.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_without_response_handling")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleDeleteShelf() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.shelfPath('[SHELF_ID]');
+  client.deleteShelf({name: formattedName}).catch(err => {
+    console.error(err);
+  });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleDeleteShelf();
+============== file: samples/v1/find_related_books_request_async_paged_all_odyssey.js ==============
+// DO NOT EDIT! This is a generated sample ("RequestAsyncPagedAll",  "odyssey")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Testing calling forms */
+function sampleFindRelatedBooks() {
+  const client = new library.LibraryServiceClient();
+  // Iterate over all elements.
+  const namesElement = 'Odyssey';
+  const names = [namesElement];
+  const shelvesElement = 'Classics';
+  const shelves = [shelvesElement];
+  const request = {
+    names: names,
+    shelves: shelves,
+  };
+
+  client.findRelatedBooks(request)
+    .then(responses => {
+      const resources = responses[0];
+      for (const resource of resources) {
+        const book = resource;
+        console.log(`Here's a related book: ${book}`);
+      }
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleFindRelatedBooks();
+============== file: samples/v1/find_related_books_request_async_paged_odyssey.js ==============
+// DO NOT EDIT! This is a generated sample ("RequestAsyncPaged",  "odyssey")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Testing calling forms */
+function sampleFindRelatedBooks() {
+  const client = new library.LibraryServiceClient();
+  // Or obtain the paged response.
+  const namesElement = 'Odyssey';
+  const names = [namesElement];
+  const shelvesElement = 'Classics';
+  const shelves = [shelvesElement];
+  const request = {
+    names: names,
+    shelves: shelves,
+  };
+
+
+  const options = {autoPaginate: false};
+  const callback = responses => {
+    // The actual resources in a response.
+    const resources = responses[0];
+    // The next request if the response shows that there are more responses.
+    const nextRequest = responses[1];
+    // The actual response object, if necessary.
+    // const rawResponse = responses[2];
+    for (const resource of resources) {
+      const book = resource;
+      console.log(`Here's a related book: ${book}`);
+    }
+    if (nextRequest) {
+      // Fetch the next page.
+      return client.findRelatedBooks(nextRequest, options).then(callback);
+    }
+  }
+  client.findRelatedBooks(request, options)
+    .then(callback)
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleFindRelatedBooks();
+============== file: samples/v1/get_big_book_long_running_event_emitter_wap.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "wap")
+'use strict';
+
+// [START hopper]
+// [START hopper_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Testing calling forms */
+function sampleGetBigBook(shelf) {
+  const client = new library.LibraryServiceClient();
+  // const shelf = 'Novel';
+  const formattedName = client.bookPath(shelf, 'War and Peace');
+
+  // Handle the operation using the event emitter pattern.
+  client.getBigBook({name: formattedName})
+    .then(responses => {
+      const [operation, initApiResponse] = responses;
+
+      // Adding a listener for the "complete" event starts polling for the
+      // completion of the operation.
+      operation.on('complete', (result, metadata, finalApiResponse) => {
+        // Testing iterating over map fields when both key and value are specified.
+        for (const [myKey, myValue] of Object.entries(result.mapListValueValue)) {
+          console.log(`key: ${myKey}, value: ${myValue}`);
+        }
+
+        // Testing iterating over map fields when only key is specified.
+        for (const anotherKey of Object.keys(result.mapListValueValue)) {
+          console.log(`key: ${anotherKey}`);
+        }
+
+        // Testing iterating over map fields when only value is specified.
+        for (const anotherValue of Object.values(result.mapListValueValue)) {
+          console.log(`value: ${anotherValue}`);
+        }
+
+        console.log(`name: ${result.name}`);
+        console.log(`author: ${result.author}`);
+      });
+
+      // Adding a listener for the "progress" event causes the callback to be
+      // called on any change in metadata when the operation is polled.
+      operation.on('progress', (metadata, apiResponse) => {
+        // doSomethingWith(metadata)
+      });
+
+      // Adding a listener for the "error" event handles any errors found during polling.
+      operation.on('error', err => {
+        // throw(err);
+      });
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END hopper_core]
+// [END hopper]
+// tslint:disable-next-line:no-any
+
+const argv = require(`yargs`)
+  .option('shelf', {
+    default: 'Novel',
+    string: true
+  })
+  .argv;
+
+sampleGetBigBook(argv.shelf);
+============== file: samples/v1/get_big_book_long_running_event_emitter_wap2.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "wap2")
+'use strict';
+
+// [START hopper]
+// [START hopper_core]
+
+const library = require('@google-cloud/library').v1;
+
+/**
+ * Testing resource name overlap
+ *
+ * @param shelf {string} Test word wrapping for long lines. This is a long comment. The name of the
+ * shelf to retrieve the big book from.
+ * @param bigBookName {string} The name of the book.
+ */
+function sampleGetBigBook(shelf, bigBookName) {
+  const client = new library.LibraryServiceClient();
+  // const shelf = 'Novel';
+  // const bigBookName = 'War and Peace';
+  const formattedName = client.bookPath(shelf, bigBookName);
+
+  // Handle the operation using the event emitter pattern.
+  client.getBigBook({name: formattedName})
+    .then(responses => {
+      const [operation, initApiResponse] = responses;
+
+      // Adding a listener for the "complete" event starts polling for the
+      // completion of the operation.
+      operation.on('complete', (result, metadata, finalApiResponse) => {
+        console.log(result);
+      });
+
+      // Adding a listener for the "progress" event causes the callback to be
+      // called on any change in metadata when the operation is polled.
+      operation.on('progress', (metadata, apiResponse) => {
+        // doSomethingWith(metadata)
+      });
+
+      // Adding a listener for the "error" event handles any errors found during polling.
+      operation.on('error', err => {
+        // throw(err);
+      });
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END hopper_core]
+// [END hopper]
+// tslint:disable-next-line:no-any
+
+const argv = require(`yargs`)
+  .option('shelf', {
+    default: 'Novel',
+    string: true
+  })
+  .option('big_book_name', {
+    default: 'War and Peace',
+    string: true
+  })
+  .argv;
+
+sampleGetBigBook(argv.shelf, argv.big_book_name);
+============== file: samples/v1/get_big_book_long_running_promise_await_wap.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "wap")
+'use strict';
+
+// [START hopper]
+// [START hopper_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Testing calling forms */
+async function sampleGetBigBook(shelf) {
+  const client = new library.LibraryServiceClient();
+  // const shelf = 'Novel';
+  const formattedName = client.bookPath(shelf, 'War and Peace');
+
+  // Create a job whose results you can either wait for now, or get later
+  const [operation] = await client.getBigBook({name: formattedName});
+
+  // Get a Promise representation of the final result of the job
+  const [response] = await operation.promise();
+
+  // Testing iterating over map fields when both key and value are specified.
+  for (const [myKey, myValue] of Object.entries(response.mapListValueValue)) {
+    console.log(`key: ${myKey}, value: ${myValue}`);
+  }
+
+  // Testing iterating over map fields when only key is specified.
+  for (const anotherKey of Object.keys(response.mapListValueValue)) {
+    console.log(`key: ${anotherKey}`);
+  }
+
+  // Testing iterating over map fields when only value is specified.
+  for (const anotherValue of Object.values(response.mapListValueValue)) {
+    console.log(`value: ${anotherValue}`);
+  }
+
+  console.log(`name: ${response.name}`);
+  console.log(`author: ${response.author}`);
+}
+
+
+// [END hopper_core]
+// [END hopper]
+// tslint:disable-next-line:no-any
+
+const argv = require(`yargs`)
+  .option('shelf', {
+    default: 'Novel',
+    string: true
+  })
+  .argv;
+
+sampleGetBigBook(argv.shelf).catch(console.error);
+============== file: samples/v1/get_big_book_long_running_promise_await_wap2.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "wap2")
+'use strict';
+
+// [START hopper]
+// [START hopper_core]
+
+const library = require('@google-cloud/library').v1;
+
+/**
+ * Testing resource name overlap
+ *
+ * @param shelf {string} Test word wrapping for long lines. This is a long comment. The name of the
+ * shelf to retrieve the big book from.
+ * @param bigBookName {string} The name of the book.
+ */
+async function sampleGetBigBook(shelf, bigBookName) {
+  const client = new library.LibraryServiceClient();
+  // const shelf = 'Novel';
+  // const bigBookName = 'War and Peace';
+  const formattedName = client.bookPath(shelf, bigBookName);
+
+  // Create a job whose results you can either wait for now, or get later
+  const [operation] = await client.getBigBook({name: formattedName});
+
+  // Get a Promise representation of the final result of the job
+  const [response] = await operation.promise();
+
+  console.log(response);
+}
+
+
+// [END hopper_core]
+// [END hopper]
+// tslint:disable-next-line:no-any
+
+const argv = require(`yargs`)
+  .option('shelf', {
+    default: 'Novel',
+    string: true
+  })
+  .option('big_book_name', {
+    default: 'War and Peace',
+    string: true
+  })
+  .argv;
+
+sampleGetBigBook(argv.shelf, argv.big_book_name).catch(console.error);
+============== file: samples/v1/get_big_book_long_running_promise_wap.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "wap")
+'use strict';
+
+// [START hopper]
+// [START hopper_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Testing calling forms */
+function sampleGetBigBook(shelf) {
+  const client = new library.LibraryServiceClient();
+  // const shelf = 'Novel';
+  const formattedName = client.bookPath(shelf, 'War and Peace');
+
+  // Handle the operation using the promise pattern.
+  client.getBigBook({name: formattedName})
+    .then(responses => {
+      const [operation, initialApiResponse] = responses;
+
+      // Operation#promise starts polling for the completion of the LRO.
+      return operation.promise();
+    })
+    .then(responses => {
+      const result = responses[0];
+      const metadata = responses[1];
+      const finalApiResponse = responses[2];
+
+      // Testing iterating over map fields when both key and value are specified.
+      for (const [myKey, myValue] of Object.entries(result.mapListValueValue)) {
+        console.log(`key: ${myKey}, value: ${myValue}`);
+      }
+
+      // Testing iterating over map fields when only key is specified.
+      for (const anotherKey of Object.keys(result.mapListValueValue)) {
+        console.log(`key: ${anotherKey}`);
+      }
+
+      // Testing iterating over map fields when only value is specified.
+      for (const anotherValue of Object.values(result.mapListValueValue)) {
+        console.log(`value: ${anotherValue}`);
+      }
+
+      console.log(`name: ${result.name}`);
+      console.log(`author: ${result.author}`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END hopper_core]
+// [END hopper]
+// tslint:disable-next-line:no-any
+
+const argv = require(`yargs`)
+  .option('shelf', {
+    default: 'Novel',
+    string: true
+  })
+  .argv;
+
+sampleGetBigBook(argv.shelf);
+============== file: samples/v1/get_big_book_long_running_promise_wap2.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "wap2")
+'use strict';
+
+// [START hopper]
+// [START hopper_core]
+
+const library = require('@google-cloud/library').v1;
+
+/**
+ * Testing resource name overlap
+ *
+ * @param shelf {string} Test word wrapping for long lines. This is a long comment. The name of the
+ * shelf to retrieve the big book from.
+ * @param bigBookName {string} The name of the book.
+ */
+function sampleGetBigBook(shelf, bigBookName) {
+  const client = new library.LibraryServiceClient();
+  // const shelf = 'Novel';
+  // const bigBookName = 'War and Peace';
+  const formattedName = client.bookPath(shelf, bigBookName);
+
+  // Handle the operation using the promise pattern.
+  client.getBigBook({name: formattedName})
+    .then(responses => {
+      const [operation, initialApiResponse] = responses;
+
+      // Operation#promise starts polling for the completion of the LRO.
+      return operation.promise();
+    })
+    .then(responses => {
+      const result = responses[0];
+      const metadata = responses[1];
+      const finalApiResponse = responses[2];
+
+      console.log(result);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END hopper_core]
+// [END hopper]
+// tslint:disable-next-line:no-any
+
+const argv = require(`yargs`)
+  .option('shelf', {
+    default: 'Novel',
+    string: true
+  })
+  .option('big_book_name', {
+    default: 'War and Peace',
+    string: true
+  })
+  .argv;
+
+sampleGetBigBook(argv.shelf, argv.big_book_name);
+============== file: samples/v1/get_big_nothing_long_running_event_emitter_empty_response_type_with_response_handling.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "empty_response_type_with_response_handling")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test response handling for methods that return empty */
+function sampleGetBigNothing() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+
+  // Handle the operation using the event emitter pattern.
+  client.getBigNothing({name: formattedName})
+    .then(responses => {
+      const [operation, initApiResponse] = responses;
+
+      // Adding a listener for the "complete" event starts polling for the
+      // completion of the operation.
+      operation.on('complete', (result, metadata, finalApiResponse) => {
+        // Got nothing
+        console.log(`Got nothing.`);
+      });
+
+      // Adding a listener for the "progress" event causes the callback to be
+      // called on any change in metadata when the operation is polled.
+      operation.on('progress', (metadata, apiResponse) => {
+        // doSomethingWith(metadata)
+      });
+
+      // Adding a listener for the "error" event handles any errors found during polling.
+      operation.on('error', err => {
+        // throw(err);
+      });
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleGetBigNothing();
+============== file: samples/v1/get_big_nothing_long_running_event_emitter_empty_response_type_without_response_handling.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "empty_response_type_without_response_handling")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleGetBigNothing() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+
+  // Handle the operation using the event emitter pattern.
+  client.getBigNothing({name: formattedName})
+    .then(responses => {
+      const [operation, initApiResponse] = responses;
+
+      // Adding a listener for the "complete" event starts polling for the
+      // completion of the operation.
+      operation.on('complete', (result, metadata, finalApiResponse) => {
+      });
+
+      // Adding a listener for the "progress" event causes the callback to be
+      // called on any change in metadata when the operation is polled.
+      operation.on('progress', (metadata, apiResponse) => {
+        // doSomethingWith(metadata)
+      });
+
+      // Adding a listener for the "error" event handles any errors found during polling.
+      operation.on('error', err => {
+        // throw(err);
+      });
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleGetBigNothing();
+============== file: samples/v1/get_big_nothing_long_running_promise_await_empty_response_type_with_response_handling.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "empty_response_type_with_response_handling")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test response handling for methods that return empty */
+async function sampleGetBigNothing() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+
+  // Create a job whose results you can either wait for now, or get later
+  const [operation] = await client.getBigNothing({name: formattedName});
+
+  // Get a Promise representation of the final result of the job
+  const [response] = await operation.promise();
+
+  // Got nothing
+  console.log(`Got nothing.`);
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleGetBigNothing().catch(console.error);
+============== file: samples/v1/get_big_nothing_long_running_promise_await_empty_response_type_without_response_handling.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "empty_response_type_without_response_handling")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test default response handling is turned off for methods that return empty */
+async function sampleGetBigNothing() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+
+  // Create a job whose results you can either wait for now, or get later
+  const [operation] = await client.getBigNothing({name: formattedName});
+
+  // Get a Promise representation of the final result of the job
+  const [response] = await operation.promise();
+
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleGetBigNothing().catch(console.error);
+============== file: samples/v1/get_big_nothing_long_running_promise_empty_response_type_with_response_handling.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "empty_response_type_with_response_handling")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test response handling for methods that return empty */
+function sampleGetBigNothing() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+
+  // Handle the operation using the promise pattern.
+  client.getBigNothing({name: formattedName})
+    .then(responses => {
+      const [operation, initialApiResponse] = responses;
+
+      // Operation#promise starts polling for the completion of the LRO.
+      return operation.promise();
+    })
+    .then(responses => {
+      const result = responses[0];
+      const metadata = responses[1];
+      const finalApiResponse = responses[2];
+
+      // Got nothing
+      console.log(`Got nothing.`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleGetBigNothing();
+============== file: samples/v1/get_big_nothing_long_running_promise_empty_response_type_without_response_handling.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "empty_response_type_without_response_handling")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleGetBigNothing() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+
+  // Handle the operation using the promise pattern.
+  client.getBigNothing({name: formattedName})
+    .then(responses => {
+      const [operation, initialApiResponse] = responses;
+
+      // Operation#promise starts polling for the completion of the LRO.
+      return operation.promise();
+    })
+    .then(responses => {
+      const result = responses[0];
+      const metadata = responses[1];
+      const finalApiResponse = responses[2];
+
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleGetBigNothing();
+============== file: samples/v1/get_book_request_test_on_success_map.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+function sampleGetBook() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  client.getBook({name: formattedName})
+    .then(responses => {
+      const response = responses[0];
+      const intKeyVal = response.mapStringValue[123];
+      const booleanKeyVal = response.mapBoolKey[true];
+      const mapValueField = response.mapMessageValue['key'].field;
+      console.log(`Test printing map fields: ${response.mapListValueValue['quoted_key']}`);
+      console.log(`Test printing enum fields of a map value: ${response.mapMessageValue['key'].alignment}`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleGetBook();
+============== file: samples/v1/lovelace.js ==============
+// DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "prog")
+'use strict';
+
+// [START lovelace]
+// [START lovelace_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Testing calling forms */
+function sampleStreamBooks() {
+  const client = new library.LibraryServiceClient();
+  const name = 'BASIC';
+    client.streamBooks({name: name}).on('data', response => {
+      console.log(response);
+    });
+}
+
+
+// [END lovelace_core]
+// [END lovelace]
+// tslint:disable-next-line:no-any
+
+sampleStreamBooks();
+============== file: samples/v1/monolog_about_book_request_streaming_client_prog.js ==============
+// DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "prog")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Testing calling forms */
+function sampleMonologAboutBook() {
+  const client = new library.LibraryServiceClient();
+  const stream = client.monologAboutBook((err, response) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    console.log(`The stage of the comment is: ${response.stage}`);
+  });
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const request = {
+    name: formattedName,
+  };
+  // Write request objects.
+  stream.write(request);
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleMonologAboutBook();
+============== file: samples/v1/publish_series_request_pi_version.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
+'use strict';
+
+// [START canonical]
+// [START canonical_core]
+
+const library = require('@google-cloud/library').v1;
+
+/**
+ * Testing <@calling forms>
+ *
+ * @param shelfName {string} The name of the shelf where books are published to.
+ * @param edition {number} The edition of the series.
+ */
+function samplePublishSeries(shelfName, edition) {
+  const client = new library.LibraryServiceClient();
+  // const shelfName = 'Math';
+  // const edition = 123;
+  const shelf = {
+    name: shelfName,
+  };
+  const books = [];
+  const seriesString = 'xyz3141592654';
+  const seriesUuid = {
+    seriesString: seriesString,
+  };
+  const request = {
+    shelf: shelf,
+    books: books,
+    seriesUuid: seriesUuid,
+    edition: edition,
+  };
+  client.publishSeries(request)
+    .then(responses => {
+      const response = responses[0];
+      // % % % output handling % % % %
+      // fourScoreAndSevenYears ago
+      //
+      // our fathers brought forth upon this continent
+      //
+      // a new nation
+      // conceived in liberty
+      //
+      // and dedicated to the proposition that allMenAreCreatedEqual.
+      //
+      // Do something with bookNames one by one
+      const bookNames = response.bookNames;
+      for (const title of response.bookNames) {
+        // Now we deal with thisSingleBook!
+        console.log(`\t%\`\` The book's title: "${title}", \\\nand the book costs $50.00 \`\`%`);
+      }
+      console.log(`The first book is: ${response.bookNames[0]}`);
+      console.log(`The author of the first book is: ${response.books[0].author}`);
+      console.log(`That's all!`);
+      console.log(`series_uuid: ${response.seriesUuid.seriesBytes}`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END canonical_core]
+// [END canonical]
+// tslint:disable-next-line:no-any
+
+const argv = require(`yargs`)
+  .option('shelf_name', {
+    default: 'Math',
+    string: true
+  })
+  .option('edition', {
+    default: 123,
+    number: true
+  })
+  .argv;
+
+samplePublishSeries(argv.shelf_name, argv.edition);
+============== file: samples/v1/publish_series_request_second_edition.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
+'use strict';
+
+// [START canonical]
+// [START canonical_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Testing calling forms */
+function samplePublishSeries() {
+  const client = new library.LibraryServiceClient();
+  const shelf = {};
+  const books = [];
+  const seriesUuid = {};
+  const edition = 2;
+  const request = {
+    shelf: shelf,
+    books: books,
+    seriesUuid: seriesUuid,
+    edition: edition,
+  };
+  client.publishSeries(request)
+    .then(responses => {
+      const response = responses[0];
+      console.log(response);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END canonical_core]
+// [END canonical]
+// tslint:disable-next-line:no-any
+
+samplePublishSeries();
+============== file: samples/v1/publish_series_request_test_request_object_field_comments.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_request_object_field_comments")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+const fs = require('fs');
+/** Test request object field comments */
+function samplePublishSeries() {
+  const client = new library.LibraryServiceClient();
+
+  // Comment on a resource name
+  const formattedName = client.shelfPath('math');
+
+  // A super long comment
+  // wraps words at newline characters
+  // as well
+  const theme = 'Math';
+
+  // Comment on a primitive field
+  const internalTheme = 'Statistics';
+  const shelf = {
+    name: formattedName,
+    theme: theme,
+    internalTheme: internalTheme,
+  };
+  const books = [];
+
+  // Comment on a file input field
+  const seriesBytes = fs.readFileSync('xyz3141592654').toString('base64');
+
+  // Comment on a message
+  const seriesUuid = {
+    seriesBytes: seriesBytes,
+  };
+
+  // A super long long long long long long long long long long long long long long comment that tests
+  // word wrapping
+  const edition = 123;
+  const request = {
+    shelf: shelf,
+    books: books,
+    seriesUuid: seriesUuid,
+    edition: edition,
+  };
+  client.publishSeries(request)
+    .then(responses => {
+      const response = responses[0];
+      console.log(response);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+samplePublishSeries();
+============== file: samples/v1/publish_series_request_test_write_to_file.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_write_to_file")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+const util = require('util');
+const fs = require('fs');
+/** Testing write fields to files. */
+function samplePublishSeries() {
+  const client = new library.LibraryServiceClient();
+  const shelf = {};
+  const books = [];
+  const seriesUuid = {};
+  const request = {
+    shelf: shelf,
+    books: books,
+    seriesUuid: seriesUuid,
+  };
+  client.publishSeries(request)
+    .then(responses => {
+      const response = responses[0];
+      // testing writing bytes field.
+      var writeFile = util.promisify(fs.writeFile);
+      writeFile(`uuid_of_series_with_book_${response.bookNames[0]}.raw`, response.seriesUuid.seriesBytes, 'binary');
+      // testing writing string field.
+      writeFile('series_uuid_in_plain_text.txt', response.seriesUuid.seriesString);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+samplePublishSeries();
+============== file: samples/v1/sample_get_shelf.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_default_calling_form_unary")
+'use strict';
+
+// [START sample_get_shelf]
+// [START sample_get_shelf_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test default calling forms for unary methods. */
+function sampleGetShelf() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.shelfPath('my-shelf');
+  const options = '';
+  const request = {
+    name: formattedName,
+    options: options,
+  };
+  client.getShelf(request)
+    .then(responses => {
+      const response = responses[0];
+      console.log(`The theme of the shelf is: ${response.theme}`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END sample_get_shelf_core]
+// [END sample_get_shelf]
+// tslint:disable-next-line:no-any
+
+sampleGetShelf();
+============== file: samples/v1/stream_shelves_request_streaming_server_empty.js ==============
+// DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "empty")
+'use strict';
+
+// [START sample]
+// [START sample_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Testing calling forms */
+function sampleStreamShelves() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+    client.streamShelves({name: formattedName}).on('data', response => {
+      console.log(response);
+    });
+}
+
+
+// [END sample_core]
+// [END sample]
+// tslint:disable-next-line:no-any
+
+sampleStreamShelves();
+============== file: samples/v1/this_tag_should_be_the_name_of_the_file.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "wap")
+'use strict';
+
+// [START this_tag_should_be_the_name_of_the_file]
+// [START this_tag_should_be_the_name_of_the_file_core]
+
+const library = require('@google-cloud/library').v1;
+
+/** Testing calling forms */
+async function sampleGetBigBook(shelf) {
+  const client = new library.LibraryServiceClient();
+  // const shelf = 'Novel';
+  const formattedName = client.bookPath(shelf, 'War and Peace');
+
+  // Create a job whose results you can either wait for now, or get later
+  const [operation] = await client.getBigBook({name: formattedName});
+
+  // Get a Promise representation of the final result of the job
+  const [response] = await operation.promise();
+
+  // Testing iterating over map fields when both key and value are specified.
+  for (const [myKey, myValue] of Object.entries(response.mapListValueValue)) {
+    console.log(`key: ${myKey}, value: ${myValue}`);
+  }
+
+  // Testing iterating over map fields when only key is specified.
+  for (const anotherKey of Object.keys(response.mapListValueValue)) {
+    console.log(`key: ${anotherKey}`);
+  }
+
+  // Testing iterating over map fields when only value is specified.
+  for (const anotherValue of Object.values(response.mapListValueValue)) {
+    console.log(`value: ${anotherValue}`);
+  }
+
+  console.log(`name: ${response.name}`);
+  console.log(`author: ${response.author}`);
+}
+
+
+// [END this_tag_should_be_the_name_of_the_file_core]
+// [END this_tag_should_be_the_name_of_the_file]
+// tslint:disable-next-line:no-any
+
+const argv = require(`yargs`)
+  .option('shelf', {
+    default: 'Novel',
+    string: true
+  })
+  .argv;
+
+sampleGetBigBook(argv.shelf).catch(console.error);
+============== file: samples/v1/turing_prog_request_streaming_bidi.js ==============
+// DO NOT EDIT! This is a generated sample ("RequestStreamingBidi",  "prog")
+'use strict';
+
+// [START turing_prog_request_streaming_bidi]
+// [START turing_prog_request_streaming_bidi_core]
+
+const library = require('@google-cloud/library').v1;
+
+const fs = require('fs');
+/** Testing calling forms */
+function sampleDiscussBook(imageFileName) {
+  const client = new library.LibraryServiceClient();
+  const stream = client.discussBook().on('data', response => {
+    console.log(response);
+  });
+  // const imageFileName = 'image_file.jpg';
+  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const comment = fs.readFileSync('comment_file').toString('base64');
+  const comment2 = {
+    comment: comment,
+  };
+  const image = fs.readFileSync(imageFileName).toString('base64');
+  const request = {
+    name: formattedName,
+    comment: comment2,
+    image: image,
+  };
+  // Write request objects.
+  stream.write(request);
+}
+
+
+// [END turing_prog_request_streaming_bidi_core]
+// [END turing_prog_request_streaming_bidi]
+// tslint:disable-next-line:no-any
+
+const argv = require(`yargs`)
+  .option('image_file_name', {
+    default: 'image_file.jpg',
+    string: true
+  })
+  .argv;
+
+sampleDiscussBook(argv.image_file_name);
 ============== file: smoke-test/library_service_smoke_test.js ==============
 // Copyright 2019 Google LLC
 //
@@ -245,1271 +1527,6 @@ module.exports.v1 = gapic.v1;
 // Alias `module.exports` as `module.exports.default`, for future-proofing.
 module.exports.default = Object.assign({}, module.exports);
 
-============== file: src/samples/v1/babble_about_book_request_streaming_client_empty_response_type_with_response_handling.js ==============
-// DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_with_response_handling")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Test response handling for methods that return empty */
-function sampleBabbleAboutBook() {
-  const client = new library.LibraryServiceClient();
-  const stream = client.babbleAboutBook((err, response) => {
-    if (err) {
-      console.error(err);
-      return;
-    }
-    // No one replied
-    console.log(`No one replied.`);
-  });
-  const request = {};
-  // Write request objects.
-  stream.write(request);
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleBabbleAboutBook();
-============== file: src/samples/v1/babble_about_book_request_streaming_client_empty_response_type_without_response_handling.js ==============
-// DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_without_response_handling")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleBabbleAboutBook() {
-  const client = new library.LibraryServiceClient();
-  const stream = client.babbleAboutBook((err, response) => {
-    if (err) {
-      console.error(err);
-      return;
-    }
-  });
-  const request = {};
-  // Write request objects.
-  stream.write(request);
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleBabbleAboutBook();
-============== file: src/samples/v1/delete_shelf_request_empty_response_type_with_response_handling.js ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_with_response_handling")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Test response handling for methods that return empty */
-function sampleDeleteShelf() {
-  const client = new library.LibraryServiceClient();
-  const formattedName = client.shelfPath('[SHELF_ID]');
-  client.deleteShelf({name: formattedName}).catch(err => {
-    console.error(err);
-  });
-  // Shelf deleted
-  console.log(`Shelf deleted.`);
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleDeleteShelf();
-============== file: src/samples/v1/delete_shelf_request_empty_response_type_without_response_handling.js ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_without_response_handling")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleDeleteShelf() {
-  const client = new library.LibraryServiceClient();
-  const formattedName = client.shelfPath('[SHELF_ID]');
-  client.deleteShelf({name: formattedName}).catch(err => {
-    console.error(err);
-  });
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleDeleteShelf();
-============== file: src/samples/v1/find_related_books_request_async_paged_all_odyssey.js ==============
-// DO NOT EDIT! This is a generated sample ("RequestAsyncPagedAll",  "odyssey")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Testing calling forms */
-function sampleFindRelatedBooks() {
-  const client = new library.LibraryServiceClient();
-  // Iterate over all elements.
-  const namesElement = 'Odyssey';
-  const names = [namesElement];
-  const shelvesElement = 'Classics';
-  const shelves = [shelvesElement];
-  const request = {
-    names: names,
-    shelves: shelves,
-  };
-
-  client.findRelatedBooks(request)
-    .then(responses => {
-      const resources = responses[0];
-      for (const resource of resources) {
-        const book = resource;
-        console.log(`Here's a related book: ${book}`);
-      }
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleFindRelatedBooks();
-============== file: src/samples/v1/find_related_books_request_async_paged_odyssey.js ==============
-// DO NOT EDIT! This is a generated sample ("RequestAsyncPaged",  "odyssey")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Testing calling forms */
-function sampleFindRelatedBooks() {
-  const client = new library.LibraryServiceClient();
-  // Or obtain the paged response.
-  const namesElement = 'Odyssey';
-  const names = [namesElement];
-  const shelvesElement = 'Classics';
-  const shelves = [shelvesElement];
-  const request = {
-    names: names,
-    shelves: shelves,
-  };
-
-
-  const options = {autoPaginate: false};
-  const callback = responses => {
-    // The actual resources in a response.
-    const resources = responses[0];
-    // The next request if the response shows that there are more responses.
-    const nextRequest = responses[1];
-    // The actual response object, if necessary.
-    // const rawResponse = responses[2];
-    for (const resource of resources) {
-      const book = resource;
-      console.log(`Here's a related book: ${book}`);
-    }
-    if (nextRequest) {
-      // Fetch the next page.
-      return client.findRelatedBooks(nextRequest, options).then(callback);
-    }
-  }
-  client.findRelatedBooks(request, options)
-    .then(callback)
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleFindRelatedBooks();
-============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "wap")
-'use strict';
-
-// [START hopper]
-// [START hopper_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Testing calling forms */
-function sampleGetBigBook(shelf) {
-  const client = new library.LibraryServiceClient();
-  // const shelf = 'Novel';
-  const formattedName = client.bookPath(shelf, 'War and Peace');
-
-  // Handle the operation using the event emitter pattern.
-  client.getBigBook({name: formattedName})
-    .then(responses => {
-      const [operation, initApiResponse] = responses;
-
-      // Adding a listener for the "complete" event starts polling for the
-      // completion of the operation.
-      operation.on('complete', (result, metadata, finalApiResponse) => {
-        // Testing iterating over map fields when both key and value are specified.
-        for (const [myKey, myValue] of Object.entries(result.mapListValueValue)) {
-          console.log(`key: ${myKey}, value: ${myValue}`);
-        }
-
-        // Testing iterating over map fields when only key is specified.
-        for (const anotherKey of Object.keys(result.mapListValueValue)) {
-          console.log(`key: ${anotherKey}`);
-        }
-
-        // Testing iterating over map fields when only value is specified.
-        for (const anotherValue of Object.values(result.mapListValueValue)) {
-          console.log(`value: ${anotherValue}`);
-        }
-
-        console.log(`name: ${result.name}`);
-        console.log(`author: ${result.author}`);
-      });
-
-      // Adding a listener for the "progress" event causes the callback to be
-      // called on any change in metadata when the operation is polled.
-      operation.on('progress', (metadata, apiResponse) => {
-        // doSomethingWith(metadata)
-      });
-
-      // Adding a listener for the "error" event handles any errors found during polling.
-      operation.on('error', err => {
-        // throw(err);
-      });
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END hopper_core]
-// [END hopper]
-// tslint:disable-next-line:no-any
-
-const argv = require(`yargs`)
-  .option('shelf', {
-    default: 'Novel',
-    string: true
-  })
-  .argv;
-
-sampleGetBigBook(argv.shelf);
-============== file: src/samples/v1/get_big_book_long_running_event_emitter_wap2.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "wap2")
-'use strict';
-
-// [START hopper]
-// [START hopper_core]
-
-const library = require('@google-cloud/library').v1;
-
-/**
- * Testing resource name overlap
- *
- * @param shelf {string} Test word wrapping for long lines. This is a long comment. The name of the
- * shelf to retrieve the big book from.
- * @param bigBookName {string} The name of the book.
- */
-function sampleGetBigBook(shelf, bigBookName) {
-  const client = new library.LibraryServiceClient();
-  // const shelf = 'Novel';
-  // const bigBookName = 'War and Peace';
-  const formattedName = client.bookPath(shelf, bigBookName);
-
-  // Handle the operation using the event emitter pattern.
-  client.getBigBook({name: formattedName})
-    .then(responses => {
-      const [operation, initApiResponse] = responses;
-
-      // Adding a listener for the "complete" event starts polling for the
-      // completion of the operation.
-      operation.on('complete', (result, metadata, finalApiResponse) => {
-        console.log(result);
-      });
-
-      // Adding a listener for the "progress" event causes the callback to be
-      // called on any change in metadata when the operation is polled.
-      operation.on('progress', (metadata, apiResponse) => {
-        // doSomethingWith(metadata)
-      });
-
-      // Adding a listener for the "error" event handles any errors found during polling.
-      operation.on('error', err => {
-        // throw(err);
-      });
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END hopper_core]
-// [END hopper]
-// tslint:disable-next-line:no-any
-
-const argv = require(`yargs`)
-  .option('shelf', {
-    default: 'Novel',
-    string: true
-  })
-  .option('big_book_name', {
-    default: 'War and Peace',
-    string: true
-  })
-  .argv;
-
-sampleGetBigBook(argv.shelf, argv.big_book_name);
-============== file: src/samples/v1/get_big_book_long_running_promise_await_wap.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "wap")
-'use strict';
-
-// [START hopper]
-// [START hopper_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Testing calling forms */
-async function sampleGetBigBook(shelf) {
-  const client = new library.LibraryServiceClient();
-  // const shelf = 'Novel';
-  const formattedName = client.bookPath(shelf, 'War and Peace');
-
-  // Create a job whose results you can either wait for now, or get later
-  const [operation] = await client.getBigBook({name: formattedName});
-
-  // Get a Promise representation of the final result of the job
-  const [response] = await operation.promise();
-
-  // Testing iterating over map fields when both key and value are specified.
-  for (const [myKey, myValue] of Object.entries(response.mapListValueValue)) {
-    console.log(`key: ${myKey}, value: ${myValue}`);
-  }
-
-  // Testing iterating over map fields when only key is specified.
-  for (const anotherKey of Object.keys(response.mapListValueValue)) {
-    console.log(`key: ${anotherKey}`);
-  }
-
-  // Testing iterating over map fields when only value is specified.
-  for (const anotherValue of Object.values(response.mapListValueValue)) {
-    console.log(`value: ${anotherValue}`);
-  }
-
-  console.log(`name: ${response.name}`);
-  console.log(`author: ${response.author}`);
-}
-
-
-// [END hopper_core]
-// [END hopper]
-// tslint:disable-next-line:no-any
-
-const argv = require(`yargs`)
-  .option('shelf', {
-    default: 'Novel',
-    string: true
-  })
-  .argv;
-
-sampleGetBigBook(argv.shelf).catch(console.error);
-============== file: src/samples/v1/get_big_book_long_running_promise_await_wap2.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "wap2")
-'use strict';
-
-// [START hopper]
-// [START hopper_core]
-
-const library = require('@google-cloud/library').v1;
-
-/**
- * Testing resource name overlap
- *
- * @param shelf {string} Test word wrapping for long lines. This is a long comment. The name of the
- * shelf to retrieve the big book from.
- * @param bigBookName {string} The name of the book.
- */
-async function sampleGetBigBook(shelf, bigBookName) {
-  const client = new library.LibraryServiceClient();
-  // const shelf = 'Novel';
-  // const bigBookName = 'War and Peace';
-  const formattedName = client.bookPath(shelf, bigBookName);
-
-  // Create a job whose results you can either wait for now, or get later
-  const [operation] = await client.getBigBook({name: formattedName});
-
-  // Get a Promise representation of the final result of the job
-  const [response] = await operation.promise();
-
-  console.log(response);
-}
-
-
-// [END hopper_core]
-// [END hopper]
-// tslint:disable-next-line:no-any
-
-const argv = require(`yargs`)
-  .option('shelf', {
-    default: 'Novel',
-    string: true
-  })
-  .option('big_book_name', {
-    default: 'War and Peace',
-    string: true
-  })
-  .argv;
-
-sampleGetBigBook(argv.shelf, argv.big_book_name).catch(console.error);
-============== file: src/samples/v1/get_big_book_long_running_promise_wap.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "wap")
-'use strict';
-
-// [START hopper]
-// [START hopper_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Testing calling forms */
-function sampleGetBigBook(shelf) {
-  const client = new library.LibraryServiceClient();
-  // const shelf = 'Novel';
-  const formattedName = client.bookPath(shelf, 'War and Peace');
-
-  // Handle the operation using the promise pattern.
-  client.getBigBook({name: formattedName})
-    .then(responses => {
-      const [operation, initialApiResponse] = responses;
-
-      // Operation#promise starts polling for the completion of the LRO.
-      return operation.promise();
-    })
-    .then(responses => {
-      const result = responses[0];
-      const metadata = responses[1];
-      const finalApiResponse = responses[2];
-
-      // Testing iterating over map fields when both key and value are specified.
-      for (const [myKey, myValue] of Object.entries(result.mapListValueValue)) {
-        console.log(`key: ${myKey}, value: ${myValue}`);
-      }
-
-      // Testing iterating over map fields when only key is specified.
-      for (const anotherKey of Object.keys(result.mapListValueValue)) {
-        console.log(`key: ${anotherKey}`);
-      }
-
-      // Testing iterating over map fields when only value is specified.
-      for (const anotherValue of Object.values(result.mapListValueValue)) {
-        console.log(`value: ${anotherValue}`);
-      }
-
-      console.log(`name: ${result.name}`);
-      console.log(`author: ${result.author}`);
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END hopper_core]
-// [END hopper]
-// tslint:disable-next-line:no-any
-
-const argv = require(`yargs`)
-  .option('shelf', {
-    default: 'Novel',
-    string: true
-  })
-  .argv;
-
-sampleGetBigBook(argv.shelf);
-============== file: src/samples/v1/get_big_book_long_running_promise_wap2.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "wap2")
-'use strict';
-
-// [START hopper]
-// [START hopper_core]
-
-const library = require('@google-cloud/library').v1;
-
-/**
- * Testing resource name overlap
- *
- * @param shelf {string} Test word wrapping for long lines. This is a long comment. The name of the
- * shelf to retrieve the big book from.
- * @param bigBookName {string} The name of the book.
- */
-function sampleGetBigBook(shelf, bigBookName) {
-  const client = new library.LibraryServiceClient();
-  // const shelf = 'Novel';
-  // const bigBookName = 'War and Peace';
-  const formattedName = client.bookPath(shelf, bigBookName);
-
-  // Handle the operation using the promise pattern.
-  client.getBigBook({name: formattedName})
-    .then(responses => {
-      const [operation, initialApiResponse] = responses;
-
-      // Operation#promise starts polling for the completion of the LRO.
-      return operation.promise();
-    })
-    .then(responses => {
-      const result = responses[0];
-      const metadata = responses[1];
-      const finalApiResponse = responses[2];
-
-      console.log(result);
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END hopper_core]
-// [END hopper]
-// tslint:disable-next-line:no-any
-
-const argv = require(`yargs`)
-  .option('shelf', {
-    default: 'Novel',
-    string: true
-  })
-  .option('big_book_name', {
-    default: 'War and Peace',
-    string: true
-  })
-  .argv;
-
-sampleGetBigBook(argv.shelf, argv.big_book_name);
-============== file: src/samples/v1/get_big_nothing_long_running_event_emitter_empty_response_type_with_response_handling.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "empty_response_type_with_response_handling")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Test response handling for methods that return empty */
-function sampleGetBigNothing() {
-  const client = new library.LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-
-  // Handle the operation using the event emitter pattern.
-  client.getBigNothing({name: formattedName})
-    .then(responses => {
-      const [operation, initApiResponse] = responses;
-
-      // Adding a listener for the "complete" event starts polling for the
-      // completion of the operation.
-      operation.on('complete', (result, metadata, finalApiResponse) => {
-        // Got nothing
-        console.log(`Got nothing.`);
-      });
-
-      // Adding a listener for the "progress" event causes the callback to be
-      // called on any change in metadata when the operation is polled.
-      operation.on('progress', (metadata, apiResponse) => {
-        // doSomethingWith(metadata)
-      });
-
-      // Adding a listener for the "error" event handles any errors found during polling.
-      operation.on('error', err => {
-        // throw(err);
-      });
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleGetBigNothing();
-============== file: src/samples/v1/get_big_nothing_long_running_event_emitter_empty_response_type_without_response_handling.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningEventEmitter",  "empty_response_type_without_response_handling")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleGetBigNothing() {
-  const client = new library.LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-
-  // Handle the operation using the event emitter pattern.
-  client.getBigNothing({name: formattedName})
-    .then(responses => {
-      const [operation, initApiResponse] = responses;
-
-      // Adding a listener for the "complete" event starts polling for the
-      // completion of the operation.
-      operation.on('complete', (result, metadata, finalApiResponse) => {
-      });
-
-      // Adding a listener for the "progress" event causes the callback to be
-      // called on any change in metadata when the operation is polled.
-      operation.on('progress', (metadata, apiResponse) => {
-        // doSomethingWith(metadata)
-      });
-
-      // Adding a listener for the "error" event handles any errors found during polling.
-      operation.on('error', err => {
-        // throw(err);
-      });
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleGetBigNothing();
-============== file: src/samples/v1/get_big_nothing_long_running_promise_await_empty_response_type_with_response_handling.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "empty_response_type_with_response_handling")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Test response handling for methods that return empty */
-async function sampleGetBigNothing() {
-  const client = new library.LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-
-  // Create a job whose results you can either wait for now, or get later
-  const [operation] = await client.getBigNothing({name: formattedName});
-
-  // Get a Promise representation of the final result of the job
-  const [response] = await operation.promise();
-
-  // Got nothing
-  console.log(`Got nothing.`);
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleGetBigNothing().catch(console.error);
-============== file: src/samples/v1/get_big_nothing_long_running_promise_await_empty_response_type_without_response_handling.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "empty_response_type_without_response_handling")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Test default response handling is turned off for methods that return empty */
-async function sampleGetBigNothing() {
-  const client = new library.LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-
-  // Create a job whose results you can either wait for now, or get later
-  const [operation] = await client.getBigNothing({name: formattedName});
-
-  // Get a Promise representation of the final result of the job
-  const [response] = await operation.promise();
-
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleGetBigNothing().catch(console.error);
-============== file: src/samples/v1/get_big_nothing_long_running_promise_empty_response_type_with_response_handling.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "empty_response_type_with_response_handling")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Test response handling for methods that return empty */
-function sampleGetBigNothing() {
-  const client = new library.LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-
-  // Handle the operation using the promise pattern.
-  client.getBigNothing({name: formattedName})
-    .then(responses => {
-      const [operation, initialApiResponse] = responses;
-
-      // Operation#promise starts polling for the completion of the LRO.
-      return operation.promise();
-    })
-    .then(responses => {
-      const result = responses[0];
-      const metadata = responses[1];
-      const finalApiResponse = responses[2];
-
-      // Got nothing
-      console.log(`Got nothing.`);
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleGetBigNothing();
-============== file: src/samples/v1/get_big_nothing_long_running_promise_empty_response_type_without_response_handling.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "empty_response_type_without_response_handling")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleGetBigNothing() {
-  const client = new library.LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-
-  // Handle the operation using the promise pattern.
-  client.getBigNothing({name: formattedName})
-    .then(responses => {
-      const [operation, initialApiResponse] = responses;
-
-      // Operation#promise starts polling for the completion of the LRO.
-      return operation.promise();
-    })
-    .then(responses => {
-      const result = responses[0];
-      const metadata = responses[1];
-      const finalApiResponse = responses[2];
-
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleGetBigNothing();
-============== file: src/samples/v1/get_book_request_test_on_success_map.js ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-function sampleGetBook() {
-  const client = new library.LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-  client.getBook({name: formattedName})
-    .then(responses => {
-      const response = responses[0];
-      const intKeyVal = response.mapStringValue[123];
-      const booleanKeyVal = response.mapBoolKey[true];
-      const mapValueField = response.mapMessageValue['key'].field;
-      console.log(`Test printing map fields: ${response.mapListValueValue['quoted_key']}`);
-      console.log(`Test printing enum fields of a map value: ${response.mapMessageValue['key'].alignment}`);
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleGetBook();
-============== file: src/samples/v1/lovelace.js ==============
-// DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "prog")
-'use strict';
-
-// [START lovelace]
-// [START lovelace_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Testing calling forms */
-function sampleStreamBooks() {
-  const client = new library.LibraryServiceClient();
-  const name = 'BASIC';
-    client.streamBooks({name: name}).on('data', response => {
-      console.log(response);
-    });
-}
-
-
-// [END lovelace_core]
-// [END lovelace]
-// tslint:disable-next-line:no-any
-
-sampleStreamBooks();
-============== file: src/samples/v1/monolog_about_book_request_streaming_client_prog.js ==============
-// DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "prog")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Testing calling forms */
-function sampleMonologAboutBook() {
-  const client = new library.LibraryServiceClient();
-  const stream = client.monologAboutBook((err, response) => {
-    if (err) {
-      console.error(err);
-      return;
-    }
-    console.log(`The stage of the comment is: ${response.stage}`);
-  });
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-  const request = {
-    name: formattedName,
-  };
-  // Write request objects.
-  stream.write(request);
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleMonologAboutBook();
-============== file: src/samples/v1/publish_series_request_pi_version.js ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
-'use strict';
-
-// [START canonical]
-// [START canonical_core]
-
-const library = require('@google-cloud/library').v1;
-
-/**
- * Testing <@calling forms>
- *
- * @param shelfName {string} The name of the shelf where books are published to.
- * @param edition {number} The edition of the series.
- */
-function samplePublishSeries(shelfName, edition) {
-  const client = new library.LibraryServiceClient();
-  // const shelfName = 'Math';
-  // const edition = 123;
-  const shelf = {
-    name: shelfName,
-  };
-  const books = [];
-  const seriesString = 'xyz3141592654';
-  const seriesUuid = {
-    seriesString: seriesString,
-  };
-  const request = {
-    shelf: shelf,
-    books: books,
-    seriesUuid: seriesUuid,
-    edition: edition,
-  };
-  client.publishSeries(request)
-    .then(responses => {
-      const response = responses[0];
-      // % % % output handling % % % %
-      // fourScoreAndSevenYears ago
-      //
-      // our fathers brought forth upon this continent
-      //
-      // a new nation
-      // conceived in liberty
-      //
-      // and dedicated to the proposition that allMenAreCreatedEqual.
-      //
-      // Do something with bookNames one by one
-      const bookNames = response.bookNames;
-      for (const title of response.bookNames) {
-        // Now we deal with thisSingleBook!
-        console.log(`\t%\`\` The book's title: "${title}", \\\nand the book costs $50.00 \`\`%`);
-      }
-      console.log(`The first book is: ${response.bookNames[0]}`);
-      console.log(`The author of the first book is: ${response.books[0].author}`);
-      console.log(`That's all!`);
-      console.log(`series_uuid: ${response.seriesUuid.seriesBytes}`);
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END canonical_core]
-// [END canonical]
-// tslint:disable-next-line:no-any
-
-const argv = require(`yargs`)
-  .option('shelf_name', {
-    default: 'Math',
-    string: true
-  })
-  .option('edition', {
-    default: 123,
-    number: true
-  })
-  .argv;
-
-samplePublishSeries(argv.shelf_name, argv.edition);
-============== file: src/samples/v1/publish_series_request_second_edition.js ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
-'use strict';
-
-// [START canonical]
-// [START canonical_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Testing calling forms */
-function samplePublishSeries() {
-  const client = new library.LibraryServiceClient();
-  const shelf = {};
-  const books = [];
-  const seriesUuid = {};
-  const edition = 2;
-  const request = {
-    shelf: shelf,
-    books: books,
-    seriesUuid: seriesUuid,
-    edition: edition,
-  };
-  client.publishSeries(request)
-    .then(responses => {
-      const response = responses[0];
-      console.log(response);
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END canonical_core]
-// [END canonical]
-// tslint:disable-next-line:no-any
-
-samplePublishSeries();
-============== file: src/samples/v1/publish_series_request_test_request_object_field_comments.js ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "test_request_object_field_comments")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-const fs = require('fs');
-/** Test request object field comments */
-function samplePublishSeries() {
-  const client = new library.LibraryServiceClient();
-
-  // Comment on a resource name
-  const formattedName = client.shelfPath('math');
-
-  // A super long comment
-  // wraps words at newline characters
-  // as well
-  const theme = 'Math';
-
-  // Comment on a primitive field
-  const internalTheme = 'Statistics';
-  const shelf = {
-    name: formattedName,
-    theme: theme,
-    internalTheme: internalTheme,
-  };
-  const books = [];
-
-  // Comment on a file input field
-  const seriesBytes = fs.readFileSync('xyz3141592654').toString('base64');
-
-  // Comment on a message
-  const seriesUuid = {
-    seriesBytes: seriesBytes,
-  };
-
-  // A super long long long long long long long long long long long long long long comment that tests
-  // word wrapping
-  const edition = 123;
-  const request = {
-    shelf: shelf,
-    books: books,
-    seriesUuid: seriesUuid,
-    edition: edition,
-  };
-  client.publishSeries(request)
-    .then(responses => {
-      const response = responses[0];
-      console.log(response);
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-samplePublishSeries();
-============== file: src/samples/v1/publish_series_request_test_write_to_file.js ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "test_write_to_file")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-const util = require('util');
-const fs = require('fs');
-/** Testing write fields to files. */
-function samplePublishSeries() {
-  const client = new library.LibraryServiceClient();
-  const shelf = {};
-  const books = [];
-  const seriesUuid = {};
-  const request = {
-    shelf: shelf,
-    books: books,
-    seriesUuid: seriesUuid,
-  };
-  client.publishSeries(request)
-    .then(responses => {
-      const response = responses[0];
-      // testing writing bytes field.
-      var writeFile = util.promisify(fs.writeFile);
-      writeFile(`uuid_of_series_with_book_${response.bookNames[0]}.raw`, response.seriesUuid.seriesBytes, 'binary');
-      // testing writing string field.
-      writeFile('series_uuid_in_plain_text.txt', response.seriesUuid.seriesString);
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-samplePublishSeries();
-============== file: src/samples/v1/sample_get_shelf.js ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "test_default_calling_form_unary")
-'use strict';
-
-// [START sample_get_shelf]
-// [START sample_get_shelf_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Test default calling forms for unary methods. */
-function sampleGetShelf() {
-  const client = new library.LibraryServiceClient();
-  const formattedName = client.shelfPath('my-shelf');
-  const options = '';
-  const request = {
-    name: formattedName,
-    options: options,
-  };
-  client.getShelf(request)
-    .then(responses => {
-      const response = responses[0];
-      console.log(`The theme of the shelf is: ${response.theme}`);
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
-
-// [END sample_get_shelf_core]
-// [END sample_get_shelf]
-// tslint:disable-next-line:no-any
-
-sampleGetShelf();
-============== file: src/samples/v1/stream_shelves_request_streaming_server_empty.js ==============
-// DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "empty")
-'use strict';
-
-// [START sample]
-// [START sample_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Testing calling forms */
-function sampleStreamShelves() {
-  const client = new library.LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-    client.streamShelves({name: formattedName}).on('data', response => {
-      console.log(response);
-    });
-}
-
-
-// [END sample_core]
-// [END sample]
-// tslint:disable-next-line:no-any
-
-sampleStreamShelves();
-============== file: src/samples/v1/this_tag_should_be_the_name_of_the_file.js ==============
-// DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "wap")
-'use strict';
-
-// [START this_tag_should_be_the_name_of_the_file]
-// [START this_tag_should_be_the_name_of_the_file_core]
-
-const library = require('@google-cloud/library').v1;
-
-/** Testing calling forms */
-async function sampleGetBigBook(shelf) {
-  const client = new library.LibraryServiceClient();
-  // const shelf = 'Novel';
-  const formattedName = client.bookPath(shelf, 'War and Peace');
-
-  // Create a job whose results you can either wait for now, or get later
-  const [operation] = await client.getBigBook({name: formattedName});
-
-  // Get a Promise representation of the final result of the job
-  const [response] = await operation.promise();
-
-  // Testing iterating over map fields when both key and value are specified.
-  for (const [myKey, myValue] of Object.entries(response.mapListValueValue)) {
-    console.log(`key: ${myKey}, value: ${myValue}`);
-  }
-
-  // Testing iterating over map fields when only key is specified.
-  for (const anotherKey of Object.keys(response.mapListValueValue)) {
-    console.log(`key: ${anotherKey}`);
-  }
-
-  // Testing iterating over map fields when only value is specified.
-  for (const anotherValue of Object.values(response.mapListValueValue)) {
-    console.log(`value: ${anotherValue}`);
-  }
-
-  console.log(`name: ${response.name}`);
-  console.log(`author: ${response.author}`);
-}
-
-
-// [END this_tag_should_be_the_name_of_the_file_core]
-// [END this_tag_should_be_the_name_of_the_file]
-// tslint:disable-next-line:no-any
-
-const argv = require(`yargs`)
-  .option('shelf', {
-    default: 'Novel',
-    string: true
-  })
-  .argv;
-
-sampleGetBigBook(argv.shelf).catch(console.error);
-============== file: src/samples/v1/turing_prog_request_streaming_bidi.js ==============
-// DO NOT EDIT! This is a generated sample ("RequestStreamingBidi",  "prog")
-'use strict';
-
-// [START turing_prog_request_streaming_bidi]
-// [START turing_prog_request_streaming_bidi_core]
-
-const library = require('@google-cloud/library').v1;
-
-const fs = require('fs');
-/** Testing calling forms */
-function sampleDiscussBook(imageFileName) {
-  const client = new library.LibraryServiceClient();
-  const stream = client.discussBook().on('data', response => {
-    console.log(response);
-  });
-  // const imageFileName = 'image_file.jpg';
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-  const comment = fs.readFileSync('comment_file').toString('base64');
-  const comment2 = {
-    comment: comment,
-  };
-  const image = fs.readFileSync(imageFileName).toString('base64');
-  const request = {
-    name: formattedName,
-    comment: comment2,
-    image: image,
-  };
-  // Write request objects.
-  stream.write(request);
-}
-
-
-// [END turing_prog_request_streaming_bidi_core]
-// [END turing_prog_request_streaming_bidi]
-// tslint:disable-next-line:no-any
-
-const argv = require(`yargs`)
-  .option('image_file_name', {
-    default: 'image_file.jpg',
-    string: true
-  })
-  .argv;
-
-sampleDiscussBook(argv.image_file_name);
 ============== file: src/v1/doc/google/example/library/v1/doc_another_service.js ==============
 // Copyright 2019 Google LLC
 //

--- a/src/test/java/com/google/api/codegen/testsrc/common/frozen_dependencies.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/frozen_dependencies.yaml
@@ -88,3 +88,7 @@ google-some-test-package-v1_version:
 commons_cli_version:
   java:
     lower: '1.4'
+  nodejs:
+    name_override: yargs
+    lower: '13.1.0'
+    upper: '13.2.2'


### PR DESCRIPTION
- pull samples out from `src` directory
- generate a `package.json` for the samples
It should be possible to run the samples this way:
```shell
artman generate nodejs_gapic ...
cd artman-output/js/[api]
npm install
cd samples
npm install
node v1/some_sample.js
```