### PR TITLE
Avoid coverage failure when no `_shared_modules` are present.

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/types.snip
+++ b/src/main/resources/com/google/api/codegen/py/types.snip
@@ -24,7 +24,7 @@
 
   names = []
 
-  for module in _shared_modules:
+  for module in _shared_modules:  # pragma: NO COVER
       for name, message in get_messages(module).items():
           setattr(sys.modules[__name__], name, message)
           names.append(name)

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4859,7 +4859,7 @@ _local_modules = [
 
 names = []
 
-for module in _shared_modules:
+for module in _shared_modules:  # pragma: NO COVER
     for name, message in get_messages(module).items():
         setattr(sys.modules[__name__], name, message)
         names.append(name)

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1618,7 +1618,7 @@ _local_modules = [
 
 names = []
 
-for module in _shared_modules:
+for module in _shared_modules:  # pragma: NO COVER
     for name, message in get_messages(module).items():
         setattr(sys.modules[__name__], name, message)
         names.append(name)

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1204,7 +1204,7 @@ _local_modules = [
 
 names = []
 
-for module in _shared_modules:
+for module in _shared_modules:  # pragma: NO COVER
     for name, message in get_messages(module).items():
         setattr(sys.modules[__name__], name, message)
         names.append(name)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -4852,7 +4852,7 @@ _local_modules = [
 
 names = []
 
-for module in _shared_modules:
+for module in _shared_modules:  # pragma: NO COVER
     for name, message in get_messages(module).items():
         setattr(sys.modules[__name__], name, message)
         names.append(name)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
@@ -430,7 +430,7 @@ _local_modules = [
 
 names = []
 
-for module in _shared_modules:
+for module in _shared_modules:  # pragma: NO COVER
     for name, message in get_messages(module).items():
         setattr(sys.modules[__name__], name, message)
         names.append(name)


### PR DESCRIPTION
See: https://github.com/googleapis/google-cloud-python/pull/7998/files