### PR TITLE
Remove all references of DEADLINE_EXCEEDED

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/mergers/RetryMerger.java
+++ b/src/main/java/com/google/api/codegen/configgen/mergers/RetryMerger.java
@@ -53,7 +53,7 @@ public class RetryMerger {
   public static final Map<String, ImmutableList<String>> DEFAULT_RETRY_CODES =
       ImmutableMap.of(
           RETRY_CODES_IDEMPOTENT_NAME,
-          ImmutableList.of(Status.Code.DEADLINE_EXCEEDED.name(), Status.Code.UNAVAILABLE.name()),
+          ImmutableList.of(Status.Code.UNAVAILABLE.name()),
           RETRY_CODES_NON_IDEMPOTENT_NAME,
           ImmutableList.of());
 

--- a/src/main/java/com/google/api/codegen/configgen/transformer/DiscoConfigTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/DiscoConfigTransformer.java
@@ -110,9 +110,7 @@ public class DiscoConfigTransformer {
               ownerName, model.getDocument().name(), model.getDocument().version(), resourceName));
 
       retryTransformer.generateRetryDefinitions(
-          interfaceView,
-          ImmutableList.of("UNAVAILABLE", "DEADLINE_EXCEEDED"),
-          ImmutableList.<String>of());
+          interfaceView, ImmutableList.of("UNAVAILABLE"), ImmutableList.<String>of());
       interfaceView.collections(collectionTransformer.generateCollections(collectionNameMap));
       interfaceView.methods(
           methodTransformer.generateMethods(

--- a/src/test/java/com/google/api/codegen/config/testdata/missing_config_schema_version.yaml
+++ b/src/test/java/com/google/api/codegen/config/testdata/missing_config_schema_version.yaml
@@ -7,7 +7,6 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:

--- a/src/test/java/com/google/api/codegen/config/testdata/missing_interface_v1.yaml
+++ b/src/test/java/com/google/api/codegen/config/testdata/missing_interface_v1.yaml
@@ -8,7 +8,6 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:
@@ -35,7 +34,6 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-      - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:

--- a/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
@@ -47,7 +47,6 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
@@ -800,7 +799,6 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []

--- a/src/test/java/com/google/api/codegen/configgen/testdata/longrunning_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/longrunning_config.baseline
@@ -41,7 +41,6 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []

--- a/src/test/java/com/google/api/codegen/configgen/testdata/multiple_services_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/multiple_services_config.baseline
@@ -39,7 +39,6 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
@@ -123,7 +122,6 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
@@ -207,7 +205,6 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
@@ -291,7 +288,6 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []

--- a/src/test/java/com/google/api/codegen/configgen/testdata/no_path_templates_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/no_path_templates_config.baseline
@@ -39,7 +39,6 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -10577,7 +10577,7 @@ public class AddressStubSettings extends StubSettings<AddressStubSettings> {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
@@ -49,7 +49,6 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
-    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_gapic.yaml
@@ -44,7 +44,6 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
-    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -5600,12 +5600,11 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// The eligible RPC <see cref="grpccore::StatusCode"/>s for retry for "Idempotent" RPC methods are:
         /// <list type="bullet">
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
         public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
-            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
+            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Unavailable);
 
         /// <summary>
         /// The filter specifying which RPC <see cref="grpccore::StatusCode"/>s are eligible for retry
@@ -5703,7 +5702,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5733,7 +5731,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5763,7 +5760,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5880,7 +5876,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5910,7 +5905,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5940,7 +5934,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5970,7 +5963,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6029,7 +6021,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6088,7 +6079,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6118,7 +6108,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6148,7 +6137,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6178,7 +6166,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6245,7 +6232,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6433,7 +6419,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -15826,12 +15811,11 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// The eligible RPC <see cref="grpccore::StatusCode"/>s for retry for "Idempotent" RPC methods are:
         /// <list type="bullet">
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
         public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
-            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
+            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Unavailable);
 
         /// <summary>
         /// The filter specifying which RPC <see cref="grpccore::StatusCode"/>s are eligible for retry

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -258,7 +258,6 @@ func defaultCallOptions() *CallOptions {
         {"default", "idempotent"}: {
             gax.WithRetry(func() gax.Retryer {
                 return gax.OnCodes([]codes.Code{
-                    codes.DeadlineExceeded,
                     codes.Unavailable,
                 }, gax.Backoff{
                     Initial: 100*time.Millisecond,

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -10739,7 +10739,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
@@ -11598,7 +11598,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
@@ -1088,7 +1088,7 @@ public class DecrementerServiceStubSettings extends StubSettings<DecrementerServ
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
@@ -1882,7 +1882,7 @@ public class IncrementerServiceStubSettings extends StubSettings<IncrementerServ
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -961,7 +961,7 @@ public class NoTemplatesApiServiceStubSettings extends StubSettings<NoTemplatesA
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -6702,7 +6702,6 @@ module.exports = LibraryServiceClient;
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -7186,7 +7185,6 @@ module.exports = MyProtoClient;
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -393,7 +393,6 @@ module.exports = DecrementerServiceClient;
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -715,7 +714,6 @@ module.exports = IncrementerServiceClient;
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -388,7 +388,6 @@ module.exports = NoTemplatesApiServiceClient;
     "google.cloud.example.v1.NoTemplatesAPIService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -2846,7 +2846,6 @@ class MyProtoClient extends MyProtoGapicClient
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -3385,7 +3384,6 @@ return [
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
@@ -522,7 +522,6 @@ class OperationsClient extends OperationsGapicClient
     "google.longrunning.Operations": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
@@ -283,7 +283,6 @@ class NoTemplatesApiServiceClient extends NoTemplatesApiServiceGapicClient
     "google.cloud.example.v1.NoTemplatesAPIService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -3711,7 +3711,6 @@ config = {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -4146,7 +4145,6 @@ config = {
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1074,7 +1074,6 @@ config = {
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -1312,7 +1311,6 @@ config = {
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1013,7 +1013,6 @@ config = {
     "google.cloud.example.v1.NoTemplatesAPIService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -4910,7 +4910,6 @@ end
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -5322,7 +5321,6 @@ end
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_longrunning.baseline
@@ -1531,7 +1531,6 @@ end
     "google.longrunning.Operations": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
@@ -1147,7 +1147,6 @@ end
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -1430,7 +1429,6 @@ end
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -5559,12 +5559,11 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// The eligible RPC <see cref="grpccore::StatusCode"/>s for retry for "Idempotent" RPC methods are:
         /// <list type="bullet">
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
         public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
-            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
+            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Unavailable);
 
         /// <summary>
         /// The filter specifying which RPC <see cref="grpccore::StatusCode"/>s are eligible for retry
@@ -5662,7 +5661,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5692,7 +5690,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5722,7 +5719,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5839,7 +5835,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5869,7 +5864,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5899,7 +5893,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5929,7 +5922,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -5988,7 +5980,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6047,7 +6038,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6077,7 +6067,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6107,7 +6096,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6137,7 +6125,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6204,7 +6191,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -6392,7 +6378,6 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -15619,12 +15604,11 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// The eligible RPC <see cref="grpccore::StatusCode"/>s for retry for "Idempotent" RPC methods are:
         /// <list type="bullet">
-        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
         public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
-            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
+            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Unavailable);
 
         /// <summary>
         /// The filter specifying which RPC <see cref="grpccore::StatusCode"/>s are eligible for retry

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -258,7 +258,6 @@ func defaultCallOptions() *CallOptions {
         {"default", "idempotent"}: {
             gax.WithRetry(func() gax.Retryer {
                 return gax.OnCodes([]codes.Code{
-                    codes.DeadlineExceeded,
                     codes.Unavailable,
                 }, gax.Backoff{
                     Initial: 100*time.Millisecond,

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -10675,7 +10675,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
@@ -11534,7 +11534,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -7369,7 +7369,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
@@ -8204,7 +8204,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
@@ -44,7 +44,6 @@ interfaces:
       - name: idempotent
         retry_codes:
           - UNAVAILABLE
-          - DEADLINE_EXCEEDED
       - name: non_idempotent
         retry_codes: []
     retry_params_def:

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -6721,7 +6721,6 @@ module.exports = LibraryServiceClient;
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -7137,7 +7136,6 @@ module.exports = MyProtoClient;
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -2770,7 +2770,6 @@ class MyProtoClient extends MyProtoGapicClient
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -3309,7 +3308,6 @@ return [
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -3716,7 +3716,6 @@ config = {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -4139,7 +4138,6 @@ config = {
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
@@ -3240,7 +3240,6 @@ config = {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -4913,7 +4913,6 @@ end
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -5306,7 +5305,6 @@ end
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -4750,7 +4750,6 @@ end
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -5131,7 +5130,6 @@ end
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
-          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -50,7 +50,6 @@ interfaces:
     - name: idempotent
       retry_codes:
         - UNAVAILABLE
-        - DEADLINE_EXCEEDED
     - name: non_idempotent
       retry_codes: []
   collections:
@@ -75,7 +74,6 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
-    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   retry_params_def:

--- a/src/test/java/com/google/api/codegen/testsrc/common/longrunning_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/longrunning_gapic.yaml
@@ -27,7 +27,6 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
-    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   retry_params_def:

--- a/src/test/java/com/google/api/codegen/testsrc/showcase/showcase_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/showcase/showcase_gapic.yaml
@@ -39,7 +39,6 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
-    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
@@ -9,7 +9,6 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
-    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:
@@ -84,7 +83,6 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
-    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/singleservice_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/singleservice_gapic.yaml
@@ -8,7 +8,6 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
-    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:


### PR DESCRIPTION
Stop generating DEADLINE_EXCEEDED as a code to retry on.

DEADLINE_EXCEEDED was likely an incorrect error code to retry on.