### PR TITLE
SampleGen: put PHP samples in the correct directory

### DIFF
--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorFactory.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorFactory.java
@@ -382,13 +382,15 @@ public class GapicGeneratorFactory {
                 .build();
 
         if (devSamples) {
+          GapicCodePathMapper phpSamplePathMapper =
+              PhpGapicCodePathMapper.newBuilder().setPrefix("samples").build();
           CodeGenerator sampleGenerator =
               GapicGenerator.newBuilder()
                   .setModel(model)
                   .setProductConfig(productConfig)
                   .setSnippetSetRunner(new CommonSnippetSetRunner(new CommonRenderingUtil()))
                   .setModelToViewTransformer(
-                      new PhpGapicSamplesTransformer(phpPathMapper, packageConfig))
+                      new PhpGapicSamplesTransformer(phpSamplePathMapper, packageConfig))
                   .build();
           generators.add(sampleGenerator);
         }

--- a/src/main/java/com/google/api/codegen/php/PhpGapicCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/php/PhpGapicCodePathMapper.java
@@ -39,18 +39,8 @@ public abstract class PhpGapicCodePathMapper implements GapicCodePathMapper {
 
   @Override
   public String getOutputPath(String elementFullName, ProductConfig config) {
-    return getOutputPath(config, null);
-  }
-
-  @Override
-  public String getSamplesOutputPath(String elementFullName, ProductConfig config, String method) {
-    return getOutputPath(config, method);
-  }
-
-  private String getOutputPath(ProductConfig config, String methodSample) {
     ArrayList<String> dirs = new ArrayList<>();
     String prefix = getPrefix();
-    boolean haveSample = !Strings.isNullOrEmpty(methodSample);
 
     if (!Strings.isNullOrEmpty(prefix)) {
       dirs.add(prefix);
@@ -61,19 +51,17 @@ public abstract class PhpGapicCodePathMapper implements GapicCodePathMapper {
       dirs.addAll(Arrays.asList(PhpPackageUtil.splitPackageName(shortenedPackageName)));
     }
 
-    if (haveSample) {
-      dirs.add(SAMPLES_DIRECTORY);
-    }
-
     String suffix = getSuffix();
     if (!Strings.isNullOrEmpty(suffix)) {
       dirs.add(suffix);
     }
 
-    if (haveSample) {
-      dirs.add(methodSample);
-    }
     return Joiner.on("/").join(dirs);
+  }
+
+  @Override
+  public String getSamplesOutputPath(String elementFullName, ProductConfig config, String method) {
+    return getOutputPath(elementFullName, config);
   }
 
   public static Builder newBuilder() {

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -282,7 +282,7 @@ public class PhpSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getApiSampleFileName(String... pieces) {
-    return Name.anyLower(pieces).toLowerUnderscore() + ".php";
+    return Name.anyLower(pieces).toUpperCamel() + ".php";
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -20,7 +20,7 @@
     "phpunit/phpunit": "^4.8|^5.0"
   }
 }
-============== file: samples/V1/babble_about_book_request_streaming_client_async_empty_response_type_with_response_handling.php ==============
+============== file: samples/V1/BabbleAboutBookRequestStreamingClientAsyncEmptyResponseTypeWithResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -76,7 +76,7 @@ function sampleBabbleAboutBook()
 // [END sample]
 
 sampleBabbleAboutBook();
-============== file: samples/V1/babble_about_book_request_streaming_client_async_empty_response_type_without_response_handling.php ==============
+============== file: samples/V1/BabbleAboutBookRequestStreamingClientAsyncEmptyResponseTypeWithoutResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -130,7 +130,7 @@ function sampleBabbleAboutBook()
 // [END sample]
 
 sampleBabbleAboutBook();
-============== file: samples/V1/babble_about_book_request_streaming_client_empty_response_type_with_response_handling.php ==============
+============== file: samples/V1/BabbleAboutBookRequestStreamingClientEmptyResponseTypeWithResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -183,7 +183,7 @@ function sampleBabbleAboutBook()
 // [END sample]
 
 sampleBabbleAboutBook();
-============== file: samples/V1/babble_about_book_request_streaming_client_empty_response_type_without_response_handling.php ==============
+============== file: samples/V1/BabbleAboutBookRequestStreamingClientEmptyResponseTypeWithoutResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -234,7 +234,7 @@ function sampleBabbleAboutBook()
 // [END sample]
 
 sampleBabbleAboutBook();
-============== file: samples/V1/delete_shelf_request_empty_response_type_with_response_handling.php ==============
+============== file: samples/V1/DeleteShelfRequestEmptyResponseTypeWithResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -283,7 +283,7 @@ function sampleDeleteShelf()
 // [END sample]
 
 sampleDeleteShelf();
-============== file: samples/V1/delete_shelf_request_empty_response_type_without_response_handling.php ==============
+============== file: samples/V1/DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -331,7 +331,7 @@ function sampleDeleteShelf()
 // [END sample]
 
 sampleDeleteShelf();
-============== file: samples/V1/find_related_books_request_paged_all_odyssey.php ==============
+============== file: samples/V1/FindRelatedBooksRequestPagedAllOdyssey.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -386,7 +386,7 @@ function sampleFindRelatedBooks()
 // [END sample]
 
 sampleFindRelatedBooks();
-============== file: samples/V1/find_related_books_request_paged_odyssey.php ==============
+============== file: samples/V1/FindRelatedBooksRequestPagedOdyssey.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -443,7 +443,7 @@ function sampleFindRelatedBooks()
 // [END sample]
 
 sampleFindRelatedBooks();
-============== file: samples/V1/get_big_book_long_running_request_async_wap.php ==============
+============== file: samples/V1/GetBigBookLongRunningRequestAsyncWap.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -535,7 +535,7 @@ $options += $defaultOptions;
 $shelf = $options['shelf'];
 
 sampleGetBigBook($shelf);
-============== file: samples/V1/get_big_book_long_running_request_async_wap2.php ==============
+============== file: samples/V1/GetBigBookLongRunningRequestAsyncWap2.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -621,7 +621,7 @@ $shelf = $options['shelf'];
 $bigBookName = $options['big_book_name'];
 
 sampleGetBigBook($shelf, $bigBookName);
-============== file: samples/V1/get_big_book_long_running_request_wap.php ==============
+============== file: samples/V1/GetBigBookLongRunningRequestWap.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -706,7 +706,7 @@ $options += $defaultOptions;
 $shelf = $options['shelf'];
 
 sampleGetBigBook($shelf);
-============== file: samples/V1/get_big_book_long_running_request_wap2.php ==============
+============== file: samples/V1/GetBigBookLongRunningRequestWap2.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -785,7 +785,7 @@ $shelf = $options['shelf'];
 $bigBookName = $options['big_book_name'];
 
 sampleGetBigBook($shelf, $bigBookName);
-============== file: samples/V1/get_big_nothing_long_running_request_async_empty_response_type_with_response_handling.php ==============
+============== file: samples/V1/GetBigNothingLongRunningRequestAsyncEmptyResponseTypeWithResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -846,7 +846,7 @@ function sampleGetBigNothing()
 // [END sample]
 
 sampleGetBigNothing();
-============== file: samples/V1/get_big_nothing_long_running_request_async_empty_response_type_without_response_handling.php ==============
+============== file: samples/V1/GetBigNothingLongRunningRequestAsyncEmptyResponseTypeWithoutResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -907,7 +907,7 @@ function sampleGetBigNothing()
 // [END sample]
 
 sampleGetBigNothing();
-============== file: samples/V1/get_big_nothing_long_running_request_empty_response_type_with_response_handling.php ==============
+============== file: samples/V1/GetBigNothingLongRunningRequestEmptyResponseTypeWithResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -961,7 +961,7 @@ function sampleGetBigNothing()
 // [END sample]
 
 sampleGetBigNothing();
-============== file: samples/V1/get_big_nothing_long_running_request_empty_response_type_without_response_handling.php ==============
+============== file: samples/V1/GetBigNothingLongRunningRequestEmptyResponseTypeWithoutResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1015,7 +1015,7 @@ function sampleGetBigNothing()
 // [END sample]
 
 sampleGetBigNothing();
-============== file: samples/V1/get_book_request_test_on_success_map.php ==============
+============== file: samples/V1/GetBookRequestTestOnSuccessMap.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1066,7 +1066,7 @@ function sampleGetBook()
 // [END sample]
 
 sampleGetBook();
-============== file: samples/V1/lovelace.php ==============
+============== file: samples/V1/Lovelace.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1117,7 +1117,7 @@ function sampleStreamBooks()
 // [END lovelace]
 
 sampleStreamBooks();
-============== file: samples/V1/monolog_about_book_request_streaming_client_async_prog.php ==============
+============== file: samples/V1/MonologAboutBookRequestStreamingClientAsyncProg.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1174,7 +1174,7 @@ function sampleMonologAboutBook()
 // [END sample]
 
 sampleMonologAboutBook();
-============== file: samples/V1/monolog_about_book_request_streaming_client_prog.php ==============
+============== file: samples/V1/MonologAboutBookRequestStreamingClientProg.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1228,7 +1228,7 @@ function sampleMonologAboutBook()
 // [END sample]
 
 sampleMonologAboutBook();
-============== file: samples/V1/publish_series_request_pi_version.php ==============
+============== file: samples/V1/PublishSeriesRequestPiVersion.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1326,7 +1326,7 @@ $shelfName = $options['shelf_name'];
 $edition = $options['edition'];
 
 samplePublishSeries($shelfName, $edition);
-============== file: samples/V1/publish_series_request_second_edition.php ==============
+============== file: samples/V1/PublishSeriesRequestSecondEdition.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1380,7 +1380,7 @@ function samplePublishSeries()
 // [END canonical]
 
 samplePublishSeries();
-============== file: samples/V1/publish_series_request_test_request_object_field_comments.php ==============
+============== file: samples/V1/PublishSeriesRequestTestRequestObjectFieldComments.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1457,7 +1457,7 @@ function samplePublishSeries()
 // [END sample]
 
 samplePublishSeries();
-============== file: samples/V1/publish_series_request_test_write_to_file.php ==============
+============== file: samples/V1/PublishSeriesRequestTestWriteToFile.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1513,7 +1513,7 @@ function samplePublishSeries()
 // [END sample]
 
 samplePublishSeries();
-============== file: samples/V1/sample_get_shelf.php ==============
+============== file: samples/V1/SampleGetShelf.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1562,7 +1562,7 @@ function sampleGetShelf()
 // [END sample_get_shelf]
 
 sampleGetShelf();
-============== file: samples/V1/stream_shelves_request_streaming_server_empty.php ==============
+============== file: samples/V1/StreamShelvesRequestStreamingServerEmpty.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1613,7 +1613,7 @@ function sampleStreamShelves()
 // [END sample]
 
 sampleStreamShelves();
-============== file: samples/V1/test_default_calling_form_for_paging.php ==============
+============== file: samples/V1/TestDefaultCallingFormForPaging.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1662,7 +1662,7 @@ function sampleListShelves()
 // [END test_default_calling_form_for_paging]
 
 sampleListShelves();
-============== file: samples/V1/this_tag_should_be_the_name_of_the_file.php ==============
+============== file: samples/V1/ThisTagShouldBeTheNameOfTheFile.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1747,7 +1747,7 @@ $options += $defaultOptions;
 $shelf = $options['shelf'];
 
 sampleGetBigBook($shelf);
-============== file: samples/V1/turing_prog_request_streaming_bidi.php ==============
+============== file: samples/V1/TuringProgRequestStreamingBidi.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1825,7 +1825,7 @@ $options += $defaultOptions;
 $imageFileName = $options['image_file_name'];
 
 sampleDiscussBook($imageFileName);
-============== file: samples/V1/turing_prog_request_streaming_bidi_async.php ==============
+============== file: samples/V1/TuringProgRequestStreamingBidiAsync.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -20,6 +20,1898 @@
     "phpunit/phpunit": "^4.8|^5.0"
   }
 }
+============== file: samples/V1/babble_about_book_request_streaming_client_async_empty_response_type_with_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "empty_response_type_with_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Test response handling for methods that return empty */
+function sampleBabbleAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $request = new DiscussBookRequest();
+
+    try {
+        // Write data as it becomes available, then wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->babbleAboutBook();
+        foreach ($requests as $request) {
+            $stream->write($request);
+        }
+        $response = $stream->readResponse();
+        // No one replied
+        printf("No one replied." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleBabbleAboutBook();
+============== file: samples/V1/babble_about_book_request_streaming_client_async_empty_response_type_without_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "empty_response_type_without_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleBabbleAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $request = new DiscussBookRequest();
+
+    try {
+        // Write data as it becomes available, then wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->babbleAboutBook();
+        foreach ($requests as $request) {
+            $stream->write($request);
+        }
+        $response = $stream->readResponse();
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleBabbleAboutBook();
+============== file: samples/V1/babble_about_book_request_streaming_client_empty_response_type_with_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_with_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Test response handling for methods that return empty */
+function sampleBabbleAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $request = new DiscussBookRequest();
+
+    try {
+        // Write data to server and wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->babbleAboutBook();
+        $response = $stream->writeAllAndReadResponse($requests);
+        // No one replied
+        printf("No one replied." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleBabbleAboutBook();
+============== file: samples/V1/babble_about_book_request_streaming_client_empty_response_type_without_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_without_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleBabbleAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $request = new DiscussBookRequest();
+
+    try {
+        // Write data to server and wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->babbleAboutBook();
+        $response = $stream->writeAllAndReadResponse($requests);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleBabbleAboutBook();
+============== file: samples/V1/delete_shelf_request_empty_response_type_with_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_with_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test response handling for methods that return empty */
+function sampleDeleteShelf()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+
+    try {
+        $libraryServiceClient->deleteShelf($formattedName);
+        // Shelf deleted
+        printf("Shelf deleted." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleDeleteShelf();
+============== file: samples/V1/delete_shelf_request_empty_response_type_without_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_without_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleDeleteShelf()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+
+    try {
+        $libraryServiceClient->deleteShelf($formattedName);
+
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleDeleteShelf();
+============== file: samples/V1/find_related_books_request_paged_all_odyssey.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestPagedAll",  "odyssey")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleFindRelatedBooks()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $namesElement = 'Odyssey';
+    $names = [$namesElement];
+    $shelvesElement = 'Classics';
+    $shelves = [$shelvesElement];
+
+    try {
+        // Iterate through all elements
+        $pagedResponse = $libraryServiceClient->findRelatedBooks($formattedNames, $formattedShelves);
+        foreach ($pagedResponse->iterateAllElements() as $responseItem) {
+            $book = $responseItem;
+            printf("Here's a related book: %s" . PHP_EOL, $book);
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleFindRelatedBooks();
+============== file: samples/V1/find_related_books_request_paged_odyssey.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestPaged",  "odyssey")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleFindRelatedBooks()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $namesElement = 'Odyssey';
+    $names = [$namesElement];
+    $shelvesElement = 'Classics';
+    $shelves = [$shelvesElement];
+
+    try {
+        // Iterate over pages of elements
+        $pagedResponse = $libraryServiceClient->findRelatedBooks($formattedNames, $formattedShelves);
+        foreach ($pagedResponse->iteratePages() as $page) {
+            foreach ($page as $responseItem) {
+                $book = $responseItem;
+                printf("Here's a related book: %s" . PHP_EOL, $book);
+            }
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleFindRelatedBooks();
+============== file: samples/V1/get_big_book_long_running_request_async_wap.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
+ */
+
+// [START hopper]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleGetBigBook($shelf)
+{
+    // [START hopper_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
+
+    try {
+        // start the operation, keep the operation name, and resume later
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationName = $operationResponse->getName();
+        // ... do other work
+        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigBook');
+        while (!$newOperationResponse->isDone()) {
+            // ... do other work
+            $newOperationResponse->reload();
+        }
+        if ($newOperationResponse->operationSucceeded()) {
+            $response = $newOperationResponse->getResult();
+            // Testing iterating over map fields when both key and value are specified.
+            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
+                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
+            }
+
+            // Testing iterating over map fields when only key is specified.
+            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
+                printf("key: %s" . PHP_EOL, $anotherKey);
+            }
+
+            // Testing iterating over map fields when only value is specified.
+            foreach ($response->getMapListValueValue() as $anotherValue) {
+                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
+            }
+
+            printf("name: %s" . PHP_EOL, $response->getName());
+            printf("author: %s" . PHP_EOL, $response->getAuthor());
+        } else {
+          $error = $newOperationResponse->getError();
+          // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END hopper_core]
+}
+// [END hopper]
+
+$opts = [
+    'shelf::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+
+sampleGetBigBook($shelf);
+============== file: samples/V1/get_big_book_long_running_request_async_wap2.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap2")
+ */
+
+// [START hopper]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/**
+ * Testing resource name overlap
+ *
+ * @param string $shelf Test word wrapping for long lines. This is a long comment. The name of the
+ * shelf to retrieve the big book from.
+ * @param string $bigBookName The name of the book.
+ */
+function sampleGetBigBook($shelf, $bigBookName)
+{
+    // [START hopper_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    // $bigBookName = 'War and Peace';
+    $formattedName = $libraryServiceClient->bookName($shelf, $bigBookName);
+
+    try {
+        // start the operation, keep the operation name, and resume later
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationName = $operationResponse->getName();
+        // ... do other work
+        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigBook');
+        while (!$newOperationResponse->isDone()) {
+            // ... do other work
+            $newOperationResponse->reload();
+        }
+        if ($newOperationResponse->operationSucceeded()) {
+            $response = $newOperationResponse->getResult();
+            printf("%s" . PHP_EOL, print_r($response, true));
+        } else {
+          $error = $newOperationResponse->getError();
+          // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END hopper_core]
+}
+// [END hopper]
+
+$opts = [
+    'shelf::',
+    'big_book_name::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+    'big_book_name' => 'War and Peace',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+$bigBookName = $options['big_book_name'];
+
+sampleGetBigBook($shelf, $bigBookName);
+============== file: samples/V1/get_big_book_long_running_request_wap.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap")
+ */
+
+// [START hopper]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleGetBigBook($shelf)
+{
+    // [START hopper_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
+
+    try {
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            $response = $operationResponse->getResult();
+            // Testing iterating over map fields when both key and value are specified.
+            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
+                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
+            }
+
+            // Testing iterating over map fields when only key is specified.
+            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
+                printf("key: %s" . PHP_EOL, $anotherKey);
+            }
+
+            // Testing iterating over map fields when only value is specified.
+            foreach ($response->getMapListValueValue() as $anotherValue) {
+                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
+            }
+
+            printf("name: %s" . PHP_EOL, $response->getName());
+            printf("author: %s" . PHP_EOL, $response->getAuthor());
+        } else {
+            $error = $operationResponse->getError();
+            // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END hopper_core]
+}
+// [END hopper]
+
+$opts = [
+    'shelf::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+
+sampleGetBigBook($shelf);
+============== file: samples/V1/get_big_book_long_running_request_wap2.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap2")
+ */
+
+// [START hopper]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/**
+ * Testing resource name overlap
+ *
+ * @param string $shelf Test word wrapping for long lines. This is a long comment. The name of the
+ * shelf to retrieve the big book from.
+ * @param string $bigBookName The name of the book.
+ */
+function sampleGetBigBook($shelf, $bigBookName)
+{
+    // [START hopper_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    // $bigBookName = 'War and Peace';
+    $formattedName = $libraryServiceClient->bookName($shelf, $bigBookName);
+
+    try {
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            $response = $operationResponse->getResult();
+            printf("%s" . PHP_EOL, print_r($response, true));
+        } else {
+            $error = $operationResponse->getError();
+            // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END hopper_core]
+}
+// [END hopper]
+
+$opts = [
+    'shelf::',
+    'big_book_name::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+    'big_book_name' => 'War and Peace',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+$bigBookName = $options['big_book_name'];
+
+sampleGetBigBook($shelf, $bigBookName);
+============== file: samples/V1/get_big_nothing_long_running_request_async_empty_response_type_with_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "empty_response_type_with_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test response handling for methods that return empty */
+function sampleGetBigNothing()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+
+    try {
+        // start the operation, keep the operation name, and resume later
+        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
+        $operationName = $operationResponse->getName();
+        // ... do other work
+        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigNothing');
+        while (!$newOperationResponse->isDone()) {
+            // ... do other work
+            $newOperationResponse->reload();
+        }
+        if ($newOperationResponse->operationSucceeded()) {
+            // operation succeeded and returns no value
+        } else {
+          $error = $newOperationResponse->getError();
+          // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleGetBigNothing();
+============== file: samples/V1/get_big_nothing_long_running_request_async_empty_response_type_without_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "empty_response_type_without_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleGetBigNothing()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+
+    try {
+        // start the operation, keep the operation name, and resume later
+        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
+        $operationName = $operationResponse->getName();
+        // ... do other work
+        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigNothing');
+        while (!$newOperationResponse->isDone()) {
+            // ... do other work
+            $newOperationResponse->reload();
+        }
+        if ($newOperationResponse->operationSucceeded()) {
+            // operation succeeded and returns no value
+        } else {
+          $error = $newOperationResponse->getError();
+          // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleGetBigNothing();
+============== file: samples/V1/get_big_nothing_long_running_request_empty_response_type_with_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "empty_response_type_with_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test response handling for methods that return empty */
+function sampleGetBigNothing()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+
+    try {
+        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            // operation succeeded and returns no value
+        } else {
+            $error = $operationResponse->getError();
+            // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleGetBigNothing();
+============== file: samples/V1/get_big_nothing_long_running_request_empty_response_type_without_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "empty_response_type_without_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleGetBigNothing()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+
+    try {
+        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            // operation succeeded and returns no value
+        } else {
+            $error = $operationResponse->getError();
+            // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleGetBigNothing();
+============== file: samples/V1/get_book_request_test_on_success_map.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+function sampleGetBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+
+    try {
+        $response = $libraryServiceClient->getBook($formattedName);
+        $intKeyVal = $response->getMapStringValue()[123];
+        $booleanKeyVal = $response->getMapBoolKey()[true];
+        $mapValueField = $response->getMapMessageValue()['key']->getField();
+        printf("Test printing map fields: %s" . PHP_EOL, print_r($response->getMapListValueValue()['quoted_key'], true));
+        printf("Test printing enum fields of a map value: %s" . PHP_EOL, SomeMessage_Alignment::name($response->getMapMessageValue()['key']->getAlignment()));
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleGetBook();
+============== file: samples/V1/lovelace.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "prog")
+ */
+
+// [START lovelace]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleStreamBooks()
+{
+    // [START lovelace_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $name = 'BASIC';
+
+    try {
+        // Read all responses until the stream is complete
+        $stream = $libraryServiceClient->streamBooks($name);
+        foreach ($stream->readAll() as $responseItem) {
+            printf("%s" . PHP_EOL, print_r($responseItem, true));
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END lovelace_core]
+}
+// [END lovelace]
+
+sampleStreamBooks();
+============== file: samples/V1/monolog_about_book_request_streaming_client_async_prog.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "prog")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Testing calling forms */
+function sampleMonologAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+
+    try {
+        // Write data as it becomes available, then wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->monologAboutBook();
+        foreach ($requests as $request) {
+            $stream->write($request);
+        }
+        $response = $stream->readResponse();
+        printf("The stage of the comment is: %s" . PHP_EOL, Comment_Stage::name($response->getStage()));
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleMonologAboutBook();
+============== file: samples/V1/monolog_about_book_request_streaming_client_prog.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "prog")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Testing calling forms */
+function sampleMonologAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+
+    try {
+        // Write data to server and wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->monologAboutBook();
+        $response = $stream->writeAllAndReadResponse($requests);
+        printf("The stage of the comment is: %s" . PHP_EOL, Comment_Stage::name($response->getStage()));
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleMonologAboutBook();
+============== file: samples/V1/publish_series_request_pi_version.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
+ */
+
+// [START canonical]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Book;
+use Google\Example\Library\V1\SeriesUuid;
+use Google\Example\Library\V1\Shelf;
+
+/**
+ * Testing <&#64;calling forms>
+ *
+ * @param string $shelfName The name of the shelf where books are published to.
+ * @param int $edition The edition of the series.
+ */
+function samplePublishSeries($shelfName, $edition)
+{
+    // [START canonical_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelfName = 'Math';
+    // $edition = 123;
+    $shelf = new Shelf();
+    $shelf->setName($shelfName);
+    $books = [];
+    $seriesString = 'xyz3141592654';
+    $seriesUuid = new SeriesUuid();
+    $seriesUuid->setSeriesString($seriesString);
+
+    try {
+        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
+        // % % % output handling % % % %
+        // fourScoreAndSevenYears ago
+        //
+        // our fathers brought forth upon this continent
+        //
+        // a new nation
+        // conceived in liberty
+        //
+        // and dedicated to the proposition that allMenAreCreatedEqual.
+        //
+        // Do something with bookNames one by one
+        $bookNames = $response->getBookNames();
+        foreach ($response->getBookNames() as $title) {
+            // Now we deal with thisSingleBook!
+            printf("\t%%`` The book's title: \"%s\", \\\nand the book costs $50.00 ``%%" . PHP_EOL, $title);
+        }
+        printf("The first book is: %s" . PHP_EOL, $response->getBookNames()[0]);
+        printf("The author of the first book is: %s" . PHP_EOL, $response->getBooks()[0]->getAuthor());
+        printf("That's all!" . PHP_EOL);
+        printf("series_uuid: %s" . PHP_EOL, $response->getSeriesUuid()->getSeriesBytes());
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END canonical_core]
+}
+// [END canonical]
+
+$opts = [
+    'shelf_name::',
+    'edition::',
+];
+
+$defaultOptions = [
+    'shelf_name' => 'Math',
+    'edition' => 123,
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelfName = $options['shelf_name'];
+$edition = $options['edition'];
+
+samplePublishSeries($shelfName, $edition);
+============== file: samples/V1/publish_series_request_second_edition.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
+ */
+
+// [START canonical]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Book;
+use Google\Example\Library\V1\SeriesUuid;
+use Google\Example\Library\V1\Shelf;
+
+/** Testing calling forms */
+function samplePublishSeries()
+{
+    // [START canonical_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $shelf = new Shelf();
+    $books = [];
+    $seriesUuid = new SeriesUuid();
+    $edition = 2;
+
+    try {
+        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
+        printf("%s" . PHP_EOL, print_r($response, true));
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END canonical_core]
+}
+// [END canonical]
+
+samplePublishSeries();
+============== file: samples/V1/publish_series_request_test_request_object_field_comments.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_request_object_field_comments")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Book;
+use Google\Example\Library\V1\SeriesUuid;
+use Google\Example\Library\V1\Shelf;
+
+/** Test request object field comments */
+function samplePublishSeries()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+
+    // Comment on a resource name
+    $formattedName = $libraryServiceClient->shelfName('math');
+
+    // A super long comment
+    // wraps words at newline characters
+    // as well
+    $theme = 'Math';
+
+    // Comment on a primitive field
+    $internalTheme = 'Statistics';
+    $shelf = new Shelf();
+    $shelf->setName($formattedName);
+    $shelf->setTheme($theme);
+    $shelf->setInternalTheme($internalTheme);
+    $books = [];
+
+    // Comment on a file input field
+    $seriesBytes = file_get_contents('xyz3141592654');
+
+    // Comment on a message
+    $seriesUuid = new SeriesUuid();
+    $seriesUuid->setSeriesBytes($seriesBytes);
+
+    // A super long long long long long long long long long long long long long long comment that tests
+    // word wrapping
+    $edition = 123;
+
+    try {
+        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
+        printf("%s" . PHP_EOL, print_r($response, true));
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+samplePublishSeries();
+============== file: samples/V1/publish_series_request_test_write_to_file.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_write_to_file")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Book;
+use Google\Example\Library\V1\SeriesUuid;
+use Google\Example\Library\V1\Shelf;
+
+/** Testing write fields to files. */
+function samplePublishSeries()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $shelf = new Shelf();
+    $books = [];
+    $seriesUuid = new SeriesUuid();
+
+    try {
+        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
+        // testing writing bytes field.
+        file_put_contents(sprintf('uuid_of_series_with_book_%s.raw', $response->getBookNames()[0]), $response->getSeriesUuid()->getSeriesBytes());
+        // testing writing string field.
+        file_put_contents('series_uuid_in_plain_text.txt', $response->getSeriesUuid()->getSeriesString());
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+samplePublishSeries();
+============== file: samples/V1/sample_get_shelf.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_default_calling_form_unary")
+ */
+
+// [START sample_get_shelf]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test default calling forms for unary methods. */
+function sampleGetShelf()
+{
+    // [START sample_get_shelf_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->shelfName('my-shelf');
+    $options = '';
+
+    try {
+        $response = $libraryServiceClient->getShelf($formattedName, $options);
+        printf("The theme of the shelf is: %s" . PHP_EOL, $response->getTheme());
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_get_shelf_core]
+}
+// [END sample_get_shelf]
+
+sampleGetShelf();
+============== file: samples/V1/stream_shelves_request_streaming_server_empty.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "empty")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleStreamShelves()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+
+    try {
+        // Read all responses until the stream is complete
+        $stream = $libraryServiceClient->streamShelves($formattedName);
+        foreach ($stream->readAll() as $responseItem) {
+            printf("%s" . PHP_EOL, print_r($responseItem, true));
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleStreamShelves();
+============== file: samples/V1/test_default_calling_form_for_paging.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestPagedAll",  "test_default_calling_form_paging")
+ */
+
+// [START test_default_calling_form_for_paging]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test default calling form for paging methods. */
+function sampleListShelves()
+{
+    // [START test_default_calling_form_for_paging_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    try {
+        // Iterate through all elements
+        $pagedResponse = $libraryServiceClient->listShelves();
+        foreach ($pagedResponse->iterateAllElements() as $responseItem) {
+            printf("shelf name: %s" . PHP_EOL, print_r($responseItem, true));
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END test_default_calling_form_for_paging_core]
+}
+// [END test_default_calling_form_for_paging]
+
+sampleListShelves();
+============== file: samples/V1/this_tag_should_be_the_name_of_the_file.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap")
+ */
+
+// [START this_tag_should_be_the_name_of_the_file]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleGetBigBook($shelf)
+{
+    // [START this_tag_should_be_the_name_of_the_file_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
+
+    try {
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            $response = $operationResponse->getResult();
+            // Testing iterating over map fields when both key and value are specified.
+            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
+                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
+            }
+
+            // Testing iterating over map fields when only key is specified.
+            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
+                printf("key: %s" . PHP_EOL, $anotherKey);
+            }
+
+            // Testing iterating over map fields when only value is specified.
+            foreach ($response->getMapListValueValue() as $anotherValue) {
+                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
+            }
+
+            printf("name: %s" . PHP_EOL, $response->getName());
+            printf("author: %s" . PHP_EOL, $response->getAuthor());
+        } else {
+            $error = $operationResponse->getError();
+            // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END this_tag_should_be_the_name_of_the_file_core]
+}
+// [END this_tag_should_be_the_name_of_the_file]
+
+$opts = [
+    'shelf::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+
+sampleGetBigBook($shelf);
+============== file: samples/V1/turing_prog_request_streaming_bidi.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingBidi",  "prog")
+ */
+
+// [START turing_prog_request_streaming_bidi]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Comment;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Testing calling forms */
+function sampleDiscussBook($imageFileName)
+{
+    // [START turing_prog_request_streaming_bidi_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $imageFileName = 'image_file.jpg';
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $comment = file_get_contents('comment_file');
+    $comment2 = new Comment();
+    $comment2->setComment($comment);
+    $image = file_get_contents($imageFileName);
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+    $request->setComment($comment2);
+    $request->setImage($image);
+
+    try {
+        // Write all requests to the server, then read all responses until the
+        // stream is complete
+        $requests = [$request];
+        $stream = $libraryServiceClient->discussBook();
+        $stream->writeAll($requests);
+        foreach ($stream->closeWriteAndReadAll() as $responseItem) {
+            printf("%s" . PHP_EOL, print_r($responseItem, true));
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END turing_prog_request_streaming_bidi_core]
+}
+// [END turing_prog_request_streaming_bidi]
+
+$opts = [
+    'image_file_name::',
+];
+
+$defaultOptions = [
+    'image_file_name' => 'image_file.jpg',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$imageFileName = $options['image_file_name'];
+
+sampleDiscussBook($imageFileName);
+============== file: samples/V1/turing_prog_request_streaming_bidi_async.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingBidiAsync",  "prog")
+ */
+
+// [START turing_prog_request_streaming_bidi_async]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Comment;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Testing calling forms */
+function sampleDiscussBook($imageFileName)
+{
+    // [START turing_prog_request_streaming_bidi_async_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $imageFileName = 'image_file.jpg';
+    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $comment = file_get_contents('comment_file');
+    $comment2 = new Comment();
+    $comment2->setComment($comment);
+    $image = file_get_contents($imageFileName);
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+    $request->setComment($comment2);
+    $request->setImage($image);
+
+    try {
+        // Write requests individually, making read() calls if
+        // required. Call closeWrite() once writes are complete, and read the
+        // remaining responses from the server.
+        $requests = [$request];
+        $stream = $libraryServiceClient->discussBook();
+        foreach ($requests as $request) {
+            $stream->write($request);
+            // if required, read a single response from the stream
+            $responseItem = $stream->read();
+            printf("%s" . PHP_EOL, print_r($responseItem, true));
+        }
+        $stream->closeWrite();
+        $responseItem = $stream->read();
+        while (!is_null($responseItem)) {
+            printf("%s" . PHP_EOL, print_r($responseItem, true));
+            $responseItem = $stream->read();
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END turing_prog_request_streaming_bidi_async_core]
+}
+// [END turing_prog_request_streaming_bidi_async]
+
+$opts = [
+    'image_file_name::',
+];
+
+$defaultOptions = [
+    'image_file_name' => 'image_file.jpg',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$imageFileName = $options['image_file_name'];
+
+sampleDiscussBook($imageFileName);
 ============== file: src/V1/Gapic/LibraryServiceGapicClient.php ==============
 <?php
 /*
@@ -3437,1898 +5329,6 @@ return [
     ]
 ];
 
-============== file: src/V1/samples/babble_about_book/babble_about_book_request_streaming_client_async_empty_response_type_with_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "empty_response_type_with_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Test response handling for methods that return empty */
-function sampleBabbleAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $request = new DiscussBookRequest();
-
-    try {
-        // Write data as it becomes available, then wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->babbleAboutBook();
-        foreach ($requests as $request) {
-            $stream->write($request);
-        }
-        $response = $stream->readResponse();
-        // No one replied
-        printf("No one replied." . PHP_EOL);
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleBabbleAboutBook();
-============== file: src/V1/samples/babble_about_book/babble_about_book_request_streaming_client_async_empty_response_type_without_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "empty_response_type_without_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleBabbleAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $request = new DiscussBookRequest();
-
-    try {
-        // Write data as it becomes available, then wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->babbleAboutBook();
-        foreach ($requests as $request) {
-            $stream->write($request);
-        }
-        $response = $stream->readResponse();
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleBabbleAboutBook();
-============== file: src/V1/samples/babble_about_book/babble_about_book_request_streaming_client_empty_response_type_with_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_with_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Test response handling for methods that return empty */
-function sampleBabbleAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $request = new DiscussBookRequest();
-
-    try {
-        // Write data to server and wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->babbleAboutBook();
-        $response = $stream->writeAllAndReadResponse($requests);
-        // No one replied
-        printf("No one replied." . PHP_EOL);
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleBabbleAboutBook();
-============== file: src/V1/samples/babble_about_book/babble_about_book_request_streaming_client_empty_response_type_without_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_without_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleBabbleAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $request = new DiscussBookRequest();
-
-    try {
-        // Write data to server and wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->babbleAboutBook();
-        $response = $stream->writeAllAndReadResponse($requests);
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleBabbleAboutBook();
-============== file: src/V1/samples/delete_shelf/delete_shelf_request_empty_response_type_with_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_with_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test response handling for methods that return empty */
-function sampleDeleteShelf()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
-
-    try {
-        $libraryServiceClient->deleteShelf($formattedName);
-        // Shelf deleted
-        printf("Shelf deleted." . PHP_EOL);
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleDeleteShelf();
-============== file: src/V1/samples/delete_shelf/delete_shelf_request_empty_response_type_without_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_without_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleDeleteShelf()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
-
-    try {
-        $libraryServiceClient->deleteShelf($formattedName);
-
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleDeleteShelf();
-============== file: src/V1/samples/discuss_book/turing_prog_request_streaming_bidi.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingBidi",  "prog")
- */
-
-// [START turing_prog_request_streaming_bidi]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Comment;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Testing calling forms */
-function sampleDiscussBook($imageFileName)
-{
-    // [START turing_prog_request_streaming_bidi_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $imageFileName = 'image_file.jpg';
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-    $comment = file_get_contents('comment_file');
-    $comment2 = new Comment();
-    $comment2->setComment($comment);
-    $image = file_get_contents($imageFileName);
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-    $request->setComment($comment2);
-    $request->setImage($image);
-
-    try {
-        // Write all requests to the server, then read all responses until the
-        // stream is complete
-        $requests = [$request];
-        $stream = $libraryServiceClient->discussBook();
-        $stream->writeAll($requests);
-        foreach ($stream->closeWriteAndReadAll() as $responseItem) {
-            printf("%s" . PHP_EOL, print_r($responseItem, true));
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END turing_prog_request_streaming_bidi_core]
-}
-// [END turing_prog_request_streaming_bidi]
-
-$opts = [
-    'image_file_name::',
-];
-
-$defaultOptions = [
-    'image_file_name' => 'image_file.jpg',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$imageFileName = $options['image_file_name'];
-
-sampleDiscussBook($imageFileName);
-============== file: src/V1/samples/discuss_book/turing_prog_request_streaming_bidi_async.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingBidiAsync",  "prog")
- */
-
-// [START turing_prog_request_streaming_bidi_async]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Comment;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Testing calling forms */
-function sampleDiscussBook($imageFileName)
-{
-    // [START turing_prog_request_streaming_bidi_async_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $imageFileName = 'image_file.jpg';
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-    $comment = file_get_contents('comment_file');
-    $comment2 = new Comment();
-    $comment2->setComment($comment);
-    $image = file_get_contents($imageFileName);
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-    $request->setComment($comment2);
-    $request->setImage($image);
-
-    try {
-        // Write requests individually, making read() calls if
-        // required. Call closeWrite() once writes are complete, and read the
-        // remaining responses from the server.
-        $requests = [$request];
-        $stream = $libraryServiceClient->discussBook();
-        foreach ($requests as $request) {
-            $stream->write($request);
-            // if required, read a single response from the stream
-            $responseItem = $stream->read();
-            printf("%s" . PHP_EOL, print_r($responseItem, true));
-        }
-        $stream->closeWrite();
-        $responseItem = $stream->read();
-        while (!is_null($responseItem)) {
-            printf("%s" . PHP_EOL, print_r($responseItem, true));
-            $responseItem = $stream->read();
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END turing_prog_request_streaming_bidi_async_core]
-}
-// [END turing_prog_request_streaming_bidi_async]
-
-$opts = [
-    'image_file_name::',
-];
-
-$defaultOptions = [
-    'image_file_name' => 'image_file.jpg',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$imageFileName = $options['image_file_name'];
-
-sampleDiscussBook($imageFileName);
-============== file: src/V1/samples/find_related_books/find_related_books_request_paged_all_odyssey.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestPagedAll",  "odyssey")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleFindRelatedBooks()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $namesElement = 'Odyssey';
-    $names = [$namesElement];
-    $shelvesElement = 'Classics';
-    $shelves = [$shelvesElement];
-
-    try {
-        // Iterate through all elements
-        $pagedResponse = $libraryServiceClient->findRelatedBooks($formattedNames, $formattedShelves);
-        foreach ($pagedResponse->iterateAllElements() as $responseItem) {
-            $book = $responseItem;
-            printf("Here's a related book: %s" . PHP_EOL, $book);
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleFindRelatedBooks();
-============== file: src/V1/samples/find_related_books/find_related_books_request_paged_odyssey.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestPaged",  "odyssey")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleFindRelatedBooks()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $namesElement = 'Odyssey';
-    $names = [$namesElement];
-    $shelvesElement = 'Classics';
-    $shelves = [$shelvesElement];
-
-    try {
-        // Iterate over pages of elements
-        $pagedResponse = $libraryServiceClient->findRelatedBooks($formattedNames, $formattedShelves);
-        foreach ($pagedResponse->iteratePages() as $page) {
-            foreach ($page as $responseItem) {
-                $book = $responseItem;
-                printf("Here's a related book: %s" . PHP_EOL, $book);
-            }
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleFindRelatedBooks();
-============== file: src/V1/samples/get_big_book/get_big_book_long_running_request_async_wap.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
- */
-
-// [START hopper]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleGetBigBook($shelf)
-{
-    // [START hopper_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelf = 'Novel';
-    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
-
-    try {
-        // start the operation, keep the operation name, and resume later
-        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
-        $operationName = $operationResponse->getName();
-        // ... do other work
-        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigBook');
-        while (!$newOperationResponse->isDone()) {
-            // ... do other work
-            $newOperationResponse->reload();
-        }
-        if ($newOperationResponse->operationSucceeded()) {
-            $response = $newOperationResponse->getResult();
-            // Testing iterating over map fields when both key and value are specified.
-            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
-                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
-            }
-
-            // Testing iterating over map fields when only key is specified.
-            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
-                printf("key: %s" . PHP_EOL, $anotherKey);
-            }
-
-            // Testing iterating over map fields when only value is specified.
-            foreach ($response->getMapListValueValue() as $anotherValue) {
-                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
-            }
-
-            printf("name: %s" . PHP_EOL, $response->getName());
-            printf("author: %s" . PHP_EOL, $response->getAuthor());
-        } else {
-          $error = $newOperationResponse->getError();
-          // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END hopper_core]
-}
-// [END hopper]
-
-$opts = [
-    'shelf::',
-];
-
-$defaultOptions = [
-    'shelf' => 'Novel',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelf = $options['shelf'];
-
-sampleGetBigBook($shelf);
-============== file: src/V1/samples/get_big_book/get_big_book_long_running_request_async_wap2.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap2")
- */
-
-// [START hopper]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/**
- * Testing resource name overlap
- *
- * @param string $shelf Test word wrapping for long lines. This is a long comment. The name of the
- * shelf to retrieve the big book from.
- * @param string $bigBookName The name of the book.
- */
-function sampleGetBigBook($shelf, $bigBookName)
-{
-    // [START hopper_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelf = 'Novel';
-    // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookName($shelf, $bigBookName);
-
-    try {
-        // start the operation, keep the operation name, and resume later
-        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
-        $operationName = $operationResponse->getName();
-        // ... do other work
-        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigBook');
-        while (!$newOperationResponse->isDone()) {
-            // ... do other work
-            $newOperationResponse->reload();
-        }
-        if ($newOperationResponse->operationSucceeded()) {
-            $response = $newOperationResponse->getResult();
-            printf("%s" . PHP_EOL, print_r($response, true));
-        } else {
-          $error = $newOperationResponse->getError();
-          // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END hopper_core]
-}
-// [END hopper]
-
-$opts = [
-    'shelf::',
-    'big_book_name::',
-];
-
-$defaultOptions = [
-    'shelf' => 'Novel',
-    'big_book_name' => 'War and Peace',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelf = $options['shelf'];
-$bigBookName = $options['big_book_name'];
-
-sampleGetBigBook($shelf, $bigBookName);
-============== file: src/V1/samples/get_big_book/get_big_book_long_running_request_wap.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap")
- */
-
-// [START hopper]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleGetBigBook($shelf)
-{
-    // [START hopper_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelf = 'Novel';
-    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
-
-    try {
-        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
-        $operationResponse->pollUntilComplete();
-        if ($operationResponse->operationSucceeded()) {
-            $response = $operationResponse->getResult();
-            // Testing iterating over map fields when both key and value are specified.
-            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
-                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
-            }
-
-            // Testing iterating over map fields when only key is specified.
-            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
-                printf("key: %s" . PHP_EOL, $anotherKey);
-            }
-
-            // Testing iterating over map fields when only value is specified.
-            foreach ($response->getMapListValueValue() as $anotherValue) {
-                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
-            }
-
-            printf("name: %s" . PHP_EOL, $response->getName());
-            printf("author: %s" . PHP_EOL, $response->getAuthor());
-        } else {
-            $error = $operationResponse->getError();
-            // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END hopper_core]
-}
-// [END hopper]
-
-$opts = [
-    'shelf::',
-];
-
-$defaultOptions = [
-    'shelf' => 'Novel',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelf = $options['shelf'];
-
-sampleGetBigBook($shelf);
-============== file: src/V1/samples/get_big_book/get_big_book_long_running_request_wap2.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap2")
- */
-
-// [START hopper]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/**
- * Testing resource name overlap
- *
- * @param string $shelf Test word wrapping for long lines. This is a long comment. The name of the
- * shelf to retrieve the big book from.
- * @param string $bigBookName The name of the book.
- */
-function sampleGetBigBook($shelf, $bigBookName)
-{
-    // [START hopper_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelf = 'Novel';
-    // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookName($shelf, $bigBookName);
-
-    try {
-        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
-        $operationResponse->pollUntilComplete();
-        if ($operationResponse->operationSucceeded()) {
-            $response = $operationResponse->getResult();
-            printf("%s" . PHP_EOL, print_r($response, true));
-        } else {
-            $error = $operationResponse->getError();
-            // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END hopper_core]
-}
-// [END hopper]
-
-$opts = [
-    'shelf::',
-    'big_book_name::',
-];
-
-$defaultOptions = [
-    'shelf' => 'Novel',
-    'big_book_name' => 'War and Peace',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelf = $options['shelf'];
-$bigBookName = $options['big_book_name'];
-
-sampleGetBigBook($shelf, $bigBookName);
-============== file: src/V1/samples/get_big_book/this_tag_should_be_the_name_of_the_file.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap")
- */
-
-// [START this_tag_should_be_the_name_of_the_file]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleGetBigBook($shelf)
-{
-    // [START this_tag_should_be_the_name_of_the_file_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelf = 'Novel';
-    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
-
-    try {
-        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
-        $operationResponse->pollUntilComplete();
-        if ($operationResponse->operationSucceeded()) {
-            $response = $operationResponse->getResult();
-            // Testing iterating over map fields when both key and value are specified.
-            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
-                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
-            }
-
-            // Testing iterating over map fields when only key is specified.
-            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
-                printf("key: %s" . PHP_EOL, $anotherKey);
-            }
-
-            // Testing iterating over map fields when only value is specified.
-            foreach ($response->getMapListValueValue() as $anotherValue) {
-                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
-            }
-
-            printf("name: %s" . PHP_EOL, $response->getName());
-            printf("author: %s" . PHP_EOL, $response->getAuthor());
-        } else {
-            $error = $operationResponse->getError();
-            // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END this_tag_should_be_the_name_of_the_file_core]
-}
-// [END this_tag_should_be_the_name_of_the_file]
-
-$opts = [
-    'shelf::',
-];
-
-$defaultOptions = [
-    'shelf' => 'Novel',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelf = $options['shelf'];
-
-sampleGetBigBook($shelf);
-============== file: src/V1/samples/get_big_nothing/get_big_nothing_long_running_request_async_empty_response_type_with_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "empty_response_type_with_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test response handling for methods that return empty */
-function sampleGetBigNothing()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-
-    try {
-        // start the operation, keep the operation name, and resume later
-        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
-        $operationName = $operationResponse->getName();
-        // ... do other work
-        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigNothing');
-        while (!$newOperationResponse->isDone()) {
-            // ... do other work
-            $newOperationResponse->reload();
-        }
-        if ($newOperationResponse->operationSucceeded()) {
-            // operation succeeded and returns no value
-        } else {
-          $error = $newOperationResponse->getError();
-          // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleGetBigNothing();
-============== file: src/V1/samples/get_big_nothing/get_big_nothing_long_running_request_async_empty_response_type_without_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "empty_response_type_without_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleGetBigNothing()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-
-    try {
-        // start the operation, keep the operation name, and resume later
-        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
-        $operationName = $operationResponse->getName();
-        // ... do other work
-        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigNothing');
-        while (!$newOperationResponse->isDone()) {
-            // ... do other work
-            $newOperationResponse->reload();
-        }
-        if ($newOperationResponse->operationSucceeded()) {
-            // operation succeeded and returns no value
-        } else {
-          $error = $newOperationResponse->getError();
-          // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleGetBigNothing();
-============== file: src/V1/samples/get_big_nothing/get_big_nothing_long_running_request_empty_response_type_with_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "empty_response_type_with_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test response handling for methods that return empty */
-function sampleGetBigNothing()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-
-    try {
-        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
-        $operationResponse->pollUntilComplete();
-        if ($operationResponse->operationSucceeded()) {
-            // operation succeeded and returns no value
-        } else {
-            $error = $operationResponse->getError();
-            // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleGetBigNothing();
-============== file: src/V1/samples/get_big_nothing/get_big_nothing_long_running_request_empty_response_type_without_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "empty_response_type_without_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleGetBigNothing()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-
-    try {
-        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
-        $operationResponse->pollUntilComplete();
-        if ($operationResponse->operationSucceeded()) {
-            // operation succeeded and returns no value
-        } else {
-            $error = $operationResponse->getError();
-            // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleGetBigNothing();
-============== file: src/V1/samples/get_book/get_book_request_test_on_success_map.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-function sampleGetBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-
-    try {
-        $response = $libraryServiceClient->getBook($formattedName);
-        $intKeyVal = $response->getMapStringValue()[123];
-        $booleanKeyVal = $response->getMapBoolKey()[true];
-        $mapValueField = $response->getMapMessageValue()['key']->getField();
-        printf("Test printing map fields: %s" . PHP_EOL, print_r($response->getMapListValueValue()['quoted_key'], true));
-        printf("Test printing enum fields of a map value: %s" . PHP_EOL, SomeMessage_Alignment::name($response->getMapMessageValue()['key']->getAlignment()));
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleGetBook();
-============== file: src/V1/samples/get_shelf/sample_get_shelf.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "test_default_calling_form_unary")
- */
-
-// [START sample_get_shelf]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test default calling forms for unary methods. */
-function sampleGetShelf()
-{
-    // [START sample_get_shelf_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->shelfName('my-shelf');
-    $options = '';
-
-    try {
-        $response = $libraryServiceClient->getShelf($formattedName, $options);
-        printf("The theme of the shelf is: %s" . PHP_EOL, $response->getTheme());
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_get_shelf_core]
-}
-// [END sample_get_shelf]
-
-sampleGetShelf();
-============== file: src/V1/samples/list_shelves/test_default_calling_form_for_paging.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestPagedAll",  "test_default_calling_form_paging")
- */
-
-// [START test_default_calling_form_for_paging]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test default calling form for paging methods. */
-function sampleListShelves()
-{
-    // [START test_default_calling_form_for_paging_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    try {
-        // Iterate through all elements
-        $pagedResponse = $libraryServiceClient->listShelves();
-        foreach ($pagedResponse->iterateAllElements() as $responseItem) {
-            printf("shelf name: %s" . PHP_EOL, print_r($responseItem, true));
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END test_default_calling_form_for_paging_core]
-}
-// [END test_default_calling_form_for_paging]
-
-sampleListShelves();
-============== file: src/V1/samples/monolog_about_book/monolog_about_book_request_streaming_client_async_prog.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "prog")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Testing calling forms */
-function sampleMonologAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-
-    try {
-        // Write data as it becomes available, then wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->monologAboutBook();
-        foreach ($requests as $request) {
-            $stream->write($request);
-        }
-        $response = $stream->readResponse();
-        printf("The stage of the comment is: %s" . PHP_EOL, Comment_Stage::name($response->getStage()));
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleMonologAboutBook();
-============== file: src/V1/samples/monolog_about_book/monolog_about_book_request_streaming_client_prog.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "prog")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Testing calling forms */
-function sampleMonologAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-
-    try {
-        // Write data to server and wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->monologAboutBook();
-        $response = $stream->writeAllAndReadResponse($requests);
-        printf("The stage of the comment is: %s" . PHP_EOL, Comment_Stage::name($response->getStage()));
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleMonologAboutBook();
-============== file: src/V1/samples/publish_series/publish_series_request_pi_version.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
- */
-
-// [START canonical]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Book;
-use Google\Example\Library\V1\SeriesUuid;
-use Google\Example\Library\V1\Shelf;
-
-/**
- * Testing <&#64;calling forms>
- *
- * @param string $shelfName The name of the shelf where books are published to.
- * @param int $edition The edition of the series.
- */
-function samplePublishSeries($shelfName, $edition)
-{
-    // [START canonical_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelfName = 'Math';
-    // $edition = 123;
-    $shelf = new Shelf();
-    $shelf->setName($shelfName);
-    $books = [];
-    $seriesString = 'xyz3141592654';
-    $seriesUuid = new SeriesUuid();
-    $seriesUuid->setSeriesString($seriesString);
-
-    try {
-        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
-        // % % % output handling % % % %
-        // fourScoreAndSevenYears ago
-        //
-        // our fathers brought forth upon this continent
-        //
-        // a new nation
-        // conceived in liberty
-        //
-        // and dedicated to the proposition that allMenAreCreatedEqual.
-        //
-        // Do something with bookNames one by one
-        $bookNames = $response->getBookNames();
-        foreach ($response->getBookNames() as $title) {
-            // Now we deal with thisSingleBook!
-            printf("\t%%`` The book's title: \"%s\", \\\nand the book costs $50.00 ``%%" . PHP_EOL, $title);
-        }
-        printf("The first book is: %s" . PHP_EOL, $response->getBookNames()[0]);
-        printf("The author of the first book is: %s" . PHP_EOL, $response->getBooks()[0]->getAuthor());
-        printf("That's all!" . PHP_EOL);
-        printf("series_uuid: %s" . PHP_EOL, $response->getSeriesUuid()->getSeriesBytes());
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END canonical_core]
-}
-// [END canonical]
-
-$opts = [
-    'shelf_name::',
-    'edition::',
-];
-
-$defaultOptions = [
-    'shelf_name' => 'Math',
-    'edition' => 123,
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelfName = $options['shelf_name'];
-$edition = $options['edition'];
-
-samplePublishSeries($shelfName, $edition);
-============== file: src/V1/samples/publish_series/publish_series_request_second_edition.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
- */
-
-// [START canonical]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Book;
-use Google\Example\Library\V1\SeriesUuid;
-use Google\Example\Library\V1\Shelf;
-
-/** Testing calling forms */
-function samplePublishSeries()
-{
-    // [START canonical_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $shelf = new Shelf();
-    $books = [];
-    $seriesUuid = new SeriesUuid();
-    $edition = 2;
-
-    try {
-        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
-        printf("%s" . PHP_EOL, print_r($response, true));
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END canonical_core]
-}
-// [END canonical]
-
-samplePublishSeries();
-============== file: src/V1/samples/publish_series/publish_series_request_test_request_object_field_comments.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "test_request_object_field_comments")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Book;
-use Google\Example\Library\V1\SeriesUuid;
-use Google\Example\Library\V1\Shelf;
-
-/** Test request object field comments */
-function samplePublishSeries()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-
-    // Comment on a resource name
-    $formattedName = $libraryServiceClient->shelfName('math');
-
-    // A super long comment
-    // wraps words at newline characters
-    // as well
-    $theme = 'Math';
-
-    // Comment on a primitive field
-    $internalTheme = 'Statistics';
-    $shelf = new Shelf();
-    $shelf->setName($formattedName);
-    $shelf->setTheme($theme);
-    $shelf->setInternalTheme($internalTheme);
-    $books = [];
-
-    // Comment on a file input field
-    $seriesBytes = file_get_contents('xyz3141592654');
-
-    // Comment on a message
-    $seriesUuid = new SeriesUuid();
-    $seriesUuid->setSeriesBytes($seriesBytes);
-
-    // A super long long long long long long long long long long long long long long comment that tests
-    // word wrapping
-    $edition = 123;
-
-    try {
-        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
-        printf("%s" . PHP_EOL, print_r($response, true));
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-samplePublishSeries();
-============== file: src/V1/samples/publish_series/publish_series_request_test_write_to_file.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "test_write_to_file")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Book;
-use Google\Example\Library\V1\SeriesUuid;
-use Google\Example\Library\V1\Shelf;
-
-/** Testing write fields to files. */
-function samplePublishSeries()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $shelf = new Shelf();
-    $books = [];
-    $seriesUuid = new SeriesUuid();
-
-    try {
-        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
-        // testing writing bytes field.
-        file_put_contents(sprintf('uuid_of_series_with_book_%s.raw', $response->getBookNames()[0]), $response->getSeriesUuid()->getSeriesBytes());
-        // testing writing string field.
-        file_put_contents('series_uuid_in_plain_text.txt', $response->getSeriesUuid()->getSeriesString());
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-samplePublishSeries();
-============== file: src/V1/samples/stream_books/lovelace.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "prog")
- */
-
-// [START lovelace]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleStreamBooks()
-{
-    // [START lovelace_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $name = 'BASIC';
-
-    try {
-        // Read all responses until the stream is complete
-        $stream = $libraryServiceClient->streamBooks($name);
-        foreach ($stream->readAll() as $responseItem) {
-            printf("%s" . PHP_EOL, print_r($responseItem, true));
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END lovelace_core]
-}
-// [END lovelace]
-
-sampleStreamBooks();
-============== file: src/V1/samples/stream_shelves/stream_shelves_request_streaming_server_empty.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "empty")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleStreamShelves()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
-
-    try {
-        // Read all responses until the stream is complete
-        $stream = $libraryServiceClient->streamShelves($formattedName);
-        foreach ($stream->readAll() as $responseItem) {
-            printf("%s" . PHP_EOL, print_r($responseItem, true));
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleStreamShelves();
 ============== file: tests/System/V1/LibraryServiceSmokeTest.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -20,7 +20,7 @@
     "phpunit/phpunit": "^4.8|^5.0"
   }
 }
-============== file: samples/V1/babble_about_book_request_streaming_client_async_empty_response_type_with_response_handling.php ==============
+============== file: samples/V1/BabbleAboutBookRequestStreamingClientAsyncEmptyResponseTypeWithResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -78,7 +78,7 @@ function sampleBabbleAboutBook()
 // [END sample]
 
 sampleBabbleAboutBook();
-============== file: samples/V1/babble_about_book_request_streaming_client_async_empty_response_type_without_response_handling.php ==============
+============== file: samples/V1/BabbleAboutBookRequestStreamingClientAsyncEmptyResponseTypeWithoutResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -134,7 +134,7 @@ function sampleBabbleAboutBook()
 // [END sample]
 
 sampleBabbleAboutBook();
-============== file: samples/V1/babble_about_book_request_streaming_client_empty_response_type_with_response_handling.php ==============
+============== file: samples/V1/BabbleAboutBookRequestStreamingClientEmptyResponseTypeWithResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -189,7 +189,7 @@ function sampleBabbleAboutBook()
 // [END sample]
 
 sampleBabbleAboutBook();
-============== file: samples/V1/babble_about_book_request_streaming_client_empty_response_type_without_response_handling.php ==============
+============== file: samples/V1/BabbleAboutBookRequestStreamingClientEmptyResponseTypeWithoutResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -242,7 +242,7 @@ function sampleBabbleAboutBook()
 // [END sample]
 
 sampleBabbleAboutBook();
-============== file: samples/V1/delete_shelf_request_empty_response_type_with_response_handling.php ==============
+============== file: samples/V1/DeleteShelfRequestEmptyResponseTypeWithResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -291,7 +291,7 @@ function sampleDeleteShelf()
 // [END sample]
 
 sampleDeleteShelf();
-============== file: samples/V1/delete_shelf_request_empty_response_type_without_response_handling.php ==============
+============== file: samples/V1/DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -339,7 +339,7 @@ function sampleDeleteShelf()
 // [END sample]
 
 sampleDeleteShelf();
-============== file: samples/V1/find_related_books_request_paged_all_odyssey.php ==============
+============== file: samples/V1/FindRelatedBooksRequestPagedAllOdyssey.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -394,7 +394,7 @@ function sampleFindRelatedBooks()
 // [END sample]
 
 sampleFindRelatedBooks();
-============== file: samples/V1/find_related_books_request_paged_odyssey.php ==============
+============== file: samples/V1/FindRelatedBooksRequestPagedOdyssey.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -451,7 +451,7 @@ function sampleFindRelatedBooks()
 // [END sample]
 
 sampleFindRelatedBooks();
-============== file: samples/V1/get_big_book_long_running_request_async_wap.php ==============
+============== file: samples/V1/GetBigBookLongRunningRequestAsyncWap.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -543,7 +543,7 @@ $options += $defaultOptions;
 $shelf = $options['shelf'];
 
 sampleGetBigBook($shelf);
-============== file: samples/V1/get_big_book_long_running_request_async_wap2.php ==============
+============== file: samples/V1/GetBigBookLongRunningRequestAsyncWap2.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -629,7 +629,7 @@ $shelf = $options['shelf'];
 $bigBookName = $options['big_book_name'];
 
 sampleGetBigBook($shelf, $bigBookName);
-============== file: samples/V1/get_big_book_long_running_request_wap.php ==============
+============== file: samples/V1/GetBigBookLongRunningRequestWap.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -714,7 +714,7 @@ $options += $defaultOptions;
 $shelf = $options['shelf'];
 
 sampleGetBigBook($shelf);
-============== file: samples/V1/get_big_book_long_running_request_wap2.php ==============
+============== file: samples/V1/GetBigBookLongRunningRequestWap2.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -793,7 +793,7 @@ $shelf = $options['shelf'];
 $bigBookName = $options['big_book_name'];
 
 sampleGetBigBook($shelf, $bigBookName);
-============== file: samples/V1/get_big_nothing_long_running_request_async_empty_response_type_with_response_handling.php ==============
+============== file: samples/V1/GetBigNothingLongRunningRequestAsyncEmptyResponseTypeWithResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -854,7 +854,7 @@ function sampleGetBigNothing()
 // [END sample]
 
 sampleGetBigNothing();
-============== file: samples/V1/get_big_nothing_long_running_request_async_empty_response_type_without_response_handling.php ==============
+============== file: samples/V1/GetBigNothingLongRunningRequestAsyncEmptyResponseTypeWithoutResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -915,7 +915,7 @@ function sampleGetBigNothing()
 // [END sample]
 
 sampleGetBigNothing();
-============== file: samples/V1/get_big_nothing_long_running_request_empty_response_type_with_response_handling.php ==============
+============== file: samples/V1/GetBigNothingLongRunningRequestEmptyResponseTypeWithResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -969,7 +969,7 @@ function sampleGetBigNothing()
 // [END sample]
 
 sampleGetBigNothing();
-============== file: samples/V1/get_big_nothing_long_running_request_empty_response_type_without_response_handling.php ==============
+============== file: samples/V1/GetBigNothingLongRunningRequestEmptyResponseTypeWithoutResponseHandling.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1023,7 +1023,7 @@ function sampleGetBigNothing()
 // [END sample]
 
 sampleGetBigNothing();
-============== file: samples/V1/get_book_request_test_on_success_map.php ==============
+============== file: samples/V1/GetBookRequestTestOnSuccessMap.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1074,7 +1074,7 @@ function sampleGetBook()
 // [END sample]
 
 sampleGetBook();
-============== file: samples/V1/lovelace.php ==============
+============== file: samples/V1/Lovelace.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1125,7 +1125,7 @@ function sampleStreamBooks()
 // [END lovelace]
 
 sampleStreamBooks();
-============== file: samples/V1/monolog_about_book_request_streaming_client_async_prog.php ==============
+============== file: samples/V1/MonologAboutBookRequestStreamingClientAsyncProg.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1182,7 +1182,7 @@ function sampleMonologAboutBook()
 // [END sample]
 
 sampleMonologAboutBook();
-============== file: samples/V1/monolog_about_book_request_streaming_client_prog.php ==============
+============== file: samples/V1/MonologAboutBookRequestStreamingClientProg.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1236,7 +1236,7 @@ function sampleMonologAboutBook()
 // [END sample]
 
 sampleMonologAboutBook();
-============== file: samples/V1/publish_series_request_pi_version.php ==============
+============== file: samples/V1/PublishSeriesRequestPiVersion.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1334,7 +1334,7 @@ $shelfName = $options['shelf_name'];
 $edition = $options['edition'];
 
 samplePublishSeries($shelfName, $edition);
-============== file: samples/V1/publish_series_request_second_edition.php ==============
+============== file: samples/V1/PublishSeriesRequestSecondEdition.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1388,7 +1388,7 @@ function samplePublishSeries()
 // [END canonical]
 
 samplePublishSeries();
-============== file: samples/V1/publish_series_request_test_request_object_field_comments.php ==============
+============== file: samples/V1/PublishSeriesRequestTestRequestObjectFieldComments.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1465,7 +1465,7 @@ function samplePublishSeries()
 // [END sample]
 
 samplePublishSeries();
-============== file: samples/V1/publish_series_request_test_write_to_file.php ==============
+============== file: samples/V1/PublishSeriesRequestTestWriteToFile.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1521,7 +1521,7 @@ function samplePublishSeries()
 // [END sample]
 
 samplePublishSeries();
-============== file: samples/V1/sample_get_shelf.php ==============
+============== file: samples/V1/SampleGetShelf.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1570,7 +1570,7 @@ function sampleGetShelf()
 // [END sample_get_shelf]
 
 sampleGetShelf();
-============== file: samples/V1/stream_shelves_request_streaming_server_empty.php ==============
+============== file: samples/V1/StreamShelvesRequestStreamingServerEmpty.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1621,7 +1621,7 @@ function sampleStreamShelves()
 // [END sample]
 
 sampleStreamShelves();
-============== file: samples/V1/test_default_calling_form_for_paging.php ==============
+============== file: samples/V1/TestDefaultCallingFormForPaging.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1670,7 +1670,7 @@ function sampleListShelves()
 // [END test_default_calling_form_for_paging]
 
 sampleListShelves();
-============== file: samples/V1/this_tag_should_be_the_name_of_the_file.php ==============
+============== file: samples/V1/ThisTagShouldBeTheNameOfTheFile.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1755,7 +1755,7 @@ $options += $defaultOptions;
 $shelf = $options['shelf'];
 
 sampleGetBigBook($shelf);
-============== file: samples/V1/turing_prog_request_streaming_bidi.php ==============
+============== file: samples/V1/TuringProgRequestStreamingBidi.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1833,7 +1833,7 @@ $options += $defaultOptions;
 $imageFileName = $options['image_file_name'];
 
 sampleDiscussBook($imageFileName);
-============== file: samples/V1/turing_prog_request_streaming_bidi_async.php ==============
+============== file: samples/V1/TuringProgRequestStreamingBidiAsync.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -20,6 +20,1906 @@
     "phpunit/phpunit": "^4.8|^5.0"
   }
 }
+============== file: samples/V1/babble_about_book_request_streaming_client_async_empty_response_type_with_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "empty_response_type_with_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Test response handling for methods that return empty */
+function sampleBabbleAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+
+    try {
+        // Write data as it becomes available, then wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->babbleAboutBook();
+        foreach ($requests as $request) {
+            $stream->write($request);
+        }
+        $response = $stream->readResponse();
+        // No one replied
+        printf("No one replied." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleBabbleAboutBook();
+============== file: samples/V1/babble_about_book_request_streaming_client_async_empty_response_type_without_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "empty_response_type_without_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleBabbleAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+
+    try {
+        // Write data as it becomes available, then wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->babbleAboutBook();
+        foreach ($requests as $request) {
+            $stream->write($request);
+        }
+        $response = $stream->readResponse();
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleBabbleAboutBook();
+============== file: samples/V1/babble_about_book_request_streaming_client_empty_response_type_with_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_with_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Test response handling for methods that return empty */
+function sampleBabbleAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+
+    try {
+        // Write data to server and wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->babbleAboutBook();
+        $response = $stream->writeAllAndReadResponse($requests);
+        // No one replied
+        printf("No one replied." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleBabbleAboutBook();
+============== file: samples/V1/babble_about_book_request_streaming_client_empty_response_type_without_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_without_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleBabbleAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+
+    try {
+        // Write data to server and wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->babbleAboutBook();
+        $response = $stream->writeAllAndReadResponse($requests);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleBabbleAboutBook();
+============== file: samples/V1/delete_shelf_request_empty_response_type_with_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_with_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test response handling for methods that return empty */
+function sampleDeleteShelf()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+
+    try {
+        $libraryServiceClient->deleteShelf($formattedName);
+        // Shelf deleted
+        printf("Shelf deleted." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleDeleteShelf();
+============== file: samples/V1/delete_shelf_request_empty_response_type_without_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_without_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleDeleteShelf()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+
+    try {
+        $libraryServiceClient->deleteShelf($formattedName);
+
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleDeleteShelf();
+============== file: samples/V1/find_related_books_request_paged_all_odyssey.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestPagedAll",  "odyssey")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleFindRelatedBooks()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $namesElement = 'Odyssey';
+    $names = [$namesElement];
+    $shelvesElement = 'Classics';
+    $shelves = [$shelvesElement];
+
+    try {
+        // Iterate through all elements
+        $pagedResponse = $libraryServiceClient->findRelatedBooks($formattedNames, $formattedShelves);
+        foreach ($pagedResponse->iterateAllElements() as $responseItem) {
+            $book = $responseItem;
+            printf("Here's a related book: %s" . PHP_EOL, $book);
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleFindRelatedBooks();
+============== file: samples/V1/find_related_books_request_paged_odyssey.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestPaged",  "odyssey")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleFindRelatedBooks()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $namesElement = 'Odyssey';
+    $names = [$namesElement];
+    $shelvesElement = 'Classics';
+    $shelves = [$shelvesElement];
+
+    try {
+        // Iterate over pages of elements
+        $pagedResponse = $libraryServiceClient->findRelatedBooks($formattedNames, $formattedShelves);
+        foreach ($pagedResponse->iteratePages() as $page) {
+            foreach ($page as $responseItem) {
+                $book = $responseItem;
+                printf("Here's a related book: %s" . PHP_EOL, $book);
+            }
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleFindRelatedBooks();
+============== file: samples/V1/get_big_book_long_running_request_async_wap.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
+ */
+
+// [START hopper]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleGetBigBook($shelf)
+{
+    // [START hopper_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        // start the operation, keep the operation name, and resume later
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationName = $operationResponse->getName();
+        // ... do other work
+        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigBook');
+        while (!$newOperationResponse->isDone()) {
+            // ... do other work
+            $newOperationResponse->reload();
+        }
+        if ($newOperationResponse->operationSucceeded()) {
+            $response = $newOperationResponse->getResult();
+            // Testing iterating over map fields when both key and value are specified.
+            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
+                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
+            }
+
+            // Testing iterating over map fields when only key is specified.
+            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
+                printf("key: %s" . PHP_EOL, $anotherKey);
+            }
+
+            // Testing iterating over map fields when only value is specified.
+            foreach ($response->getMapListValueValue() as $anotherValue) {
+                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
+            }
+
+            printf("name: %s" . PHP_EOL, $response->getName());
+            printf("author: %s" . PHP_EOL, $response->getAuthor());
+        } else {
+          $error = $newOperationResponse->getError();
+          // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END hopper_core]
+}
+// [END hopper]
+
+$opts = [
+    'shelf::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+
+sampleGetBigBook($shelf);
+============== file: samples/V1/get_big_book_long_running_request_async_wap2.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap2")
+ */
+
+// [START hopper]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/**
+ * Testing resource name overlap
+ *
+ * @param string $shelf Test word wrapping for long lines. This is a long comment. The name of the
+ * shelf to retrieve the big book from.
+ * @param string $bigBookName The name of the book.
+ */
+function sampleGetBigBook($shelf, $bigBookName)
+{
+    // [START hopper_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    // $bigBookName = 'War and Peace';
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        // start the operation, keep the operation name, and resume later
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationName = $operationResponse->getName();
+        // ... do other work
+        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigBook');
+        while (!$newOperationResponse->isDone()) {
+            // ... do other work
+            $newOperationResponse->reload();
+        }
+        if ($newOperationResponse->operationSucceeded()) {
+            $response = $newOperationResponse->getResult();
+            printf("%s" . PHP_EOL, print_r($response, true));
+        } else {
+          $error = $newOperationResponse->getError();
+          // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END hopper_core]
+}
+// [END hopper]
+
+$opts = [
+    'shelf::',
+    'big_book_name::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+    'big_book_name' => 'War and Peace',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+$bigBookName = $options['big_book_name'];
+
+sampleGetBigBook($shelf, $bigBookName);
+============== file: samples/V1/get_big_book_long_running_request_wap.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap")
+ */
+
+// [START hopper]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleGetBigBook($shelf)
+{
+    // [START hopper_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            $response = $operationResponse->getResult();
+            // Testing iterating over map fields when both key and value are specified.
+            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
+                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
+            }
+
+            // Testing iterating over map fields when only key is specified.
+            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
+                printf("key: %s" . PHP_EOL, $anotherKey);
+            }
+
+            // Testing iterating over map fields when only value is specified.
+            foreach ($response->getMapListValueValue() as $anotherValue) {
+                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
+            }
+
+            printf("name: %s" . PHP_EOL, $response->getName());
+            printf("author: %s" . PHP_EOL, $response->getAuthor());
+        } else {
+            $error = $operationResponse->getError();
+            // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END hopper_core]
+}
+// [END hopper]
+
+$opts = [
+    'shelf::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+
+sampleGetBigBook($shelf);
+============== file: samples/V1/get_big_book_long_running_request_wap2.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap2")
+ */
+
+// [START hopper]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/**
+ * Testing resource name overlap
+ *
+ * @param string $shelf Test word wrapping for long lines. This is a long comment. The name of the
+ * shelf to retrieve the big book from.
+ * @param string $bigBookName The name of the book.
+ */
+function sampleGetBigBook($shelf, $bigBookName)
+{
+    // [START hopper_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    // $bigBookName = 'War and Peace';
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            $response = $operationResponse->getResult();
+            printf("%s" . PHP_EOL, print_r($response, true));
+        } else {
+            $error = $operationResponse->getError();
+            // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END hopper_core]
+}
+// [END hopper]
+
+$opts = [
+    'shelf::',
+    'big_book_name::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+    'big_book_name' => 'War and Peace',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+$bigBookName = $options['big_book_name'];
+
+sampleGetBigBook($shelf, $bigBookName);
+============== file: samples/V1/get_big_nothing_long_running_request_async_empty_response_type_with_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "empty_response_type_with_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test response handling for methods that return empty */
+function sampleGetBigNothing()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        // start the operation, keep the operation name, and resume later
+        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
+        $operationName = $operationResponse->getName();
+        // ... do other work
+        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigNothing');
+        while (!$newOperationResponse->isDone()) {
+            // ... do other work
+            $newOperationResponse->reload();
+        }
+        if ($newOperationResponse->operationSucceeded()) {
+            // operation succeeded and returns no value
+        } else {
+          $error = $newOperationResponse->getError();
+          // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleGetBigNothing();
+============== file: samples/V1/get_big_nothing_long_running_request_async_empty_response_type_without_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "empty_response_type_without_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleGetBigNothing()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        // start the operation, keep the operation name, and resume later
+        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
+        $operationName = $operationResponse->getName();
+        // ... do other work
+        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigNothing');
+        while (!$newOperationResponse->isDone()) {
+            // ... do other work
+            $newOperationResponse->reload();
+        }
+        if ($newOperationResponse->operationSucceeded()) {
+            // operation succeeded and returns no value
+        } else {
+          $error = $newOperationResponse->getError();
+          // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleGetBigNothing();
+============== file: samples/V1/get_big_nothing_long_running_request_empty_response_type_with_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "empty_response_type_with_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test response handling for methods that return empty */
+function sampleGetBigNothing()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            // operation succeeded and returns no value
+        } else {
+            $error = $operationResponse->getError();
+            // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleGetBigNothing();
+============== file: samples/V1/get_big_nothing_long_running_request_empty_response_type_without_response_handling.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "empty_response_type_without_response_handling")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test default response handling is turned off for methods that return empty */
+function sampleGetBigNothing()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            // operation succeeded and returns no value
+        } else {
+            $error = $operationResponse->getError();
+            // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleGetBigNothing();
+============== file: samples/V1/get_book_request_test_on_success_map.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+function sampleGetBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        $response = $libraryServiceClient->getBook($formattedName);
+        $intKeyVal = $response->getMapStringValue()[123];
+        $booleanKeyVal = $response->getMapBoolKey()[true];
+        $mapValueField = $response->getMapMessageValue()['key']->getField();
+        printf("Test printing map fields: %s" . PHP_EOL, print_r($response->getMapListValueValue()['quoted_key'], true));
+        printf("Test printing enum fields of a map value: %s" . PHP_EOL, SomeMessage_Alignment::name($response->getMapMessageValue()['key']->getAlignment()));
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleGetBook();
+============== file: samples/V1/lovelace.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "prog")
+ */
+
+// [START lovelace]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleStreamBooks()
+{
+    // [START lovelace_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $name = 'BASIC';
+
+    try {
+        // Read all responses until the stream is complete
+        $stream = $libraryServiceClient->streamBooks($name);
+        foreach ($stream->readAll() as $responseItem) {
+            printf("%s" . PHP_EOL, print_r($responseItem, true));
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END lovelace_core]
+}
+// [END lovelace]
+
+sampleStreamBooks();
+============== file: samples/V1/monolog_about_book_request_streaming_client_async_prog.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "prog")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Testing calling forms */
+function sampleMonologAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+
+    try {
+        // Write data as it becomes available, then wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->monologAboutBook();
+        foreach ($requests as $request) {
+            $stream->write($request);
+        }
+        $response = $stream->readResponse();
+        printf("The stage of the comment is: %s" . PHP_EOL, Comment_Stage::name($response->getStage()));
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleMonologAboutBook();
+============== file: samples/V1/monolog_about_book_request_streaming_client_prog.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "prog")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Testing calling forms */
+function sampleMonologAboutBook()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+
+    try {
+        // Write data to server and wait for a response
+        $requests = [$request];
+        $stream = $libraryServiceClient->monologAboutBook();
+        $response = $stream->writeAllAndReadResponse($requests);
+        printf("The stage of the comment is: %s" . PHP_EOL, Comment_Stage::name($response->getStage()));
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleMonologAboutBook();
+============== file: samples/V1/publish_series_request_pi_version.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
+ */
+
+// [START canonical]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Book;
+use Google\Example\Library\V1\SeriesUuid;
+use Google\Example\Library\V1\Shelf;
+
+/**
+ * Testing <&#64;calling forms>
+ *
+ * @param string $shelfName The name of the shelf where books are published to.
+ * @param int $edition The edition of the series.
+ */
+function samplePublishSeries($shelfName, $edition)
+{
+    // [START canonical_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelfName = 'Math';
+    // $edition = 123;
+    $shelf = new Shelf();
+    $shelf->setName($shelfName);
+    $books = [];
+    $seriesString = 'xyz3141592654';
+    $seriesUuid = new SeriesUuid();
+    $seriesUuid->setSeriesString($seriesString);
+
+    try {
+        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
+        // % % % output handling % % % %
+        // fourScoreAndSevenYears ago
+        //
+        // our fathers brought forth upon this continent
+        //
+        // a new nation
+        // conceived in liberty
+        //
+        // and dedicated to the proposition that allMenAreCreatedEqual.
+        //
+        // Do something with bookNames one by one
+        $bookNames = $response->getBookNames();
+        foreach ($response->getBookNames() as $title) {
+            // Now we deal with thisSingleBook!
+            printf("\t%%`` The book's title: \"%s\", \\\nand the book costs $50.00 ``%%" . PHP_EOL, $title);
+        }
+        printf("The first book is: %s" . PHP_EOL, $response->getBookNames()[0]);
+        printf("The author of the first book is: %s" . PHP_EOL, $response->getBooks()[0]->getAuthor());
+        printf("That's all!" . PHP_EOL);
+        printf("series_uuid: %s" . PHP_EOL, $response->getSeriesUuid()->getSeriesBytes());
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END canonical_core]
+}
+// [END canonical]
+
+$opts = [
+    'shelf_name::',
+    'edition::',
+];
+
+$defaultOptions = [
+    'shelf_name' => 'Math',
+    'edition' => 123,
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelfName = $options['shelf_name'];
+$edition = $options['edition'];
+
+samplePublishSeries($shelfName, $edition);
+============== file: samples/V1/publish_series_request_second_edition.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
+ */
+
+// [START canonical]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Book;
+use Google\Example\Library\V1\SeriesUuid;
+use Google\Example\Library\V1\Shelf;
+
+/** Testing calling forms */
+function samplePublishSeries()
+{
+    // [START canonical_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $shelf = new Shelf();
+    $books = [];
+    $seriesUuid = new SeriesUuid();
+    $edition = 2;
+
+    try {
+        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
+        printf("%s" . PHP_EOL, print_r($response, true));
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END canonical_core]
+}
+// [END canonical]
+
+samplePublishSeries();
+============== file: samples/V1/publish_series_request_test_request_object_field_comments.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_request_object_field_comments")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Book;
+use Google\Example\Library\V1\SeriesUuid;
+use Google\Example\Library\V1\Shelf;
+
+/** Test request object field comments */
+function samplePublishSeries()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+
+    // Comment on a resource name
+    $formattedName = $libraryServiceClient->shelfName('math');
+
+    // A super long comment
+    // wraps words at newline characters
+    // as well
+    $theme = 'Math';
+
+    // Comment on a primitive field
+    $internalTheme = 'Statistics';
+    $shelf = new Shelf();
+    $shelf->setName($formattedName);
+    $shelf->setTheme($theme);
+    $shelf->setInternalTheme($internalTheme);
+    $books = [];
+
+    // Comment on a file input field
+    $seriesBytes = file_get_contents('xyz3141592654');
+
+    // Comment on a message
+    $seriesUuid = new SeriesUuid();
+    $seriesUuid->setSeriesBytes($seriesBytes);
+
+    // A super long long long long long long long long long long long long long long comment that tests
+    // word wrapping
+    $edition = 123;
+
+    try {
+        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
+        printf("%s" . PHP_EOL, print_r($response, true));
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+samplePublishSeries();
+============== file: samples/V1/publish_series_request_test_write_to_file.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_write_to_file")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Book;
+use Google\Example\Library\V1\SeriesUuid;
+use Google\Example\Library\V1\Shelf;
+
+/** Testing write fields to files. */
+function samplePublishSeries()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $shelf = new Shelf();
+    $books = [];
+    $seriesUuid = new SeriesUuid();
+
+    try {
+        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
+        // testing writing bytes field.
+        file_put_contents(sprintf('uuid_of_series_with_book_%s.raw', $response->getBookNames()[0]), $response->getSeriesUuid()->getSeriesBytes());
+        // testing writing string field.
+        file_put_contents('series_uuid_in_plain_text.txt', $response->getSeriesUuid()->getSeriesString());
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+samplePublishSeries();
+============== file: samples/V1/sample_get_shelf.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_default_calling_form_unary")
+ */
+
+// [START sample_get_shelf]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test default calling forms for unary methods. */
+function sampleGetShelf()
+{
+    // [START sample_get_shelf_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->shelfName('my-shelf');
+    $options = '';
+
+    try {
+        $response = $libraryServiceClient->getShelf($formattedName, $options);
+        printf("The theme of the shelf is: %s" . PHP_EOL, $response->getTheme());
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_get_shelf_core]
+}
+// [END sample_get_shelf]
+
+sampleGetShelf();
+============== file: samples/V1/stream_shelves_request_streaming_server_empty.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "empty")
+ */
+
+// [START sample]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleStreamShelves()
+{
+    // [START sample_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+
+    try {
+        // Read all responses until the stream is complete
+        $stream = $libraryServiceClient->streamShelves($formattedName);
+        foreach ($stream->readAll() as $responseItem) {
+            printf("%s" . PHP_EOL, print_r($responseItem, true));
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END sample_core]
+}
+// [END sample]
+
+sampleStreamShelves();
+============== file: samples/V1/test_default_calling_form_for_paging.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestPagedAll",  "test_default_calling_form_paging")
+ */
+
+// [START test_default_calling_form_for_paging]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Test default calling form for paging methods. */
+function sampleListShelves()
+{
+    // [START test_default_calling_form_for_paging_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    try {
+        // Iterate through all elements
+        $pagedResponse = $libraryServiceClient->listShelves();
+        foreach ($pagedResponse->iterateAllElements() as $responseItem) {
+            printf("shelf name: %s" . PHP_EOL, print_r($responseItem, true));
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END test_default_calling_form_for_paging_core]
+}
+// [END test_default_calling_form_for_paging]
+
+sampleListShelves();
+============== file: samples/V1/this_tag_should_be_the_name_of_the_file.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap")
+ */
+
+// [START this_tag_should_be_the_name_of_the_file]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Testing calling forms */
+function sampleGetBigBook($shelf)
+{
+    // [START this_tag_should_be_the_name_of_the_file_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $shelf = 'Novel';
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
+        $operationResponse->pollUntilComplete();
+        if ($operationResponse->operationSucceeded()) {
+            $response = $operationResponse->getResult();
+            // Testing iterating over map fields when both key and value are specified.
+            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
+                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
+            }
+
+            // Testing iterating over map fields when only key is specified.
+            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
+                printf("key: %s" . PHP_EOL, $anotherKey);
+            }
+
+            // Testing iterating over map fields when only value is specified.
+            foreach ($response->getMapListValueValue() as $anotherValue) {
+                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
+            }
+
+            printf("name: %s" . PHP_EOL, $response->getName());
+            printf("author: %s" . PHP_EOL, $response->getAuthor());
+        } else {
+            $error = $operationResponse->getError();
+            // handleError($error)
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END this_tag_should_be_the_name_of_the_file_core]
+}
+// [END this_tag_should_be_the_name_of_the_file]
+
+$opts = [
+    'shelf::',
+];
+
+$defaultOptions = [
+    'shelf' => 'Novel',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$shelf = $options['shelf'];
+
+sampleGetBigBook($shelf);
+============== file: samples/V1/turing_prog_request_streaming_bidi.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingBidi",  "prog")
+ */
+
+// [START turing_prog_request_streaming_bidi]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Comment;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Testing calling forms */
+function sampleDiscussBook($imageFileName)
+{
+    // [START turing_prog_request_streaming_bidi_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $imageFileName = 'image_file.jpg';
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $comment = file_get_contents('comment_file');
+    $comment2 = new Comment();
+    $comment2->setComment($comment);
+    $image = file_get_contents($imageFileName);
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+    $request->setComment($comment2);
+    $request->setImage($image);
+
+    try {
+        // Write all requests to the server, then read all responses until the
+        // stream is complete
+        $requests = [$request];
+        $stream = $libraryServiceClient->discussBook();
+        $stream->writeAll($requests);
+        foreach ($stream->closeWriteAndReadAll() as $responseItem) {
+            printf("%s" . PHP_EOL, print_r($responseItem, true));
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END turing_prog_request_streaming_bidi_core]
+}
+// [END turing_prog_request_streaming_bidi]
+
+$opts = [
+    'image_file_name::',
+];
+
+$defaultOptions = [
+    'image_file_name' => 'image_file.jpg',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$imageFileName = $options['image_file_name'];
+
+sampleDiscussBook($imageFileName);
+============== file: samples/V1/turing_prog_request_streaming_bidi_async.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("RequestStreamingBidiAsync",  "prog")
+ */
+
+// [START turing_prog_request_streaming_bidi_async]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\Comment;
+use Google\Example\Library\V1\DiscussBookRequest;
+
+/** Testing calling forms */
+function sampleDiscussBook($imageFileName)
+{
+    // [START turing_prog_request_streaming_bidi_async_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $imageFileName = 'image_file.jpg';
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $comment = file_get_contents('comment_file');
+    $comment2 = new Comment();
+    $comment2->setComment($comment);
+    $image = file_get_contents($imageFileName);
+    $request = new DiscussBookRequest();
+    $request->setName($formattedName);
+    $request->setComment($comment2);
+    $request->setImage($image);
+
+    try {
+        // Write requests individually, making read() calls if
+        // required. Call closeWrite() once writes are complete, and read the
+        // remaining responses from the server.
+        $requests = [$request];
+        $stream = $libraryServiceClient->discussBook();
+        foreach ($requests as $request) {
+            $stream->write($request);
+            // if required, read a single response from the stream
+            $responseItem = $stream->read();
+            printf("%s" . PHP_EOL, print_r($responseItem, true));
+        }
+        $stream->closeWrite();
+        $responseItem = $stream->read();
+        while (!is_null($responseItem)) {
+            printf("%s" . PHP_EOL, print_r($responseItem, true));
+            $responseItem = $stream->read();
+        }
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END turing_prog_request_streaming_bidi_async_core]
+}
+// [END turing_prog_request_streaming_bidi_async]
+
+$opts = [
+    'image_file_name::',
+];
+
+$defaultOptions = [
+    'image_file_name' => 'image_file.jpg',
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$imageFileName = $options['image_file_name'];
+
+sampleDiscussBook($imageFileName);
 ============== file: src/V1/Gapic/LibraryServiceGapicClient.php ==============
 <?php
 /*
@@ -3361,1906 +5261,6 @@ return [
     ]
 ];
 
-============== file: src/V1/samples/babble_about_book/babble_about_book_request_streaming_client_async_empty_response_type_with_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "empty_response_type_with_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Test response handling for methods that return empty */
-function sampleBabbleAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-
-    try {
-        // Write data as it becomes available, then wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->babbleAboutBook();
-        foreach ($requests as $request) {
-            $stream->write($request);
-        }
-        $response = $stream->readResponse();
-        // No one replied
-        printf("No one replied." . PHP_EOL);
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleBabbleAboutBook();
-============== file: src/V1/samples/babble_about_book/babble_about_book_request_streaming_client_async_empty_response_type_without_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "empty_response_type_without_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleBabbleAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-
-    try {
-        // Write data as it becomes available, then wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->babbleAboutBook();
-        foreach ($requests as $request) {
-            $stream->write($request);
-        }
-        $response = $stream->readResponse();
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleBabbleAboutBook();
-============== file: src/V1/samples/babble_about_book/babble_about_book_request_streaming_client_empty_response_type_with_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_with_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Test response handling for methods that return empty */
-function sampleBabbleAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-
-    try {
-        // Write data to server and wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->babbleAboutBook();
-        $response = $stream->writeAllAndReadResponse($requests);
-        // No one replied
-        printf("No one replied." . PHP_EOL);
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleBabbleAboutBook();
-============== file: src/V1/samples/babble_about_book/babble_about_book_request_streaming_client_empty_response_type_without_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "empty_response_type_without_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleBabbleAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-
-    try {
-        // Write data to server and wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->babbleAboutBook();
-        $response = $stream->writeAllAndReadResponse($requests);
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleBabbleAboutBook();
-============== file: src/V1/samples/delete_shelf/delete_shelf_request_empty_response_type_with_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_with_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test response handling for methods that return empty */
-function sampleDeleteShelf()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
-
-    try {
-        $libraryServiceClient->deleteShelf($formattedName);
-        // Shelf deleted
-        printf("Shelf deleted." . PHP_EOL);
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleDeleteShelf();
-============== file: src/V1/samples/delete_shelf/delete_shelf_request_empty_response_type_without_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "empty_response_type_without_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleDeleteShelf()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
-
-    try {
-        $libraryServiceClient->deleteShelf($formattedName);
-
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleDeleteShelf();
-============== file: src/V1/samples/discuss_book/turing_prog_request_streaming_bidi.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingBidi",  "prog")
- */
-
-// [START turing_prog_request_streaming_bidi]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Comment;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Testing calling forms */
-function sampleDiscussBook($imageFileName)
-{
-    // [START turing_prog_request_streaming_bidi_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $imageFileName = 'image_file.jpg';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-    $comment = file_get_contents('comment_file');
-    $comment2 = new Comment();
-    $comment2->setComment($comment);
-    $image = file_get_contents($imageFileName);
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-    $request->setComment($comment2);
-    $request->setImage($image);
-
-    try {
-        // Write all requests to the server, then read all responses until the
-        // stream is complete
-        $requests = [$request];
-        $stream = $libraryServiceClient->discussBook();
-        $stream->writeAll($requests);
-        foreach ($stream->closeWriteAndReadAll() as $responseItem) {
-            printf("%s" . PHP_EOL, print_r($responseItem, true));
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END turing_prog_request_streaming_bidi_core]
-}
-// [END turing_prog_request_streaming_bidi]
-
-$opts = [
-    'image_file_name::',
-];
-
-$defaultOptions = [
-    'image_file_name' => 'image_file.jpg',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$imageFileName = $options['image_file_name'];
-
-sampleDiscussBook($imageFileName);
-============== file: src/V1/samples/discuss_book/turing_prog_request_streaming_bidi_async.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingBidiAsync",  "prog")
- */
-
-// [START turing_prog_request_streaming_bidi_async]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Comment;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Testing calling forms */
-function sampleDiscussBook($imageFileName)
-{
-    // [START turing_prog_request_streaming_bidi_async_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $imageFileName = 'image_file.jpg';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-    $comment = file_get_contents('comment_file');
-    $comment2 = new Comment();
-    $comment2->setComment($comment);
-    $image = file_get_contents($imageFileName);
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-    $request->setComment($comment2);
-    $request->setImage($image);
-
-    try {
-        // Write requests individually, making read() calls if
-        // required. Call closeWrite() once writes are complete, and read the
-        // remaining responses from the server.
-        $requests = [$request];
-        $stream = $libraryServiceClient->discussBook();
-        foreach ($requests as $request) {
-            $stream->write($request);
-            // if required, read a single response from the stream
-            $responseItem = $stream->read();
-            printf("%s" . PHP_EOL, print_r($responseItem, true));
-        }
-        $stream->closeWrite();
-        $responseItem = $stream->read();
-        while (!is_null($responseItem)) {
-            printf("%s" . PHP_EOL, print_r($responseItem, true));
-            $responseItem = $stream->read();
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END turing_prog_request_streaming_bidi_async_core]
-}
-// [END turing_prog_request_streaming_bidi_async]
-
-$opts = [
-    'image_file_name::',
-];
-
-$defaultOptions = [
-    'image_file_name' => 'image_file.jpg',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$imageFileName = $options['image_file_name'];
-
-sampleDiscussBook($imageFileName);
-============== file: src/V1/samples/find_related_books/find_related_books_request_paged_all_odyssey.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestPagedAll",  "odyssey")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleFindRelatedBooks()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $namesElement = 'Odyssey';
-    $names = [$namesElement];
-    $shelvesElement = 'Classics';
-    $shelves = [$shelvesElement];
-
-    try {
-        // Iterate through all elements
-        $pagedResponse = $libraryServiceClient->findRelatedBooks($formattedNames, $formattedShelves);
-        foreach ($pagedResponse->iterateAllElements() as $responseItem) {
-            $book = $responseItem;
-            printf("Here's a related book: %s" . PHP_EOL, $book);
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleFindRelatedBooks();
-============== file: src/V1/samples/find_related_books/find_related_books_request_paged_odyssey.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestPaged",  "odyssey")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleFindRelatedBooks()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $namesElement = 'Odyssey';
-    $names = [$namesElement];
-    $shelvesElement = 'Classics';
-    $shelves = [$shelvesElement];
-
-    try {
-        // Iterate over pages of elements
-        $pagedResponse = $libraryServiceClient->findRelatedBooks($formattedNames, $formattedShelves);
-        foreach ($pagedResponse->iteratePages() as $page) {
-            foreach ($page as $responseItem) {
-                $book = $responseItem;
-                printf("Here's a related book: %s" . PHP_EOL, $book);
-            }
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleFindRelatedBooks();
-============== file: src/V1/samples/get_big_book/get_big_book_long_running_request_async_wap.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap")
- */
-
-// [START hopper]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleGetBigBook($shelf)
-{
-    // [START hopper_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelf = 'Novel';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-
-    try {
-        // start the operation, keep the operation name, and resume later
-        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
-        $operationName = $operationResponse->getName();
-        // ... do other work
-        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigBook');
-        while (!$newOperationResponse->isDone()) {
-            // ... do other work
-            $newOperationResponse->reload();
-        }
-        if ($newOperationResponse->operationSucceeded()) {
-            $response = $newOperationResponse->getResult();
-            // Testing iterating over map fields when both key and value are specified.
-            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
-                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
-            }
-
-            // Testing iterating over map fields when only key is specified.
-            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
-                printf("key: %s" . PHP_EOL, $anotherKey);
-            }
-
-            // Testing iterating over map fields when only value is specified.
-            foreach ($response->getMapListValueValue() as $anotherValue) {
-                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
-            }
-
-            printf("name: %s" . PHP_EOL, $response->getName());
-            printf("author: %s" . PHP_EOL, $response->getAuthor());
-        } else {
-          $error = $newOperationResponse->getError();
-          // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END hopper_core]
-}
-// [END hopper]
-
-$opts = [
-    'shelf::',
-];
-
-$defaultOptions = [
-    'shelf' => 'Novel',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelf = $options['shelf'];
-
-sampleGetBigBook($shelf);
-============== file: src/V1/samples/get_big_book/get_big_book_long_running_request_async_wap2.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "wap2")
- */
-
-// [START hopper]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/**
- * Testing resource name overlap
- *
- * @param string $shelf Test word wrapping for long lines. This is a long comment. The name of the
- * shelf to retrieve the big book from.
- * @param string $bigBookName The name of the book.
- */
-function sampleGetBigBook($shelf, $bigBookName)
-{
-    // [START hopper_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelf = 'Novel';
-    // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-
-    try {
-        // start the operation, keep the operation name, and resume later
-        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
-        $operationName = $operationResponse->getName();
-        // ... do other work
-        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigBook');
-        while (!$newOperationResponse->isDone()) {
-            // ... do other work
-            $newOperationResponse->reload();
-        }
-        if ($newOperationResponse->operationSucceeded()) {
-            $response = $newOperationResponse->getResult();
-            printf("%s" . PHP_EOL, print_r($response, true));
-        } else {
-          $error = $newOperationResponse->getError();
-          // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END hopper_core]
-}
-// [END hopper]
-
-$opts = [
-    'shelf::',
-    'big_book_name::',
-];
-
-$defaultOptions = [
-    'shelf' => 'Novel',
-    'big_book_name' => 'War and Peace',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelf = $options['shelf'];
-$bigBookName = $options['big_book_name'];
-
-sampleGetBigBook($shelf, $bigBookName);
-============== file: src/V1/samples/get_big_book/get_big_book_long_running_request_wap.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap")
- */
-
-// [START hopper]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleGetBigBook($shelf)
-{
-    // [START hopper_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelf = 'Novel';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-
-    try {
-        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
-        $operationResponse->pollUntilComplete();
-        if ($operationResponse->operationSucceeded()) {
-            $response = $operationResponse->getResult();
-            // Testing iterating over map fields when both key and value are specified.
-            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
-                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
-            }
-
-            // Testing iterating over map fields when only key is specified.
-            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
-                printf("key: %s" . PHP_EOL, $anotherKey);
-            }
-
-            // Testing iterating over map fields when only value is specified.
-            foreach ($response->getMapListValueValue() as $anotherValue) {
-                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
-            }
-
-            printf("name: %s" . PHP_EOL, $response->getName());
-            printf("author: %s" . PHP_EOL, $response->getAuthor());
-        } else {
-            $error = $operationResponse->getError();
-            // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END hopper_core]
-}
-// [END hopper]
-
-$opts = [
-    'shelf::',
-];
-
-$defaultOptions = [
-    'shelf' => 'Novel',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelf = $options['shelf'];
-
-sampleGetBigBook($shelf);
-============== file: src/V1/samples/get_big_book/get_big_book_long_running_request_wap2.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap2")
- */
-
-// [START hopper]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/**
- * Testing resource name overlap
- *
- * @param string $shelf Test word wrapping for long lines. This is a long comment. The name of the
- * shelf to retrieve the big book from.
- * @param string $bigBookName The name of the book.
- */
-function sampleGetBigBook($shelf, $bigBookName)
-{
-    // [START hopper_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelf = 'Novel';
-    // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-
-    try {
-        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
-        $operationResponse->pollUntilComplete();
-        if ($operationResponse->operationSucceeded()) {
-            $response = $operationResponse->getResult();
-            printf("%s" . PHP_EOL, print_r($response, true));
-        } else {
-            $error = $operationResponse->getError();
-            // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END hopper_core]
-}
-// [END hopper]
-
-$opts = [
-    'shelf::',
-    'big_book_name::',
-];
-
-$defaultOptions = [
-    'shelf' => 'Novel',
-    'big_book_name' => 'War and Peace',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelf = $options['shelf'];
-$bigBookName = $options['big_book_name'];
-
-sampleGetBigBook($shelf, $bigBookName);
-============== file: src/V1/samples/get_big_book/this_tag_should_be_the_name_of_the_file.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "wap")
- */
-
-// [START this_tag_should_be_the_name_of_the_file]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleGetBigBook($shelf)
-{
-    // [START this_tag_should_be_the_name_of_the_file_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelf = 'Novel';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-
-    try {
-        $operationResponse = $libraryServiceClient->getBigBook($formattedName);
-        $operationResponse->pollUntilComplete();
-        if ($operationResponse->operationSucceeded()) {
-            $response = $operationResponse->getResult();
-            // Testing iterating over map fields when both key and value are specified.
-            foreach ($response->getMapListValueValue() as $myKey => $myValue) {
-                printf("key: %s, value: %s" . PHP_EOL, $myKey, print_r($myValue, true));
-            }
-
-            // Testing iterating over map fields when only key is specified.
-            foreach (array_keys($response->getMapListValueValue()) as $anotherKey) {
-                printf("key: %s" . PHP_EOL, $anotherKey);
-            }
-
-            // Testing iterating over map fields when only value is specified.
-            foreach ($response->getMapListValueValue() as $anotherValue) {
-                printf("value: %s" . PHP_EOL, print_r($anotherValue, true));
-            }
-
-            printf("name: %s" . PHP_EOL, $response->getName());
-            printf("author: %s" . PHP_EOL, $response->getAuthor());
-        } else {
-            $error = $operationResponse->getError();
-            // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END this_tag_should_be_the_name_of_the_file_core]
-}
-// [END this_tag_should_be_the_name_of_the_file]
-
-$opts = [
-    'shelf::',
-];
-
-$defaultOptions = [
-    'shelf' => 'Novel',
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelf = $options['shelf'];
-
-sampleGetBigBook($shelf);
-============== file: src/V1/samples/get_big_nothing/get_big_nothing_long_running_request_async_empty_response_type_with_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "empty_response_type_with_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test response handling for methods that return empty */
-function sampleGetBigNothing()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-
-    try {
-        // start the operation, keep the operation name, and resume later
-        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
-        $operationName = $operationResponse->getName();
-        // ... do other work
-        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigNothing');
-        while (!$newOperationResponse->isDone()) {
-            // ... do other work
-            $newOperationResponse->reload();
-        }
-        if ($newOperationResponse->operationSucceeded()) {
-            // operation succeeded and returns no value
-        } else {
-          $error = $newOperationResponse->getError();
-          // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleGetBigNothing();
-============== file: src/V1/samples/get_big_nothing/get_big_nothing_long_running_request_async_empty_response_type_without_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequestAsync",  "empty_response_type_without_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleGetBigNothing()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-
-    try {
-        // start the operation, keep the operation name, and resume later
-        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
-        $operationName = $operationResponse->getName();
-        // ... do other work
-        $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'getBigNothing');
-        while (!$newOperationResponse->isDone()) {
-            // ... do other work
-            $newOperationResponse->reload();
-        }
-        if ($newOperationResponse->operationSucceeded()) {
-            // operation succeeded and returns no value
-        } else {
-          $error = $newOperationResponse->getError();
-          // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleGetBigNothing();
-============== file: src/V1/samples/get_big_nothing/get_big_nothing_long_running_request_empty_response_type_with_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "empty_response_type_with_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test response handling for methods that return empty */
-function sampleGetBigNothing()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-
-    try {
-        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
-        $operationResponse->pollUntilComplete();
-        if ($operationResponse->operationSucceeded()) {
-            // operation succeeded and returns no value
-        } else {
-            $error = $operationResponse->getError();
-            // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleGetBigNothing();
-============== file: src/V1/samples/get_big_nothing/get_big_nothing_long_running_request_empty_response_type_without_response_handling.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("LongRunningRequest",  "empty_response_type_without_response_handling")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test default response handling is turned off for methods that return empty */
-function sampleGetBigNothing()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-
-    try {
-        $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
-        $operationResponse->pollUntilComplete();
-        if ($operationResponse->operationSucceeded()) {
-            // operation succeeded and returns no value
-        } else {
-            $error = $operationResponse->getError();
-            // handleError($error)
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleGetBigNothing();
-============== file: src/V1/samples/get_book/get_book_request_test_on_success_map.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-function sampleGetBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-
-    try {
-        $response = $libraryServiceClient->getBook($formattedName);
-        $intKeyVal = $response->getMapStringValue()[123];
-        $booleanKeyVal = $response->getMapBoolKey()[true];
-        $mapValueField = $response->getMapMessageValue()['key']->getField();
-        printf("Test printing map fields: %s" . PHP_EOL, print_r($response->getMapListValueValue()['quoted_key'], true));
-        printf("Test printing enum fields of a map value: %s" . PHP_EOL, SomeMessage_Alignment::name($response->getMapMessageValue()['key']->getAlignment()));
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleGetBook();
-============== file: src/V1/samples/get_shelf/sample_get_shelf.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "test_default_calling_form_unary")
- */
-
-// [START sample_get_shelf]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test default calling forms for unary methods. */
-function sampleGetShelf()
-{
-    // [START sample_get_shelf_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->shelfName('my-shelf');
-    $options = '';
-
-    try {
-        $response = $libraryServiceClient->getShelf($formattedName, $options);
-        printf("The theme of the shelf is: %s" . PHP_EOL, $response->getTheme());
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_get_shelf_core]
-}
-// [END sample_get_shelf]
-
-sampleGetShelf();
-============== file: src/V1/samples/list_shelves/test_default_calling_form_for_paging.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestPagedAll",  "test_default_calling_form_paging")
- */
-
-// [START test_default_calling_form_for_paging]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Test default calling form for paging methods. */
-function sampleListShelves()
-{
-    // [START test_default_calling_form_for_paging_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    try {
-        // Iterate through all elements
-        $pagedResponse = $libraryServiceClient->listShelves();
-        foreach ($pagedResponse->iterateAllElements() as $responseItem) {
-            printf("shelf name: %s" . PHP_EOL, print_r($responseItem, true));
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END test_default_calling_form_for_paging_core]
-}
-// [END test_default_calling_form_for_paging]
-
-sampleListShelves();
-============== file: src/V1/samples/monolog_about_book/monolog_about_book_request_streaming_client_async_prog.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClientAsync",  "prog")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Testing calling forms */
-function sampleMonologAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-
-    try {
-        // Write data as it becomes available, then wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->monologAboutBook();
-        foreach ($requests as $request) {
-            $stream->write($request);
-        }
-        $response = $stream->readResponse();
-        printf("The stage of the comment is: %s" . PHP_EOL, Comment_Stage::name($response->getStage()));
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleMonologAboutBook();
-============== file: src/V1/samples/monolog_about_book/monolog_about_book_request_streaming_client_prog.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingClient",  "prog")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\DiscussBookRequest;
-
-/** Testing calling forms */
-function sampleMonologAboutBook()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-    $request = new DiscussBookRequest();
-    $request->setName($formattedName);
-
-    try {
-        // Write data to server and wait for a response
-        $requests = [$request];
-        $stream = $libraryServiceClient->monologAboutBook();
-        $response = $stream->writeAllAndReadResponse($requests);
-        printf("The stage of the comment is: %s" . PHP_EOL, Comment_Stage::name($response->getStage()));
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleMonologAboutBook();
-============== file: src/V1/samples/publish_series/publish_series_request_pi_version.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "pi_version")
- */
-
-// [START canonical]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Book;
-use Google\Example\Library\V1\SeriesUuid;
-use Google\Example\Library\V1\Shelf;
-
-/**
- * Testing <&#64;calling forms>
- *
- * @param string $shelfName The name of the shelf where books are published to.
- * @param int $edition The edition of the series.
- */
-function samplePublishSeries($shelfName, $edition)
-{
-    // [START canonical_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    // $shelfName = 'Math';
-    // $edition = 123;
-    $shelf = new Shelf();
-    $shelf->setName($shelfName);
-    $books = [];
-    $seriesString = 'xyz3141592654';
-    $seriesUuid = new SeriesUuid();
-    $seriesUuid->setSeriesString($seriesString);
-
-    try {
-        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
-        // % % % output handling % % % %
-        // fourScoreAndSevenYears ago
-        //
-        // our fathers brought forth upon this continent
-        //
-        // a new nation
-        // conceived in liberty
-        //
-        // and dedicated to the proposition that allMenAreCreatedEqual.
-        //
-        // Do something with bookNames one by one
-        $bookNames = $response->getBookNames();
-        foreach ($response->getBookNames() as $title) {
-            // Now we deal with thisSingleBook!
-            printf("\t%%`` The book's title: \"%s\", \\\nand the book costs $50.00 ``%%" . PHP_EOL, $title);
-        }
-        printf("The first book is: %s" . PHP_EOL, $response->getBookNames()[0]);
-        printf("The author of the first book is: %s" . PHP_EOL, $response->getBooks()[0]->getAuthor());
-        printf("That's all!" . PHP_EOL);
-        printf("series_uuid: %s" . PHP_EOL, $response->getSeriesUuid()->getSeriesBytes());
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END canonical_core]
-}
-// [END canonical]
-
-$opts = [
-    'shelf_name::',
-    'edition::',
-];
-
-$defaultOptions = [
-    'shelf_name' => 'Math',
-    'edition' => 123,
-];
-
-$options = getopt('', $opts);
-$options += $defaultOptions;
-
-$shelfName = $options['shelf_name'];
-$edition = $options['edition'];
-
-samplePublishSeries($shelfName, $edition);
-============== file: src/V1/samples/publish_series/publish_series_request_second_edition.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "second_edition")
- */
-
-// [START canonical]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Book;
-use Google\Example\Library\V1\SeriesUuid;
-use Google\Example\Library\V1\Shelf;
-
-/** Testing calling forms */
-function samplePublishSeries()
-{
-    // [START canonical_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $shelf = new Shelf();
-    $books = [];
-    $seriesUuid = new SeriesUuid();
-    $edition = 2;
-
-    try {
-        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
-        printf("%s" . PHP_EOL, print_r($response, true));
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END canonical_core]
-}
-// [END canonical]
-
-samplePublishSeries();
-============== file: src/V1/samples/publish_series/publish_series_request_test_request_object_field_comments.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "test_request_object_field_comments")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Book;
-use Google\Example\Library\V1\SeriesUuid;
-use Google\Example\Library\V1\Shelf;
-
-/** Test request object field comments */
-function samplePublishSeries()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-
-    // Comment on a resource name
-    $formattedName = $libraryServiceClient->shelfName('math');
-
-    // A super long comment
-    // wraps words at newline characters
-    // as well
-    $theme = 'Math';
-
-    // Comment on a primitive field
-    $internalTheme = 'Statistics';
-    $shelf = new Shelf();
-    $shelf->setName($formattedName);
-    $shelf->setTheme($theme);
-    $shelf->setInternalTheme($internalTheme);
-    $books = [];
-
-    // Comment on a file input field
-    $seriesBytes = file_get_contents('xyz3141592654');
-
-    // Comment on a message
-    $seriesUuid = new SeriesUuid();
-    $seriesUuid->setSeriesBytes($seriesBytes);
-
-    // A super long long long long long long long long long long long long long long comment that tests
-    // word wrapping
-    $edition = 123;
-
-    try {
-        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
-        printf("%s" . PHP_EOL, print_r($response, true));
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-samplePublishSeries();
-============== file: src/V1/samples/publish_series/publish_series_request_test_write_to_file.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("Request",  "test_write_to_file")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-use Google\Example\Library\V1\Book;
-use Google\Example\Library\V1\SeriesUuid;
-use Google\Example\Library\V1\Shelf;
-
-/** Testing write fields to files. */
-function samplePublishSeries()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $shelf = new Shelf();
-    $books = [];
-    $seriesUuid = new SeriesUuid();
-
-    try {
-        $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid, ['edition' => $edition]);
-        // testing writing bytes field.
-        file_put_contents(sprintf('uuid_of_series_with_book_%s.raw', $response->getBookNames()[0]), $response->getSeriesUuid()->getSeriesBytes());
-        // testing writing string field.
-        file_put_contents('series_uuid_in_plain_text.txt', $response->getSeriesUuid()->getSeriesString());
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-samplePublishSeries();
-============== file: src/V1/samples/stream_books/lovelace.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "prog")
- */
-
-// [START lovelace]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleStreamBooks()
-{
-    // [START lovelace_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $name = 'BASIC';
-
-    try {
-        // Read all responses until the stream is complete
-        $stream = $libraryServiceClient->streamBooks($name);
-        foreach ($stream->readAll() as $responseItem) {
-            printf("%s" . PHP_EOL, print_r($responseItem, true));
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END lovelace_core]
-}
-// [END lovelace]
-
-sampleStreamBooks();
-============== file: src/V1/samples/stream_shelves/stream_shelves_request_streaming_server_empty.php ==============
-<?php
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * DO NOT EDIT! This is a generated sample ("RequestStreamingServer",  "empty")
- */
-
-// [START sample]
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-use Google\Cloud\Example\Library\V1\LibraryServiceClient;
-
-/** Testing calling forms */
-function sampleStreamShelves()
-{
-    // [START sample_core]
-
-    $libraryServiceClient = new LibraryServiceClient();
-
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
-
-    try {
-        // Read all responses until the stream is complete
-        $stream = $libraryServiceClient->streamShelves($formattedName);
-        foreach ($stream->readAll() as $responseItem) {
-            printf("%s" . PHP_EOL, print_r($responseItem, true));
-        }
-    } finally {
-        $libraryServiceClient->close();
-    }
-
-    // [END sample_core]
-}
-// [END sample]
-
-sampleStreamShelves();
 ============== file: tests/System/V1/LibraryServiceSmokeTest.php ==============
 <?php
 /*


### PR DESCRIPTION
- Samples now live in `.../google-cloud-language-v1/samples/V1/`.
- Change sample file names to `UpperCamelCase.php`.