### PR TITLE
SampleGen: Clearer error message when parameter default values are not set

### DIFF
--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -70,6 +70,18 @@ public class FieldStructureParser {
     return valueConfig;
   }
 
+  // Parses `config` to construct the `InitCodeNode` it specifies. `config` must be a valid
+  // config satisfying the eBNF grammar below:
+  //
+  // config = path ['%' ident] ['=' value];
+  // path = ident pathElem*
+  // pathElem = ('.' ident) | ('[' int ']') | ('{' value '}');
+  // value = int | string | ident;
+  //
+  // For compatibility with the previous parser, when ident is used as a value, the value is
+  // the name of the ident. Eg, if the ident is "x", the value is simply "x", not the content
+  // of the variable named "x".
+  //
   private static InitCodeNode parseConfig(
       InitCodeNode root, String config, Map<String, InitValueConfig> initValueConfigMap) {
     Scanner scanner = new Scanner(config);
@@ -171,14 +183,6 @@ public class FieldStructureParser {
       }
     }
   }
-
-  // **
-  //  * Parses the path found in {@code scanner} and descend the tree rooted at {@code root}. If
-  //  * children specified by the path do not exist, throw an {@code IllegalArgumentException}.
-  //  */
-  // public static InitCodeNode findPath(InitCodeNode root, Scanner scanner) {
-
-  // }
 
   /** Returns the entity name specified by `path` or null if `path` does not contain `%`. */
   public static String parseEntityName(String path) {

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -70,18 +70,6 @@ public class FieldStructureParser {
     return valueConfig;
   }
 
-  // Parses `config` to construct the `InitCodeNode` it specifies. `config` must be a valid
-  // config satisfying the eBNF grammar below:
-  //
-  // config = path ['%' ident] ['=' value];
-  // path = ident pathElem*
-  // pathElem = ('.' ident) | ('[' int ']') | ('{' value '}');
-  // value = int | string | ident;
-  //
-  // For compatibility with the previous parser, when ident is used as a value, the value is
-  // the name of the ident. Eg, if the ident is "x", the value is simply "x", not the content
-  // of the variable named "x".
-  //
   private static InitCodeNode parseConfig(
       InitCodeNode root, String config, Map<String, InitValueConfig> initValueConfigMap) {
     Scanner scanner = new Scanner(config);
@@ -183,6 +171,14 @@ public class FieldStructureParser {
       }
     }
   }
+
+  // **
+  //  * Parses the path found in {@code scanner} and descend the tree rooted at {@code root}. If
+  //  * children specified by the path do not exist, throw an {@code IllegalArgumentException}.
+  //  */
+  // public static InitCodeNode findPath(InitCodeNode root, Scanner scanner) {
+
+  // }
 
   /** Returns the entity name specified by `path` or null if `path` does not contain `%`. */
   public static String parseEntityName(String path) {

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -401,6 +401,10 @@ public class InitCodeNode {
   /** Apply {@code sampleParamConfig} to this node. */
   private void resolveSampleParamConfig(
       InitCodeContext context, SampleParameterConfig sampleParamConfig) {
+    Preconditions.checkArgument(
+        initValueConfig.getInitialValue() != null || !sampleParamConfig.isSampleArgument(),
+        "Cannot configure attributes for parameter \"%s\", default value not set.",
+        sampleParamConfig.identifier());
     if (sampleParamConfig.readFromFile()) {
       setupReadFileNode(context, sampleParamConfig);
       return;
@@ -421,6 +425,11 @@ public class InitCodeNode {
     Preconditions.checkArgument(
         !sampleParamConfig.readFromFile(),
         "cannot configure a resource name entity to read from file");
+    Preconditions.checkArgument(
+        !initValueConfig.getResourceNameBindingValues().isEmpty()
+            || !sampleParamConfig.isSampleArgument(),
+        "Cannot configure attributes for parameter \"%s\", default value not set.",
+        sampleParamConfig.identifier());
     if (!sampleParamConfig.isSampleArgument()) {
       return;
     }


### PR DESCRIPTION
It's hard to add a test case for this PR.

Manual test result:

When I comment out this in googleapis/googleapis/language/v1/gapic.yaml:
```yaml
parameters:
  defaults:
    # - document.content="I am so happy and joyful."
```

I am seeing the following error:
```
toplevel: Unexpected exception:
java.lang.IllegalArgumentException: Cannot configure attributes for parameter "document.content", default value not set.
```

Fix: #2511 #2793