### PR TITLE
Fix PHP LRO unit tests

### DIFF
--- a/src/main/resources/com/google/api/codegen/php/test.snip
+++ b/src/main/resources/com/google/api/codegen/php/test.snip
@@ -33,8 +33,8 @@
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)
-	    ->disableOriginalConstructor()
-	    ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /**
@@ -367,7 +367,7 @@
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
             'transport' => $operationsTransport,
-	    'credentials' => $this->createCredentials(),
+            'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([

--- a/src/main/resources/com/google/api/codegen/php/test.snip
+++ b/src/main/resources/com/google/api/codegen/php/test.snip
@@ -439,7 +439,8 @@
         $operationsTransport = $this->createTransport();
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
-            'transport' => $operationsTransport
+            'transport' => $operationsTransport,
+            'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([

--- a/src/main/resources/com/google/api/codegen/php/test.snip
+++ b/src/main/resources/com/google/api/codegen/php/test.snip
@@ -28,14 +28,22 @@
     }
 
     /**
+     * @@return CredentialsWrapper
+     */
+    private function createCredentials()
+    {
+        return $this->getMockBuilder(CredentialsWrapper::class)
+	    ->disableOriginalConstructor()
+	    ->getMock();
+    }
+
+    /**
      * @@return {@testClass.apiClassName}
      */
     private function createClient(array $options = [])
     {
         $options += [
-            'credentials' => $this->getMockBuilder(CredentialsWrapper::class)
-                ->disableOriginalConstructor()
-                ->getMock(),
+            'credentials' => $this->createCredentials(),
             @if testClass.hasMissingDefaultOptions
                 @if testClass.missingDefaultServiceAddress
                     'serviceAddress' => '',
@@ -358,7 +366,8 @@
         $operationsTransport = $this->createTransport();
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
-            'transport' => $operationsTransport
+            'transport' => $operationsTransport,
+	    'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -7534,7 +7534,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport = $this->createTransport();
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
-            'transport' => $operationsTransport
+            'transport' => $operationsTransport,
+            'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([
@@ -7673,7 +7674,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport = $this->createTransport();
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
-            'transport' => $operationsTransport
+            'transport' => $operationsTransport,
+            'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -5505,8 +5505,8 @@ class LibraryServiceClientTest extends GeneratedTest
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)
-     ->disableOriginalConstructor()
-     ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /**
@@ -7453,7 +7453,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
             'transport' => $operationsTransport,
-     'credentials' => $this->createCredentials(),
+            'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([
@@ -7600,7 +7600,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
             'transport' => $operationsTransport,
-     'credentials' => $this->createCredentials(),
+            'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([
@@ -8075,8 +8075,8 @@ class MyProtoClientTest extends GeneratedTest
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)
-     ->disableOriginalConstructor()
-     ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /**

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -5500,14 +5500,22 @@ class LibraryServiceClientTest extends GeneratedTest
     }
 
     /**
+     * @return CredentialsWrapper
+     */
+    private function createCredentials()
+    {
+        return $this->getMockBuilder(CredentialsWrapper::class)
+     ->disableOriginalConstructor()
+     ->getMock();
+    }
+
+    /**
      * @return LibraryServiceClient
      */
     private function createClient(array $options = [])
     {
         $options += [
-            'credentials' => $this->getMockBuilder(CredentialsWrapper::class)
-                ->disableOriginalConstructor()
-                ->getMock(),
+            'credentials' => $this->createCredentials(),
         ];
         return new LibraryServiceClient($options);
     }
@@ -7444,7 +7452,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport = $this->createTransport();
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
-            'transport' => $operationsTransport
+            'transport' => $operationsTransport,
+     'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([
@@ -7590,7 +7599,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport = $this->createTransport();
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
-            'transport' => $operationsTransport
+            'transport' => $operationsTransport,
+     'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([
@@ -8060,14 +8070,22 @@ class MyProtoClientTest extends GeneratedTest
     }
 
     /**
+     * @return CredentialsWrapper
+     */
+    private function createCredentials()
+    {
+        return $this->getMockBuilder(CredentialsWrapper::class)
+     ->disableOriginalConstructor()
+     ->getMock();
+    }
+
+    /**
      * @return MyProtoClient
      */
     private function createClient(array $options = [])
     {
         $options += [
-            'credentials' => $this->getMockBuilder(CredentialsWrapper::class)
-                ->disableOriginalConstructor()
-                ->getMock(),
+            'credentials' => $this->createCredentials(),
         ];
         return new MyProtoClient($options);
     }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
@@ -751,14 +751,22 @@ class OperationsClientTest extends GeneratedTest
     }
 
     /**
+     * @return CredentialsWrapper
+     */
+    private function createCredentials()
+    {
+        return $this->getMockBuilder(CredentialsWrapper::class)
+     ->disableOriginalConstructor()
+     ->getMock();
+    }
+
+    /**
      * @return OperationsClient
      */
     private function createClient(array $options = [])
     {
         $options += [
-            'credentials' => $this->getMockBuilder(CredentialsWrapper::class)
-                ->disableOriginalConstructor()
-                ->getMock(),
+            'credentials' => $this->createCredentials(),
             'serviceAddress' => '',
             'credentialsConfig' => [
                 'scopes' => [],

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
@@ -756,8 +756,8 @@ class OperationsClientTest extends GeneratedTest
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)
-     ->disableOriginalConstructor()
-     ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /**

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
@@ -392,14 +392,22 @@ class NoTemplatesApiServiceClientTest extends GeneratedTest
     }
 
     /**
+     * @return CredentialsWrapper
+     */
+    private function createCredentials()
+    {
+        return $this->getMockBuilder(CredentialsWrapper::class)
+     ->disableOriginalConstructor()
+     ->getMock();
+    }
+
+    /**
      * @return NoTemplatesApiServiceClient
      */
     private function createClient(array $options = [])
     {
         $options += [
-            'credentials' => $this->getMockBuilder(CredentialsWrapper::class)
-                ->disableOriginalConstructor()
-                ->getMock(),
+            'credentials' => $this->createCredentials(),
             'serviceAddress' => '',
             'credentialsConfig' => [
                 'scopes' => [],

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
@@ -397,8 +397,8 @@ class NoTemplatesApiServiceClientTest extends GeneratedTest
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)
-     ->disableOriginalConstructor()
-     ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /**

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -5428,14 +5428,22 @@ class LibraryServiceClientTest extends GeneratedTest
     }
 
     /**
+     * @return CredentialsWrapper
+     */
+    private function createCredentials()
+    {
+        return $this->getMockBuilder(CredentialsWrapper::class)
+     ->disableOriginalConstructor()
+     ->getMock();
+    }
+
+    /**
      * @return LibraryServiceClient
      */
     private function createClient(array $options = [])
     {
         $options += [
-            'credentials' => $this->getMockBuilder(CredentialsWrapper::class)
-                ->disableOriginalConstructor()
-                ->getMock(),
+            'credentials' => $this->createCredentials(),
         ];
         return new LibraryServiceClient($options);
     }
@@ -7372,7 +7380,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport = $this->createTransport();
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
-            'transport' => $operationsTransport
+            'transport' => $operationsTransport,
+     'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([
@@ -7518,7 +7527,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport = $this->createTransport();
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
-            'transport' => $operationsTransport
+            'transport' => $operationsTransport,
+     'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([
@@ -7988,14 +7998,22 @@ class MyProtoClientTest extends GeneratedTest
     }
 
     /**
+     * @return CredentialsWrapper
+     */
+    private function createCredentials()
+    {
+        return $this->getMockBuilder(CredentialsWrapper::class)
+     ->disableOriginalConstructor()
+     ->getMock();
+    }
+
+    /**
      * @return MyProtoClient
      */
     private function createClient(array $options = [])
     {
         $options += [
-            'credentials' => $this->getMockBuilder(CredentialsWrapper::class)
-                ->disableOriginalConstructor()
-                ->getMock(),
+            'credentials' => $this->createCredentials(),
         ];
         return new MyProtoClient($options);
     }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -7462,7 +7462,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport = $this->createTransport();
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
-            'transport' => $operationsTransport
+            'transport' => $operationsTransport,
+            'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([
@@ -7601,7 +7602,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport = $this->createTransport();
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
-            'transport' => $operationsTransport
+            'transport' => $operationsTransport,
+            'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -5433,8 +5433,8 @@ class LibraryServiceClientTest extends GeneratedTest
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)
-     ->disableOriginalConstructor()
-     ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /**
@@ -7381,7 +7381,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
             'transport' => $operationsTransport,
-     'credentials' => $this->createCredentials(),
+            'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([
@@ -7528,7 +7528,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsClient = new OperationsClient([
             'serviceAddress' => '',
             'transport' => $operationsTransport,
-     'credentials' => $this->createCredentials(),
+            'credentials' => $this->createCredentials(),
         ]);
         $transport = $this->createTransport();
         $client = $this->createClient([
@@ -8003,8 +8003,8 @@ class MyProtoClientTest extends GeneratedTest
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)
-     ->disableOriginalConstructor()
-     ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /**


### PR DESCRIPTION
We are observing intermittent failures in generated PHP unit tests which have longrunning methods. This is caused because the OperationsClient is being constructed incorrectly - it is looking for APPLICATION_DEFAULT_CREDENTIALS, even though these credentials are not necessary for unit tests to run. This means that generated unit tests for longrunning methods will fail if the application default credentials are not configured, but will succeed otherwise.

This change makes sure that the OperationsClient is constructed using dummy credentials, the same as standard clients.