### PR TITLE
Add partial class resource names for C for resource types

### DIFF
--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.config;
 
+import com.google.api.ResourceDescriptor;
 import com.google.api.ResourceReference;
 import com.google.api.codegen.ConfigProto;
 import com.google.api.codegen.ResourceNameMessageConfigProto;
@@ -58,48 +59,39 @@ public abstract class ResourceNameMessageConfigs {
     for (ProtoFile protoFile : protoFiles) {
       for (MessageType message : protoFile.getMessages()) {
         ImmutableMap.Builder<String, String> fieldEntityMapBuilder = ImmutableMap.builder();
+
+        ResourceDescriptor resourceDescriptor = parser.getResourceDescriptor(message);
+        String resourceFieldName = null;
+        if (resourceDescriptor != null) {
+          resourceFieldName = resourceDescriptor.getNameField();
+          if (Strings.isNullOrEmpty(resourceFieldName)) {
+            resourceFieldName = "name"; // Default field containing the resource path.
+          }
+          Field resourceField = message.lookupField(resourceFieldName);
+          String entityName =
+              getResourceDescriptorTypeForField(
+                  false,
+                  diagCollector,
+                  descriptorConfigMap,
+                  resourceDescriptor.getType(),
+                  message,
+                  resourceField);
+          if (Strings.isNullOrEmpty(entityName)) continue;
+          fieldEntityMapBuilder.put(resourceField.getSimpleName(), entityName);
+        }
+
         for (Field field : message.getFields()) {
-          if (!parser.hasResourceReference(field)) {
+          if (!parser.hasResourceReference(field)
+              || field.getSimpleName().equals(resourceFieldName)) {
             continue;
           }
           ResourceReference reference = parser.getResourceReference(field);
           boolean isChildReference = !Strings.isNullOrEmpty(reference.getChildType());
           String type = isChildReference ? reference.getChildType() : reference.getType();
-          ResourceDescriptorConfig config = descriptorConfigMap.get(type);
-          if (config == null) {
-            diagCollector.addDiag(
-                Diag.error(
-                    SimpleLocation.TOPLEVEL,
-                    "Reference to unknown type \"%s\" on field %s.%s",
-                    type,
-                    message.getFullName(),
-                    field.getFullName()));
-            continue;
-          }
-
-          String entityName;
-          if (isChildReference) {
-            // Attempt to resolve the reference to an existing type. If we can't, mark this
-            // type as having a child reference, and resolve the reference to the derived
-            // parent type.
-            List<String> parentPatterns = config.getParentPatterns();
-            Optional<ResourceDescriptorConfig> parentConfig =
-                descriptorConfigMap
-                    .values()
-                    .stream()
-                    .filter(
-                        c ->
-                            parentPatterns.size() == c.getPatterns().size()
-                                && parentPatterns.containsAll(c.getPatterns()))
-                    .findFirst();
-            if (parentConfig.isPresent()) {
-              entityName = parentConfig.get().getDerivedEntityName();
-            } else {
-              entityName = config.getDerivedParentEntityName();
-            }
-          } else {
-            entityName = config.getDerivedEntityName();
-          }
+          String entityName =
+              getResourceDescriptorTypeForField(
+                  isChildReference, diagCollector, descriptorConfigMap, type, message, field);
+          if (Strings.isNullOrEmpty(entityName)) continue;
           fieldEntityMapBuilder.put(field.getSimpleName(), entityName);
         }
         ImmutableMap<String, String> fieldEntityMap = fieldEntityMapBuilder.build();
@@ -110,8 +102,62 @@ public abstract class ResourceNameMessageConfigs {
         }
       }
     }
-    ImmutableMap<String, ResourceNameMessageConfig> map = builder.build();
+    ImmutableMap<String, ResourceNameMessageConfig> map;
+    try {
+      map = builder.build();
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "The field '%s' of Resource message type '%s' "
+              + "was assigned a different resource_reference than the Resource message's "
+              + "resource descriptor type. They must be the same.",
+          e);
+    }
     return new AutoValue_ResourceNameMessageConfigs(map, createFieldsByMessage(protoFiles, map));
+  }
+
+  private static String getResourceDescriptorTypeForField(
+      boolean isChildReference,
+      DiagCollector diagCollector,
+      Map<String, ResourceDescriptorConfig> descriptorConfigMap,
+      String type,
+      MessageType message,
+      Field field) {
+    ResourceDescriptorConfig config = descriptorConfigMap.get(type);
+    if (config == null) {
+      diagCollector.addDiag(
+          Diag.error(
+              SimpleLocation.TOPLEVEL,
+              "Reference to unknown type \"%s\" on field %s.%s",
+              type,
+              message.getFullName(),
+              field.getFullName()));
+      return null;
+    }
+
+    String entityName;
+    if (isChildReference) {
+      // Attempt to resolve the reference to an existing type. If we can't, mark this
+      // type as having a child reference, and resolve the reference to the derived
+      // parent type.
+      List<String> parentPatterns = config.getParentPatterns();
+      Optional<ResourceDescriptorConfig> parentConfig =
+          descriptorConfigMap
+              .values()
+              .stream()
+              .filter(
+                  c ->
+                      parentPatterns.size() == c.getPatterns().size()
+                          && parentPatterns.containsAll(c.getPatterns()))
+              .findFirst();
+      if (parentConfig.isPresent()) {
+        entityName = parentConfig.get().getDerivedEntityName();
+      } else {
+        entityName = config.getDerivedParentEntityName();
+      }
+    } else {
+      entityName = config.getDerivedEntityName();
+    }
+    return entityName;
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -60,8 +60,8 @@ public abstract class ResourceNameMessageConfigs {
       for (MessageType message : protoFile.getMessages()) {
         ImmutableMap.Builder<String, String> fieldEntityMapBuilder = ImmutableMap.builder();
 
-        ResourceDescriptor resourceDescriptor = parser.getResourceDescriptor(message);
         String resourceFieldName = null;
+        ResourceDescriptor resourceDescriptor = parser.getResourceDescriptor(message);
         if (resourceDescriptor != null) {
           resourceFieldName = resourceDescriptor.getNameField();
           if (Strings.isNullOrEmpty(resourceFieldName)) {
@@ -81,8 +81,11 @@ public abstract class ResourceNameMessageConfigs {
         }
 
         for (Field field : message.getFields()) {
-          if (!parser.hasResourceReference(field)
-              || field.getSimpleName().equals(resourceFieldName)) {
+          if (!parser.hasResourceReference(field)) {
+            continue;
+          }
+          if (field.getSimpleName().equals(resourceFieldName)) {
+            // We've already processed the Resource message's "name" field above.
             continue;
           }
 
@@ -108,16 +111,7 @@ public abstract class ResourceNameMessageConfigs {
         }
       }
     }
-    ImmutableMap<String, ResourceNameMessageConfig> map;
-    try {
-      map = builder.build();
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(
-          "The field '%s' of Resource message type '%s' "
-              + "was assigned a different resource_reference than the Resource message's "
-              + "resource descriptor type. They must be the same.",
-          e);
-    }
+    ImmutableMap<String, ResourceNameMessageConfig> map = builder.build();
     return new AutoValue_ResourceNameMessageConfigs(map, createFieldsByMessage(protoFiles, map));
   }
 

--- a/src/test/java/com/google/api/codegen/testsrc/common/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library.proto
@@ -366,8 +366,7 @@ message Book {
   // Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
   // Message field comment may include special characters: <>&"`'@.
   string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "library.googleapis.com/Book"
+    (google.api.field_behavior) = REQUIRED
   ];
 
   // The name of the book author.


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator/issues/2763.

Currently, we only generate the C# resource name partial classes from `resource_reference`s. However, if there is a message type that represents a resource, it is unnecessary to annotate the `name` field with a resource_reference (see issue). We should still generate the partial class for this resource message type.