### PR TITLE
Revert deadline exceeded removal

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/mergers/RetryMerger.java
+++ b/src/main/java/com/google/api/codegen/configgen/mergers/RetryMerger.java
@@ -53,7 +53,7 @@ public class RetryMerger {
   public static final Map<String, ImmutableList<String>> DEFAULT_RETRY_CODES =
       ImmutableMap.of(
           RETRY_CODES_IDEMPOTENT_NAME,
-          ImmutableList.of(Status.Code.UNAVAILABLE.name()),
+          ImmutableList.of(Status.Code.DEADLINE_EXCEEDED.name(), Status.Code.UNAVAILABLE.name()),
           RETRY_CODES_NON_IDEMPOTENT_NAME,
           ImmutableList.of());
 

--- a/src/main/java/com/google/api/codegen/configgen/transformer/DiscoConfigTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/DiscoConfigTransformer.java
@@ -110,7 +110,9 @@ public class DiscoConfigTransformer {
               ownerName, model.getDocument().name(), model.getDocument().version(), resourceName));
 
       retryTransformer.generateRetryDefinitions(
-          interfaceView, ImmutableList.of("UNAVAILABLE"), ImmutableList.<String>of());
+          interfaceView,
+          ImmutableList.of("UNAVAILABLE", "DEADLINE_EXCEEDED"),
+          ImmutableList.<String>of());
       interfaceView.collections(collectionTransformer.generateCollections(collectionNameMap));
       interfaceView.methods(
           methodTransformer.generateMethods(

--- a/src/test/java/com/google/api/codegen/config/testdata/missing_config_schema_version.yaml
+++ b/src/test/java/com/google/api/codegen/config/testdata/missing_config_schema_version.yaml
@@ -7,6 +7,7 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
+      - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:

--- a/src/test/java/com/google/api/codegen/config/testdata/missing_interface_v1.yaml
+++ b/src/test/java/com/google/api/codegen/config/testdata/missing_interface_v1.yaml
@@ -8,6 +8,7 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
+      - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:
@@ -34,6 +35,7 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
+      - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:

--- a/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
@@ -47,6 +47,7 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
+    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
@@ -799,6 +800,7 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
+    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []

--- a/src/test/java/com/google/api/codegen/configgen/testdata/longrunning_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/longrunning_config.baseline
@@ -41,6 +41,7 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
+    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []

--- a/src/test/java/com/google/api/codegen/configgen/testdata/multiple_services_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/multiple_services_config.baseline
@@ -39,6 +39,7 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
+    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
@@ -122,6 +123,7 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
+    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
@@ -205,6 +207,7 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
+    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []
@@ -288,6 +291,7 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
+    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []

--- a/src/test/java/com/google/api/codegen/configgen/testdata/no_path_templates_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/no_path_templates_config.baseline
@@ -39,6 +39,7 @@ interfaces:
   retry_codes_def:
   - name: idempotent
     retry_codes:
+    - DEADLINE_EXCEEDED
     - UNAVAILABLE
   - name: non_idempotent
     retry_codes: []

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -10577,7 +10577,7 @@ public class AddressStubSettings extends StubSettings<AddressStubSettings> {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_config.baseline
@@ -49,6 +49,7 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/simplecompute_gapic.yaml
@@ -44,6 +44,7 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -7464,6 +7464,7 @@ namespace Google.Example.Library.V1
         /// The eligible RPC <see cref="grpccore::StatusCode"/>s for retry for "Idempotent" RPC methods are:
         /// <list type="bullet">
         /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
+        /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
         public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -7463,11 +7463,11 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// The eligible RPC <see cref="grpccore::StatusCode"/>s for retry for "Idempotent" RPC methods are:
         /// <list type="bullet">
-        /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// </list>
         /// </remarks>
         public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
-            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Unavailable);
+            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
         /// The filter specifying which RPC <see cref="grpccore::StatusCode"/>s are eligible for retry
@@ -7565,6 +7565,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7594,6 +7595,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7623,6 +7625,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7739,6 +7742,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7768,6 +7772,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7797,6 +7802,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7826,6 +7832,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7884,6 +7891,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7942,6 +7950,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7971,6 +7980,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -8000,6 +8010,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -8029,6 +8040,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -8095,6 +8107,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -8282,6 +8295,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -17674,11 +17688,12 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// The eligible RPC <see cref="grpccore::StatusCode"/>s for retry for "Idempotent" RPC methods are:
         /// <list type="bullet">
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
         public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
-            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Unavailable);
+            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
         /// The filter specifying which RPC <see cref="grpccore::StatusCode"/>s are eligible for retry

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -258,6 +258,7 @@ func defaultCallOptions() *CallOptions {
         {"default", "idempotent"}: {
             gax.WithRetry(func() gax.Retryer {
                 return gax.OnCodes([]codes.Code{
+                    codes.DeadlineExceeded,
                     codes.Unavailable,
                 }, gax.Backoff{
                     Initial: 100*time.Millisecond,

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -11369,7 +11369,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
@@ -12228,7 +12228,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
@@ -1088,7 +1088,7 @@ public class DecrementerServiceStubSettings extends StubSettings<DecrementerServ
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
@@ -1882,7 +1882,7 @@ public class IncrementerServiceStubSettings extends StubSettings<IncrementerServ
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -961,7 +961,7 @@ public class NoTemplatesApiServiceStubSettings extends StubSettings<NoTemplatesA
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -6696,6 +6696,7 @@ module.exports = LibraryServiceClient;
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -7177,6 +7178,7 @@ module.exports = MyProtoClient;
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -390,6 +390,7 @@ module.exports = DecrementerServiceClient;
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -709,6 +710,7 @@ module.exports = IncrementerServiceClient;
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -385,6 +385,7 @@ module.exports = NoTemplatesApiServiceClient;
     "google.cloud.example.v1.NoTemplatesAPIService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -4741,6 +4741,7 @@ class MyProtoClient extends MyProtoGapicClient
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -5279,6 +5280,7 @@ return [
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
@@ -524,7 +524,7 @@ class OperationsClient extends OperationsGapicClient
         "idempotent": [
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],,
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
@@ -522,8 +522,9 @@ class OperationsClient extends OperationsGapicClient
     "google.longrunning.Operations": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],
+        ],,
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
@@ -285,7 +285,7 @@ class NoTemplatesApiServiceClient extends NoTemplatesApiServiceGapicClient
         "idempotent": [
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],,
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
@@ -283,8 +283,9 @@ class NoTemplatesApiServiceClient extends NoTemplatesApiServiceGapicClient
     "google.cloud.example.v1.NoTemplatesAPIService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],
+        ],,
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -3713,7 +3713,7 @@ config = {
         "idempotent": [
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],,
+        ],
         "non_idempotent": []
       },
       "retry_params": {
@@ -4148,7 +4148,7 @@ config = {
         "idempotent": [
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],,
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -3711,8 +3711,9 @@ config = {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],
+        ],,
         "non_idempotent": []
       },
       "retry_params": {
@@ -4145,8 +4146,9 @@ config = {
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],
+        ],,
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1074,8 +1074,9 @@ config = {
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],
+        ],,
         "non_idempotent": []
       },
       "retry_params": {
@@ -1311,8 +1312,9 @@ config = {
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],
+        ],,
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1076,7 +1076,7 @@ config = {
         "idempotent": [
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],,
+        ],
         "non_idempotent": []
       },
       "retry_params": {
@@ -1314,7 +1314,7 @@ config = {
         "idempotent": [
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],,
+        ],
         "non_idempotent": []
       },
       "retry_params": {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1013,6 +1013,7 @@ config = {
     "google.cloud.example.v1.NoTemplatesAPIService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -4910,6 +4910,7 @@ end
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -5321,6 +5322,7 @@ end
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_longrunning.baseline
@@ -1531,6 +1531,7 @@ end
     "google.longrunning.Operations": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
@@ -1147,6 +1147,7 @@ end
     "google.cloud.example.v1.foo.DecrementerService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -1429,6 +1430,7 @@ end
     "google.cloud.example.v1.foo.IncrementerService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -7422,11 +7422,12 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// The eligible RPC <see cref="grpccore::StatusCode"/>s for retry for "Idempotent" RPC methods are:
         /// <list type="bullet">
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
         public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
-            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Unavailable);
+            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
         /// The filter specifying which RPC <see cref="grpccore::StatusCode"/>s are eligible for retry
@@ -7524,6 +7525,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7553,6 +7555,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7582,6 +7585,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7698,6 +7702,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7727,6 +7732,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7756,6 +7762,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7785,6 +7792,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7843,6 +7851,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7901,6 +7910,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7930,6 +7940,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7959,6 +7970,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -7988,6 +8000,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -8054,6 +8067,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -8241,6 +8255,7 @@ namespace Google.Example.Library.V1
         /// </list>
         /// Retry will be attempted on the following response status codes:
         /// <list>
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// Default RPC expiration is 30000 milliseconds.
@@ -17533,11 +17548,12 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// The eligible RPC <see cref="grpccore::StatusCode"/>s for retry for "Idempotent" RPC methods are:
         /// <list type="bullet">
+        /// <item><description><see cref="grpccore::StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="grpccore::StatusCode.Unavailable"/></description></item>
         /// </list>
         /// </remarks>
         public static sys::Predicate<grpccore::RpcException> IdempotentRetryFilter { get; } =
-            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.Unavailable);
+            gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.Unavailable);
 
         /// <summary>
         /// The filter specifying which RPC <see cref="grpccore::StatusCode"/>s are eligible for retry

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -258,6 +258,7 @@ func defaultCallOptions() *CallOptions {
         {"default", "idempotent"}: {
             gax.WithRetry(func() gax.Retryer {
                 return gax.OnCodes([]codes.Code{
+                    codes.DeadlineExceeded,
                     codes.Unavailable,
                 }, gax.Backoff{
                     Initial: 100*time.Millisecond,

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -11366,7 +11366,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
@@ -12225,7 +12225,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -7430,7 +7430,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
@@ -8265,7 +8265,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.UNAVAILABLE)));
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
       definitions.put(
           "non_idempotent",
           ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
@@ -44,6 +44,7 @@ interfaces:
       - name: idempotent
         retry_codes:
           - UNAVAILABLE
+          - DEADLINE_EXCEEDED
       - name: non_idempotent
         retry_codes: []
     retry_params_def:

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -6715,6 +6715,7 @@ module.exports = LibraryServiceClient;
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -7128,6 +7129,7 @@ module.exports = MyProtoClient;
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -4673,6 +4673,7 @@ class MyProtoClient extends MyProtoGapicClient
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -5211,6 +5212,7 @@ return [
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -3716,6 +3716,7 @@ config = {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -4138,6 +4139,7 @@ config = {
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
@@ -3240,6 +3240,7 @@ config = {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -4913,6 +4913,7 @@ end
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -5305,6 +5306,7 @@ end
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -4750,6 +4750,7 @@ end
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []
@@ -5130,6 +5131,7 @@ end
     "google.example.library.v1.MyProto": {
       "retry_codes": {
         "idempotent": [
+          "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
         "non_idempotent": []

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -50,6 +50,7 @@ interfaces:
     - name: idempotent
       retry_codes:
         - UNAVAILABLE
+        - DEADLINE_EXCEEDED
     - name: non_idempotent
       retry_codes: []
   collections:
@@ -74,6 +75,7 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   retry_params_def:

--- a/src/test/java/com/google/api/codegen/testsrc/common/longrunning_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/longrunning_gapic.yaml
@@ -27,6 +27,7 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   retry_params_def:

--- a/src/test/java/com/google/api/codegen/testsrc/showcase/showcase_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/showcase/showcase_gapic.yaml
@@ -39,6 +39,7 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
@@ -9,6 +9,7 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:
@@ -83,6 +84,7 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/singleservice_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/singleservice_gapic.yaml
@@ -8,6 +8,7 @@ interfaces:
   - name: idempotent
     retry_codes:
     - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes:
   retry_params_def:


### PR DESCRIPTION
Reverts https://github.com/googleapis/gapic-generator/pull/2752/, which we are not ready to have in production; this PR blocks the artman release.