### PR TITLE
[C#] Always generate the string param flattening method for resource-name methods

### DIFF
--- a/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
@@ -329,4 +329,13 @@ public abstract class FlatteningConfig {
     paramList.forEach(p -> paramsAsString.append(p.getSimpleName()).append(", "));
     return paramsAsString.toString();
   }
+
+  /** Return if the flattening config contains a parameter that is a resource name. */
+  public static boolean hasAnyResourceNameParameter(FlatteningConfig flatteningGroup) {
+    return flatteningGroup
+        .getFlattenedFieldConfigs()
+        .values()
+        .stream()
+        .anyMatch(FieldConfig::useResourceNameType);
+  }
 }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpApiMethodTransformer.java
@@ -148,6 +148,14 @@ public class CSharpApiMethodTransformer extends StaticLangApiMethodTransformer {
             apiMethods.add(
                 generateGrpcStreamingFlattenedMethod(
                     methodContext, csharpCommonTransformer.callSettingsParam()));
+            if (FlatteningConfig.hasAnyResourceNameParameter(flatteningGroup)) {
+              apiMethods.add(
+                  generateGrpcStreamingFlattenedMethod(
+                      methodContext
+                          .withResourceNamesInSamplesOnly()
+                          .withCallingForms(Collections.singletonList(CallingForm.Flattened)),
+                      csharpCommonTransformer.callSettingsParam()));
+            }
           }
         }
         // TODO: replace the empty list with real calling forms:
@@ -196,6 +204,14 @@ public class CSharpApiMethodTransformer extends StaticLangApiMethodTransformer {
                     // LRO methods for now so that the baseline does not explode
                     methodContext.withCallingForms(Collections.emptyList()),
                     csharpCommonTransformer.callSettingsParam()));
+            if (FlatteningConfig.hasAnyResourceNameParameter(flatteningGroup)) {
+              apiMethods.add(
+                  generateOperationFlattenedMethod(
+                      methodContext
+                          .withResourceNamesInSamplesOnly()
+                          .withCallingForms(Collections.singletonList(CallingForm.Flattened)),
+                      csharpCommonTransformer.callSettingsParam()));
+            }
           }
         }
         apiMethods.add(
@@ -244,6 +260,14 @@ public class CSharpApiMethodTransformer extends StaticLangApiMethodTransformer {
                             CallingForm.FlattenedPagedAll,
                             CallingForm.FlattenedPagedPageSize)),
                     pagedMethodAdditionalParams));
+            if (FlatteningConfig.hasAnyResourceNameParameter(flatteningGroup)) {
+              apiMethods.add(
+                  generatePagedFlattenedMethod(
+                      methodContext
+                          .withResourceNamesInSamplesOnly()
+                          .withCallingForms(Collections.singletonList(CallingForm.Flattened)),
+                      csharpCommonTransformer.callSettingsParam()));
+            }
           }
         }
         apiMethods.add(
@@ -286,6 +310,14 @@ public class CSharpApiMethodTransformer extends StaticLangApiMethodTransformer {
                     methodContext.withCallingForms(
                         Collections.singletonList(CallingForm.Flattened)),
                     csharpCommonTransformer.callSettingsParam()));
+            if (FlatteningConfig.hasAnyResourceNameParameter(flatteningGroup)) {
+              apiMethods.add(
+                  generateFlattenedMethod(
+                      methodContext
+                          .withResourceNamesInSamplesOnly()
+                          .withCallingForms(Collections.singletonList(CallingForm.Flattened)),
+                      csharpCommonTransformer.callSettingsParam()));
+            }
           }
         }
         apiMethods.add(

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpApiMethodTransformer.java
@@ -241,10 +241,10 @@ public class CSharpApiMethodTransformer extends StaticLangApiMethodTransformer {
           for (FlatteningConfig flatteningGroup : methodConfig.getFlatteningConfigs()) {
             GapicMethodContext methodContext =
                 context.asFlattenedMethodContext(requestMethodContext, flatteningGroup);
-            apiMethods.addAll(generateFlattenedAsyncMethods(methodContext));
+            apiMethods.addAll(generateNormalFlattenedMethods(methodContext));
             if (FlatteningConfig.hasAnyResourceNameParameter(flatteningGroup)) {
               apiMethods.addAll(
-                  generateFlattenedAsyncMethods(methodContext.withResourceNamesInSamplesOnly()));
+                  generateNormalFlattenedMethods(methodContext.withResourceNamesInSamplesOnly()));
             }
           }
         }
@@ -328,7 +328,8 @@ public class CSharpApiMethodTransformer extends StaticLangApiMethodTransformer {
     return apiMethods;
   }
 
-  private List<StaticLangApiMethodView> generateFlattenedAsyncMethods(MethodContext methodContext) {
+  private List<StaticLangApiMethodView> generateNormalFlattenedMethods(
+      MethodContext methodContext) {
     List<StaticLangApiMethodView> apiMethods = new ArrayList<>();
     apiMethods.add(
         generateFlattenedAsyncMethod(

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
@@ -15,7 +15,6 @@
 
 package com.google.api.codegen.transformer.java;
 
-import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.InterfaceContext;
 import com.google.api.codegen.config.MethodConfig;
@@ -76,7 +75,7 @@ public class JavaMethodViewGenerator {
               apiMethods.add(
                   clientMethodTransformer.generatePagedFlattenedMethod(flattenedMethodContext));
             }
-            if (hasAnyResourceNameParameter(flatteningGroup)) {
+            if (FlatteningConfig.hasAnyResourceNameParameter(flatteningGroup)) {
               apiMethods.add(
                   clientMethodTransformer.generatePagedFlattenedMethod(
                       flattenedMethodContext.withResourceNamesInSamplesOnly()));
@@ -137,7 +136,7 @@ public class JavaMethodViewGenerator {
             apiMethods.add(
                 clientMethodTransformer.generateAsyncOperationFlattenedMethod(
                     flattenedMethodContext));
-            if (hasAnyResourceNameParameter(flatteningGroup)) {
+            if (FlatteningConfig.hasAnyResourceNameParameter(flatteningGroup)) {
               apiMethods.add(
                   clientMethodTransformer.generateAsyncOperationFlattenedMethod(
                       flattenedMethodContext.withResourceNamesInSamplesOnly()));
@@ -171,7 +170,7 @@ public class JavaMethodViewGenerator {
                     flattenedMethodContext.withCallingForms(
                         Collections.singletonList(CallingForm.Flattened))));
 
-            if (hasAnyResourceNameParameter(flatteningGroup)) {
+            if (FlatteningConfig.hasAnyResourceNameParameter(flatteningGroup)) {
               apiMethods.add(
                   clientMethodTransformer.generateFlattenedMethod(
                       flattenedMethodContext
@@ -193,13 +192,5 @@ public class JavaMethodViewGenerator {
     }
 
     return apiMethods;
-  }
-
-  private boolean hasAnyResourceNameParameter(FlatteningConfig flatteningGroup) {
-    return flatteningGroup
-        .getFlattenedFieldConfigs()
-        .values()
-        .stream()
-        .anyMatch(FieldConfig::useResourceNameType);
   }
 }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -6765,6 +6765,45 @@ namespace Google.Example.Library.V1
         /// If not null, applies overrides to this RPC call.
         /// </param>
         /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetShelfAsync(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetShelfAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
         /// The RPC response.
         /// </returns>
         public virtual Shelf GetShelf(
@@ -6850,6 +6889,55 @@ namespace Google.Example.Library.V1
                     Message = message, // Optional
                 },
                 callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            SomeMessage message,
+            gaxgrpc::CallSettings callSettings = null) => GetShelfAsync(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Message = message, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            SomeMessage message,
+            st::CancellationToken cancellationToken) => GetShelfAsync(
+                name,
+                message,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Gets a shelf.
@@ -6966,6 +7054,65 @@ namespace Google.Example.Library.V1
                     StringBuilder = stringBuilder, // Optional
                 },
                 callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="stringBuilder">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            SomeMessage message,
+            StringBuilder stringBuilder,
+            gaxgrpc::CallSettings callSettings = null) => GetShelfAsync(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Message = message, // Optional
+                    StringBuilder = stringBuilder, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="stringBuilder">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            SomeMessage message,
+            StringBuilder stringBuilder,
+            st::CancellationToken cancellationToken) => GetShelfAsync(
+                name,
+                message,
+                stringBuilder,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Gets a shelf.
@@ -7221,6 +7368,45 @@ namespace Google.Example.Library.V1
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task DeleteShelfAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => DeleteShelfAsync(
+                new DeleteShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to delete.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task DeleteShelfAsync(
+            string name,
+            st::CancellationToken cancellationToken) => DeleteShelfAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Deletes a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to delete.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
         public virtual void DeleteShelf(
             string name,
             gaxgrpc::CallSettings callSettings = null) => DeleteShelf(
@@ -7363,6 +7549,59 @@ namespace Google.Example.Library.V1
                     OtherShelfNameAsShelfName = gax::GaxPreconditions.CheckNotNull(otherShelfName, nameof(otherShelfName)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Merges two shelves by adding all books from the shelf named
+        /// `other_shelf_name` to shelf `name`, and deletes
+        /// `other_shelf_name`. Returns the updated shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf we're adding books to.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the shelf we're removing books from and deleting.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> MergeShelvesAsync(
+            string name,
+            string otherShelfName,
+            gaxgrpc::CallSettings callSettings = null) => MergeShelvesAsync(
+                new MergeShelvesRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    OtherShelfName = gax::GaxPreconditions.CheckNotNullOrEmpty(otherShelfName, nameof(otherShelfName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Merges two shelves by adding all books from the shelf named
+        /// `other_shelf_name` to shelf `name`, and deletes
+        /// `other_shelf_name`. Returns the updated shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf we're adding books to.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the shelf we're removing books from and deleting.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> MergeShelvesAsync(
+            string name,
+            string otherShelfName,
+            st::CancellationToken cancellationToken) => MergeShelvesAsync(
+                name,
+                otherShelfName,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Merges two shelves by adding all books from the shelf named
@@ -7528,6 +7767,55 @@ namespace Google.Example.Library.V1
                     Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Creates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf in which the book is created.
+        /// </param>
+        /// <param name="book">
+        /// The book to create.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> CreateBookAsync(
+            string name,
+            Book book,
+            gaxgrpc::CallSettings callSettings = null) => CreateBookAsync(
+                new CreateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf in which the book is created.
+        /// </param>
+        /// <param name="book">
+        /// The book to create.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> CreateBookAsync(
+            string name,
+            Book book,
+            st::CancellationToken cancellationToken) => CreateBookAsync(
+                name,
+                book,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Creates a book.
@@ -7842,6 +8130,45 @@ namespace Google.Example.Library.V1
         /// If not null, applies overrides to this RPC call.
         /// </param>
         /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> GetBookAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBookAsync(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> GetBookAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetBookAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Gets a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
         /// The RPC response.
         /// </returns>
         public virtual Book GetBook(
@@ -7994,6 +8321,52 @@ namespace Google.Example.Library.V1
         /// <param name="filter">
         /// To test python built-in wrapping.
         /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request.
+        /// A value of <c>null</c> or an empty string retrieves the first page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller.
+        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="Book"/> resources.
+        /// </returns>
+        public virtual gax::PagedAsyncEnumerable<ListBooksResponse, Book> ListBooksAsync(
+            string name,
+            string filter,
+            string pageToken = null,
+            int? pageSize = null,
+            gaxgrpc::CallSettings callSettings = null) => ListBooksAsync(
+                new ListBooksRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Filter = filter ?? "", // Optional
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists books in a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf whose books we'd like to list.
+        /// </param>
+        /// <param name="filter">
+        /// To test python built-in wrapping.
+        /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request.
+        /// A value of <c>null</c> or an empty string retrieves the first page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller.
+        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
@@ -8003,6 +8376,8 @@ namespace Google.Example.Library.V1
         public virtual gax::PagedEnumerable<ListBooksResponse, Book> ListBooks(
             string name,
             string filter,
+            string pageToken = null,
+            int? pageSize = null,
             gaxgrpc::CallSettings callSettings = null) => ListBooks(
                 new ListBooksRequest
                 {
@@ -8107,6 +8482,45 @@ namespace Google.Example.Library.V1
                     BookName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Deletes a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to delete.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task DeleteBookAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => DeleteBookAsync(
+                new DeleteBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to delete.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task DeleteBookAsync(
+            string name,
+            st::CancellationToken cancellationToken) => DeleteBookAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Deletes a book.
@@ -8267,6 +8681,55 @@ namespace Google.Example.Library.V1
         /// If not null, applies overrides to this RPC call.
         /// </param>
         /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> UpdateBookAsync(
+            string name,
+            Book book,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBookAsync(
+                new UpdateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> UpdateBookAsync(
+            string name,
+            Book book,
+            st::CancellationToken cancellationToken) => UpdateBookAsync(
+                name,
+                book,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
         /// The RPC response.
         /// </returns>
         public virtual Book UpdateBook(
@@ -8399,6 +8862,85 @@ namespace Google.Example.Library.V1
                     PhysicalMask = physicalMask, // Optional
                 },
                 callSettings);
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="optionalFoo">
+        /// An optional foo.
+        /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="updateMask">
+        /// A field mask to apply, rendered as an HTTP parameter.
+        /// </param>
+        /// <param name="physicalMask">
+        /// To test Python import clash resolution.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> UpdateBookAsync(
+            string name,
+            string optionalFoo,
+            Book book,
+            pbwkt::FieldMask updateMask,
+            FieldMask physicalMask,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBookAsync(
+                new UpdateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    OptionalFoo = optionalFoo ?? "", // Optional
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                    UpdateMask = updateMask, // Optional
+                    PhysicalMask = physicalMask, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="optionalFoo">
+        /// An optional foo.
+        /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="updateMask">
+        /// A field mask to apply, rendered as an HTTP parameter.
+        /// </param>
+        /// <param name="physicalMask">
+        /// To test Python import clash resolution.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> UpdateBookAsync(
+            string name,
+            string optionalFoo,
+            Book book,
+            pbwkt::FieldMask updateMask,
+            FieldMask physicalMask,
+            st::CancellationToken cancellationToken) => UpdateBookAsync(
+                name,
+                optionalFoo,
+                book,
+                updateMask,
+                physicalMask,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Updates a book.
@@ -8571,6 +9113,55 @@ namespace Google.Example.Library.V1
                     OtherShelfNameAsShelfName = gax::GaxPreconditions.CheckNotNull(otherShelfName, nameof(otherShelfName)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Moves a book to another shelf, and returns the new book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to move.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the destination shelf.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> MoveBookAsync(
+            string name,
+            string otherShelfName,
+            gaxgrpc::CallSettings callSettings = null) => MoveBookAsync(
+                new MoveBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    OtherShelfName = gax::GaxPreconditions.CheckNotNullOrEmpty(otherShelfName, nameof(otherShelfName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Moves a book to another shelf, and returns the new book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to move.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the destination shelf.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> MoveBookAsync(
+            string name,
+            string otherShelfName,
+            st::CancellationToken cancellationToken) => MoveBookAsync(
+                name,
+                otherShelfName,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Moves a book to another shelf, and returns the new book.
@@ -8782,6 +9373,47 @@ namespace Google.Example.Library.V1
         /// <param name="name">
         ///
         /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request.
+        /// A value of <c>null</c> or an empty string retrieves the first page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller.
+        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="string"/> resources.
+        /// </returns>
+        public virtual gax::PagedAsyncEnumerable<ListStringsResponse, IResourceName> ListStringsAsync(
+            string name,
+            string pageToken = null,
+            int? pageSize = null,
+            gaxgrpc::CallSettings callSettings = null) => ListStringsAsync(
+                new ListStringsRequest
+                {
+                    Name = name ?? "", // Optional
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists a primitive resource. To test go page streaming.
+        /// </summary>
+        /// <param name="name">
+        ///
+        /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request.
+        /// A value of <c>null</c> or an empty string retrieves the first page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller.
+        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
@@ -8790,6 +9422,8 @@ namespace Google.Example.Library.V1
         /// </returns>
         public virtual gax::PagedEnumerable<ListStringsResponse, IResourceName> ListStrings(
             string name,
+            string pageToken = null,
+            int? pageSize = null,
             gaxgrpc::CallSettings callSettings = null) => ListStrings(
                 new ListStringsRequest
                 {
@@ -8908,6 +9542,55 @@ namespace Google.Example.Library.V1
                     Comments = { gax::GaxPreconditions.CheckNotNull(comments, nameof(comments)) },
                 },
                 callSettings);
+
+        /// <summary>
+        /// Adds comments to a book
+        /// </summary>
+        /// <param name="name">
+        ///
+        /// </param>
+        /// <param name="comments">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task AddCommentsAsync(
+            string name,
+            scg::IEnumerable<Comment> comments,
+            gaxgrpc::CallSettings callSettings = null) => AddCommentsAsync(
+                new AddCommentsRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Comments = { gax::GaxPreconditions.CheckNotNull(comments, nameof(comments)) },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Adds comments to a book
+        /// </summary>
+        /// <param name="name">
+        ///
+        /// </param>
+        /// <param name="comments">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task AddCommentsAsync(
+            string name,
+            scg::IEnumerable<Comment> comments,
+            st::CancellationToken cancellationToken) => AddCommentsAsync(
+                name,
+                comments,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Adds comments to a book
@@ -9044,6 +9727,45 @@ namespace Google.Example.Library.V1
                     ArchivedBookName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Gets a book from an archive.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromArchive> GetBookFromArchiveAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromArchiveAsync(
+                new GetBookFromArchiveRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book from an archive.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromArchive> GetBookFromArchiveAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetBookFromArchiveAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Gets a book from an archive.
@@ -9214,6 +9936,57 @@ namespace Google.Example.Library.V1
         /// If not null, applies overrides to this RPC call.
         /// </param>
         /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromAnywhere> GetBookFromAnywhereAsync(
+            string name,
+            string altBookName,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromAnywhereAsync(
+                new GetBookFromAnywhereRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    AltBookName = gax::GaxPreconditions.CheckNotNullOrEmpty(altBookName, nameof(altBookName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book from a shelf or archive.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="altBookName">
+        /// An alternate book name, used to test restricting flattened field to a
+        /// single resource name type in a oneof.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromAnywhere> GetBookFromAnywhereAsync(
+            string name,
+            string altBookName,
+            st::CancellationToken cancellationToken) => GetBookFromAnywhereAsync(
+                name,
+                altBookName,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Gets a book from a shelf or archive.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="altBookName">
+        /// An alternate book name, used to test restricting flattened field to a
+        /// single resource name type in a oneof.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
         /// The RPC response.
         /// </returns>
         public virtual BookFromAnywhere GetBookFromAnywhere(
@@ -9342,6 +10115,45 @@ namespace Google.Example.Library.V1
                     AsResourceName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Test proper OneOf-Any resource name mapping
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromAnywhere> GetBookFromAbsolutelyAnywhereAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromAbsolutelyAnywhereAsync(
+                new GetBookFromAbsolutelyAnywhereRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test proper OneOf-Any resource name mapping
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromAnywhere> GetBookFromAbsolutelyAnywhereAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetBookFromAbsolutelyAnywhereAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Test proper OneOf-Any resource name mapping
@@ -9506,6 +10318,65 @@ namespace Google.Example.Library.V1
                     IndexMap = { gax::GaxPreconditions.CheckNotNull(indexMap, nameof(indexMap)) },
                 },
                 callSettings);
+
+        /// <summary>
+        /// Updates the index of a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="indexName">
+        /// The name of the index for the book
+        /// </param>
+        /// <param name="indexMap">
+        /// The index to update the book with
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task UpdateBookIndexAsync(
+            string name,
+            string indexName,
+            scg::IDictionary<string, string> indexMap,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBookIndexAsync(
+                new UpdateBookIndexRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    IndexName = gax::GaxPreconditions.CheckNotNullOrEmpty(indexName, nameof(indexName)),
+                    IndexMap = { gax::GaxPreconditions.CheckNotNull(indexMap, nameof(indexMap)) },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates the index of a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="indexName">
+        /// The name of the index for the book
+        /// </param>
+        /// <param name="indexMap">
+        /// The index to update the book with
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task UpdateBookIndexAsync(
+            string name,
+            string indexName,
+            scg::IDictionary<string, string> indexMap,
+            st::CancellationToken cancellationToken) => UpdateBookIndexAsync(
+                name,
+                indexName,
+                indexMap,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Updates the index of a book.
@@ -9819,6 +10690,52 @@ namespace Google.Example.Library.V1
         /// <param name="shelves">
         ///
         /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request.
+        /// A value of <c>null</c> or an empty string retrieves the first page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller.
+        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="string"/> resources.
+        /// </returns>
+        public virtual gax::PagedAsyncEnumerable<FindRelatedBooksResponse, BookName> FindRelatedBooksAsync(
+            scg::IEnumerable<string> names,
+            scg::IEnumerable<string> shelves,
+            string pageToken = null,
+            int? pageSize = null,
+            gaxgrpc::CallSettings callSettings = null) => FindRelatedBooksAsync(
+                new FindRelatedBooksRequest
+                {
+                    Names = { gax::GaxPreconditions.CheckNotNull(names, nameof(names)) },
+                    Shelves = { gax::GaxPreconditions.CheckNotNull(shelves, nameof(shelves)) },
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="names">
+        ///
+        /// </param>
+        /// <param name="shelves">
+        ///
+        /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request.
+        /// A value of <c>null</c> or an empty string retrieves the first page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller.
+        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
@@ -9828,6 +10745,8 @@ namespace Google.Example.Library.V1
         public virtual gax::PagedEnumerable<FindRelatedBooksResponse, BookName> FindRelatedBooks(
             scg::IEnumerable<string> names,
             scg::IEnumerable<string> shelves,
+            string pageToken = null,
+            int? pageSize = null,
             gaxgrpc::CallSettings callSettings = null) => FindRelatedBooks(
                 new FindRelatedBooksRequest
                 {
@@ -10080,6 +10999,45 @@ namespace Google.Example.Library.V1
         /// If not null, applies overrides to this RPC call.
         /// </param>
         /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<Book, GetBigBookMetadata>> GetBigBookAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBigBookAsync(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test long-running operations
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<Book, GetBigBookMetadata>> GetBigBookAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetBigBookAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Test long-running operations
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
         /// The RPC response.
         /// </returns>
         public virtual lro::Operation<Book, GetBigBookMetadata> GetBigBook(
@@ -10222,6 +11180,45 @@ namespace Google.Example.Library.V1
                     BookName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, GetBigBookMetadata>> GetBigNothingAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBigNothingAsync(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, GetBigBookMetadata>> GetBigNothingAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetBigNothingAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Test long-running operations with empty return type.
@@ -11755,6 +12752,935 @@ namespace Google.Example.Library.V1
                     RepeatedBytesValue = { repeatedBytesValue ?? linq::Enumerable.Empty<pb::ByteString>() }, // Optional
                 },
                 callSettings);
+
+        /// <summary>
+        /// Test optional flattening parameters of all types
+        /// </summary>
+        /// <param name="requiredSingularInt32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularInt64">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFloat">
+        ///
+        /// </param>
+        /// <param name="requiredSingularDouble">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBool">
+        ///
+        /// </param>
+        /// <param name="requiredSingularEnum">
+        ///
+        /// </param>
+        /// <param name="requiredSingularString">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBytes">
+        ///
+        /// </param>
+        /// <param name="requiredSingularMessage">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedString">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredMap">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt64">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFloat">
+        ///
+        /// </param>
+        /// <param name="optionalSingularDouble">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBool">
+        ///
+        /// </param>
+        /// <param name="optionalSingularEnum">
+        ///
+        /// </param>
+        /// <param name="optionalSingularString">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBytes">
+        ///
+        /// </param>
+        /// <param name="optionalSingularMessage">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedString">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalMap">
+        ///
+        /// </param>
+        /// <param name="anyValue">
+        ///
+        /// </param>
+        /// <param name="structValue">
+        ///
+        /// </param>
+        /// <param name="valueValue">
+        ///
+        /// </param>
+        /// <param name="listValueValue">
+        ///
+        /// </param>
+        /// <param name="timeValue">
+        ///
+        /// </param>
+        /// <param name="durationValue">
+        ///
+        /// </param>
+        /// <param name="fieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="int32Value">
+        ///
+        /// </param>
+        /// <param name="uint32Value">
+        ///
+        /// </param>
+        /// <param name="int64Value">
+        ///
+        /// </param>
+        /// <param name="uint64Value">
+        ///
+        /// </param>
+        /// <param name="floatValue">
+        ///
+        /// </param>
+        /// <param name="doubleValue">
+        ///
+        /// </param>
+        /// <param name="stringValue">
+        ///
+        /// </param>
+        /// <param name="boolValue">
+        ///
+        /// </param>
+        /// <param name="bytesValue">
+        ///
+        /// </param>
+        /// <param name="repeatedAnyValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStructValue">
+        ///
+        /// </param>
+        /// <param name="repeatedValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedListValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedTimeValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDurationValue">
+        ///
+        /// </param>
+        /// <param name="repeatedFieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="repeatedInt32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedInt64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedFloatValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDoubleValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStringValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBoolValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBytesValue">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<TestOptionalRequiredFlatteningParamsResponse> TestOptionalRequiredFlatteningParamsAsync(
+            int requiredSingularInt32,
+            long requiredSingularInt64,
+            float requiredSingularFloat,
+            double requiredSingularDouble,
+            bool requiredSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum requiredSingularEnum,
+            string requiredSingularString,
+            pb::ByteString requiredSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage,
+            string requiredSingularResourceName,
+            string requiredSingularResourceNameOneof,
+            string requiredSingularResourceNameCommon,
+            int requiredSingularFixed32,
+            long requiredSingularFixed64,
+            scg::IEnumerable<int> requiredRepeatedInt32,
+            scg::IEnumerable<long> requiredRepeatedInt64,
+            scg::IEnumerable<float> requiredRepeatedFloat,
+            scg::IEnumerable<double> requiredRepeatedDouble,
+            scg::IEnumerable<bool> requiredRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> requiredRepeatedEnum,
+            scg::IEnumerable<string> requiredRepeatedString,
+            scg::IEnumerable<pb::ByteString> requiredRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage,
+            scg::IEnumerable<string> requiredRepeatedResourceName,
+            scg::IEnumerable<string> requiredRepeatedResourceNameOneof,
+            scg::IEnumerable<string> requiredRepeatedResourceNameCommon,
+            scg::IEnumerable<int> requiredRepeatedFixed32,
+            scg::IEnumerable<long> requiredRepeatedFixed64,
+            scg::IDictionary<int, string> requiredMap,
+            int? optionalSingularInt32,
+            long? optionalSingularInt64,
+            float? optionalSingularFloat,
+            double? optionalSingularDouble,
+            bool? optionalSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum? optionalSingularEnum,
+            string optionalSingularString,
+            pb::ByteString optionalSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage,
+            string optionalSingularResourceName,
+            string optionalSingularResourceNameOneof,
+            string optionalSingularResourceNameCommon,
+            int? optionalSingularFixed32,
+            long? optionalSingularFixed64,
+            scg::IEnumerable<int> optionalRepeatedInt32,
+            scg::IEnumerable<long> optionalRepeatedInt64,
+            scg::IEnumerable<float> optionalRepeatedFloat,
+            scg::IEnumerable<double> optionalRepeatedDouble,
+            scg::IEnumerable<bool> optionalRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> optionalRepeatedEnum,
+            scg::IEnumerable<string> optionalRepeatedString,
+            scg::IEnumerable<pb::ByteString> optionalRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage,
+            scg::IEnumerable<string> optionalRepeatedResourceName,
+            scg::IEnumerable<string> optionalRepeatedResourceNameOneof,
+            scg::IEnumerable<string> optionalRepeatedResourceNameCommon,
+            scg::IEnumerable<int> optionalRepeatedFixed32,
+            scg::IEnumerable<long> optionalRepeatedFixed64,
+            scg::IDictionary<int, string> optionalMap,
+            pbwkt::Any anyValue,
+            pbwkt::Struct structValue,
+            pbwkt::Value valueValue,
+            pbwkt::ListValue listValueValue,
+            pbwkt::Timestamp timeValue,
+            pbwkt::Duration durationValue,
+            pbwkt::FieldMask fieldMaskValue,
+            int? int32Value,
+            uint? uint32Value,
+            long? int64Value,
+            ulong? uint64Value,
+            float? floatValue,
+            double? doubleValue,
+            string stringValue,
+            bool? boolValue,
+            pb::ByteString bytesValue,
+            scg::IEnumerable<pbwkt::Any> repeatedAnyValue,
+            scg::IEnumerable<pbwkt::Struct> repeatedStructValue,
+            scg::IEnumerable<pbwkt::Value> repeatedValueValue,
+            scg::IEnumerable<pbwkt::ListValue> repeatedListValueValue,
+            scg::IEnumerable<pbwkt::Timestamp> repeatedTimeValue,
+            scg::IEnumerable<pbwkt::Duration> repeatedDurationValue,
+            scg::IEnumerable<pbwkt::FieldMask> repeatedFieldMaskValue,
+            scg::IEnumerable<int?> repeatedInt32Value,
+            scg::IEnumerable<uint?> repeatedUint32Value,
+            scg::IEnumerable<long?> repeatedInt64Value,
+            scg::IEnumerable<ulong?> repeatedUint64Value,
+            scg::IEnumerable<float?> repeatedFloatValue,
+            scg::IEnumerable<double?> repeatedDoubleValue,
+            scg::IEnumerable<string> repeatedStringValue,
+            scg::IEnumerable<bool?> repeatedBoolValue,
+            scg::IEnumerable<pb::ByteString> repeatedBytesValue,
+            gaxgrpc::CallSettings callSettings = null) => TestOptionalRequiredFlatteningParamsAsync(
+                new TestOptionalRequiredFlatteningParamsRequest
+                {
+                    RequiredSingularInt32 = requiredSingularInt32,
+                    RequiredSingularInt64 = requiredSingularInt64,
+                    RequiredSingularFloat = requiredSingularFloat,
+                    RequiredSingularDouble = requiredSingularDouble,
+                    RequiredSingularBool = requiredSingularBool,
+                    RequiredSingularEnum = requiredSingularEnum,
+                    RequiredSingularString = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularString, nameof(requiredSingularString)),
+                    RequiredSingularBytes = gax::GaxPreconditions.CheckNotNull(requiredSingularBytes, nameof(requiredSingularBytes)),
+                    RequiredSingularMessage = gax::GaxPreconditions.CheckNotNull(requiredSingularMessage, nameof(requiredSingularMessage)),
+                    RequiredSingularResourceName = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceName, nameof(requiredSingularResourceName)),
+                    RequiredSingularResourceNameOneof = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceNameOneof, nameof(requiredSingularResourceNameOneof)),
+                    RequiredSingularResourceNameCommon = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceNameCommon, nameof(requiredSingularResourceNameCommon)),
+                    RequiredSingularFixed32 = requiredSingularFixed32,
+                    RequiredSingularFixed64 = requiredSingularFixed64,
+                    RequiredRepeatedInt32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedInt32, nameof(requiredRepeatedInt32)) },
+                    RequiredRepeatedInt64 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedInt64, nameof(requiredRepeatedInt64)) },
+                    RequiredRepeatedFloat = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFloat, nameof(requiredRepeatedFloat)) },
+                    RequiredRepeatedDouble = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedDouble, nameof(requiredRepeatedDouble)) },
+                    RequiredRepeatedBool = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedBool, nameof(requiredRepeatedBool)) },
+                    RequiredRepeatedEnum = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedEnum, nameof(requiredRepeatedEnum)) },
+                    RequiredRepeatedString = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedString, nameof(requiredRepeatedString)) },
+                    RequiredRepeatedBytes = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedBytes, nameof(requiredRepeatedBytes)) },
+                    RequiredRepeatedMessage = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedMessage, nameof(requiredRepeatedMessage)) },
+                    RequiredRepeatedResourceName = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceName, nameof(requiredRepeatedResourceName)) },
+                    RequiredRepeatedResourceNameOneof = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameOneof, nameof(requiredRepeatedResourceNameOneof)) },
+                    RequiredRepeatedResourceNameCommon = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameCommon, nameof(requiredRepeatedResourceNameCommon)) },
+                    RequiredRepeatedFixed32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed32, nameof(requiredRepeatedFixed32)) },
+                    RequiredRepeatedFixed64 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed64, nameof(requiredRepeatedFixed64)) },
+                    RequiredMap = { gax::GaxPreconditions.CheckNotNull(requiredMap, nameof(requiredMap)) },
+                    OptionalSingularInt32 = optionalSingularInt32 ?? 0, // Optional
+                    OptionalSingularInt64 = optionalSingularInt64 ?? 0L, // Optional
+                    OptionalSingularFloat = optionalSingularFloat ?? 0.0f, // Optional
+                    OptionalSingularDouble = optionalSingularDouble ?? 0.0, // Optional
+                    OptionalSingularBool = optionalSingularBool ?? false, // Optional
+                    OptionalSingularEnum = optionalSingularEnum ?? TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum.Zero, // Optional
+                    OptionalSingularString = optionalSingularString ?? "", // Optional
+                    OptionalSingularBytes = optionalSingularBytes ?? pb::ByteString.Empty, // Optional
+                    OptionalSingularMessage = optionalSingularMessage, // Optional
+                    OptionalSingularResourceName = optionalSingularResourceName ?? "", // Optional
+                    OptionalSingularResourceNameOneof = optionalSingularResourceNameOneof ?? "", // Optional
+                    OptionalSingularResourceNameCommon = optionalSingularResourceNameCommon ?? "", // Optional
+                    OptionalSingularFixed32 = optionalSingularFixed32 ?? 0, // Optional
+                    OptionalSingularFixed64 = optionalSingularFixed64 ?? 0L, // Optional
+                    OptionalRepeatedInt32 = { optionalRepeatedInt32 ?? linq::Enumerable.Empty<int>() }, // Optional
+                    OptionalRepeatedInt64 = { optionalRepeatedInt64 ?? linq::Enumerable.Empty<long>() }, // Optional
+                    OptionalRepeatedFloat = { optionalRepeatedFloat ?? linq::Enumerable.Empty<float>() }, // Optional
+                    OptionalRepeatedDouble = { optionalRepeatedDouble ?? linq::Enumerable.Empty<double>() }, // Optional
+                    OptionalRepeatedBool = { optionalRepeatedBool ?? linq::Enumerable.Empty<bool>() }, // Optional
+                    OptionalRepeatedEnum = { optionalRepeatedEnum ?? linq::Enumerable.Empty<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>() }, // Optional
+                    OptionalRepeatedString = { optionalRepeatedString ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedBytes = { optionalRepeatedBytes ?? linq::Enumerable.Empty<pb::ByteString>() }, // Optional
+                    OptionalRepeatedMessage = { optionalRepeatedMessage ?? linq::Enumerable.Empty<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>() }, // Optional
+                    OptionalRepeatedResourceName = { optionalRepeatedResourceName ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedResourceNameOneof = { optionalRepeatedResourceNameOneof ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedResourceNameCommon = { optionalRepeatedResourceNameCommon ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedFixed32 = { optionalRepeatedFixed32 ?? linq::Enumerable.Empty<int>() }, // Optional
+                    OptionalRepeatedFixed64 = { optionalRepeatedFixed64 ?? linq::Enumerable.Empty<long>() }, // Optional
+                    OptionalMap = { optionalMap ?? gax::EmptyDictionary<int, string>.Instance }, // Optional
+                    AnyValue = anyValue, // Optional
+                    StructValue = structValue, // Optional
+                    ValueValue = valueValue, // Optional
+                    ListValueValue = listValueValue, // Optional
+                    TimeValue = timeValue, // Optional
+                    DurationValue = durationValue, // Optional
+                    FieldMaskValue = fieldMaskValue, // Optional
+                    Int32Value = int32Value, // Optional
+                    Uint32Value = uint32Value, // Optional
+                    Int64Value = int64Value, // Optional
+                    Uint64Value = uint64Value, // Optional
+                    FloatValue = floatValue, // Optional
+                    DoubleValue = doubleValue, // Optional
+                    StringValue = stringValue, // Optional
+                    BoolValue = boolValue, // Optional
+                    BytesValue = bytesValue, // Optional
+                    RepeatedAnyValue = { repeatedAnyValue ?? linq::Enumerable.Empty<pbwkt::Any>() }, // Optional
+                    RepeatedStructValue = { repeatedStructValue ?? linq::Enumerable.Empty<pbwkt::Struct>() }, // Optional
+                    RepeatedValueValue = { repeatedValueValue ?? linq::Enumerable.Empty<pbwkt::Value>() }, // Optional
+                    RepeatedListValueValue = { repeatedListValueValue ?? linq::Enumerable.Empty<pbwkt::ListValue>() }, // Optional
+                    RepeatedTimeValue = { repeatedTimeValue ?? linq::Enumerable.Empty<pbwkt::Timestamp>() }, // Optional
+                    RepeatedDurationValue = { repeatedDurationValue ?? linq::Enumerable.Empty<pbwkt::Duration>() }, // Optional
+                    RepeatedFieldMaskValue = { repeatedFieldMaskValue ?? linq::Enumerable.Empty<pbwkt::FieldMask>() }, // Optional
+                    RepeatedInt32Value = { repeatedInt32Value ?? linq::Enumerable.Empty<int?>() }, // Optional
+                    RepeatedUint32Value = { repeatedUint32Value ?? linq::Enumerable.Empty<uint?>() }, // Optional
+                    RepeatedInt64Value = { repeatedInt64Value ?? linq::Enumerable.Empty<long?>() }, // Optional
+                    RepeatedUint64Value = { repeatedUint64Value ?? linq::Enumerable.Empty<ulong?>() }, // Optional
+                    RepeatedFloatValue = { repeatedFloatValue ?? linq::Enumerable.Empty<float?>() }, // Optional
+                    RepeatedDoubleValue = { repeatedDoubleValue ?? linq::Enumerable.Empty<double?>() }, // Optional
+                    RepeatedStringValue = { repeatedStringValue ?? linq::Enumerable.Empty<string>() }, // Optional
+                    RepeatedBoolValue = { repeatedBoolValue ?? linq::Enumerable.Empty<bool?>() }, // Optional
+                    RepeatedBytesValue = { repeatedBytesValue ?? linq::Enumerable.Empty<pb::ByteString>() }, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test optional flattening parameters of all types
+        /// </summary>
+        /// <param name="requiredSingularInt32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularInt64">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFloat">
+        ///
+        /// </param>
+        /// <param name="requiredSingularDouble">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBool">
+        ///
+        /// </param>
+        /// <param name="requiredSingularEnum">
+        ///
+        /// </param>
+        /// <param name="requiredSingularString">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBytes">
+        ///
+        /// </param>
+        /// <param name="requiredSingularMessage">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedString">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredMap">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt64">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFloat">
+        ///
+        /// </param>
+        /// <param name="optionalSingularDouble">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBool">
+        ///
+        /// </param>
+        /// <param name="optionalSingularEnum">
+        ///
+        /// </param>
+        /// <param name="optionalSingularString">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBytes">
+        ///
+        /// </param>
+        /// <param name="optionalSingularMessage">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedString">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalMap">
+        ///
+        /// </param>
+        /// <param name="anyValue">
+        ///
+        /// </param>
+        /// <param name="structValue">
+        ///
+        /// </param>
+        /// <param name="valueValue">
+        ///
+        /// </param>
+        /// <param name="listValueValue">
+        ///
+        /// </param>
+        /// <param name="timeValue">
+        ///
+        /// </param>
+        /// <param name="durationValue">
+        ///
+        /// </param>
+        /// <param name="fieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="int32Value">
+        ///
+        /// </param>
+        /// <param name="uint32Value">
+        ///
+        /// </param>
+        /// <param name="int64Value">
+        ///
+        /// </param>
+        /// <param name="uint64Value">
+        ///
+        /// </param>
+        /// <param name="floatValue">
+        ///
+        /// </param>
+        /// <param name="doubleValue">
+        ///
+        /// </param>
+        /// <param name="stringValue">
+        ///
+        /// </param>
+        /// <param name="boolValue">
+        ///
+        /// </param>
+        /// <param name="bytesValue">
+        ///
+        /// </param>
+        /// <param name="repeatedAnyValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStructValue">
+        ///
+        /// </param>
+        /// <param name="repeatedValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedListValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedTimeValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDurationValue">
+        ///
+        /// </param>
+        /// <param name="repeatedFieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="repeatedInt32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedInt64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedFloatValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDoubleValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStringValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBoolValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBytesValue">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<TestOptionalRequiredFlatteningParamsResponse> TestOptionalRequiredFlatteningParamsAsync(
+            int requiredSingularInt32,
+            long requiredSingularInt64,
+            float requiredSingularFloat,
+            double requiredSingularDouble,
+            bool requiredSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum requiredSingularEnum,
+            string requiredSingularString,
+            pb::ByteString requiredSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage,
+            string requiredSingularResourceName,
+            string requiredSingularResourceNameOneof,
+            string requiredSingularResourceNameCommon,
+            int requiredSingularFixed32,
+            long requiredSingularFixed64,
+            scg::IEnumerable<int> requiredRepeatedInt32,
+            scg::IEnumerable<long> requiredRepeatedInt64,
+            scg::IEnumerable<float> requiredRepeatedFloat,
+            scg::IEnumerable<double> requiredRepeatedDouble,
+            scg::IEnumerable<bool> requiredRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> requiredRepeatedEnum,
+            scg::IEnumerable<string> requiredRepeatedString,
+            scg::IEnumerable<pb::ByteString> requiredRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage,
+            scg::IEnumerable<string> requiredRepeatedResourceName,
+            scg::IEnumerable<string> requiredRepeatedResourceNameOneof,
+            scg::IEnumerable<string> requiredRepeatedResourceNameCommon,
+            scg::IEnumerable<int> requiredRepeatedFixed32,
+            scg::IEnumerable<long> requiredRepeatedFixed64,
+            scg::IDictionary<int, string> requiredMap,
+            int? optionalSingularInt32,
+            long? optionalSingularInt64,
+            float? optionalSingularFloat,
+            double? optionalSingularDouble,
+            bool? optionalSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum? optionalSingularEnum,
+            string optionalSingularString,
+            pb::ByteString optionalSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage,
+            string optionalSingularResourceName,
+            string optionalSingularResourceNameOneof,
+            string optionalSingularResourceNameCommon,
+            int? optionalSingularFixed32,
+            long? optionalSingularFixed64,
+            scg::IEnumerable<int> optionalRepeatedInt32,
+            scg::IEnumerable<long> optionalRepeatedInt64,
+            scg::IEnumerable<float> optionalRepeatedFloat,
+            scg::IEnumerable<double> optionalRepeatedDouble,
+            scg::IEnumerable<bool> optionalRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> optionalRepeatedEnum,
+            scg::IEnumerable<string> optionalRepeatedString,
+            scg::IEnumerable<pb::ByteString> optionalRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage,
+            scg::IEnumerable<string> optionalRepeatedResourceName,
+            scg::IEnumerable<string> optionalRepeatedResourceNameOneof,
+            scg::IEnumerable<string> optionalRepeatedResourceNameCommon,
+            scg::IEnumerable<int> optionalRepeatedFixed32,
+            scg::IEnumerable<long> optionalRepeatedFixed64,
+            scg::IDictionary<int, string> optionalMap,
+            pbwkt::Any anyValue,
+            pbwkt::Struct structValue,
+            pbwkt::Value valueValue,
+            pbwkt::ListValue listValueValue,
+            pbwkt::Timestamp timeValue,
+            pbwkt::Duration durationValue,
+            pbwkt::FieldMask fieldMaskValue,
+            int? int32Value,
+            uint? uint32Value,
+            long? int64Value,
+            ulong? uint64Value,
+            float? floatValue,
+            double? doubleValue,
+            string stringValue,
+            bool? boolValue,
+            pb::ByteString bytesValue,
+            scg::IEnumerable<pbwkt::Any> repeatedAnyValue,
+            scg::IEnumerable<pbwkt::Struct> repeatedStructValue,
+            scg::IEnumerable<pbwkt::Value> repeatedValueValue,
+            scg::IEnumerable<pbwkt::ListValue> repeatedListValueValue,
+            scg::IEnumerable<pbwkt::Timestamp> repeatedTimeValue,
+            scg::IEnumerable<pbwkt::Duration> repeatedDurationValue,
+            scg::IEnumerable<pbwkt::FieldMask> repeatedFieldMaskValue,
+            scg::IEnumerable<int?> repeatedInt32Value,
+            scg::IEnumerable<uint?> repeatedUint32Value,
+            scg::IEnumerable<long?> repeatedInt64Value,
+            scg::IEnumerable<ulong?> repeatedUint64Value,
+            scg::IEnumerable<float?> repeatedFloatValue,
+            scg::IEnumerable<double?> repeatedDoubleValue,
+            scg::IEnumerable<string> repeatedStringValue,
+            scg::IEnumerable<bool?> repeatedBoolValue,
+            scg::IEnumerable<pb::ByteString> repeatedBytesValue,
+            st::CancellationToken cancellationToken) => TestOptionalRequiredFlatteningParamsAsync(
+                requiredSingularInt32,
+                requiredSingularInt64,
+                requiredSingularFloat,
+                requiredSingularDouble,
+                requiredSingularBool,
+                requiredSingularEnum,
+                requiredSingularString,
+                requiredSingularBytes,
+                requiredSingularMessage,
+                requiredSingularResourceName,
+                requiredSingularResourceNameOneof,
+                requiredSingularResourceNameCommon,
+                requiredSingularFixed32,
+                requiredSingularFixed64,
+                requiredRepeatedInt32,
+                requiredRepeatedInt64,
+                requiredRepeatedFloat,
+                requiredRepeatedDouble,
+                requiredRepeatedBool,
+                requiredRepeatedEnum,
+                requiredRepeatedString,
+                requiredRepeatedBytes,
+                requiredRepeatedMessage,
+                requiredRepeatedResourceName,
+                requiredRepeatedResourceNameOneof,
+                requiredRepeatedResourceNameCommon,
+                requiredRepeatedFixed32,
+                requiredRepeatedFixed64,
+                requiredMap,
+                optionalSingularInt32,
+                optionalSingularInt64,
+                optionalSingularFloat,
+                optionalSingularDouble,
+                optionalSingularBool,
+                optionalSingularEnum,
+                optionalSingularString,
+                optionalSingularBytes,
+                optionalSingularMessage,
+                optionalSingularResourceName,
+                optionalSingularResourceNameOneof,
+                optionalSingularResourceNameCommon,
+                optionalSingularFixed32,
+                optionalSingularFixed64,
+                optionalRepeatedInt32,
+                optionalRepeatedInt64,
+                optionalRepeatedFloat,
+                optionalRepeatedDouble,
+                optionalRepeatedBool,
+                optionalRepeatedEnum,
+                optionalRepeatedString,
+                optionalRepeatedBytes,
+                optionalRepeatedMessage,
+                optionalRepeatedResourceName,
+                optionalRepeatedResourceNameOneof,
+                optionalRepeatedResourceNameCommon,
+                optionalRepeatedFixed32,
+                optionalRepeatedFixed64,
+                optionalMap,
+                anyValue,
+                structValue,
+                valueValue,
+                listValueValue,
+                timeValue,
+                durationValue,
+                fieldMaskValue,
+                int32Value,
+                uint32Value,
+                int64Value,
+                uint64Value,
+                floatValue,
+                doubleValue,
+                stringValue,
+                boolValue,
+                bytesValue,
+                repeatedAnyValue,
+                repeatedStructValue,
+                repeatedValueValue,
+                repeatedListValueValue,
+                repeatedTimeValue,
+                repeatedDurationValue,
+                repeatedFieldMaskValue,
+                repeatedInt32Value,
+                repeatedUint32Value,
+                repeatedInt64Value,
+                repeatedUint64Value,
+                repeatedFloatValue,
+                repeatedDoubleValue,
+                repeatedStringValue,
+                repeatedBoolValue,
+                repeatedBytesValue,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Test optional flattening parameters of all types
@@ -16142,59 +18068,6 @@ class FindRelatedBooksAsyncRequestAsyncPagedPageSizeOdyssey
    	// FIXME: call the sample function
    }
 }
-============== file: Samples/FindRelatedBooksFlattenedOdyssey.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "odyssey")
-
-// [START sample]
-// FIXME: import everything this sample needs
-class FindRelatedBooksFlattenedOdyssey
-{
-    // [START sample_core]
-   /// <summary>
-   /// Testing calling forms
-   /// </summary>
-   public static void SampleFindRelatedBooks()
-   {
-       public static void SampleFindRelatedBooks()
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           IEnumerable<BookName> names = new[]
-           {
-               new BookName("[SHELF_ID]", "[BOOK_ID]"),
-           };
-           IEnumerable<ShelfName> shelves = new[]
-           {
-               new ShelfName("[SHELF_ID]"),
-           };
-           gax::PagedEnumerable<FindRelatedBooksRequest, FindRelatedBooksResponse, BookName> response = libraryServiceClient.FindRelatedBooks(names, shelves);
-           // FIXME: inspect the results
-       }
-       // [END sample_core]
-   }
-
-   // [END sample]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
 ============== file: Samples/FindRelatedBooksFlattenedPagedAllOdyssey.cs ==============
 // Copyright 2019 Google LLC
 //
@@ -16545,196 +18418,6 @@ class FindRelatedBooksRequestPagedPageSizeOdyssey
            }
            // Store the pageToken, for when the next page is required.
            string nextPageToken = singlePage.NextPageToken;
-       }
-       // [END sample_core]
-   }
-
-   // [END sample]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
-============== file: Samples/GetBigBookFlattenedWap.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "wap")
-
-// [START hopper]
-// FIXME: import everything this sample needs
-class GetBigBookFlattenedWap
-{
-    // [START hopper_core]
-   /// <summary>
-   /// Testing calling forms
-   /// </summary>
-   public static void SampleGetBigBook(string shelf)
-   {
-       public static void SampleGetBigBook(string shelf)
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           // string shelf = "Novel"
-           BookName name = new BookName(shelf, "War and Peace");
-           Book response = libraryServiceClient.GetBigBook(name);
-           // FIXME: inspect the results
-       }
-       // [END hopper_core]
-   }
-
-   // [END hopper]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
-============== file: Samples/GetBigBookFlattenedWap2.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "wap2")
-
-// [START hopper]
-// FIXME: import everything this sample needs
-class GetBigBookFlattenedWap2
-{
-    // [START hopper_core]
-   /// <summary>
-   /// Testing resource name overlap
-   /// </summary>
-   /// <param name="shelf">Test word wrapping for long lines. This is a long comment. The name of the
-   /// shelf to retrieve the big book from.</param>
-   /// <param name="bigBookName">The name of the book.</param>
-   public static void SampleGetBigBook(string shelf, string bigBookName)
-   {
-       public static void SampleGetBigBook(string shelf, string bigBookName)
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           // string shelf = "Novel"
-           // string bigBookName = "War and Peace"
-           BookName name = new BookName(shelf, bigBookName);
-           Book response = libraryServiceClient.GetBigBook(name);
-           // FIXME: inspect the results
-       }
-       // [END hopper_core]
-   }
-
-   // [END hopper]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
-============== file: Samples/GetBigNothingFlattenedEmptyResponseTypeWithResponseHandling.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "empty_response_type_with_response_handling")
-
-// [START sample]
-// FIXME: import everything this sample needs
-class GetBigNothingFlattenedEmptyResponseTypeWithResponseHandling
-{
-    // [START sample_core]
-   /// <summary>
-   /// Test response handling for methods that return empty
-   /// </summary>
-   public static void SampleGetBigNothing()
-   {
-       public static void SampleGetBigNothing()
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
-           libraryServiceClient.GetBigNothing(name);
-           // FIXME: inspect the results
-       }
-       // [END sample_core]
-   }
-
-   // [END sample]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
-============== file: Samples/GetBigNothingFlattenedEmptyResponseTypeWithoutResponseHandling.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "empty_response_type_without_response_handling")
-
-// [START sample]
-// FIXME: import everything this sample needs
-class GetBigNothingFlattenedEmptyResponseTypeWithoutResponseHandling
-{
-    // [START sample_core]
-   /// <summary>
-   /// Test default response handling is turned off for methods that return empty
-   /// </summary>
-   public static void SampleGetBigNothing()
-   {
-       public static void SampleGetBigNothing()
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
-           libraryServiceClient.GetBigNothing(name);
-           // FIXME: inspect the results
        }
        // [END sample_core]
    }
@@ -17467,52 +19150,6 @@ class PublishSeriesRequestTestWriteToFile
                SeriesUuid = new SeriesUuid(),
            };
            PublishSeriesResponse response = libraryServiceClient.PublishSeries(request);
-           // FIXME: inspect the results
-       }
-       // [END sample_core]
-   }
-
-   // [END sample]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
-============== file: Samples/StreamShelvesFlattenedEmpty.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "empty")
-
-// [START sample]
-// FIXME: import everything this sample needs
-class StreamShelvesFlattenedEmpty
-{
-    // [START sample_core]
-   /// <summary>
-   /// Testing calling forms
-   /// </summary>
-   public static void SampleStreamShelves()
-   {
-       public static void SampleStreamShelves()
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           ShelfName name = new ShelfName("[SHELF_ID]");
-           grpccore::AsyncServerStreamingCall<StreamShelvesResponse> response = libraryServiceClient.StreamShelves(name);
            // FIXME: inspect the results
        }
        // [END sample_core]

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -6761,6 +6761,27 @@ namespace Google.Example.Library.V1
         /// <param name="name">
         /// The name of the shelf to retrieve.
         /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Shelf GetShelf(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetShelf(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
         /// <param name="message">
         /// Field to verify that message-type query parameter gets flattened.
         /// </param>
@@ -6826,6 +6847,32 @@ namespace Google.Example.Library.V1
                 new GetShelfRequest
                 {
                     ShelfName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    Message = message, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Shelf GetShelf(
+            string name,
+            SomeMessage message,
+            gaxgrpc::CallSettings callSettings = null) => GetShelf(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                     Message = message, // Optional
                 },
                 callSettings);
@@ -6915,6 +6962,37 @@ namespace Google.Example.Library.V1
                 new GetShelfRequest
                 {
                     ShelfName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    Message = message, // Optional
+                    StringBuilder = stringBuilder, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="stringBuilder">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Shelf GetShelf(
+            string name,
+            SomeMessage message,
+            StringBuilder stringBuilder,
+            gaxgrpc::CallSettings callSettings = null) => GetShelf(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                     Message = message, // Optional
                     StringBuilder = stringBuilder, // Optional
                 },
@@ -7137,6 +7215,24 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Deletes a shelf.
         /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to delete.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void DeleteShelf(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => DeleteShelf(
+                new DeleteShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a shelf.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -7273,6 +7369,34 @@ namespace Google.Example.Library.V1
         /// `other_shelf_name` to shelf `name`, and deletes
         /// `other_shelf_name`. Returns the updated shelf.
         /// </summary>
+        /// <param name="name">
+        /// The name of the shelf we're adding books to.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the shelf we're removing books from and deleting.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Shelf MergeShelves(
+            string name,
+            string otherShelfName,
+            gaxgrpc::CallSettings callSettings = null) => MergeShelves(
+                new MergeShelvesRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    OtherShelfName = gax::GaxPreconditions.CheckNotNullOrEmpty(otherShelfName, nameof(otherShelfName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Merges two shelves by adding all books from the shelf named
+        /// `other_shelf_name` to shelf `name`, and deletes
+        /// `other_shelf_name`. Returns the updated shelf.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -7401,6 +7525,32 @@ namespace Google.Example.Library.V1
                 new CreateBookRequest
                 {
                     ShelfName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf in which the book is created.
+        /// </param>
+        /// <param name="book">
+        /// The book to create.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Book CreateBook(
+            string name,
+            Book book,
+            gaxgrpc::CallSettings callSettings = null) => CreateBook(
+                new CreateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                     Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
                 },
                 callSettings);
@@ -7685,6 +7835,27 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Gets a book.
         /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Book GetBook(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBook(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -7817,6 +7988,34 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Lists books in a shelf.
         /// </summary>
+        /// <param name="name">
+        /// The name of the shelf whose books we'd like to list.
+        /// </param>
+        /// <param name="filter">
+        /// To test python built-in wrapping.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="Book"/> resources.
+        /// </returns>
+        public virtual gax::PagedEnumerable<ListBooksResponse, Book> ListBooks(
+            string name,
+            string filter,
+            gaxgrpc::CallSettings callSettings = null) => ListBooks(
+                new ListBooksRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Filter = filter ?? "", // Optional
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists books in a shelf.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -7906,6 +8105,24 @@ namespace Google.Example.Library.V1
                 new DeleteBookRequest
                 {
                     BookName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to delete.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void DeleteBook(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => DeleteBook(
+                new DeleteBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                 },
                 callSettings);
 
@@ -8043,6 +8260,32 @@ namespace Google.Example.Library.V1
         /// <param name="name">
         /// The name of the book to update.
         /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Book UpdateBook(
+            string name,
+            Book book,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBook(
+                new UpdateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
         /// <param name="optionalFoo">
         /// An optional foo.
         /// </param>
@@ -8150,6 +8393,47 @@ namespace Google.Example.Library.V1
                 new UpdateBookRequest
                 {
                     BookName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    OptionalFoo = optionalFoo ?? "", // Optional
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                    UpdateMask = updateMask, // Optional
+                    PhysicalMask = physicalMask, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="optionalFoo">
+        /// An optional foo.
+        /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="updateMask">
+        /// A field mask to apply, rendered as an HTTP parameter.
+        /// </param>
+        /// <param name="physicalMask">
+        /// To test Python import clash resolution.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Book UpdateBook(
+            string name,
+            string optionalFoo,
+            Book book,
+            pbwkt::FieldMask updateMask,
+            FieldMask physicalMask,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBook(
+                new UpdateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                     OptionalFoo = optionalFoo ?? "", // Optional
                     Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
                     UpdateMask = updateMask, // Optional
@@ -8291,6 +8575,32 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Moves a book to another shelf, and returns the new book.
         /// </summary>
+        /// <param name="name">
+        /// The name of the book to move.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the destination shelf.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Book MoveBook(
+            string name,
+            string otherShelfName,
+            gaxgrpc::CallSettings callSettings = null) => MoveBook(
+                new MoveBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    OtherShelfName = gax::GaxPreconditions.CheckNotNullOrEmpty(otherShelfName, nameof(otherShelfName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Moves a book to another shelf, and returns the new book.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -8469,6 +8779,29 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Lists a primitive resource. To test go page streaming.
         /// </summary>
+        /// <param name="name">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="string"/> resources.
+        /// </returns>
+        public virtual gax::PagedEnumerable<ListStringsResponse, IResourceName> ListStrings(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => ListStrings(
+                new ListStringsRequest
+                {
+                    Name = name ?? "", // Optional
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists a primitive resource. To test go page streaming.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -8572,6 +8905,29 @@ namespace Google.Example.Library.V1
                 new AddCommentsRequest
                 {
                     BookName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    Comments = { gax::GaxPreconditions.CheckNotNull(comments, nameof(comments)) },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Adds comments to a book
+        /// </summary>
+        /// <param name="name">
+        ///
+        /// </param>
+        /// <param name="comments">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void AddComments(
+            string name,
+            scg::IEnumerable<Comment> comments,
+            gaxgrpc::CallSettings callSettings = null) => AddComments(
+                new AddCommentsRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                     Comments = { gax::GaxPreconditions.CheckNotNull(comments, nameof(comments)) },
                 },
                 callSettings);
@@ -8686,6 +9042,27 @@ namespace Google.Example.Library.V1
                 new GetBookFromArchiveRequest
                 {
                     ArchivedBookName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book from an archive.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual BookFromArchive GetBookFromArchive(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromArchive(
+                new GetBookFromArchiveRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                 },
                 callSettings);
 
@@ -8826,6 +9203,33 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Gets a book from a shelf or archive.
         /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="altBookName">
+        /// An alternate book name, used to test restricting flattened field to a
+        /// single resource name type in a oneof.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual BookFromAnywhere GetBookFromAnywhere(
+            string name,
+            string altBookName,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromAnywhere(
+                new GetBookFromAnywhereRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    AltBookName = gax::GaxPreconditions.CheckNotNullOrEmpty(altBookName, nameof(altBookName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book from a shelf or archive.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -8936,6 +9340,27 @@ namespace Google.Example.Library.V1
                 new GetBookFromAbsolutelyAnywhereRequest
                 {
                     AsResourceName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test proper OneOf-Any resource name mapping
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual BookFromAnywhere GetBookFromAbsolutelyAnywhere(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromAbsolutelyAnywhere(
+                new GetBookFromAbsolutelyAnywhereRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                 },
                 callSettings);
 
@@ -9085,6 +9510,34 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Updates the index of a book.
         /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="indexName">
+        /// The name of the index for the book
+        /// </param>
+        /// <param name="indexMap">
+        /// The index to update the book with
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void UpdateBookIndex(
+            string name,
+            string indexName,
+            scg::IDictionary<string, string> indexMap,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBookIndex(
+                new UpdateBookIndexRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    IndexName = gax::GaxPreconditions.CheckNotNullOrEmpty(indexName, nameof(indexName)),
+                    IndexMap = { gax::GaxPreconditions.CheckNotNull(indexMap, nameof(indexMap)) },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates the index of a book.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -9154,6 +9607,28 @@ namespace Google.Example.Library.V1
                 new StreamShelvesRequest
                 {
                     ShelfName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test server streaming
+        /// gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to stream.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The server stream.
+        /// </returns>
+        public virtual StreamShelvesStream StreamShelves(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => StreamShelves(
+                new StreamShelvesRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                 },
                 callSettings);
 
@@ -9330,6 +9805,34 @@ namespace Google.Example.Library.V1
                 {
                     BookNames = { gax::GaxPreconditions.CheckNotNull(names, nameof(names)) },
                     ShelvesAsShelfNames = { gax::GaxPreconditions.CheckNotNull(shelves, nameof(shelves)) },
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="names">
+        ///
+        /// </param>
+        /// <param name="shelves">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="string"/> resources.
+        /// </returns>
+        public virtual gax::PagedEnumerable<FindRelatedBooksResponse, BookName> FindRelatedBooks(
+            scg::IEnumerable<string> names,
+            scg::IEnumerable<string> shelves,
+            gaxgrpc::CallSettings callSettings = null) => FindRelatedBooks(
+                new FindRelatedBooksRequest
+                {
+                    Names = { gax::GaxPreconditions.CheckNotNull(names, nameof(names)) },
+                    Shelves = { gax::GaxPreconditions.CheckNotNull(shelves, nameof(shelves)) },
                     PageToken = pageToken ?? "",
                     PageSize = pageSize ?? 0,
                 },
@@ -9570,6 +10073,27 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Test long-running operations
         /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual lro::Operation<Book, GetBigBookMetadata> GetBigBook(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBigBook(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test long-running operations
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -9696,6 +10220,27 @@ namespace Google.Example.Library.V1
                 new GetBookRequest
                 {
                     BookName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual lro::Operation<pbwkt::Empty, GetBigBookMetadata> GetBigNothing(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBigNothing(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                 },
                 callSettings);
 
@@ -11173,6 +11718,472 @@ namespace Google.Example.Library.V1
                     OptionalRepeatedResourceNameAsBookNames = { optionalRepeatedResourceName ?? linq::Enumerable.Empty<BookName>() }, // Optional
                     OptionalRepeatedResourceNameOneofAsBookNameOneofs = { optionalRepeatedResourceNameOneof ?? linq::Enumerable.Empty<BookNameOneof>() }, // Optional
                     OptionalRepeatedResourceNameCommonAsProjectNames = { optionalRepeatedResourceNameCommon ?? linq::Enumerable.Empty<gaxres::ProjectName>() }, // Optional
+                    OptionalRepeatedFixed32 = { optionalRepeatedFixed32 ?? linq::Enumerable.Empty<int>() }, // Optional
+                    OptionalRepeatedFixed64 = { optionalRepeatedFixed64 ?? linq::Enumerable.Empty<long>() }, // Optional
+                    OptionalMap = { optionalMap ?? gax::EmptyDictionary<int, string>.Instance }, // Optional
+                    AnyValue = anyValue, // Optional
+                    StructValue = structValue, // Optional
+                    ValueValue = valueValue, // Optional
+                    ListValueValue = listValueValue, // Optional
+                    TimeValue = timeValue, // Optional
+                    DurationValue = durationValue, // Optional
+                    FieldMaskValue = fieldMaskValue, // Optional
+                    Int32Value = int32Value, // Optional
+                    Uint32Value = uint32Value, // Optional
+                    Int64Value = int64Value, // Optional
+                    Uint64Value = uint64Value, // Optional
+                    FloatValue = floatValue, // Optional
+                    DoubleValue = doubleValue, // Optional
+                    StringValue = stringValue, // Optional
+                    BoolValue = boolValue, // Optional
+                    BytesValue = bytesValue, // Optional
+                    RepeatedAnyValue = { repeatedAnyValue ?? linq::Enumerable.Empty<pbwkt::Any>() }, // Optional
+                    RepeatedStructValue = { repeatedStructValue ?? linq::Enumerable.Empty<pbwkt::Struct>() }, // Optional
+                    RepeatedValueValue = { repeatedValueValue ?? linq::Enumerable.Empty<pbwkt::Value>() }, // Optional
+                    RepeatedListValueValue = { repeatedListValueValue ?? linq::Enumerable.Empty<pbwkt::ListValue>() }, // Optional
+                    RepeatedTimeValue = { repeatedTimeValue ?? linq::Enumerable.Empty<pbwkt::Timestamp>() }, // Optional
+                    RepeatedDurationValue = { repeatedDurationValue ?? linq::Enumerable.Empty<pbwkt::Duration>() }, // Optional
+                    RepeatedFieldMaskValue = { repeatedFieldMaskValue ?? linq::Enumerable.Empty<pbwkt::FieldMask>() }, // Optional
+                    RepeatedInt32Value = { repeatedInt32Value ?? linq::Enumerable.Empty<int?>() }, // Optional
+                    RepeatedUint32Value = { repeatedUint32Value ?? linq::Enumerable.Empty<uint?>() }, // Optional
+                    RepeatedInt64Value = { repeatedInt64Value ?? linq::Enumerable.Empty<long?>() }, // Optional
+                    RepeatedUint64Value = { repeatedUint64Value ?? linq::Enumerable.Empty<ulong?>() }, // Optional
+                    RepeatedFloatValue = { repeatedFloatValue ?? linq::Enumerable.Empty<float?>() }, // Optional
+                    RepeatedDoubleValue = { repeatedDoubleValue ?? linq::Enumerable.Empty<double?>() }, // Optional
+                    RepeatedStringValue = { repeatedStringValue ?? linq::Enumerable.Empty<string>() }, // Optional
+                    RepeatedBoolValue = { repeatedBoolValue ?? linq::Enumerable.Empty<bool?>() }, // Optional
+                    RepeatedBytesValue = { repeatedBytesValue ?? linq::Enumerable.Empty<pb::ByteString>() }, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test optional flattening parameters of all types
+        /// </summary>
+        /// <param name="requiredSingularInt32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularInt64">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFloat">
+        ///
+        /// </param>
+        /// <param name="requiredSingularDouble">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBool">
+        ///
+        /// </param>
+        /// <param name="requiredSingularEnum">
+        ///
+        /// </param>
+        /// <param name="requiredSingularString">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBytes">
+        ///
+        /// </param>
+        /// <param name="requiredSingularMessage">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedString">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredMap">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt64">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFloat">
+        ///
+        /// </param>
+        /// <param name="optionalSingularDouble">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBool">
+        ///
+        /// </param>
+        /// <param name="optionalSingularEnum">
+        ///
+        /// </param>
+        /// <param name="optionalSingularString">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBytes">
+        ///
+        /// </param>
+        /// <param name="optionalSingularMessage">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedString">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalMap">
+        ///
+        /// </param>
+        /// <param name="anyValue">
+        ///
+        /// </param>
+        /// <param name="structValue">
+        ///
+        /// </param>
+        /// <param name="valueValue">
+        ///
+        /// </param>
+        /// <param name="listValueValue">
+        ///
+        /// </param>
+        /// <param name="timeValue">
+        ///
+        /// </param>
+        /// <param name="durationValue">
+        ///
+        /// </param>
+        /// <param name="fieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="int32Value">
+        ///
+        /// </param>
+        /// <param name="uint32Value">
+        ///
+        /// </param>
+        /// <param name="int64Value">
+        ///
+        /// </param>
+        /// <param name="uint64Value">
+        ///
+        /// </param>
+        /// <param name="floatValue">
+        ///
+        /// </param>
+        /// <param name="doubleValue">
+        ///
+        /// </param>
+        /// <param name="stringValue">
+        ///
+        /// </param>
+        /// <param name="boolValue">
+        ///
+        /// </param>
+        /// <param name="bytesValue">
+        ///
+        /// </param>
+        /// <param name="repeatedAnyValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStructValue">
+        ///
+        /// </param>
+        /// <param name="repeatedValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedListValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedTimeValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDurationValue">
+        ///
+        /// </param>
+        /// <param name="repeatedFieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="repeatedInt32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedInt64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedFloatValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDoubleValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStringValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBoolValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBytesValue">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual TestOptionalRequiredFlatteningParamsResponse TestOptionalRequiredFlatteningParams(
+            int requiredSingularInt32,
+            long requiredSingularInt64,
+            float requiredSingularFloat,
+            double requiredSingularDouble,
+            bool requiredSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum requiredSingularEnum,
+            string requiredSingularString,
+            pb::ByteString requiredSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage,
+            string requiredSingularResourceName,
+            string requiredSingularResourceNameOneof,
+            string requiredSingularResourceNameCommon,
+            int requiredSingularFixed32,
+            long requiredSingularFixed64,
+            scg::IEnumerable<int> requiredRepeatedInt32,
+            scg::IEnumerable<long> requiredRepeatedInt64,
+            scg::IEnumerable<float> requiredRepeatedFloat,
+            scg::IEnumerable<double> requiredRepeatedDouble,
+            scg::IEnumerable<bool> requiredRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> requiredRepeatedEnum,
+            scg::IEnumerable<string> requiredRepeatedString,
+            scg::IEnumerable<pb::ByteString> requiredRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage,
+            scg::IEnumerable<string> requiredRepeatedResourceName,
+            scg::IEnumerable<string> requiredRepeatedResourceNameOneof,
+            scg::IEnumerable<string> requiredRepeatedResourceNameCommon,
+            scg::IEnumerable<int> requiredRepeatedFixed32,
+            scg::IEnumerable<long> requiredRepeatedFixed64,
+            scg::IDictionary<int, string> requiredMap,
+            int? optionalSingularInt32,
+            long? optionalSingularInt64,
+            float? optionalSingularFloat,
+            double? optionalSingularDouble,
+            bool? optionalSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum? optionalSingularEnum,
+            string optionalSingularString,
+            pb::ByteString optionalSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage,
+            string optionalSingularResourceName,
+            string optionalSingularResourceNameOneof,
+            string optionalSingularResourceNameCommon,
+            int? optionalSingularFixed32,
+            long? optionalSingularFixed64,
+            scg::IEnumerable<int> optionalRepeatedInt32,
+            scg::IEnumerable<long> optionalRepeatedInt64,
+            scg::IEnumerable<float> optionalRepeatedFloat,
+            scg::IEnumerable<double> optionalRepeatedDouble,
+            scg::IEnumerable<bool> optionalRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> optionalRepeatedEnum,
+            scg::IEnumerable<string> optionalRepeatedString,
+            scg::IEnumerable<pb::ByteString> optionalRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage,
+            scg::IEnumerable<string> optionalRepeatedResourceName,
+            scg::IEnumerable<string> optionalRepeatedResourceNameOneof,
+            scg::IEnumerable<string> optionalRepeatedResourceNameCommon,
+            scg::IEnumerable<int> optionalRepeatedFixed32,
+            scg::IEnumerable<long> optionalRepeatedFixed64,
+            scg::IDictionary<int, string> optionalMap,
+            pbwkt::Any anyValue,
+            pbwkt::Struct structValue,
+            pbwkt::Value valueValue,
+            pbwkt::ListValue listValueValue,
+            pbwkt::Timestamp timeValue,
+            pbwkt::Duration durationValue,
+            pbwkt::FieldMask fieldMaskValue,
+            int? int32Value,
+            uint? uint32Value,
+            long? int64Value,
+            ulong? uint64Value,
+            float? floatValue,
+            double? doubleValue,
+            string stringValue,
+            bool? boolValue,
+            pb::ByteString bytesValue,
+            scg::IEnumerable<pbwkt::Any> repeatedAnyValue,
+            scg::IEnumerable<pbwkt::Struct> repeatedStructValue,
+            scg::IEnumerable<pbwkt::Value> repeatedValueValue,
+            scg::IEnumerable<pbwkt::ListValue> repeatedListValueValue,
+            scg::IEnumerable<pbwkt::Timestamp> repeatedTimeValue,
+            scg::IEnumerable<pbwkt::Duration> repeatedDurationValue,
+            scg::IEnumerable<pbwkt::FieldMask> repeatedFieldMaskValue,
+            scg::IEnumerable<int?> repeatedInt32Value,
+            scg::IEnumerable<uint?> repeatedUint32Value,
+            scg::IEnumerable<long?> repeatedInt64Value,
+            scg::IEnumerable<ulong?> repeatedUint64Value,
+            scg::IEnumerable<float?> repeatedFloatValue,
+            scg::IEnumerable<double?> repeatedDoubleValue,
+            scg::IEnumerable<string> repeatedStringValue,
+            scg::IEnumerable<bool?> repeatedBoolValue,
+            scg::IEnumerable<pb::ByteString> repeatedBytesValue,
+            gaxgrpc::CallSettings callSettings = null) => TestOptionalRequiredFlatteningParams(
+                new TestOptionalRequiredFlatteningParamsRequest
+                {
+                    RequiredSingularInt32 = requiredSingularInt32,
+                    RequiredSingularInt64 = requiredSingularInt64,
+                    RequiredSingularFloat = requiredSingularFloat,
+                    RequiredSingularDouble = requiredSingularDouble,
+                    RequiredSingularBool = requiredSingularBool,
+                    RequiredSingularEnum = requiredSingularEnum,
+                    RequiredSingularString = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularString, nameof(requiredSingularString)),
+                    RequiredSingularBytes = gax::GaxPreconditions.CheckNotNull(requiredSingularBytes, nameof(requiredSingularBytes)),
+                    RequiredSingularMessage = gax::GaxPreconditions.CheckNotNull(requiredSingularMessage, nameof(requiredSingularMessage)),
+                    RequiredSingularResourceName = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceName, nameof(requiredSingularResourceName)),
+                    RequiredSingularResourceNameOneof = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceNameOneof, nameof(requiredSingularResourceNameOneof)),
+                    RequiredSingularResourceNameCommon = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceNameCommon, nameof(requiredSingularResourceNameCommon)),
+                    RequiredSingularFixed32 = requiredSingularFixed32,
+                    RequiredSingularFixed64 = requiredSingularFixed64,
+                    RequiredRepeatedInt32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedInt32, nameof(requiredRepeatedInt32)) },
+                    RequiredRepeatedInt64 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedInt64, nameof(requiredRepeatedInt64)) },
+                    RequiredRepeatedFloat = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFloat, nameof(requiredRepeatedFloat)) },
+                    RequiredRepeatedDouble = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedDouble, nameof(requiredRepeatedDouble)) },
+                    RequiredRepeatedBool = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedBool, nameof(requiredRepeatedBool)) },
+                    RequiredRepeatedEnum = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedEnum, nameof(requiredRepeatedEnum)) },
+                    RequiredRepeatedString = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedString, nameof(requiredRepeatedString)) },
+                    RequiredRepeatedBytes = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedBytes, nameof(requiredRepeatedBytes)) },
+                    RequiredRepeatedMessage = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedMessage, nameof(requiredRepeatedMessage)) },
+                    RequiredRepeatedResourceName = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceName, nameof(requiredRepeatedResourceName)) },
+                    RequiredRepeatedResourceNameOneof = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameOneof, nameof(requiredRepeatedResourceNameOneof)) },
+                    RequiredRepeatedResourceNameCommon = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameCommon, nameof(requiredRepeatedResourceNameCommon)) },
+                    RequiredRepeatedFixed32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed32, nameof(requiredRepeatedFixed32)) },
+                    RequiredRepeatedFixed64 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed64, nameof(requiredRepeatedFixed64)) },
+                    RequiredMap = { gax::GaxPreconditions.CheckNotNull(requiredMap, nameof(requiredMap)) },
+                    OptionalSingularInt32 = optionalSingularInt32 ?? 0, // Optional
+                    OptionalSingularInt64 = optionalSingularInt64 ?? 0L, // Optional
+                    OptionalSingularFloat = optionalSingularFloat ?? 0.0f, // Optional
+                    OptionalSingularDouble = optionalSingularDouble ?? 0.0, // Optional
+                    OptionalSingularBool = optionalSingularBool ?? false, // Optional
+                    OptionalSingularEnum = optionalSingularEnum ?? TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum.Zero, // Optional
+                    OptionalSingularString = optionalSingularString ?? "", // Optional
+                    OptionalSingularBytes = optionalSingularBytes ?? pb::ByteString.Empty, // Optional
+                    OptionalSingularMessage = optionalSingularMessage, // Optional
+                    OptionalSingularResourceName = optionalSingularResourceName ?? "", // Optional
+                    OptionalSingularResourceNameOneof = optionalSingularResourceNameOneof ?? "", // Optional
+                    OptionalSingularResourceNameCommon = optionalSingularResourceNameCommon ?? "", // Optional
+                    OptionalSingularFixed32 = optionalSingularFixed32 ?? 0, // Optional
+                    OptionalSingularFixed64 = optionalSingularFixed64 ?? 0L, // Optional
+                    OptionalRepeatedInt32 = { optionalRepeatedInt32 ?? linq::Enumerable.Empty<int>() }, // Optional
+                    OptionalRepeatedInt64 = { optionalRepeatedInt64 ?? linq::Enumerable.Empty<long>() }, // Optional
+                    OptionalRepeatedFloat = { optionalRepeatedFloat ?? linq::Enumerable.Empty<float>() }, // Optional
+                    OptionalRepeatedDouble = { optionalRepeatedDouble ?? linq::Enumerable.Empty<double>() }, // Optional
+                    OptionalRepeatedBool = { optionalRepeatedBool ?? linq::Enumerable.Empty<bool>() }, // Optional
+                    OptionalRepeatedEnum = { optionalRepeatedEnum ?? linq::Enumerable.Empty<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>() }, // Optional
+                    OptionalRepeatedString = { optionalRepeatedString ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedBytes = { optionalRepeatedBytes ?? linq::Enumerable.Empty<pb::ByteString>() }, // Optional
+                    OptionalRepeatedMessage = { optionalRepeatedMessage ?? linq::Enumerable.Empty<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>() }, // Optional
+                    OptionalRepeatedResourceName = { optionalRepeatedResourceName ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedResourceNameOneof = { optionalRepeatedResourceNameOneof ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedResourceNameCommon = { optionalRepeatedResourceNameCommon ?? linq::Enumerable.Empty<string>() }, // Optional
                     OptionalRepeatedFixed32 = { optionalRepeatedFixed32 ?? linq::Enumerable.Empty<int>() }, // Optional
                     OptionalRepeatedFixed64 = { optionalRepeatedFixed64 ?? linq::Enumerable.Empty<long>() }, // Optional
                     OptionalMap = { optionalMap ?? gax::EmptyDictionary<int, string>.Instance }, // Optional
@@ -15131,6 +16142,59 @@ class FindRelatedBooksAsyncRequestAsyncPagedPageSizeOdyssey
    	// FIXME: call the sample function
    }
 }
+============== file: Samples/FindRelatedBooksFlattenedOdyssey.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "odyssey")
+
+// [START sample]
+// FIXME: import everything this sample needs
+class FindRelatedBooksFlattenedOdyssey
+{
+    // [START sample_core]
+   /// <summary>
+   /// Testing calling forms
+   /// </summary>
+   public static void SampleFindRelatedBooks()
+   {
+       public static void SampleFindRelatedBooks()
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           IEnumerable<BookName> names = new[]
+           {
+               new BookName("[SHELF_ID]", "[BOOK_ID]"),
+           };
+           IEnumerable<ShelfName> shelves = new[]
+           {
+               new ShelfName("[SHELF_ID]"),
+           };
+           gax::PagedEnumerable<FindRelatedBooksRequest, FindRelatedBooksResponse, BookName> response = libraryServiceClient.FindRelatedBooks(names, shelves);
+           // FIXME: inspect the results
+       }
+       // [END sample_core]
+   }
+
+   // [END sample]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
 ============== file: Samples/FindRelatedBooksFlattenedPagedAllOdyssey.cs ==============
 // Copyright 2019 Google LLC
 //
@@ -15481,6 +16545,196 @@ class FindRelatedBooksRequestPagedPageSizeOdyssey
            }
            // Store the pageToken, for when the next page is required.
            string nextPageToken = singlePage.NextPageToken;
+       }
+       // [END sample_core]
+   }
+
+   // [END sample]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
+============== file: Samples/GetBigBookFlattenedWap.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "wap")
+
+// [START hopper]
+// FIXME: import everything this sample needs
+class GetBigBookFlattenedWap
+{
+    // [START hopper_core]
+   /// <summary>
+   /// Testing calling forms
+   /// </summary>
+   public static void SampleGetBigBook(string shelf)
+   {
+       public static void SampleGetBigBook(string shelf)
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           // string shelf = "Novel"
+           BookName name = new BookName(shelf, "War and Peace");
+           Book response = libraryServiceClient.GetBigBook(name);
+           // FIXME: inspect the results
+       }
+       // [END hopper_core]
+   }
+
+   // [END hopper]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
+============== file: Samples/GetBigBookFlattenedWap2.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "wap2")
+
+// [START hopper]
+// FIXME: import everything this sample needs
+class GetBigBookFlattenedWap2
+{
+    // [START hopper_core]
+   /// <summary>
+   /// Testing resource name overlap
+   /// </summary>
+   /// <param name="shelf">Test word wrapping for long lines. This is a long comment. The name of the
+   /// shelf to retrieve the big book from.</param>
+   /// <param name="bigBookName">The name of the book.</param>
+   public static void SampleGetBigBook(string shelf, string bigBookName)
+   {
+       public static void SampleGetBigBook(string shelf, string bigBookName)
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           // string shelf = "Novel"
+           // string bigBookName = "War and Peace"
+           BookName name = new BookName(shelf, bigBookName);
+           Book response = libraryServiceClient.GetBigBook(name);
+           // FIXME: inspect the results
+       }
+       // [END hopper_core]
+   }
+
+   // [END hopper]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
+============== file: Samples/GetBigNothingFlattenedEmptyResponseTypeWithResponseHandling.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "empty_response_type_with_response_handling")
+
+// [START sample]
+// FIXME: import everything this sample needs
+class GetBigNothingFlattenedEmptyResponseTypeWithResponseHandling
+{
+    // [START sample_core]
+   /// <summary>
+   /// Test response handling for methods that return empty
+   /// </summary>
+   public static void SampleGetBigNothing()
+   {
+       public static void SampleGetBigNothing()
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+           libraryServiceClient.GetBigNothing(name);
+           // FIXME: inspect the results
+       }
+       // [END sample_core]
+   }
+
+   // [END sample]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
+============== file: Samples/GetBigNothingFlattenedEmptyResponseTypeWithoutResponseHandling.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "empty_response_type_without_response_handling")
+
+// [START sample]
+// FIXME: import everything this sample needs
+class GetBigNothingFlattenedEmptyResponseTypeWithoutResponseHandling
+{
+    // [START sample_core]
+   /// <summary>
+   /// Test default response handling is turned off for methods that return empty
+   /// </summary>
+   public static void SampleGetBigNothing()
+   {
+       public static void SampleGetBigNothing()
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+           libraryServiceClient.GetBigNothing(name);
+           // FIXME: inspect the results
        }
        // [END sample_core]
    }
@@ -16213,6 +17467,52 @@ class PublishSeriesRequestTestWriteToFile
                SeriesUuid = new SeriesUuid(),
            };
            PublishSeriesResponse response = libraryServiceClient.PublishSeries(request);
+           // FIXME: inspect the results
+       }
+       // [END sample_core]
+   }
+
+   // [END sample]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
+============== file: Samples/StreamShelvesFlattenedEmpty.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "empty")
+
+// [START sample]
+// FIXME: import everything this sample needs
+class StreamShelvesFlattenedEmpty
+{
+    // [START sample_core]
+   /// <summary>
+   /// Testing calling forms
+   /// </summary>
+   public static void SampleStreamShelves()
+   {
+       public static void SampleStreamShelves()
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           ShelfName name = new ShelfName("[SHELF_ID]");
+           grpccore::AsyncServerStreamingCall<StreamShelvesResponse> response = libraryServiceClient.StreamShelves(name);
            // FIXME: inspect the results
        }
        // [END sample_core]

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -6720,6 +6720,27 @@ namespace Google.Example.Library.V1
         /// <param name="name">
         /// The name of the shelf to retrieve.
         /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Shelf GetShelf(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetShelf(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
         /// <param name="message">
         /// Field to verify that message-type query parameter gets flattened.
         /// </param>
@@ -6785,6 +6806,32 @@ namespace Google.Example.Library.V1
                 new GetShelfRequest
                 {
                     ShelfName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    Message = message, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Shelf GetShelf(
+            string name,
+            SomeMessage message,
+            gaxgrpc::CallSettings callSettings = null) => GetShelf(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                     Message = message, // Optional
                 },
                 callSettings);
@@ -6874,6 +6921,37 @@ namespace Google.Example.Library.V1
                 new GetShelfRequest
                 {
                     ShelfName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    Message = message, // Optional
+                    StringBuilder = stringBuilder, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="stringBuilder">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Shelf GetShelf(
+            string name,
+            SomeMessage message,
+            StringBuilder stringBuilder,
+            gaxgrpc::CallSettings callSettings = null) => GetShelf(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                     Message = message, // Optional
                     StringBuilder = stringBuilder, // Optional
                 },
@@ -7096,6 +7174,24 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Deletes a shelf.
         /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to delete.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void DeleteShelf(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => DeleteShelf(
+                new DeleteShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a shelf.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -7232,6 +7328,34 @@ namespace Google.Example.Library.V1
         /// `other_shelf_name` to shelf `name`, and deletes
         /// `other_shelf_name`. Returns the updated shelf.
         /// </summary>
+        /// <param name="name">
+        /// The name of the shelf we're adding books to.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the shelf we're removing books from and deleting.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Shelf MergeShelves(
+            string name,
+            string otherShelfName,
+            gaxgrpc::CallSettings callSettings = null) => MergeShelves(
+                new MergeShelvesRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    OtherShelfName = gax::GaxPreconditions.CheckNotNullOrEmpty(otherShelfName, nameof(otherShelfName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Merges two shelves by adding all books from the shelf named
+        /// `other_shelf_name` to shelf `name`, and deletes
+        /// `other_shelf_name`. Returns the updated shelf.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -7360,6 +7484,32 @@ namespace Google.Example.Library.V1
                 new CreateBookRequest
                 {
                     ShelfName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf in which the book is created.
+        /// </param>
+        /// <param name="book">
+        /// The book to create.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Book CreateBook(
+            string name,
+            Book book,
+            gaxgrpc::CallSettings callSettings = null) => CreateBook(
+                new CreateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                     Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
                 },
                 callSettings);
@@ -7644,6 +7794,27 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Gets a book.
         /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Book GetBook(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBook(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -7776,6 +7947,34 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Lists books in a shelf.
         /// </summary>
+        /// <param name="name">
+        /// The name of the shelf whose books we'd like to list.
+        /// </param>
+        /// <param name="filter">
+        /// To test python built-in wrapping.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="Book"/> resources.
+        /// </returns>
+        public virtual gax::PagedEnumerable<ListBooksResponse, Book> ListBooks(
+            string name,
+            string filter,
+            gaxgrpc::CallSettings callSettings = null) => ListBooks(
+                new ListBooksRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Filter = filter ?? "", // Optional
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists books in a shelf.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -7865,6 +8064,24 @@ namespace Google.Example.Library.V1
                 new DeleteBookRequest
                 {
                     BookNameOneof = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to delete.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void DeleteBook(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => DeleteBook(
+                new DeleteBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                 },
                 callSettings);
 
@@ -8002,6 +8219,32 @@ namespace Google.Example.Library.V1
         /// <param name="name">
         /// The name of the book to update.
         /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Book UpdateBook(
+            string name,
+            Book book,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBook(
+                new UpdateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
         /// <param name="optionalFoo">
         /// An optional foo.
         /// </param>
@@ -8109,6 +8352,47 @@ namespace Google.Example.Library.V1
                 new UpdateBookRequest
                 {
                     BookNameOneof = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    OptionalFoo = optionalFoo ?? "", // Optional
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                    UpdateMask = updateMask, // Optional
+                    PhysicalMask = physicalMask, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="optionalFoo">
+        /// An optional foo.
+        /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="updateMask">
+        /// A field mask to apply, rendered as an HTTP parameter.
+        /// </param>
+        /// <param name="physicalMask">
+        /// To test Python import clash resolution.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Book UpdateBook(
+            string name,
+            string optionalFoo,
+            Book book,
+            pbwkt::FieldMask updateMask,
+            FieldMask physicalMask,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBook(
+                new UpdateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                     OptionalFoo = optionalFoo ?? "", // Optional
                     Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
                     UpdateMask = updateMask, // Optional
@@ -8244,6 +8528,32 @@ namespace Google.Example.Library.V1
                 {
                     BookNameOneof = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
                     OtherShelfNameAsShelfName = gax::GaxPreconditions.CheckNotNull(otherShelfName, nameof(otherShelfName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Moves a book to another shelf, and returns the new book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to move.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the destination shelf.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Book MoveBook(
+            string name,
+            string otherShelfName,
+            gaxgrpc::CallSettings callSettings = null) => MoveBook(
+                new MoveBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    OtherShelfName = gax::GaxPreconditions.CheckNotNullOrEmpty(otherShelfName, nameof(otherShelfName)),
                 },
                 callSettings);
 
@@ -8538,6 +8848,29 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Adds comments to a book
         /// </summary>
+        /// <param name="name">
+        ///
+        /// </param>
+        /// <param name="comments">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void AddComments(
+            string name,
+            scg::IEnumerable<Comment> comments,
+            gaxgrpc::CallSettings callSettings = null) => AddComments(
+                new AddCommentsRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Comments = { gax::GaxPreconditions.CheckNotNull(comments, nameof(comments)) },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Adds comments to a book
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -8645,6 +8978,27 @@ namespace Google.Example.Library.V1
                 new GetBookFromArchiveRequest
                 {
                     ArchivedBookName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book from an archive.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual BookFromArchive GetBookFromArchive(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromArchive(
+                new GetBookFromArchiveRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                 },
                 callSettings);
 
@@ -8785,6 +9139,33 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Gets a book from a shelf or archive.
         /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="altBookName">
+        /// An alternate book name, used to test restricting flattened field to a
+        /// single resource name type in a oneof.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual BookFromAnywhere GetBookFromAnywhere(
+            string name,
+            string altBookName,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromAnywhere(
+                new GetBookFromAnywhereRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    AltBookName = gax::GaxPreconditions.CheckNotNullOrEmpty(altBookName, nameof(altBookName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book from a shelf or archive.
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -8895,6 +9276,27 @@ namespace Google.Example.Library.V1
                 new GetBookFromAbsolutelyAnywhereRequest
                 {
                     BookNameOneof = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test proper OneOf-Any resource name mapping
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual BookFromAnywhere GetBookFromAbsolutelyAnywhere(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromAbsolutelyAnywhere(
+                new GetBookFromAbsolutelyAnywhereRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                 },
                 callSettings);
 
@@ -9036,6 +9438,34 @@ namespace Google.Example.Library.V1
                 new UpdateBookIndexRequest
                 {
                     BookNameOneof = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    IndexName = gax::GaxPreconditions.CheckNotNullOrEmpty(indexName, nameof(indexName)),
+                    IndexMap = { gax::GaxPreconditions.CheckNotNull(indexMap, nameof(indexMap)) },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates the index of a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="indexName">
+        /// The name of the index for the book
+        /// </param>
+        /// <param name="indexMap">
+        /// The index to update the book with
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void UpdateBookIndex(
+            string name,
+            string indexName,
+            scg::IDictionary<string, string> indexMap,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBookIndex(
+                new UpdateBookIndexRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                     IndexName = gax::GaxPreconditions.CheckNotNullOrEmpty(indexName, nameof(indexName)),
                     IndexMap = { gax::GaxPreconditions.CheckNotNull(indexMap, nameof(indexMap)) },
                 },
@@ -9187,6 +9617,17 @@ namespace Google.Example.Library.V1
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
+        /// <returns>
+        /// The client-server stream.
+        /// </returns>
+        *** ERROR: Cannot handle streaming type 'BidiStreaming' ***
+
+        /// <summary>
+        /// Test bidi-streaming.
+        /// </summary>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
         /// <param name="streamingSettings">
         /// If not null, applies streaming overrides to this RPC call.
         /// </param>
@@ -9278,6 +9719,34 @@ namespace Google.Example.Library.V1
                 {
                     BookNameOneofs = { gax::GaxPreconditions.CheckNotNull(names, nameof(names)) },
                     ShelvesAsShelfNames = { gax::GaxPreconditions.CheckNotNull(shelves, nameof(shelves)) },
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="names">
+        ///
+        /// </param>
+        /// <param name="shelves">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable sequence of <see cref="string"/> resources.
+        /// </returns>
+        public virtual gax::PagedEnumerable<FindRelatedBooksResponse, BookNameOneof> FindRelatedBooks(
+            scg::IEnumerable<string> names,
+            scg::IEnumerable<string> shelves,
+            gaxgrpc::CallSettings callSettings = null) => FindRelatedBooks(
+                new FindRelatedBooksRequest
+                {
+                    Names = { gax::GaxPreconditions.CheckNotNull(names, nameof(names)) },
+                    Shelves = { gax::GaxPreconditions.CheckNotNull(shelves, nameof(shelves)) },
                     PageToken = pageToken ?? "",
                     PageSize = pageSize ?? 0,
                 },
@@ -9440,6 +9909,27 @@ namespace Google.Example.Library.V1
         /// <summary>
         /// Test long-running operations
         /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual lro::Operation<Book, GetBigBookMetadata> GetBigBook(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBigBook(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test long-running operations
+        /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
         /// </param>
@@ -9566,6 +10056,27 @@ namespace Google.Example.Library.V1
                 new GetBookRequest
                 {
                     BookNameOneof = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual lro::Operation<pbwkt::Empty, GetBigBookMetadata> GetBigNothing(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBigNothing(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
                 },
                 callSettings);
 
@@ -11042,6 +11553,472 @@ namespace Google.Example.Library.V1
                     OptionalRepeatedMessage = { optionalRepeatedMessage ?? linq::Enumerable.Empty<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>() }, // Optional
                     OptionalRepeatedResourceNameAsBookNameOneofs = { optionalRepeatedResourceName ?? linq::Enumerable.Empty<BookNameOneof>() }, // Optional
                     OptionalRepeatedResourceNameOneofAsBookNameOneofs = { optionalRepeatedResourceNameOneof ?? linq::Enumerable.Empty<BookNameOneof>() }, // Optional
+                    OptionalRepeatedResourceNameCommon = { optionalRepeatedResourceNameCommon ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedFixed32 = { optionalRepeatedFixed32 ?? linq::Enumerable.Empty<int>() }, // Optional
+                    OptionalRepeatedFixed64 = { optionalRepeatedFixed64 ?? linq::Enumerable.Empty<long>() }, // Optional
+                    OptionalMap = { optionalMap ?? gax::EmptyDictionary<int, string>.Instance }, // Optional
+                    AnyValue = anyValue, // Optional
+                    StructValue = structValue, // Optional
+                    ValueValue = valueValue, // Optional
+                    ListValueValue = listValueValue, // Optional
+                    TimeValue = timeValue, // Optional
+                    DurationValue = durationValue, // Optional
+                    FieldMaskValue = fieldMaskValue, // Optional
+                    Int32Value = int32Value, // Optional
+                    Uint32Value = uint32Value, // Optional
+                    Int64Value = int64Value, // Optional
+                    Uint64Value = uint64Value, // Optional
+                    FloatValue = floatValue, // Optional
+                    DoubleValue = doubleValue, // Optional
+                    StringValue = stringValue, // Optional
+                    BoolValue = boolValue, // Optional
+                    BytesValue = bytesValue, // Optional
+                    RepeatedAnyValue = { repeatedAnyValue ?? linq::Enumerable.Empty<pbwkt::Any>() }, // Optional
+                    RepeatedStructValue = { repeatedStructValue ?? linq::Enumerable.Empty<pbwkt::Struct>() }, // Optional
+                    RepeatedValueValue = { repeatedValueValue ?? linq::Enumerable.Empty<pbwkt::Value>() }, // Optional
+                    RepeatedListValueValue = { repeatedListValueValue ?? linq::Enumerable.Empty<pbwkt::ListValue>() }, // Optional
+                    RepeatedTimeValue = { repeatedTimeValue ?? linq::Enumerable.Empty<pbwkt::Timestamp>() }, // Optional
+                    RepeatedDurationValue = { repeatedDurationValue ?? linq::Enumerable.Empty<pbwkt::Duration>() }, // Optional
+                    RepeatedFieldMaskValue = { repeatedFieldMaskValue ?? linq::Enumerable.Empty<pbwkt::FieldMask>() }, // Optional
+                    RepeatedInt32Value = { repeatedInt32Value ?? linq::Enumerable.Empty<int?>() }, // Optional
+                    RepeatedUint32Value = { repeatedUint32Value ?? linq::Enumerable.Empty<uint?>() }, // Optional
+                    RepeatedInt64Value = { repeatedInt64Value ?? linq::Enumerable.Empty<long?>() }, // Optional
+                    RepeatedUint64Value = { repeatedUint64Value ?? linq::Enumerable.Empty<ulong?>() }, // Optional
+                    RepeatedFloatValue = { repeatedFloatValue ?? linq::Enumerable.Empty<float?>() }, // Optional
+                    RepeatedDoubleValue = { repeatedDoubleValue ?? linq::Enumerable.Empty<double?>() }, // Optional
+                    RepeatedStringValue = { repeatedStringValue ?? linq::Enumerable.Empty<string>() }, // Optional
+                    RepeatedBoolValue = { repeatedBoolValue ?? linq::Enumerable.Empty<bool?>() }, // Optional
+                    RepeatedBytesValue = { repeatedBytesValue ?? linq::Enumerable.Empty<pb::ByteString>() }, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test optional flattening parameters of all types
+        /// </summary>
+        /// <param name="requiredSingularInt32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularInt64">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFloat">
+        ///
+        /// </param>
+        /// <param name="requiredSingularDouble">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBool">
+        ///
+        /// </param>
+        /// <param name="requiredSingularEnum">
+        ///
+        /// </param>
+        /// <param name="requiredSingularString">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBytes">
+        ///
+        /// </param>
+        /// <param name="requiredSingularMessage">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedString">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredMap">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt64">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFloat">
+        ///
+        /// </param>
+        /// <param name="optionalSingularDouble">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBool">
+        ///
+        /// </param>
+        /// <param name="optionalSingularEnum">
+        ///
+        /// </param>
+        /// <param name="optionalSingularString">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBytes">
+        ///
+        /// </param>
+        /// <param name="optionalSingularMessage">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedString">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalMap">
+        ///
+        /// </param>
+        /// <param name="anyValue">
+        ///
+        /// </param>
+        /// <param name="structValue">
+        ///
+        /// </param>
+        /// <param name="valueValue">
+        ///
+        /// </param>
+        /// <param name="listValueValue">
+        ///
+        /// </param>
+        /// <param name="timeValue">
+        ///
+        /// </param>
+        /// <param name="durationValue">
+        ///
+        /// </param>
+        /// <param name="fieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="int32Value">
+        ///
+        /// </param>
+        /// <param name="uint32Value">
+        ///
+        /// </param>
+        /// <param name="int64Value">
+        ///
+        /// </param>
+        /// <param name="uint64Value">
+        ///
+        /// </param>
+        /// <param name="floatValue">
+        ///
+        /// </param>
+        /// <param name="doubleValue">
+        ///
+        /// </param>
+        /// <param name="stringValue">
+        ///
+        /// </param>
+        /// <param name="boolValue">
+        ///
+        /// </param>
+        /// <param name="bytesValue">
+        ///
+        /// </param>
+        /// <param name="repeatedAnyValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStructValue">
+        ///
+        /// </param>
+        /// <param name="repeatedValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedListValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedTimeValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDurationValue">
+        ///
+        /// </param>
+        /// <param name="repeatedFieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="repeatedInt32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedInt64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedFloatValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDoubleValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStringValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBoolValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBytesValue">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual TestOptionalRequiredFlatteningParamsResponse TestOptionalRequiredFlatteningParams(
+            int requiredSingularInt32,
+            long requiredSingularInt64,
+            float requiredSingularFloat,
+            double requiredSingularDouble,
+            bool requiredSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum requiredSingularEnum,
+            string requiredSingularString,
+            pb::ByteString requiredSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage,
+            string requiredSingularResourceName,
+            string requiredSingularResourceNameOneof,
+            string requiredSingularResourceNameCommon,
+            int requiredSingularFixed32,
+            long requiredSingularFixed64,
+            scg::IEnumerable<int> requiredRepeatedInt32,
+            scg::IEnumerable<long> requiredRepeatedInt64,
+            scg::IEnumerable<float> requiredRepeatedFloat,
+            scg::IEnumerable<double> requiredRepeatedDouble,
+            scg::IEnumerable<bool> requiredRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> requiredRepeatedEnum,
+            scg::IEnumerable<string> requiredRepeatedString,
+            scg::IEnumerable<pb::ByteString> requiredRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage,
+            scg::IEnumerable<string> requiredRepeatedResourceName,
+            scg::IEnumerable<string> requiredRepeatedResourceNameOneof,
+            scg::IEnumerable<string> requiredRepeatedResourceNameCommon,
+            scg::IEnumerable<int> requiredRepeatedFixed32,
+            scg::IEnumerable<long> requiredRepeatedFixed64,
+            scg::IDictionary<int, string> requiredMap,
+            int? optionalSingularInt32,
+            long? optionalSingularInt64,
+            float? optionalSingularFloat,
+            double? optionalSingularDouble,
+            bool? optionalSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum? optionalSingularEnum,
+            string optionalSingularString,
+            pb::ByteString optionalSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage,
+            string optionalSingularResourceName,
+            string optionalSingularResourceNameOneof,
+            string optionalSingularResourceNameCommon,
+            int? optionalSingularFixed32,
+            long? optionalSingularFixed64,
+            scg::IEnumerable<int> optionalRepeatedInt32,
+            scg::IEnumerable<long> optionalRepeatedInt64,
+            scg::IEnumerable<float> optionalRepeatedFloat,
+            scg::IEnumerable<double> optionalRepeatedDouble,
+            scg::IEnumerable<bool> optionalRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> optionalRepeatedEnum,
+            scg::IEnumerable<string> optionalRepeatedString,
+            scg::IEnumerable<pb::ByteString> optionalRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage,
+            scg::IEnumerable<string> optionalRepeatedResourceName,
+            scg::IEnumerable<string> optionalRepeatedResourceNameOneof,
+            scg::IEnumerable<string> optionalRepeatedResourceNameCommon,
+            scg::IEnumerable<int> optionalRepeatedFixed32,
+            scg::IEnumerable<long> optionalRepeatedFixed64,
+            scg::IDictionary<int, string> optionalMap,
+            pbwkt::Any anyValue,
+            pbwkt::Struct structValue,
+            pbwkt::Value valueValue,
+            pbwkt::ListValue listValueValue,
+            pbwkt::Timestamp timeValue,
+            pbwkt::Duration durationValue,
+            pbwkt::FieldMask fieldMaskValue,
+            int? int32Value,
+            uint? uint32Value,
+            long? int64Value,
+            ulong? uint64Value,
+            float? floatValue,
+            double? doubleValue,
+            string stringValue,
+            bool? boolValue,
+            pb::ByteString bytesValue,
+            scg::IEnumerable<pbwkt::Any> repeatedAnyValue,
+            scg::IEnumerable<pbwkt::Struct> repeatedStructValue,
+            scg::IEnumerable<pbwkt::Value> repeatedValueValue,
+            scg::IEnumerable<pbwkt::ListValue> repeatedListValueValue,
+            scg::IEnumerable<pbwkt::Timestamp> repeatedTimeValue,
+            scg::IEnumerable<pbwkt::Duration> repeatedDurationValue,
+            scg::IEnumerable<pbwkt::FieldMask> repeatedFieldMaskValue,
+            scg::IEnumerable<int?> repeatedInt32Value,
+            scg::IEnumerable<uint?> repeatedUint32Value,
+            scg::IEnumerable<long?> repeatedInt64Value,
+            scg::IEnumerable<ulong?> repeatedUint64Value,
+            scg::IEnumerable<float?> repeatedFloatValue,
+            scg::IEnumerable<double?> repeatedDoubleValue,
+            scg::IEnumerable<string> repeatedStringValue,
+            scg::IEnumerable<bool?> repeatedBoolValue,
+            scg::IEnumerable<pb::ByteString> repeatedBytesValue,
+            gaxgrpc::CallSettings callSettings = null) => TestOptionalRequiredFlatteningParams(
+                new TestOptionalRequiredFlatteningParamsRequest
+                {
+                    RequiredSingularInt32 = requiredSingularInt32,
+                    RequiredSingularInt64 = requiredSingularInt64,
+                    RequiredSingularFloat = requiredSingularFloat,
+                    RequiredSingularDouble = requiredSingularDouble,
+                    RequiredSingularBool = requiredSingularBool,
+                    RequiredSingularEnum = requiredSingularEnum,
+                    RequiredSingularString = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularString, nameof(requiredSingularString)),
+                    RequiredSingularBytes = gax::GaxPreconditions.CheckNotNull(requiredSingularBytes, nameof(requiredSingularBytes)),
+                    RequiredSingularMessage = gax::GaxPreconditions.CheckNotNull(requiredSingularMessage, nameof(requiredSingularMessage)),
+                    RequiredSingularResourceName = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceName, nameof(requiredSingularResourceName)),
+                    RequiredSingularResourceNameOneof = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceNameOneof, nameof(requiredSingularResourceNameOneof)),
+                    RequiredSingularResourceNameCommon = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceNameCommon, nameof(requiredSingularResourceNameCommon)),
+                    RequiredSingularFixed32 = requiredSingularFixed32,
+                    RequiredSingularFixed64 = requiredSingularFixed64,
+                    RequiredRepeatedInt32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedInt32, nameof(requiredRepeatedInt32)) },
+                    RequiredRepeatedInt64 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedInt64, nameof(requiredRepeatedInt64)) },
+                    RequiredRepeatedFloat = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFloat, nameof(requiredRepeatedFloat)) },
+                    RequiredRepeatedDouble = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedDouble, nameof(requiredRepeatedDouble)) },
+                    RequiredRepeatedBool = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedBool, nameof(requiredRepeatedBool)) },
+                    RequiredRepeatedEnum = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedEnum, nameof(requiredRepeatedEnum)) },
+                    RequiredRepeatedString = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedString, nameof(requiredRepeatedString)) },
+                    RequiredRepeatedBytes = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedBytes, nameof(requiredRepeatedBytes)) },
+                    RequiredRepeatedMessage = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedMessage, nameof(requiredRepeatedMessage)) },
+                    RequiredRepeatedResourceName = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceName, nameof(requiredRepeatedResourceName)) },
+                    RequiredRepeatedResourceNameOneof = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameOneof, nameof(requiredRepeatedResourceNameOneof)) },
+                    RequiredRepeatedResourceNameCommon = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameCommon, nameof(requiredRepeatedResourceNameCommon)) },
+                    RequiredRepeatedFixed32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed32, nameof(requiredRepeatedFixed32)) },
+                    RequiredRepeatedFixed64 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed64, nameof(requiredRepeatedFixed64)) },
+                    RequiredMap = { gax::GaxPreconditions.CheckNotNull(requiredMap, nameof(requiredMap)) },
+                    OptionalSingularInt32 = optionalSingularInt32 ?? 0, // Optional
+                    OptionalSingularInt64 = optionalSingularInt64 ?? 0L, // Optional
+                    OptionalSingularFloat = optionalSingularFloat ?? 0.0f, // Optional
+                    OptionalSingularDouble = optionalSingularDouble ?? 0.0, // Optional
+                    OptionalSingularBool = optionalSingularBool ?? false, // Optional
+                    OptionalSingularEnum = optionalSingularEnum ?? TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum.Zero, // Optional
+                    OptionalSingularString = optionalSingularString ?? "", // Optional
+                    OptionalSingularBytes = optionalSingularBytes ?? pb::ByteString.Empty, // Optional
+                    OptionalSingularMessage = optionalSingularMessage, // Optional
+                    OptionalSingularResourceName = optionalSingularResourceName ?? "", // Optional
+                    OptionalSingularResourceNameOneof = optionalSingularResourceNameOneof ?? "", // Optional
+                    OptionalSingularResourceNameCommon = optionalSingularResourceNameCommon ?? "", // Optional
+                    OptionalSingularFixed32 = optionalSingularFixed32 ?? 0, // Optional
+                    OptionalSingularFixed64 = optionalSingularFixed64 ?? 0L, // Optional
+                    OptionalRepeatedInt32 = { optionalRepeatedInt32 ?? linq::Enumerable.Empty<int>() }, // Optional
+                    OptionalRepeatedInt64 = { optionalRepeatedInt64 ?? linq::Enumerable.Empty<long>() }, // Optional
+                    OptionalRepeatedFloat = { optionalRepeatedFloat ?? linq::Enumerable.Empty<float>() }, // Optional
+                    OptionalRepeatedDouble = { optionalRepeatedDouble ?? linq::Enumerable.Empty<double>() }, // Optional
+                    OptionalRepeatedBool = { optionalRepeatedBool ?? linq::Enumerable.Empty<bool>() }, // Optional
+                    OptionalRepeatedEnum = { optionalRepeatedEnum ?? linq::Enumerable.Empty<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>() }, // Optional
+                    OptionalRepeatedString = { optionalRepeatedString ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedBytes = { optionalRepeatedBytes ?? linq::Enumerable.Empty<pb::ByteString>() }, // Optional
+                    OptionalRepeatedMessage = { optionalRepeatedMessage ?? linq::Enumerable.Empty<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>() }, // Optional
+                    OptionalRepeatedResourceName = { optionalRepeatedResourceName ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedResourceNameOneof = { optionalRepeatedResourceNameOneof ?? linq::Enumerable.Empty<string>() }, // Optional
                     OptionalRepeatedResourceNameCommon = { optionalRepeatedResourceNameCommon ?? linq::Enumerable.Empty<string>() }, // Optional
                     OptionalRepeatedFixed32 = { optionalRepeatedFixed32 ?? linq::Enumerable.Empty<int>() }, // Optional
                     OptionalRepeatedFixed64 = { optionalRepeatedFixed64 ?? linq::Enumerable.Empty<long>() }, // Optional
@@ -14833,6 +15810,59 @@ class FindRelatedBooksAsyncRequestAsyncPagedPageSizeOdyssey
    	// FIXME: call the sample function
    }
 }
+============== file: Samples/FindRelatedBooksFlattenedOdyssey.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "odyssey")
+
+// [START sample]
+// FIXME: import everything this sample needs
+class FindRelatedBooksFlattenedOdyssey
+{
+    // [START sample_core]
+   /// <summary>
+   /// Testing calling forms
+   /// </summary>
+   public static void SampleFindRelatedBooks()
+   {
+       public static void SampleFindRelatedBooks()
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           IEnumerable<BookNameOneof> names = new[]
+           {
+               BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+           };
+           IEnumerable<ShelfName> shelves = new[]
+           {
+               new ShelfName("[SHELF_ID]"),
+           };
+           gax::PagedEnumerable<FindRelatedBooksRequest, FindRelatedBooksResponse, BookNameOneof> response = libraryServiceClient.FindRelatedBooks(names, shelves);
+           // FIXME: inspect the results
+       }
+       // [END sample_core]
+   }
+
+   // [END sample]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
 ============== file: Samples/FindRelatedBooksFlattenedPagedAllOdyssey.cs ==============
 // Copyright 2019 Google LLC
 //
@@ -15183,6 +16213,196 @@ class FindRelatedBooksRequestPagedPageSizeOdyssey
            }
            // Store the pageToken, for when the next page is required.
            string nextPageToken = singlePage.NextPageToken;
+       }
+       // [END sample_core]
+   }
+
+   // [END sample]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
+============== file: Samples/GetBigBookFlattenedWap.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "wap")
+
+// [START hopper]
+// FIXME: import everything this sample needs
+class GetBigBookFlattenedWap
+{
+    // [START hopper_core]
+   /// <summary>
+   /// Testing calling forms
+   /// </summary>
+   public static void SampleGetBigBook(string shelf)
+   {
+       public static void SampleGetBigBook(string shelf)
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           // string shelf = "Novel"
+           BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+           Book response = libraryServiceClient.GetBigBook(name);
+           // FIXME: inspect the results
+       }
+       // [END hopper_core]
+   }
+
+   // [END hopper]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
+============== file: Samples/GetBigBookFlattenedWap2.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "wap2")
+
+// [START hopper]
+// FIXME: import everything this sample needs
+class GetBigBookFlattenedWap2
+{
+    // [START hopper_core]
+   /// <summary>
+   /// Testing resource name overlap
+   /// </summary>
+   /// <param name="shelf">Test word wrapping for long lines. This is a long comment. The name of the
+   /// shelf to retrieve the big book from.</param>
+   /// <param name="bigBookName">The name of the book.</param>
+   public static void SampleGetBigBook(string shelf, string bigBookName)
+   {
+       public static void SampleGetBigBook(string shelf, string bigBookName)
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           // string shelf = "Novel"
+           // string bigBookName = "War and Peace"
+           BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+           Book response = libraryServiceClient.GetBigBook(name);
+           // FIXME: inspect the results
+       }
+       // [END hopper_core]
+   }
+
+   // [END hopper]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
+============== file: Samples/GetBigNothingFlattenedEmptyResponseTypeWithResponseHandling.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "empty_response_type_with_response_handling")
+
+// [START sample]
+// FIXME: import everything this sample needs
+class GetBigNothingFlattenedEmptyResponseTypeWithResponseHandling
+{
+    // [START sample_core]
+   /// <summary>
+   /// Test response handling for methods that return empty
+   /// </summary>
+   public static void SampleGetBigNothing()
+   {
+       public static void SampleGetBigNothing()
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+           libraryServiceClient.GetBigNothing(name);
+           // FIXME: inspect the results
+       }
+       // [END sample_core]
+   }
+
+   // [END sample]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
+============== file: Samples/GetBigNothingFlattenedEmptyResponseTypeWithoutResponseHandling.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "empty_response_type_without_response_handling")
+
+// [START sample]
+// FIXME: import everything this sample needs
+class GetBigNothingFlattenedEmptyResponseTypeWithoutResponseHandling
+{
+    // [START sample_core]
+   /// <summary>
+   /// Test default response handling is turned off for methods that return empty
+   /// </summary>
+   public static void SampleGetBigNothing()
+   {
+       public static void SampleGetBigNothing()
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+           libraryServiceClient.GetBigNothing(name);
+           // FIXME: inspect the results
        }
        // [END sample_core]
    }
@@ -15921,6 +17141,58 @@ class PublishSeriesRequestTestWriteToFile
    }
 
    // [END sample]
+   public static void Main(String[] args)
+   {
+   	// FIXME: pass in commandline arguments
+   	// FIXME: call the sample function
+   }
+}
+============== file: Samples/TuringProgFlattened.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Flattened", "prog")
+
+// [START turing_prog_flattened]
+// FIXME: import everything this sample needs
+class TuringProgFlattened
+{
+    // [START turing_prog_flattened_core]
+   /// <summary>
+   /// Testing calling forms
+   /// </summary>
+   public static void SampleDiscussBook(string imageFileName)
+   {
+       public static void SampleDiscussBook(string imageFileName)
+       {
+           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+           // string imageFileName = "image_file.jpg"
+           BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+           Comment comment2 = new Comment
+           {
+               Comment = File.ReadAllBytes("comment_file"),
+           };
+           ByteString image = File.ReadAllBytes(imageFileName);
+           grpccore::AsyncDuplexStreamingCall<DiscussBookRequest, Comment> response = libraryServiceClient.DiscussBook(name, comment2, image);
+           // FIXME: inspect the results
+       }
+       // [END turing_prog_flattened_core]
+   }
+
+   // [END turing_prog_flattened]
    public static void Main(String[] args)
    {
    	// FIXME: pass in commandline arguments

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -6724,6 +6724,45 @@ namespace Google.Example.Library.V1
         /// If not null, applies overrides to this RPC call.
         /// </param>
         /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetShelfAsync(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetShelfAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
         /// The RPC response.
         /// </returns>
         public virtual Shelf GetShelf(
@@ -6809,6 +6848,55 @@ namespace Google.Example.Library.V1
                     Message = message, // Optional
                 },
                 callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            SomeMessage message,
+            gaxgrpc::CallSettings callSettings = null) => GetShelfAsync(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Message = message, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            SomeMessage message,
+            st::CancellationToken cancellationToken) => GetShelfAsync(
+                name,
+                message,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Gets a shelf.
@@ -6925,6 +7013,65 @@ namespace Google.Example.Library.V1
                     StringBuilder = stringBuilder, // Optional
                 },
                 callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="stringBuilder">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            SomeMessage message,
+            StringBuilder stringBuilder,
+            gaxgrpc::CallSettings callSettings = null) => GetShelfAsync(
+                new GetShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Message = message, // Optional
+                    StringBuilder = stringBuilder, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to retrieve.
+        /// </param>
+        /// <param name="message">
+        /// Field to verify that message-type query parameter gets flattened.
+        /// </param>
+        /// <param name="stringBuilder">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> GetShelfAsync(
+            string name,
+            SomeMessage message,
+            StringBuilder stringBuilder,
+            st::CancellationToken cancellationToken) => GetShelfAsync(
+                name,
+                message,
+                stringBuilder,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Gets a shelf.
@@ -7180,6 +7327,45 @@ namespace Google.Example.Library.V1
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task DeleteShelfAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => DeleteShelfAsync(
+                new DeleteShelfRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to delete.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task DeleteShelfAsync(
+            string name,
+            st::CancellationToken cancellationToken) => DeleteShelfAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Deletes a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf to delete.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
         public virtual void DeleteShelf(
             string name,
             gaxgrpc::CallSettings callSettings = null) => DeleteShelf(
@@ -7322,6 +7508,59 @@ namespace Google.Example.Library.V1
                     OtherShelfNameAsShelfName = gax::GaxPreconditions.CheckNotNull(otherShelfName, nameof(otherShelfName)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Merges two shelves by adding all books from the shelf named
+        /// `other_shelf_name` to shelf `name`, and deletes
+        /// `other_shelf_name`. Returns the updated shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf we're adding books to.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the shelf we're removing books from and deleting.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> MergeShelvesAsync(
+            string name,
+            string otherShelfName,
+            gaxgrpc::CallSettings callSettings = null) => MergeShelvesAsync(
+                new MergeShelvesRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    OtherShelfName = gax::GaxPreconditions.CheckNotNullOrEmpty(otherShelfName, nameof(otherShelfName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Merges two shelves by adding all books from the shelf named
+        /// `other_shelf_name` to shelf `name`, and deletes
+        /// `other_shelf_name`. Returns the updated shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf we're adding books to.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the shelf we're removing books from and deleting.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Shelf> MergeShelvesAsync(
+            string name,
+            string otherShelfName,
+            st::CancellationToken cancellationToken) => MergeShelvesAsync(
+                name,
+                otherShelfName,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Merges two shelves by adding all books from the shelf named
@@ -7487,6 +7726,55 @@ namespace Google.Example.Library.V1
                     Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Creates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf in which the book is created.
+        /// </param>
+        /// <param name="book">
+        /// The book to create.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> CreateBookAsync(
+            string name,
+            Book book,
+            gaxgrpc::CallSettings callSettings = null) => CreateBookAsync(
+                new CreateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf in which the book is created.
+        /// </param>
+        /// <param name="book">
+        /// The book to create.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> CreateBookAsync(
+            string name,
+            Book book,
+            st::CancellationToken cancellationToken) => CreateBookAsync(
+                name,
+                book,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Creates a book.
@@ -7801,6 +8089,45 @@ namespace Google.Example.Library.V1
         /// If not null, applies overrides to this RPC call.
         /// </param>
         /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> GetBookAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBookAsync(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> GetBookAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetBookAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Gets a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
         /// The RPC response.
         /// </returns>
         public virtual Book GetBook(
@@ -7953,6 +8280,52 @@ namespace Google.Example.Library.V1
         /// <param name="filter">
         /// To test python built-in wrapping.
         /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request.
+        /// A value of <c>null</c> or an empty string retrieves the first page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller.
+        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="Book"/> resources.
+        /// </returns>
+        public virtual gax::PagedAsyncEnumerable<ListBooksResponse, Book> ListBooksAsync(
+            string name,
+            string filter,
+            string pageToken = null,
+            int? pageSize = null,
+            gaxgrpc::CallSettings callSettings = null) => ListBooksAsync(
+                new ListBooksRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Filter = filter ?? "", // Optional
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Lists books in a shelf.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the shelf whose books we'd like to list.
+        /// </param>
+        /// <param name="filter">
+        /// To test python built-in wrapping.
+        /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request.
+        /// A value of <c>null</c> or an empty string retrieves the first page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller.
+        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
@@ -7962,6 +8335,8 @@ namespace Google.Example.Library.V1
         public virtual gax::PagedEnumerable<ListBooksResponse, Book> ListBooks(
             string name,
             string filter,
+            string pageToken = null,
+            int? pageSize = null,
             gaxgrpc::CallSettings callSettings = null) => ListBooks(
                 new ListBooksRequest
                 {
@@ -8066,6 +8441,45 @@ namespace Google.Example.Library.V1
                     BookNameOneof = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Deletes a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to delete.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task DeleteBookAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => DeleteBookAsync(
+                new DeleteBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Deletes a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to delete.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task DeleteBookAsync(
+            string name,
+            st::CancellationToken cancellationToken) => DeleteBookAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Deletes a book.
@@ -8226,6 +8640,55 @@ namespace Google.Example.Library.V1
         /// If not null, applies overrides to this RPC call.
         /// </param>
         /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> UpdateBookAsync(
+            string name,
+            Book book,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBookAsync(
+                new UpdateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> UpdateBookAsync(
+            string name,
+            Book book,
+            st::CancellationToken cancellationToken) => UpdateBookAsync(
+                name,
+                book,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
         /// The RPC response.
         /// </returns>
         public virtual Book UpdateBook(
@@ -8358,6 +8821,85 @@ namespace Google.Example.Library.V1
                     PhysicalMask = physicalMask, // Optional
                 },
                 callSettings);
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="optionalFoo">
+        /// An optional foo.
+        /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="updateMask">
+        /// A field mask to apply, rendered as an HTTP parameter.
+        /// </param>
+        /// <param name="physicalMask">
+        /// To test Python import clash resolution.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> UpdateBookAsync(
+            string name,
+            string optionalFoo,
+            Book book,
+            pbwkt::FieldMask updateMask,
+            FieldMask physicalMask,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBookAsync(
+                new UpdateBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    OptionalFoo = optionalFoo ?? "", // Optional
+                    Book = gax::GaxPreconditions.CheckNotNull(book, nameof(book)),
+                    UpdateMask = updateMask, // Optional
+                    PhysicalMask = physicalMask, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="optionalFoo">
+        /// An optional foo.
+        /// </param>
+        /// <param name="book">
+        /// The book to update with.
+        /// </param>
+        /// <param name="updateMask">
+        /// A field mask to apply, rendered as an HTTP parameter.
+        /// </param>
+        /// <param name="physicalMask">
+        /// To test Python import clash resolution.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> UpdateBookAsync(
+            string name,
+            string optionalFoo,
+            Book book,
+            pbwkt::FieldMask updateMask,
+            FieldMask physicalMask,
+            st::CancellationToken cancellationToken) => UpdateBookAsync(
+                name,
+                optionalFoo,
+                book,
+                updateMask,
+                physicalMask,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Updates a book.
@@ -8530,6 +9072,55 @@ namespace Google.Example.Library.V1
                     OtherShelfNameAsShelfName = gax::GaxPreconditions.CheckNotNull(otherShelfName, nameof(otherShelfName)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Moves a book to another shelf, and returns the new book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to move.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the destination shelf.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> MoveBookAsync(
+            string name,
+            string otherShelfName,
+            gaxgrpc::CallSettings callSettings = null) => MoveBookAsync(
+                new MoveBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    OtherShelfName = gax::GaxPreconditions.CheckNotNullOrEmpty(otherShelfName, nameof(otherShelfName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Moves a book to another shelf, and returns the new book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to move.
+        /// </param>
+        /// <param name="otherShelfName">
+        /// The name of the destination shelf.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Book> MoveBookAsync(
+            string name,
+            string otherShelfName,
+            st::CancellationToken cancellationToken) => MoveBookAsync(
+                name,
+                otherShelfName,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Moves a book to another shelf, and returns the new book.
@@ -8857,6 +9448,55 @@ namespace Google.Example.Library.V1
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task AddCommentsAsync(
+            string name,
+            scg::IEnumerable<Comment> comments,
+            gaxgrpc::CallSettings callSettings = null) => AddCommentsAsync(
+                new AddCommentsRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Comments = { gax::GaxPreconditions.CheckNotNull(comments, nameof(comments)) },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Adds comments to a book
+        /// </summary>
+        /// <param name="name">
+        ///
+        /// </param>
+        /// <param name="comments">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task AddCommentsAsync(
+            string name,
+            scg::IEnumerable<Comment> comments,
+            st::CancellationToken cancellationToken) => AddCommentsAsync(
+                name,
+                comments,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Adds comments to a book
+        /// </summary>
+        /// <param name="name">
+        ///
+        /// </param>
+        /// <param name="comments">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
         public virtual void AddComments(
             string name,
             scg::IEnumerable<Comment> comments,
@@ -8980,6 +9620,45 @@ namespace Google.Example.Library.V1
                     ArchivedBookName = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Gets a book from an archive.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromArchive> GetBookFromArchiveAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromArchiveAsync(
+                new GetBookFromArchiveRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book from an archive.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromArchive> GetBookFromArchiveAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetBookFromArchiveAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Gets a book from an archive.
@@ -9150,6 +9829,57 @@ namespace Google.Example.Library.V1
         /// If not null, applies overrides to this RPC call.
         /// </param>
         /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromAnywhere> GetBookFromAnywhereAsync(
+            string name,
+            string altBookName,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromAnywhereAsync(
+                new GetBookFromAnywhereRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    AltBookName = gax::GaxPreconditions.CheckNotNullOrEmpty(altBookName, nameof(altBookName)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Gets a book from a shelf or archive.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="altBookName">
+        /// An alternate book name, used to test restricting flattened field to a
+        /// single resource name type in a oneof.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromAnywhere> GetBookFromAnywhereAsync(
+            string name,
+            string altBookName,
+            st::CancellationToken cancellationToken) => GetBookFromAnywhereAsync(
+                name,
+                altBookName,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Gets a book from a shelf or archive.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="altBookName">
+        /// An alternate book name, used to test restricting flattened field to a
+        /// single resource name type in a oneof.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
         /// The RPC response.
         /// </returns>
         public virtual BookFromAnywhere GetBookFromAnywhere(
@@ -9278,6 +10008,45 @@ namespace Google.Example.Library.V1
                     BookNameOneof = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Test proper OneOf-Any resource name mapping
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromAnywhere> GetBookFromAbsolutelyAnywhereAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBookFromAbsolutelyAnywhereAsync(
+                new GetBookFromAbsolutelyAnywhereRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test proper OneOf-Any resource name mapping
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<BookFromAnywhere> GetBookFromAbsolutelyAnywhereAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetBookFromAbsolutelyAnywhereAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Test proper OneOf-Any resource name mapping
@@ -9442,6 +10211,65 @@ namespace Google.Example.Library.V1
                     IndexMap = { gax::GaxPreconditions.CheckNotNull(indexMap, nameof(indexMap)) },
                 },
                 callSettings);
+
+        /// <summary>
+        /// Updates the index of a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="indexName">
+        /// The name of the index for the book
+        /// </param>
+        /// <param name="indexMap">
+        /// The index to update the book with
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task UpdateBookIndexAsync(
+            string name,
+            string indexName,
+            scg::IDictionary<string, string> indexMap,
+            gaxgrpc::CallSettings callSettings = null) => UpdateBookIndexAsync(
+                new UpdateBookIndexRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    IndexName = gax::GaxPreconditions.CheckNotNullOrEmpty(indexName, nameof(indexName)),
+                    IndexMap = { gax::GaxPreconditions.CheckNotNull(indexMap, nameof(indexMap)) },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates the index of a book.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to update.
+        /// </param>
+        /// <param name="indexName">
+        /// The name of the index for the book
+        /// </param>
+        /// <param name="indexMap">
+        /// The index to update the book with
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task UpdateBookIndexAsync(
+            string name,
+            string indexName,
+            scg::IDictionary<string, string> indexMap,
+            st::CancellationToken cancellationToken) => UpdateBookIndexAsync(
+                name,
+                indexName,
+                indexMap,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Updates the index of a book.
@@ -9733,6 +10561,52 @@ namespace Google.Example.Library.V1
         /// <param name="shelves">
         ///
         /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request.
+        /// A value of <c>null</c> or an empty string retrieves the first page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller.
+        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A pageable asynchronous sequence of <see cref="string"/> resources.
+        /// </returns>
+        public virtual gax::PagedAsyncEnumerable<FindRelatedBooksResponse, BookNameOneof> FindRelatedBooksAsync(
+            scg::IEnumerable<string> names,
+            scg::IEnumerable<string> shelves,
+            string pageToken = null,
+            int? pageSize = null,
+            gaxgrpc::CallSettings callSettings = null) => FindRelatedBooksAsync(
+                new FindRelatedBooksRequest
+                {
+                    Names = { gax::GaxPreconditions.CheckNotNull(names, nameof(names)) },
+                    Shelves = { gax::GaxPreconditions.CheckNotNull(shelves, nameof(shelves)) },
+                    PageToken = pageToken ?? "",
+                    PageSize = pageSize ?? 0,
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="names">
+        ///
+        /// </param>
+        /// <param name="shelves">
+        ///
+        /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request.
+        /// A value of <c>null</c> or an empty string retrieves the first page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller.
+        /// A value of <c>null</c> or 0 uses a server-defined page size.
+        /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
@@ -9742,6 +10616,8 @@ namespace Google.Example.Library.V1
         public virtual gax::PagedEnumerable<FindRelatedBooksResponse, BookNameOneof> FindRelatedBooks(
             scg::IEnumerable<string> names,
             scg::IEnumerable<string> shelves,
+            string pageToken = null,
+            int? pageSize = null,
             gaxgrpc::CallSettings callSettings = null) => FindRelatedBooks(
                 new FindRelatedBooksRequest
                 {
@@ -9916,6 +10792,45 @@ namespace Google.Example.Library.V1
         /// If not null, applies overrides to this RPC call.
         /// </param>
         /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<Book, GetBigBookMetadata>> GetBigBookAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBigBookAsync(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test long-running operations
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<Book, GetBigBookMetadata>> GetBigBookAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetBigBookAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Test long-running operations
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
         /// The RPC response.
         /// </returns>
         public virtual lro::Operation<Book, GetBigBookMetadata> GetBigBook(
@@ -10058,6 +10973,45 @@ namespace Google.Example.Library.V1
                     BookNameOneof = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
                 },
                 callSettings);
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, GetBigBookMetadata>> GetBigNothingAsync(
+            string name,
+            gaxgrpc::CallSettings callSettings = null) => GetBigNothingAsync(
+                new GetBookRequest
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<pbwkt::Empty, GetBigBookMetadata>> GetBigNothingAsync(
+            string name,
+            st::CancellationToken cancellationToken) => GetBigNothingAsync(
+                name,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Test long-running operations with empty return type.
@@ -11591,6 +12545,935 @@ namespace Google.Example.Library.V1
                     RepeatedBytesValue = { repeatedBytesValue ?? linq::Enumerable.Empty<pb::ByteString>() }, // Optional
                 },
                 callSettings);
+
+        /// <summary>
+        /// Test optional flattening parameters of all types
+        /// </summary>
+        /// <param name="requiredSingularInt32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularInt64">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFloat">
+        ///
+        /// </param>
+        /// <param name="requiredSingularDouble">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBool">
+        ///
+        /// </param>
+        /// <param name="requiredSingularEnum">
+        ///
+        /// </param>
+        /// <param name="requiredSingularString">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBytes">
+        ///
+        /// </param>
+        /// <param name="requiredSingularMessage">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedString">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredMap">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt64">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFloat">
+        ///
+        /// </param>
+        /// <param name="optionalSingularDouble">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBool">
+        ///
+        /// </param>
+        /// <param name="optionalSingularEnum">
+        ///
+        /// </param>
+        /// <param name="optionalSingularString">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBytes">
+        ///
+        /// </param>
+        /// <param name="optionalSingularMessage">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedString">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalMap">
+        ///
+        /// </param>
+        /// <param name="anyValue">
+        ///
+        /// </param>
+        /// <param name="structValue">
+        ///
+        /// </param>
+        /// <param name="valueValue">
+        ///
+        /// </param>
+        /// <param name="listValueValue">
+        ///
+        /// </param>
+        /// <param name="timeValue">
+        ///
+        /// </param>
+        /// <param name="durationValue">
+        ///
+        /// </param>
+        /// <param name="fieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="int32Value">
+        ///
+        /// </param>
+        /// <param name="uint32Value">
+        ///
+        /// </param>
+        /// <param name="int64Value">
+        ///
+        /// </param>
+        /// <param name="uint64Value">
+        ///
+        /// </param>
+        /// <param name="floatValue">
+        ///
+        /// </param>
+        /// <param name="doubleValue">
+        ///
+        /// </param>
+        /// <param name="stringValue">
+        ///
+        /// </param>
+        /// <param name="boolValue">
+        ///
+        /// </param>
+        /// <param name="bytesValue">
+        ///
+        /// </param>
+        /// <param name="repeatedAnyValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStructValue">
+        ///
+        /// </param>
+        /// <param name="repeatedValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedListValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedTimeValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDurationValue">
+        ///
+        /// </param>
+        /// <param name="repeatedFieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="repeatedInt32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedInt64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedFloatValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDoubleValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStringValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBoolValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBytesValue">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<TestOptionalRequiredFlatteningParamsResponse> TestOptionalRequiredFlatteningParamsAsync(
+            int requiredSingularInt32,
+            long requiredSingularInt64,
+            float requiredSingularFloat,
+            double requiredSingularDouble,
+            bool requiredSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum requiredSingularEnum,
+            string requiredSingularString,
+            pb::ByteString requiredSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage,
+            string requiredSingularResourceName,
+            string requiredSingularResourceNameOneof,
+            string requiredSingularResourceNameCommon,
+            int requiredSingularFixed32,
+            long requiredSingularFixed64,
+            scg::IEnumerable<int> requiredRepeatedInt32,
+            scg::IEnumerable<long> requiredRepeatedInt64,
+            scg::IEnumerable<float> requiredRepeatedFloat,
+            scg::IEnumerable<double> requiredRepeatedDouble,
+            scg::IEnumerable<bool> requiredRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> requiredRepeatedEnum,
+            scg::IEnumerable<string> requiredRepeatedString,
+            scg::IEnumerable<pb::ByteString> requiredRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage,
+            scg::IEnumerable<string> requiredRepeatedResourceName,
+            scg::IEnumerable<string> requiredRepeatedResourceNameOneof,
+            scg::IEnumerable<string> requiredRepeatedResourceNameCommon,
+            scg::IEnumerable<int> requiredRepeatedFixed32,
+            scg::IEnumerable<long> requiredRepeatedFixed64,
+            scg::IDictionary<int, string> requiredMap,
+            int? optionalSingularInt32,
+            long? optionalSingularInt64,
+            float? optionalSingularFloat,
+            double? optionalSingularDouble,
+            bool? optionalSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum? optionalSingularEnum,
+            string optionalSingularString,
+            pb::ByteString optionalSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage,
+            string optionalSingularResourceName,
+            string optionalSingularResourceNameOneof,
+            string optionalSingularResourceNameCommon,
+            int? optionalSingularFixed32,
+            long? optionalSingularFixed64,
+            scg::IEnumerable<int> optionalRepeatedInt32,
+            scg::IEnumerable<long> optionalRepeatedInt64,
+            scg::IEnumerable<float> optionalRepeatedFloat,
+            scg::IEnumerable<double> optionalRepeatedDouble,
+            scg::IEnumerable<bool> optionalRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> optionalRepeatedEnum,
+            scg::IEnumerable<string> optionalRepeatedString,
+            scg::IEnumerable<pb::ByteString> optionalRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage,
+            scg::IEnumerable<string> optionalRepeatedResourceName,
+            scg::IEnumerable<string> optionalRepeatedResourceNameOneof,
+            scg::IEnumerable<string> optionalRepeatedResourceNameCommon,
+            scg::IEnumerable<int> optionalRepeatedFixed32,
+            scg::IEnumerable<long> optionalRepeatedFixed64,
+            scg::IDictionary<int, string> optionalMap,
+            pbwkt::Any anyValue,
+            pbwkt::Struct structValue,
+            pbwkt::Value valueValue,
+            pbwkt::ListValue listValueValue,
+            pbwkt::Timestamp timeValue,
+            pbwkt::Duration durationValue,
+            pbwkt::FieldMask fieldMaskValue,
+            int? int32Value,
+            uint? uint32Value,
+            long? int64Value,
+            ulong? uint64Value,
+            float? floatValue,
+            double? doubleValue,
+            string stringValue,
+            bool? boolValue,
+            pb::ByteString bytesValue,
+            scg::IEnumerable<pbwkt::Any> repeatedAnyValue,
+            scg::IEnumerable<pbwkt::Struct> repeatedStructValue,
+            scg::IEnumerable<pbwkt::Value> repeatedValueValue,
+            scg::IEnumerable<pbwkt::ListValue> repeatedListValueValue,
+            scg::IEnumerable<pbwkt::Timestamp> repeatedTimeValue,
+            scg::IEnumerable<pbwkt::Duration> repeatedDurationValue,
+            scg::IEnumerable<pbwkt::FieldMask> repeatedFieldMaskValue,
+            scg::IEnumerable<int?> repeatedInt32Value,
+            scg::IEnumerable<uint?> repeatedUint32Value,
+            scg::IEnumerable<long?> repeatedInt64Value,
+            scg::IEnumerable<ulong?> repeatedUint64Value,
+            scg::IEnumerable<float?> repeatedFloatValue,
+            scg::IEnumerable<double?> repeatedDoubleValue,
+            scg::IEnumerable<string> repeatedStringValue,
+            scg::IEnumerable<bool?> repeatedBoolValue,
+            scg::IEnumerable<pb::ByteString> repeatedBytesValue,
+            gaxgrpc::CallSettings callSettings = null) => TestOptionalRequiredFlatteningParamsAsync(
+                new TestOptionalRequiredFlatteningParamsRequest
+                {
+                    RequiredSingularInt32 = requiredSingularInt32,
+                    RequiredSingularInt64 = requiredSingularInt64,
+                    RequiredSingularFloat = requiredSingularFloat,
+                    RequiredSingularDouble = requiredSingularDouble,
+                    RequiredSingularBool = requiredSingularBool,
+                    RequiredSingularEnum = requiredSingularEnum,
+                    RequiredSingularString = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularString, nameof(requiredSingularString)),
+                    RequiredSingularBytes = gax::GaxPreconditions.CheckNotNull(requiredSingularBytes, nameof(requiredSingularBytes)),
+                    RequiredSingularMessage = gax::GaxPreconditions.CheckNotNull(requiredSingularMessage, nameof(requiredSingularMessage)),
+                    RequiredSingularResourceName = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceName, nameof(requiredSingularResourceName)),
+                    RequiredSingularResourceNameOneof = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceNameOneof, nameof(requiredSingularResourceNameOneof)),
+                    RequiredSingularResourceNameCommon = gax::GaxPreconditions.CheckNotNullOrEmpty(requiredSingularResourceNameCommon, nameof(requiredSingularResourceNameCommon)),
+                    RequiredSingularFixed32 = requiredSingularFixed32,
+                    RequiredSingularFixed64 = requiredSingularFixed64,
+                    RequiredRepeatedInt32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedInt32, nameof(requiredRepeatedInt32)) },
+                    RequiredRepeatedInt64 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedInt64, nameof(requiredRepeatedInt64)) },
+                    RequiredRepeatedFloat = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFloat, nameof(requiredRepeatedFloat)) },
+                    RequiredRepeatedDouble = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedDouble, nameof(requiredRepeatedDouble)) },
+                    RequiredRepeatedBool = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedBool, nameof(requiredRepeatedBool)) },
+                    RequiredRepeatedEnum = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedEnum, nameof(requiredRepeatedEnum)) },
+                    RequiredRepeatedString = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedString, nameof(requiredRepeatedString)) },
+                    RequiredRepeatedBytes = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedBytes, nameof(requiredRepeatedBytes)) },
+                    RequiredRepeatedMessage = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedMessage, nameof(requiredRepeatedMessage)) },
+                    RequiredRepeatedResourceName = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceName, nameof(requiredRepeatedResourceName)) },
+                    RequiredRepeatedResourceNameOneof = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameOneof, nameof(requiredRepeatedResourceNameOneof)) },
+                    RequiredRepeatedResourceNameCommon = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameCommon, nameof(requiredRepeatedResourceNameCommon)) },
+                    RequiredRepeatedFixed32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed32, nameof(requiredRepeatedFixed32)) },
+                    RequiredRepeatedFixed64 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed64, nameof(requiredRepeatedFixed64)) },
+                    RequiredMap = { gax::GaxPreconditions.CheckNotNull(requiredMap, nameof(requiredMap)) },
+                    OptionalSingularInt32 = optionalSingularInt32 ?? 0, // Optional
+                    OptionalSingularInt64 = optionalSingularInt64 ?? 0L, // Optional
+                    OptionalSingularFloat = optionalSingularFloat ?? 0.0f, // Optional
+                    OptionalSingularDouble = optionalSingularDouble ?? 0.0, // Optional
+                    OptionalSingularBool = optionalSingularBool ?? false, // Optional
+                    OptionalSingularEnum = optionalSingularEnum ?? TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum.Zero, // Optional
+                    OptionalSingularString = optionalSingularString ?? "", // Optional
+                    OptionalSingularBytes = optionalSingularBytes ?? pb::ByteString.Empty, // Optional
+                    OptionalSingularMessage = optionalSingularMessage, // Optional
+                    OptionalSingularResourceName = optionalSingularResourceName ?? "", // Optional
+                    OptionalSingularResourceNameOneof = optionalSingularResourceNameOneof ?? "", // Optional
+                    OptionalSingularResourceNameCommon = optionalSingularResourceNameCommon ?? "", // Optional
+                    OptionalSingularFixed32 = optionalSingularFixed32 ?? 0, // Optional
+                    OptionalSingularFixed64 = optionalSingularFixed64 ?? 0L, // Optional
+                    OptionalRepeatedInt32 = { optionalRepeatedInt32 ?? linq::Enumerable.Empty<int>() }, // Optional
+                    OptionalRepeatedInt64 = { optionalRepeatedInt64 ?? linq::Enumerable.Empty<long>() }, // Optional
+                    OptionalRepeatedFloat = { optionalRepeatedFloat ?? linq::Enumerable.Empty<float>() }, // Optional
+                    OptionalRepeatedDouble = { optionalRepeatedDouble ?? linq::Enumerable.Empty<double>() }, // Optional
+                    OptionalRepeatedBool = { optionalRepeatedBool ?? linq::Enumerable.Empty<bool>() }, // Optional
+                    OptionalRepeatedEnum = { optionalRepeatedEnum ?? linq::Enumerable.Empty<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>() }, // Optional
+                    OptionalRepeatedString = { optionalRepeatedString ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedBytes = { optionalRepeatedBytes ?? linq::Enumerable.Empty<pb::ByteString>() }, // Optional
+                    OptionalRepeatedMessage = { optionalRepeatedMessage ?? linq::Enumerable.Empty<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>() }, // Optional
+                    OptionalRepeatedResourceName = { optionalRepeatedResourceName ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedResourceNameOneof = { optionalRepeatedResourceNameOneof ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedResourceNameCommon = { optionalRepeatedResourceNameCommon ?? linq::Enumerable.Empty<string>() }, // Optional
+                    OptionalRepeatedFixed32 = { optionalRepeatedFixed32 ?? linq::Enumerable.Empty<int>() }, // Optional
+                    OptionalRepeatedFixed64 = { optionalRepeatedFixed64 ?? linq::Enumerable.Empty<long>() }, // Optional
+                    OptionalMap = { optionalMap ?? gax::EmptyDictionary<int, string>.Instance }, // Optional
+                    AnyValue = anyValue, // Optional
+                    StructValue = structValue, // Optional
+                    ValueValue = valueValue, // Optional
+                    ListValueValue = listValueValue, // Optional
+                    TimeValue = timeValue, // Optional
+                    DurationValue = durationValue, // Optional
+                    FieldMaskValue = fieldMaskValue, // Optional
+                    Int32Value = int32Value, // Optional
+                    Uint32Value = uint32Value, // Optional
+                    Int64Value = int64Value, // Optional
+                    Uint64Value = uint64Value, // Optional
+                    FloatValue = floatValue, // Optional
+                    DoubleValue = doubleValue, // Optional
+                    StringValue = stringValue, // Optional
+                    BoolValue = boolValue, // Optional
+                    BytesValue = bytesValue, // Optional
+                    RepeatedAnyValue = { repeatedAnyValue ?? linq::Enumerable.Empty<pbwkt::Any>() }, // Optional
+                    RepeatedStructValue = { repeatedStructValue ?? linq::Enumerable.Empty<pbwkt::Struct>() }, // Optional
+                    RepeatedValueValue = { repeatedValueValue ?? linq::Enumerable.Empty<pbwkt::Value>() }, // Optional
+                    RepeatedListValueValue = { repeatedListValueValue ?? linq::Enumerable.Empty<pbwkt::ListValue>() }, // Optional
+                    RepeatedTimeValue = { repeatedTimeValue ?? linq::Enumerable.Empty<pbwkt::Timestamp>() }, // Optional
+                    RepeatedDurationValue = { repeatedDurationValue ?? linq::Enumerable.Empty<pbwkt::Duration>() }, // Optional
+                    RepeatedFieldMaskValue = { repeatedFieldMaskValue ?? linq::Enumerable.Empty<pbwkt::FieldMask>() }, // Optional
+                    RepeatedInt32Value = { repeatedInt32Value ?? linq::Enumerable.Empty<int?>() }, // Optional
+                    RepeatedUint32Value = { repeatedUint32Value ?? linq::Enumerable.Empty<uint?>() }, // Optional
+                    RepeatedInt64Value = { repeatedInt64Value ?? linq::Enumerable.Empty<long?>() }, // Optional
+                    RepeatedUint64Value = { repeatedUint64Value ?? linq::Enumerable.Empty<ulong?>() }, // Optional
+                    RepeatedFloatValue = { repeatedFloatValue ?? linq::Enumerable.Empty<float?>() }, // Optional
+                    RepeatedDoubleValue = { repeatedDoubleValue ?? linq::Enumerable.Empty<double?>() }, // Optional
+                    RepeatedStringValue = { repeatedStringValue ?? linq::Enumerable.Empty<string>() }, // Optional
+                    RepeatedBoolValue = { repeatedBoolValue ?? linq::Enumerable.Empty<bool?>() }, // Optional
+                    RepeatedBytesValue = { repeatedBytesValue ?? linq::Enumerable.Empty<pb::ByteString>() }, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test optional flattening parameters of all types
+        /// </summary>
+        /// <param name="requiredSingularInt32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularInt64">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFloat">
+        ///
+        /// </param>
+        /// <param name="requiredSingularDouble">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBool">
+        ///
+        /// </param>
+        /// <param name="requiredSingularEnum">
+        ///
+        /// </param>
+        /// <param name="requiredSingularString">
+        ///
+        /// </param>
+        /// <param name="requiredSingularBytes">
+        ///
+        /// </param>
+        /// <param name="requiredSingularMessage">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedString">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="requiredMap">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularInt64">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFloat">
+        ///
+        /// </param>
+        /// <param name="optionalSingularDouble">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBool">
+        ///
+        /// </param>
+        /// <param name="optionalSingularEnum">
+        ///
+        /// </param>
+        /// <param name="optionalSingularString">
+        ///
+        /// </param>
+        /// <param name="optionalSingularBytes">
+        ///
+        /// </param>
+        /// <param name="optionalSingularMessage">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalSingularResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalSingularFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedInt64">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFloat">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedDouble">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBool">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedEnum">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedString">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedBytes">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedMessage">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceName">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedResourceNameCommon">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed32">
+        ///
+        /// </param>
+        /// <param name="optionalRepeatedFixed64">
+        ///
+        /// </param>
+        /// <param name="optionalMap">
+        ///
+        /// </param>
+        /// <param name="anyValue">
+        ///
+        /// </param>
+        /// <param name="structValue">
+        ///
+        /// </param>
+        /// <param name="valueValue">
+        ///
+        /// </param>
+        /// <param name="listValueValue">
+        ///
+        /// </param>
+        /// <param name="timeValue">
+        ///
+        /// </param>
+        /// <param name="durationValue">
+        ///
+        /// </param>
+        /// <param name="fieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="int32Value">
+        ///
+        /// </param>
+        /// <param name="uint32Value">
+        ///
+        /// </param>
+        /// <param name="int64Value">
+        ///
+        /// </param>
+        /// <param name="uint64Value">
+        ///
+        /// </param>
+        /// <param name="floatValue">
+        ///
+        /// </param>
+        /// <param name="doubleValue">
+        ///
+        /// </param>
+        /// <param name="stringValue">
+        ///
+        /// </param>
+        /// <param name="boolValue">
+        ///
+        /// </param>
+        /// <param name="bytesValue">
+        ///
+        /// </param>
+        /// <param name="repeatedAnyValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStructValue">
+        ///
+        /// </param>
+        /// <param name="repeatedValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedListValueValue">
+        ///
+        /// </param>
+        /// <param name="repeatedTimeValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDurationValue">
+        ///
+        /// </param>
+        /// <param name="repeatedFieldMaskValue">
+        ///
+        /// </param>
+        /// <param name="repeatedInt32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint32Value">
+        ///
+        /// </param>
+        /// <param name="repeatedInt64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedUint64Value">
+        ///
+        /// </param>
+        /// <param name="repeatedFloatValue">
+        ///
+        /// </param>
+        /// <param name="repeatedDoubleValue">
+        ///
+        /// </param>
+        /// <param name="repeatedStringValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBoolValue">
+        ///
+        /// </param>
+        /// <param name="repeatedBytesValue">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<TestOptionalRequiredFlatteningParamsResponse> TestOptionalRequiredFlatteningParamsAsync(
+            int requiredSingularInt32,
+            long requiredSingularInt64,
+            float requiredSingularFloat,
+            double requiredSingularDouble,
+            bool requiredSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum requiredSingularEnum,
+            string requiredSingularString,
+            pb::ByteString requiredSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage,
+            string requiredSingularResourceName,
+            string requiredSingularResourceNameOneof,
+            string requiredSingularResourceNameCommon,
+            int requiredSingularFixed32,
+            long requiredSingularFixed64,
+            scg::IEnumerable<int> requiredRepeatedInt32,
+            scg::IEnumerable<long> requiredRepeatedInt64,
+            scg::IEnumerable<float> requiredRepeatedFloat,
+            scg::IEnumerable<double> requiredRepeatedDouble,
+            scg::IEnumerable<bool> requiredRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> requiredRepeatedEnum,
+            scg::IEnumerable<string> requiredRepeatedString,
+            scg::IEnumerable<pb::ByteString> requiredRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage,
+            scg::IEnumerable<string> requiredRepeatedResourceName,
+            scg::IEnumerable<string> requiredRepeatedResourceNameOneof,
+            scg::IEnumerable<string> requiredRepeatedResourceNameCommon,
+            scg::IEnumerable<int> requiredRepeatedFixed32,
+            scg::IEnumerable<long> requiredRepeatedFixed64,
+            scg::IDictionary<int, string> requiredMap,
+            int? optionalSingularInt32,
+            long? optionalSingularInt64,
+            float? optionalSingularFloat,
+            double? optionalSingularDouble,
+            bool? optionalSingularBool,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum? optionalSingularEnum,
+            string optionalSingularString,
+            pb::ByteString optionalSingularBytes,
+            TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage,
+            string optionalSingularResourceName,
+            string optionalSingularResourceNameOneof,
+            string optionalSingularResourceNameCommon,
+            int? optionalSingularFixed32,
+            long? optionalSingularFixed64,
+            scg::IEnumerable<int> optionalRepeatedInt32,
+            scg::IEnumerable<long> optionalRepeatedInt64,
+            scg::IEnumerable<float> optionalRepeatedFloat,
+            scg::IEnumerable<double> optionalRepeatedDouble,
+            scg::IEnumerable<bool> optionalRepeatedBool,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum> optionalRepeatedEnum,
+            scg::IEnumerable<string> optionalRepeatedString,
+            scg::IEnumerable<pb::ByteString> optionalRepeatedBytes,
+            scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage,
+            scg::IEnumerable<string> optionalRepeatedResourceName,
+            scg::IEnumerable<string> optionalRepeatedResourceNameOneof,
+            scg::IEnumerable<string> optionalRepeatedResourceNameCommon,
+            scg::IEnumerable<int> optionalRepeatedFixed32,
+            scg::IEnumerable<long> optionalRepeatedFixed64,
+            scg::IDictionary<int, string> optionalMap,
+            pbwkt::Any anyValue,
+            pbwkt::Struct structValue,
+            pbwkt::Value valueValue,
+            pbwkt::ListValue listValueValue,
+            pbwkt::Timestamp timeValue,
+            pbwkt::Duration durationValue,
+            pbwkt::FieldMask fieldMaskValue,
+            int? int32Value,
+            uint? uint32Value,
+            long? int64Value,
+            ulong? uint64Value,
+            float? floatValue,
+            double? doubleValue,
+            string stringValue,
+            bool? boolValue,
+            pb::ByteString bytesValue,
+            scg::IEnumerable<pbwkt::Any> repeatedAnyValue,
+            scg::IEnumerable<pbwkt::Struct> repeatedStructValue,
+            scg::IEnumerable<pbwkt::Value> repeatedValueValue,
+            scg::IEnumerable<pbwkt::ListValue> repeatedListValueValue,
+            scg::IEnumerable<pbwkt::Timestamp> repeatedTimeValue,
+            scg::IEnumerable<pbwkt::Duration> repeatedDurationValue,
+            scg::IEnumerable<pbwkt::FieldMask> repeatedFieldMaskValue,
+            scg::IEnumerable<int?> repeatedInt32Value,
+            scg::IEnumerable<uint?> repeatedUint32Value,
+            scg::IEnumerable<long?> repeatedInt64Value,
+            scg::IEnumerable<ulong?> repeatedUint64Value,
+            scg::IEnumerable<float?> repeatedFloatValue,
+            scg::IEnumerable<double?> repeatedDoubleValue,
+            scg::IEnumerable<string> repeatedStringValue,
+            scg::IEnumerable<bool?> repeatedBoolValue,
+            scg::IEnumerable<pb::ByteString> repeatedBytesValue,
+            st::CancellationToken cancellationToken) => TestOptionalRequiredFlatteningParamsAsync(
+                requiredSingularInt32,
+                requiredSingularInt64,
+                requiredSingularFloat,
+                requiredSingularDouble,
+                requiredSingularBool,
+                requiredSingularEnum,
+                requiredSingularString,
+                requiredSingularBytes,
+                requiredSingularMessage,
+                requiredSingularResourceName,
+                requiredSingularResourceNameOneof,
+                requiredSingularResourceNameCommon,
+                requiredSingularFixed32,
+                requiredSingularFixed64,
+                requiredRepeatedInt32,
+                requiredRepeatedInt64,
+                requiredRepeatedFloat,
+                requiredRepeatedDouble,
+                requiredRepeatedBool,
+                requiredRepeatedEnum,
+                requiredRepeatedString,
+                requiredRepeatedBytes,
+                requiredRepeatedMessage,
+                requiredRepeatedResourceName,
+                requiredRepeatedResourceNameOneof,
+                requiredRepeatedResourceNameCommon,
+                requiredRepeatedFixed32,
+                requiredRepeatedFixed64,
+                requiredMap,
+                optionalSingularInt32,
+                optionalSingularInt64,
+                optionalSingularFloat,
+                optionalSingularDouble,
+                optionalSingularBool,
+                optionalSingularEnum,
+                optionalSingularString,
+                optionalSingularBytes,
+                optionalSingularMessage,
+                optionalSingularResourceName,
+                optionalSingularResourceNameOneof,
+                optionalSingularResourceNameCommon,
+                optionalSingularFixed32,
+                optionalSingularFixed64,
+                optionalRepeatedInt32,
+                optionalRepeatedInt64,
+                optionalRepeatedFloat,
+                optionalRepeatedDouble,
+                optionalRepeatedBool,
+                optionalRepeatedEnum,
+                optionalRepeatedString,
+                optionalRepeatedBytes,
+                optionalRepeatedMessage,
+                optionalRepeatedResourceName,
+                optionalRepeatedResourceNameOneof,
+                optionalRepeatedResourceNameCommon,
+                optionalRepeatedFixed32,
+                optionalRepeatedFixed64,
+                optionalMap,
+                anyValue,
+                structValue,
+                valueValue,
+                listValueValue,
+                timeValue,
+                durationValue,
+                fieldMaskValue,
+                int32Value,
+                uint32Value,
+                int64Value,
+                uint64Value,
+                floatValue,
+                doubleValue,
+                stringValue,
+                boolValue,
+                bytesValue,
+                repeatedAnyValue,
+                repeatedStructValue,
+                repeatedValueValue,
+                repeatedListValueValue,
+                repeatedTimeValue,
+                repeatedDurationValue,
+                repeatedFieldMaskValue,
+                repeatedInt32Value,
+                repeatedUint32Value,
+                repeatedInt64Value,
+                repeatedUint64Value,
+                repeatedFloatValue,
+                repeatedDoubleValue,
+                repeatedStringValue,
+                repeatedBoolValue,
+                repeatedBytesValue,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// Test optional flattening parameters of all types
@@ -15810,59 +17693,6 @@ class FindRelatedBooksAsyncRequestAsyncPagedPageSizeOdyssey
    	// FIXME: call the sample function
    }
 }
-============== file: Samples/FindRelatedBooksFlattenedOdyssey.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "odyssey")
-
-// [START sample]
-// FIXME: import everything this sample needs
-class FindRelatedBooksFlattenedOdyssey
-{
-    // [START sample_core]
-   /// <summary>
-   /// Testing calling forms
-   /// </summary>
-   public static void SampleFindRelatedBooks()
-   {
-       public static void SampleFindRelatedBooks()
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           IEnumerable<BookNameOneof> names = new[]
-           {
-               BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-           };
-           IEnumerable<ShelfName> shelves = new[]
-           {
-               new ShelfName("[SHELF_ID]"),
-           };
-           gax::PagedEnumerable<FindRelatedBooksRequest, FindRelatedBooksResponse, BookNameOneof> response = libraryServiceClient.FindRelatedBooks(names, shelves);
-           // FIXME: inspect the results
-       }
-       // [END sample_core]
-   }
-
-   // [END sample]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
 ============== file: Samples/FindRelatedBooksFlattenedPagedAllOdyssey.cs ==============
 // Copyright 2019 Google LLC
 //
@@ -16213,196 +18043,6 @@ class FindRelatedBooksRequestPagedPageSizeOdyssey
            }
            // Store the pageToken, for when the next page is required.
            string nextPageToken = singlePage.NextPageToken;
-       }
-       // [END sample_core]
-   }
-
-   // [END sample]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
-============== file: Samples/GetBigBookFlattenedWap.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "wap")
-
-// [START hopper]
-// FIXME: import everything this sample needs
-class GetBigBookFlattenedWap
-{
-    // [START hopper_core]
-   /// <summary>
-   /// Testing calling forms
-   /// </summary>
-   public static void SampleGetBigBook(string shelf)
-   {
-       public static void SampleGetBigBook(string shelf)
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           // string shelf = "Novel"
-           BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-           Book response = libraryServiceClient.GetBigBook(name);
-           // FIXME: inspect the results
-       }
-       // [END hopper_core]
-   }
-
-   // [END hopper]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
-============== file: Samples/GetBigBookFlattenedWap2.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "wap2")
-
-// [START hopper]
-// FIXME: import everything this sample needs
-class GetBigBookFlattenedWap2
-{
-    // [START hopper_core]
-   /// <summary>
-   /// Testing resource name overlap
-   /// </summary>
-   /// <param name="shelf">Test word wrapping for long lines. This is a long comment. The name of the
-   /// shelf to retrieve the big book from.</param>
-   /// <param name="bigBookName">The name of the book.</param>
-   public static void SampleGetBigBook(string shelf, string bigBookName)
-   {
-       public static void SampleGetBigBook(string shelf, string bigBookName)
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           // string shelf = "Novel"
-           // string bigBookName = "War and Peace"
-           BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-           Book response = libraryServiceClient.GetBigBook(name);
-           // FIXME: inspect the results
-       }
-       // [END hopper_core]
-   }
-
-   // [END hopper]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
-============== file: Samples/GetBigNothingFlattenedEmptyResponseTypeWithResponseHandling.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "empty_response_type_with_response_handling")
-
-// [START sample]
-// FIXME: import everything this sample needs
-class GetBigNothingFlattenedEmptyResponseTypeWithResponseHandling
-{
-    // [START sample_core]
-   /// <summary>
-   /// Test response handling for methods that return empty
-   /// </summary>
-   public static void SampleGetBigNothing()
-   {
-       public static void SampleGetBigNothing()
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-           libraryServiceClient.GetBigNothing(name);
-           // FIXME: inspect the results
-       }
-       // [END sample_core]
-   }
-
-   // [END sample]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
-============== file: Samples/GetBigNothingFlattenedEmptyResponseTypeWithoutResponseHandling.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "empty_response_type_without_response_handling")
-
-// [START sample]
-// FIXME: import everything this sample needs
-class GetBigNothingFlattenedEmptyResponseTypeWithoutResponseHandling
-{
-    // [START sample_core]
-   /// <summary>
-   /// Test default response handling is turned off for methods that return empty
-   /// </summary>
-   public static void SampleGetBigNothing()
-   {
-       public static void SampleGetBigNothing()
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-           libraryServiceClient.GetBigNothing(name);
-           // FIXME: inspect the results
        }
        // [END sample_core]
    }
@@ -17141,58 +18781,6 @@ class PublishSeriesRequestTestWriteToFile
    }
 
    // [END sample]
-   public static void Main(String[] args)
-   {
-   	// FIXME: pass in commandline arguments
-   	// FIXME: call the sample function
-   }
-}
-============== file: Samples/TuringProgFlattened.cs ==============
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Generated code. DO NOT EDIT!
-
-// This is a generated sample ("Flattened", "prog")
-
-// [START turing_prog_flattened]
-// FIXME: import everything this sample needs
-class TuringProgFlattened
-{
-    // [START turing_prog_flattened_core]
-   /// <summary>
-   /// Testing calling forms
-   /// </summary>
-   public static void SampleDiscussBook(string imageFileName)
-   {
-       public static void SampleDiscussBook(string imageFileName)
-       {
-           LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-           // string imageFileName = "image_file.jpg"
-           BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-           Comment comment2 = new Comment
-           {
-               Comment = File.ReadAllBytes("comment_file"),
-           };
-           ByteString image = File.ReadAllBytes(imageFileName);
-           grpccore::AsyncDuplexStreamingCall<DiscussBookRequest, Comment> response = libraryServiceClient.DiscussBook(name, comment2, image);
-           // FIXME: inspect the results
-       }
-       // [END turing_prog_flattened_core]
-   }
-
-   // [END turing_prog_flattened]
    public static void Main(String[] args)
    {
    	// FIXME: pass in commandline arguments


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator/issues/2739

For C#, for _all_ flattened method configurations (LRO/streaming/etc), if one of the params in the method signature is a _resource entity_, then _also_ create a flattened method context in which the resource entity param is instead a _string_ field.

This allows an API to not have resource names and then later introduce resource names for existing methods without breaking the previous string-based methods.



--- Addendum ---
For transparency, this does allow for a bug where this new method overload conflicts with another flattening, e.g.
Let's say there is an RPC request message
```
message GetShelfRequest {
   Shelf shelf = 1;
   String id = 2;
   String genre = 3;
}
```
And the RPC has method signatures `"shelf, id"` and `"id, genre"`, then we will generate methods
```
public virtual Shelf GetShelf(Shelf shelf, String id);
public virtual Shelf GetShelf(String shelf, String id);
public virtual Shelf GetShelf(String id, String genre);
```
where the last two method overloads have the same type signature and (I think) will not compile.

But this is very similar to the possibility of someone defining two different method signatures with the same list of parameter types, which would result in the same compile-time error.