### PR TITLE
Add GAPIC_CODE artifact type support for PHP

### DIFF
--- a/src/main/java/com/google/api/codegen/discogapic/DiscoGapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/discogapic/DiscoGapicGeneratorApp.java
@@ -157,7 +157,7 @@ public class DiscoGapicGeneratorApp {
 
     GapicProductConfig productConfig = GapicProductConfig.create(model, configProto, language);
 
-    ArtifactFlags artifactFlags = new ArtifactFlags(enabledArtifacts, artifactType);
+    ArtifactFlags artifactFlags = new ArtifactFlags(enabledArtifacts, artifactType, false);
     return DiscoGapicGeneratorFactory.create(
         language, model, productConfig, packageConfig, artifactFlags);
   }

--- a/src/main/java/com/google/api/codegen/gapic/ArtifactFlags.java
+++ b/src/main/java/com/google/api/codegen/gapic/ArtifactFlags.java
@@ -21,12 +21,15 @@ public class ArtifactFlags {
   public static final String ARTIFACT_SURFACE = "surface";
   public static final String ARTIFACT_TEST = "test";
 
-  private List<String> enabledArtifacts;
-  private ArtifactType artifactType;
+  private final List<String> enabledArtifacts;
+  private final ArtifactType artifactType;
+  private final boolean devSamples;
 
-  public ArtifactFlags(List<String> enabledArtifacts, ArtifactType artifactType) {
+  public ArtifactFlags(
+      List<String> enabledArtifacts, ArtifactType artifactType, boolean devSamples) {
     this.enabledArtifacts = enabledArtifacts;
     this.artifactType = artifactType;
+    this.devSamples = devSamples;
   }
 
   public boolean surfaceGeneratorEnabled() {
@@ -48,5 +51,9 @@ public class ArtifactFlags {
     return artifactType == ArtifactType.LEGACY_GAPIC_AND_PACKAGE
         || artifactType == ArtifactType.GAPIC_PACKAGE
         || artifactType == ArtifactType.LEGACY_DISCOGAPIC_AND_PACKAGE;
+  }
+
+  public boolean devSamplesEnabled() {
+    return devSamples;
   }
 }

--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
@@ -172,10 +172,10 @@ public class GapicGeneratorApp extends ToolDriverBase {
       return;
     }
 
-    ArtifactFlags artifactFlags = new ArtifactFlags(options.get(ENABLED_ARTIFACTS), artifactType);
+    ArtifactFlags artifactFlags =
+        new ArtifactFlags(options.get(ENABLED_ARTIFACTS), artifactType, options.get(DEV_SAMPLES));
     List<CodeGenerator<?>> generators =
-        GapicGeneratorFactory.create(
-            language, model, productConfig, packageConfig, artifactFlags, options.get(DEV_SAMPLES));
+        GapicGeneratorFactory.create(language, model, productConfig, packageConfig, artifactFlags);
     ImmutableMap.Builder<String, GeneratedResult<?>> generatedResults = ImmutableMap.builder();
     for (CodeGenerator<?> generator : generators) {
       Map<String, ? extends GeneratedResult<?>> generatorResult = generator.generate();

--- a/src/test/java/com/google/api/codegen/gapic/GapicTestBase2.java
+++ b/src/test/java/com/google/api/codegen/gapic/GapicTestBase2.java
@@ -174,11 +174,12 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
     PackageMetadataConfig packageConfig = PackageMetadataConfig.createDummyPackageMetadataConfig();
     ArtifactFlags artifactFlags =
         new ArtifactFlags(
-            Arrays.asList("surface", "test", "samples"), ArtifactType.LEGACY_GAPIC_AND_PACKAGE);
+            Arrays.asList("surface", "test", "samples"),
+            ArtifactType.LEGACY_GAPIC_AND_PACKAGE,
+            true);
 
     List<CodeGenerator<?>> generators =
-        GapicGeneratorFactory.create(
-            language, model, productConfig, packageConfig, artifactFlags, true);
+        GapicGeneratorFactory.create(language, model, productConfig, packageConfig, artifactFlags);
 
     List<String> snippetNames = new ArrayList<>();
     for (CodeGenerator<?> generator : generators) {
@@ -235,11 +236,10 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
       enabledArtifacts.addAll(Arrays.asList("surface", "test", "samples"));
     }
     ArtifactFlags artifactFlags =
-        new ArtifactFlags(enabledArtifacts, ArtifactType.LEGACY_GAPIC_AND_PACKAGE);
+        new ArtifactFlags(enabledArtifacts, ArtifactType.LEGACY_GAPIC_AND_PACKAGE, true);
 
     List<CodeGenerator<?>> generators =
-        GapicGeneratorFactory.create(
-            language, model, productConfig, packageConfig, artifactFlags, true);
+        GapicGeneratorFactory.create(language, model, productConfig, packageConfig, artifactFlags);
 
     // Don't run any generators we're not testing.
     ArrayList<CodeGenerator<?>> testedGenerators = new ArrayList<>();

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
@@ -378,7 +378,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
- * @group library
+ * @group example
  * @group gapic
  */
 class NoTemplatesApiServiceClientTest extends GeneratedTest


### PR DESCRIPTION
This is needed to support bazel generation and avoid generating `composer.json`, since it is already broken and should not be generated by the generator. `Gapic-generator` generates code, but not packaging-specific files, because same generated code can be packaged differently depending on now it is deployed/used.