### PR TITLE
remove the condition that is always false

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -308,7 +308,7 @@ public class PhpSurfaceNamer extends SurfaceNamer {
         "Expected non-repeated fields in print statement, found %s",
         type.getTypeName());
     String arg = "$" + variable + String.join("", accessors);
-    if (type == null || !(type instanceof ProtoTypeRef) || type.isPrimitive()) {
+    if (!(type instanceof ProtoTypeRef) || type.isPrimitive()) {
       return arg;
     }
     if (type.isMessage()) {


### PR DESCRIPTION
The condition `type == null` is always false. If this condition was true,  this line ` Preconditions.checkArgument(
        !type.isRepeated() && !type.isMap(),
        "Expected non-repeated fields in print statement, found %s",
        type.getTypeName());
` would throw exception.
So to improve the code quality, consider to remove the condition that is always false.

[https://rules.sonarsource.com/java/type/Bug/RSPEC-1145](url)