### PR TITLE
node: make apiEndpoint an alias for servicePath

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -68,7 +68,7 @@
         {
           clientConfig: {},
           port: this.constructor.port,
-          servicePath: servicePath,
+          servicePath,
         },
         opts
       );

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -58,12 +58,17 @@
     constructor(opts) {
       this._descriptors = {};
 
+      const servicePath =
+        opts.servicePath ||
+        opts.apiEndpoint ||
+        this.constructor.servicePath;
+
       // Ensure that options include the service address and port.
       opts = Object.assign(
         {
           clientConfig: {},
           port: this.constructor.port,
-          servicePath: this.constructor.servicePath,
+          servicePath: servicePath,
         },
         opts
       );
@@ -257,6 +262,14 @@
      * The DNS address for this API service.
      */
     static get servicePath() {
+      return '{@xapi.serviceHostname}';
+    }
+
+    /**
+     * The DNS address for this API service - same as servicePath(),
+     * exists for compatibility reasons.
+     */
+    static get apiEndpoint() {
       return '{@xapi.serviceHostname}';
     }
 

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -13,6 +13,22 @@
 
   @join testClass : apiTest.testClasses
     describe('{@testClass.apiClassName}', () => {
+      it('has servicePath', () => {
+        const servicePath = {@clientClassName(testClass, apiTest)}.servicePath;
+        assert(servicePath);
+      });
+
+      it('has apiEndpoint', () => {
+        const apiEndpoint = {@clientClassName(testClass, apiTest)}.apiEndpoint;
+        assert(apiEndpoint);
+      });
+
+      it('has port', () => {
+        const port = {@clientClassName(testClass, apiTest)}.port;
+        assert(port);
+        assert(typeof port === 'number');
+      });
+
       @join test : testClass.testCases
         {@testCase(test, testClass, apiTest)}
 
@@ -358,16 +374,17 @@
 @end
 
 @private clientInit(testClass, apiTest)
+  const client = new {@clientClassName(testClass, apiTest)}({
+    credentials: {client_email: 'bogus', private_key: 'bogus'},
+    projectId: 'bogus',
+  });
+@end
+
+@private clientClassName(testClass, apiTest)
   @if apiTest.fileHeader.hasVersion
-    const client = new {@apiTest.localPackageName}Module.{@apiTest.fileHeader.version}.{@testClass.apiClassName}({
-      credentials: {client_email: 'bogus', private_key: 'bogus'},
-      projectId: 'bogus',
-    });
+    {@apiTest.localPackageName}Module.{@apiTest.fileHeader.version}.{@testClass.apiClassName}
   @else
-    const client = new {@apiTest.localPackageName}Module.{@testClass.apiClassName}({
-      credentials: {client_email: 'bogus', private_key: 'bogus'},
-      projectId: 'bogus',
-    });
+    {@apiTest.localPackageName}Module.{@testClass.apiClassName}
   @end
 @end
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -4062,12 +4062,17 @@ class LibraryServiceClient {
   constructor(opts) {
     this._descriptors = {};
 
+    const servicePath =
+      opts.servicePath ||
+      opts.apiEndpoint ||
+      this.constructor.servicePath;
+
     // Ensure that options include the service address and port.
     opts = Object.assign(
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: this.constructor.servicePath,
+        servicePath: servicePath,
       },
       opts
     );
@@ -4325,6 +4330,14 @@ class LibraryServiceClient {
    * The DNS address for this API service.
    */
   static get servicePath() {
+    return 'library-example.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath(),
+   * exists for compatibility reasons.
+   */
+  static get apiEndpoint() {
     return 'library-example.googleapis.com';
   }
 
@@ -6939,12 +6952,17 @@ class MyProtoClient {
   constructor(opts) {
     this._descriptors = {};
 
+    const servicePath =
+      opts.servicePath ||
+      opts.apiEndpoint ||
+      this.constructor.servicePath;
+
     // Ensure that options include the service address and port.
     opts = Object.assign(
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: this.constructor.servicePath,
+        servicePath: servicePath,
       },
       opts
     );
@@ -7033,6 +7051,14 @@ class MyProtoClient {
    * The DNS address for this API service.
    */
   static get servicePath() {
+    return 'library-example.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath(),
+   * exists for compatibility reasons.
+   */
+  static get apiEndpoint() {
     return 'library-example.googleapis.com';
   }
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -4072,7 +4072,7 @@ class LibraryServiceClient {
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: servicePath,
+        servicePath,
       },
       opts
     );
@@ -6962,7 +6962,7 @@ class MyProtoClient {
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: servicePath,
+        servicePath,
       },
       opts
     );

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -7264,6 +7264,22 @@ const error = new Error();
 error.code = FAKE_STATUS_CODE;
 
 describe('LibraryServiceClient', () => {
+  it('has servicePath', () => {
+    const servicePath = libraryModule.v1.LibraryServiceClient.servicePath;
+    assert(servicePath);
+  });
+
+  it('has apiEndpoint', () => {
+    const apiEndpoint = libraryModule.v1.LibraryServiceClient.apiEndpoint;
+    assert(apiEndpoint);
+  });
+
+  it('has port', () => {
+    const port = libraryModule.v1.LibraryServiceClient.port;
+    assert(port);
+    assert(typeof port === 'number');
+  });
+
   describe('createShelf', () => {
     it('invokes createShelf without error', done => {
       const client = new libraryModule.v1.LibraryServiceClient({
@@ -9122,6 +9138,22 @@ describe('LibraryServiceClient', () => {
 
 });
 describe('MyProtoClient', () => {
+  it('has servicePath', () => {
+    const servicePath = libraryModule.v1.MyProtoClient.servicePath;
+    assert(servicePath);
+  });
+
+  it('has apiEndpoint', () => {
+    const apiEndpoint = libraryModule.v1.MyProtoClient.apiEndpoint;
+    assert(apiEndpoint);
+  });
+
+  it('has port', () => {
+    const port = libraryModule.v1.MyProtoClient.port;
+    assert(port);
+    assert(typeof port === 'number');
+  });
+
   describe('myMethod', () => {
     it('invokes myMethod without error', done => {
       const client = new libraryModule.v1.MyProtoClient({

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -235,7 +235,7 @@ class DecrementerServiceClient {
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: servicePath,
+        servicePath,
       },
       opts
     );
@@ -568,7 +568,7 @@ class IncrementerServiceClient {
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: servicePath,
+        servicePath,
       },
       opts
     );

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -225,12 +225,17 @@ class DecrementerServiceClient {
   constructor(opts) {
     this._descriptors = {};
 
+    const servicePath =
+      opts.servicePath ||
+      opts.apiEndpoint ||
+      this.constructor.servicePath;
+
     // Ensure that options include the service address and port.
     opts = Object.assign(
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: this.constructor.servicePath,
+        servicePath: servicePath,
       },
       opts
     );
@@ -316,6 +321,14 @@ class DecrementerServiceClient {
    * The DNS address for this API service.
    */
   static get servicePath() {
+    return 'no-path-templates.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath(),
+   * exists for compatibility reasons.
+   */
+  static get apiEndpoint() {
     return 'no-path-templates.googleapis.com';
   }
 
@@ -545,12 +558,17 @@ class IncrementerServiceClient {
   constructor(opts) {
     this._descriptors = {};
 
+    const servicePath =
+      opts.servicePath ||
+      opts.apiEndpoint ||
+      this.constructor.servicePath;
+
     // Ensure that options include the service address and port.
     opts = Object.assign(
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: this.constructor.servicePath,
+        servicePath: servicePath,
       },
       opts
     );
@@ -630,6 +648,14 @@ class IncrementerServiceClient {
    * The DNS address for this API service.
    */
   static get servicePath() {
+    return 'no-path-templates.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath(),
+   * exists for compatibility reasons.
+   */
+  static get apiEndpoint() {
     return 'no-path-templates.googleapis.com';
   }
 
@@ -911,3 +937,4 @@ function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
     return mockStream;
   }
 }
+

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -813,6 +813,22 @@ const error = new Error();
 error.code = FAKE_STATUS_CODE;
 
 describe('IncrementerServiceClient', () => {
+  it('has servicePath', () => {
+    const servicePath = multipleServicesModule.v1.IncrementerServiceClient.servicePath;
+    assert(servicePath);
+  });
+
+  it('has apiEndpoint', () => {
+    const apiEndpoint = multipleServicesModule.v1.IncrementerServiceClient.apiEndpoint;
+    assert(apiEndpoint);
+  });
+
+  it('has port', () => {
+    const port = multipleServicesModule.v1.IncrementerServiceClient.port;
+    assert(port);
+    assert(typeof port === 'number');
+  });
+
   describe('increment', () => {
     it('invokes increment without error', done => {
       const client = new multipleServicesModule.v1.IncrementerServiceClient({
@@ -858,6 +874,22 @@ describe('IncrementerServiceClient', () => {
 
 });
 describe('DecrementerServiceClient', () => {
+  it('has servicePath', () => {
+    const servicePath = multipleServicesModule.v1.DecrementerServiceClient.servicePath;
+    assert(servicePath);
+  });
+
+  it('has apiEndpoint', () => {
+    const apiEndpoint = multipleServicesModule.v1.DecrementerServiceClient.apiEndpoint;
+    assert(apiEndpoint);
+  });
+
+  it('has port', () => {
+    const port = multipleServicesModule.v1.DecrementerServiceClient.port;
+    assert(port);
+    assert(typeof port === 'number');
+  });
+
   describe('decrement', () => {
     it('invokes decrement without error', done => {
       const client = new multipleServicesModule.v1.DecrementerServiceClient({

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -451,6 +451,22 @@ const error = new Error();
 error.code = FAKE_STATUS_CODE;
 
 describe('NoTemplatesApiServiceClient', () => {
+  it('has servicePath', () => {
+    const servicePath = exampleModule.NoTemplatesApiServiceClient.servicePath;
+    assert(servicePath);
+  });
+
+  it('has apiEndpoint', () => {
+    const apiEndpoint = exampleModule.NoTemplatesApiServiceClient.apiEndpoint;
+    assert(apiEndpoint);
+  });
+
+  it('has port', () => {
+    const port = exampleModule.NoTemplatesApiServiceClient.port;
+    assert(port);
+    assert(typeof port === 'number');
+  });
+
   describe('increment', () => {
     it('invokes increment without error', done => {
       const client = new exampleModule.NoTemplatesApiServiceClient({

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -225,7 +225,7 @@ class NoTemplatesApiServiceClient {
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: servicePath,
+        servicePath,
       },
       opts
     );

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -215,12 +215,17 @@ class NoTemplatesApiServiceClient {
   constructor(opts) {
     this._descriptors = {};
 
+    const servicePath =
+      opts.servicePath ||
+      opts.apiEndpoint ||
+      this.constructor.servicePath;
+
     // Ensure that options include the service address and port.
     opts = Object.assign(
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: this.constructor.servicePath,
+        servicePath: servicePath,
       },
       opts
     );
@@ -300,6 +305,14 @@ class NoTemplatesApiServiceClient {
    * The DNS address for this API service.
    */
   static get servicePath() {
+    return 'no-path-templates.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath(),
+   * exists for compatibility reasons.
+   */
+  static get apiEndpoint() {
     return 'no-path-templates.googleapis.com';
   }
 
@@ -495,3 +508,4 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
     }
   };
 }
+

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -7215,6 +7215,22 @@ const error = new Error();
 error.code = FAKE_STATUS_CODE;
 
 describe('LibraryServiceClient', () => {
+  it('has servicePath', () => {
+    const servicePath = libraryModule.v1.LibraryServiceClient.servicePath;
+    assert(servicePath);
+  });
+
+  it('has apiEndpoint', () => {
+    const apiEndpoint = libraryModule.v1.LibraryServiceClient.apiEndpoint;
+    assert(apiEndpoint);
+  });
+
+  it('has port', () => {
+    const port = libraryModule.v1.LibraryServiceClient.port;
+    assert(port);
+    assert(typeof port === 'number');
+  });
+
   describe('createShelf', () => {
     it('invokes createShelf without error', done => {
       const client = new libraryModule.v1.LibraryServiceClient({
@@ -9073,6 +9089,22 @@ describe('LibraryServiceClient', () => {
 
 });
 describe('MyProtoClient', () => {
+  it('has servicePath', () => {
+    const servicePath = libraryModule.v1.MyProtoClient.servicePath;
+    assert(servicePath);
+  });
+
+  it('has apiEndpoint', () => {
+    const apiEndpoint = libraryModule.v1.MyProtoClient.apiEndpoint;
+    assert(apiEndpoint);
+  });
+
+  it('has port', () => {
+    const port = libraryModule.v1.MyProtoClient.port;
+    assert(port);
+    assert(typeof port === 'number');
+  });
+
   describe('myMethod', () => {
     it('invokes myMethod without error', done => {
       const client = new libraryModule.v1.MyProtoClient({

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -4073,7 +4073,7 @@ class LibraryServiceClient {
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: servicePath,
+        servicePath,
       },
       opts
     );
@@ -6981,7 +6981,7 @@ class MyProtoClient {
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: servicePath,
+        servicePath,
       },
       opts
     );

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -4063,12 +4063,17 @@ class LibraryServiceClient {
   constructor(opts) {
     this._descriptors = {};
 
+    const servicePath =
+      opts.servicePath ||
+      opts.apiEndpoint ||
+      this.constructor.servicePath;
+
     // Ensure that options include the service address and port.
     opts = Object.assign(
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: this.constructor.servicePath,
+        servicePath: servicePath,
       },
       opts
     );
@@ -4326,6 +4331,14 @@ class LibraryServiceClient {
    * The DNS address for this API service.
    */
   static get servicePath() {
+    return 'library-example.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath(),
+   * exists for compatibility reasons.
+   */
+  static get apiEndpoint() {
     return 'library-example.googleapis.com';
   }
 
@@ -6958,12 +6971,17 @@ class MyProtoClient {
   constructor(opts) {
     this._descriptors = {};
 
+    const servicePath =
+      opts.servicePath ||
+      opts.apiEndpoint ||
+      this.constructor.servicePath;
+
     // Ensure that options include the service address and port.
     opts = Object.assign(
       {
         clientConfig: {},
         port: this.constructor.port,
-        servicePath: this.constructor.servicePath,
+        servicePath: servicePath,
       },
       opts
     );
@@ -7043,6 +7061,14 @@ class MyProtoClient {
    * The DNS address for this API service.
    */
   static get servicePath() {
+    return 'library-example.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath(),
+   * exists for compatibility reasons.
+   */
+  static get apiEndpoint() {
     return 'library-example.googleapis.com';
   }
 


### PR DESCRIPTION
Fixes #2787. Also, adds some test coverage for the new generated static method.