### PR TITLE
SampleGen: Choose the resource name that matches binding values for Oneof resource names

### DIFF
--- a/src/main/java/com/google/api/codegen/config/ResourceNameOneofConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameOneofConfig.java
@@ -22,9 +22,9 @@ import com.google.api.tools.framework.model.ProtoFile;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /** ResourceNameOneofConfig represents the configuration for a oneof set of resource names. */
@@ -45,8 +45,12 @@ public abstract class ResourceNameOneofConfig implements ResourceNameConfig {
     return null;
   }
 
-  public Iterable<SingleResourceNameConfig> getSingleResourceNameConfigs() {
-    return Iterables.filter(getResourceNameConfigs(), SingleResourceNameConfig.class);
+  public List<SingleResourceNameConfig> getSingleResourceNameConfigs() {
+    return getResourceNameConfigs()
+        .stream()
+        .filter(c -> c.getResourceNameType() == ResourceNameType.SINGLE)
+        .map(c -> (SingleResourceNameConfig) c)
+        .collect(Collectors.toList());
   }
 
   @Nullable

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -961,7 +961,7 @@ public class InitCodeTransformer {
                         .vars()
                         .equals(node.getInitValueConfig().getResourceNameBindingValues().keySet()))
             .collect(Collectors.toList());
-    // Return the first one to not break incode samples and unit tests when
+    // Return the first one to not break in-code samples and unit tests when
     // there are no matching resource name binding values
     if (matchingConfigs.isEmpty()) {
       return oneofConfig.getSingleResourceNameConfigs().get(0);

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -1885,6 +1885,48 @@ public class TestResourceNameOneof
         SampleGetBookFromAbsolutelyAnywhere();
     }
 }
+============== file: Google.Example.Library.V1/Google.Example.Library.V1.Samples/TestResourceNameOneof2.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Request", "test_resource_name_oneof_2")
+
+// [START test_resource_name_oneof_2]
+// FIXME: import everything this sample needs
+public class TestResourceNameOneof2
+{
+    // [START test_resource_name_oneof_2_core]
+    public static void SampleGetBookFromAbsolutelyAnywhere()
+    {
+        LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+        GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
+        {
+            AsResourceName = BookNameOneof.From(new BookName("The Shelf to search for the book", "The ID of the book")),
+        };
+        BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
+        // FIXME: inspect the results
+    }
+    // [END test_resource_name_oneof_2_core]
+
+    // [END test_resource_name_oneof_2]
+    public static void Main(string[] args)
+    {
+        SampleGetBookFromAbsolutelyAnywhere();
+    }
+}
 ============== file: Google.Example.Library.V1/Google.Example.Library.V1.SmokeTests/Google.Example.Library.V1.SmokeTests.csproj ==============
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -1843,6 +1843,48 @@ public class TestDefaultCallingFormForPaging
         SampleListShelves();
     }
 }
+============== file: Google.Example.Library.V1/Google.Example.Library.V1.Samples/TestResourceNameOneof.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Request", "test_resource_name_oneof")
+
+// [START test_resource_name_oneof]
+// FIXME: import everything this sample needs
+public class TestResourceNameOneof
+{
+    // [START test_resource_name_oneof_core]
+    public static void SampleGetBookFromAbsolutelyAnywhere()
+    {
+        LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+        GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
+        {
+            AsResourceName = BookNameOneof.From(new ArchivedBookName("The archive to search for the book", "The ID of the book")),
+        };
+        BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
+        // FIXME: inspect the results
+    }
+    // [END test_resource_name_oneof_core]
+
+    // [END test_resource_name_oneof]
+    public static void Main(string[] args)
+    {
+        SampleGetBookFromAbsolutelyAnywhere();
+    }
+}
 ============== file: Google.Example.Library.V1/Google.Example.Library.V1.SmokeTests/Google.Example.Library.V1.SmokeTests.csproj ==============
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -3377,13 +3377,72 @@ public class TestResourceNameOneof {
         .setName(name.toString())
         .build();
       BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(request);
-      System.out.println("Book found.");
+      System.out.println("Archived book found.");
     } catch (Exception exception) {
       System.err.println("Failed to create the client due to: " + exception);
     }
     // [END test_resource_name_oneof_core]
   }
   // [END test_resource_name_oneof]
+
+  public static void main(String[] args) {
+    sampleGetBookFromAbsolutelyAnywhere();
+  }
+}
+============== file: samples/src/main/java/com/google/example/examples/library/v1/TestResourceNameOneof2.java ==============
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
+package com.google.example.examples.library.v1;
+
+import com.google.api.resourcenames.ResourceName;
+import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookName;
+import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class TestResourceNameOneof2 {
+  // [START test_resource_name_oneof_2]
+  /*
+   * Please include the following imports to run this sample.
+   *
+   * import com.google.api.resourcenames.ResourceName;
+   * import com.google.example.library.v1.BookFromAnywhere;
+   * import com.google.example.library.v1.BookName;
+   * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+   * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
+   */
+
+  public static void sampleGetBookFromAbsolutelyAnywhere() {
+    // [START test_resource_name_oneof_2_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ResourceName name = ShelfBookName.of("The Shelf to search for the book", "The ID of the book");
+      GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(request);
+      System.out.println("Book on shelf found.");
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END test_resource_name_oneof_2_core]
+  }
+  // [END test_resource_name_oneof_2]
 
   public static void main(String[] args) {
     sampleGetBookFromAbsolutelyAnywhere();

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -3330,6 +3330,65 @@ public class TestDefaultCallingFormForPaging {
     sampleListShelves();
   }
 }
+============== file: samples/src/main/java/com/google/example/examples/library/v1/TestResourceNameOneof.java ==============
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
+package com.google.example.examples.library.v1;
+
+import com.google.api.resourcenames.ResourceName;
+import com.google.example.library.v1.ArchivedBookName;
+import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookName;
+import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+import com.google.example.library.v1.LibraryClient;
+
+public class TestResourceNameOneof {
+  // [START test_resource_name_oneof]
+  /*
+   * Please include the following imports to run this sample.
+   *
+   * import com.google.api.resourcenames.ResourceName;
+   * import com.google.example.library.v1.ArchivedBookName;
+   * import com.google.example.library.v1.BookFromAnywhere;
+   * import com.google.example.library.v1.BookName;
+   * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+   * import com.google.example.library.v1.LibraryClient;
+   */
+
+  public static void sampleGetBookFromAbsolutelyAnywhere() {
+    // [START test_resource_name_oneof_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ResourceName name = ArchivedBookName.of("The archive to search for the book", "The ID of the book");
+      GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(request);
+      System.out.println("Book found.");
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END test_resource_name_oneof_core]
+  }
+  // [END test_resource_name_oneof]
+
+  public static void main(String[] args) {
+    sampleGetBookFromAbsolutelyAnywhere();
+  }
+}
 ============== file: samples/src/main/java/com/google/example/examples/library/v1/ThisTagShouldBeTheNameOfTheFile.java ==============
 /*
  * Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -1321,6 +1321,34 @@ function sampleListShelves() {
 // tslint:disable-next-line:no-any
 
 sampleListShelves();
+============== file: samples/v1/test_resource_name_oneof.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
+'use strict';
+
+// [START test_resource_name_oneof]
+// [START test_resource_name_oneof_core]
+
+const library = require('@google-cloud/library').v1;
+
+function sampleGetBookFromAbsolutelyAnywhere() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.archivedBookPath('The archive to search for the book', 'The ID of the book');
+  client.getBookFromAbsolutelyAnywhere({name: formattedName})
+    .then(responses => {
+      const response = responses[0];
+      console.log(`Book found.`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END test_resource_name_oneof_core]
+// [END test_resource_name_oneof]
+// tslint:disable-next-line:no-any
+
+sampleGetBookFromAbsolutelyAnywhere();
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.js ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "wap")
 'use strict';

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -1336,7 +1336,7 @@ function sampleGetBookFromAbsolutelyAnywhere() {
   client.getBookFromAbsolutelyAnywhere({name: formattedName})
     .then(responses => {
       const response = responses[0];
-      console.log(`Book found.`);
+      console.log(`Archived book found.`);
     })
     .catch(err => {
       console.error(err);
@@ -1346,6 +1346,34 @@ function sampleGetBookFromAbsolutelyAnywhere() {
 
 // [END test_resource_name_oneof_core]
 // [END test_resource_name_oneof]
+// tslint:disable-next-line:no-any
+
+sampleGetBookFromAbsolutelyAnywhere();
+============== file: samples/v1/test_resource_name_oneof_2.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
+'use strict';
+
+// [START test_resource_name_oneof_2]
+// [START test_resource_name_oneof_2_core]
+
+const library = require('@google-cloud/library').v1;
+
+function sampleGetBookFromAbsolutelyAnywhere() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('The Shelf to search for the book', 'The ID of the book');
+  client.getBookFromAbsolutelyAnywhere({name: formattedName})
+    .then(responses => {
+      const response = responses[0];
+      console.log(`Book on shelf found.`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END test_resource_name_oneof_2_core]
+// [END test_resource_name_oneof_2]
 // tslint:disable-next-line:no-any
 
 sampleGetBookFromAbsolutelyAnywhere();

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -1702,7 +1702,7 @@ function sampleGetBookFromAbsolutelyAnywhere()
 
     try {
         $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
-        printf("Book found." . PHP_EOL);
+        printf("Archived book found." . PHP_EOL);
     } finally {
         $libraryServiceClient->close();
     }
@@ -1710,6 +1710,53 @@ function sampleGetBookFromAbsolutelyAnywhere()
     // [END test_resource_name_oneof_core]
 }
 // [END test_resource_name_oneof]
+
+sampleGetBookFromAbsolutelyAnywhere();
+============== file: samples/V1/TestResourceNameOneof2.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
+ */
+
+// [START test_resource_name_oneof_2]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+function sampleGetBookFromAbsolutelyAnywhere()
+{
+    // [START test_resource_name_oneof_2_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('The Shelf to search for the book', 'The ID of the book');
+
+    try {
+        $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
+        printf("Book on shelf found." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END test_resource_name_oneof_2_core]
+}
+// [END test_resource_name_oneof_2]
 
 sampleGetBookFromAbsolutelyAnywhere();
 ============== file: samples/V1/ThisTagShouldBeTheNameOfTheFile.php ==============

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -1665,6 +1665,53 @@ function sampleListShelves()
 // [END test_default_calling_form_for_paging]
 
 sampleListShelves();
+============== file: samples/V1/TestResourceNameOneof.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
+ */
+
+// [START test_resource_name_oneof]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+function sampleGetBookFromAbsolutelyAnywhere()
+{
+    // [START test_resource_name_oneof_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->archivedBookName('The archive to search for the book', 'The ID of the book');
+
+    try {
+        $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
+        printf("Book found." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END test_resource_name_oneof_core]
+}
+// [END test_resource_name_oneof]
+
+sampleGetBookFromAbsolutelyAnywhere();
 ============== file: samples/V1/ThisTagShouldBeTheNameOfTheFile.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -6053,6 +6053,52 @@ def main():
 
 if __name__ == '__main__':
   main()
+============== file: samples/v1/test_resource_name_oneof.py ==============
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-library
+
+import sys
+
+# [START test_resource_name_oneof]
+
+from google.cloud.example import library_v1
+
+def sample_get_book_from_absolutely_anywhere():
+  # [START test_resource_name_oneof_core]
+
+  client = library_v1.LibraryServiceClient()
+
+  name = client.archived_book_path('The archive to search for the book', 'The ID of the book')
+
+  response = client.get_book_from_absolutely_anywhere(name)
+  print('Book found.')
+
+  # [END test_resource_name_oneof_core]
+# [END test_resource_name_oneof]
+
+def main():
+  sample_get_book_from_absolutely_anywhere()
+
+if __name__ == '__main__':
+  main()
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.py ==============
 # -*- coding: utf-8 -*-
 #

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -6089,10 +6089,56 @@ def sample_get_book_from_absolutely_anywhere():
   name = client.archived_book_path('The archive to search for the book', 'The ID of the book')
 
   response = client.get_book_from_absolutely_anywhere(name)
-  print('Book found.')
+  print('Archived book found.')
 
   # [END test_resource_name_oneof_core]
 # [END test_resource_name_oneof]
+
+def main():
+  sample_get_book_from_absolutely_anywhere()
+
+if __name__ == '__main__':
+  main()
+============== file: samples/v1/test_resource_name_oneof_2.py ==============
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-library
+
+import sys
+
+# [START test_resource_name_oneof_2]
+
+from google.cloud.example import library_v1
+
+def sample_get_book_from_absolutely_anywhere():
+  # [START test_resource_name_oneof_2_core]
+
+  client = library_v1.LibraryServiceClient()
+
+  name = client.book_path('The Shelf to search for the book', 'The ID of the book')
+
+  response = client.get_book_from_absolutely_anywhere(name)
+  print('Book on shelf found.')
+
+  # [END test_resource_name_oneof_2_core]
+# [END test_resource_name_oneof_2]
 
 def main():
   sample_get_book_from_absolutely_anywhere()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -6408,6 +6408,47 @@ require "optparse"
 if $0 == __FILE__
   sample_list_shelves
 end
+============== file: samples/v1/test_resource_name_oneof.rb ==============
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
+
+require "library"
+
+# [START test_resource_name_oneof]
+
+def sample_get_book_from_absolutely_anywhere
+  # [START test_resource_name_oneof_core]
+  # Instantiate a client
+  library_client = Library::Library.new version: :v1
+
+  formatted_name = library_client.class.archived_book_path("The archive to search for the book", "The ID of the book")
+
+  response = library_client.get_book_from_absolutely_anywhere(formatted_name)
+  puts "Book found."
+
+  # [END test_resource_name_oneof_core]
+end
+# [END test_resource_name_oneof]
+
+
+require "optparse"
+
+if $0 == __FILE__
+  sample_get_book_from_absolutely_anywhere
+end
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.rb ==============
 # Copyright 2019 Google LLC
 #

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -6437,11 +6437,52 @@ def sample_get_book_from_absolutely_anywhere
   formatted_name = library_client.class.archived_book_path("The archive to search for the book", "The ID of the book")
 
   response = library_client.get_book_from_absolutely_anywhere(formatted_name)
-  puts "Book found."
+  puts "Archived book found."
 
   # [END test_resource_name_oneof_core]
 end
 # [END test_resource_name_oneof]
+
+
+require "optparse"
+
+if $0 == __FILE__
+  sample_get_book_from_absolutely_anywhere
+end
+============== file: samples/v1/test_resource_name_oneof_2.rb ==============
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
+
+require "library"
+
+# [START test_resource_name_oneof_2]
+
+def sample_get_book_from_absolutely_anywhere
+  # [START test_resource_name_oneof_2_core]
+  # Instantiate a client
+  library_client = Library::Library.new version: :v1
+
+  formatted_name = library_client.class.book_path("The Shelf to search for the book", "The ID of the book")
+
+  response = library_client.get_book_from_absolutely_anywhere(formatted_name)
+  puts "Book on shelf found."
+
+  # [END test_resource_name_oneof_2_core]
+end
+# [END test_resource_name_oneof_2]
 
 
 require "optparse"

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -1843,6 +1843,48 @@ public class TestDefaultCallingFormForPaging
         SampleListShelves();
     }
 }
+============== file: Google.Example.Library.V1/Google.Example.Library.V1.Samples/TestResourceNameOneof.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Request", "test_resource_name_oneof")
+
+// [START test_resource_name_oneof]
+// FIXME: import everything this sample needs
+public class TestResourceNameOneof
+{
+    // [START test_resource_name_oneof_core]
+    public static void SampleGetBookFromAbsolutelyAnywhere()
+    {
+        LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+        GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
+        {
+            BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+        };
+        BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
+        // FIXME: inspect the results
+    }
+    // [END test_resource_name_oneof_core]
+
+    // [END test_resource_name_oneof]
+    public static void Main(string[] args)
+    {
+        SampleGetBookFromAbsolutelyAnywhere();
+    }
+}
 ============== file: Google.Example.Library.V1/Google.Example.Library.V1.SmokeTests/Google.Example.Library.V1.SmokeTests.csproj ==============
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -1885,6 +1885,48 @@ public class TestResourceNameOneof
         SampleGetBookFromAbsolutelyAnywhere();
     }
 }
+============== file: Google.Example.Library.V1/Google.Example.Library.V1.Samples/TestResourceNameOneof2.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Request", "test_resource_name_oneof_2")
+
+// [START test_resource_name_oneof_2]
+// FIXME: import everything this sample needs
+public class TestResourceNameOneof2
+{
+    // [START test_resource_name_oneof_2_core]
+    public static void SampleGetBookFromAbsolutelyAnywhere()
+    {
+        LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+        GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
+        {
+            BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+        };
+        BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
+        // FIXME: inspect the results
+    }
+    // [END test_resource_name_oneof_2_core]
+
+    // [END test_resource_name_oneof_2]
+    public static void Main(string[] args)
+    {
+        SampleGetBookFromAbsolutelyAnywhere();
+    }
+}
 ============== file: Google.Example.Library.V1/Google.Example.Library.V1.SmokeTests/Google.Example.Library.V1.SmokeTests.csproj ==============
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -3435,13 +3435,70 @@ public class TestResourceNameOneof {
         .setName(name.toString())
         .build();
       BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(request);
-      System.out.println("Book found.");
+      System.out.println("Archived book found.");
     } catch (Exception exception) {
       System.err.println("Failed to create the client due to: " + exception);
     }
     // [END test_resource_name_oneof_core]
   }
   // [END test_resource_name_oneof]
+
+  public static void main(String[] args) {
+    sampleGetBookFromAbsolutelyAnywhere();
+  }
+}
+============== file: samples/src/main/java/com/google/example/examples/library/v1/TestResourceNameOneof2.java ==============
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
+package com.google.example.examples.library.v1;
+
+import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookName;
+import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class TestResourceNameOneof2 {
+  // [START test_resource_name_oneof_2]
+  /*
+   * Please include the following imports to run this sample.
+   *
+   * import com.google.example.library.v1.BookFromAnywhere;
+   * import com.google.example.library.v1.BookName;
+   * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+   * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
+   */
+
+  public static void sampleGetBookFromAbsolutelyAnywhere() {
+    // [START test_resource_name_oneof_2_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(request);
+      System.out.println("Book on shelf found.");
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END test_resource_name_oneof_2_core]
+  }
+  // [END test_resource_name_oneof_2]
 
   public static void main(String[] args) {
     sampleGetBookFromAbsolutelyAnywhere();

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -3390,6 +3390,63 @@ public class TestDefaultCallingFormForPaging {
     sampleListShelves();
   }
 }
+============== file: samples/src/main/java/com/google/example/examples/library/v1/TestResourceNameOneof.java ==============
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
+package com.google.example.examples.library.v1;
+
+import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookName;
+import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class TestResourceNameOneof {
+  // [START test_resource_name_oneof]
+  /*
+   * Please include the following imports to run this sample.
+   *
+   * import com.google.example.library.v1.BookFromAnywhere;
+   * import com.google.example.library.v1.BookName;
+   * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
+   * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
+   */
+
+  public static void sampleGetBookFromAbsolutelyAnywhere() {
+    // [START test_resource_name_oneof_core]
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(request);
+      System.out.println("Book found.");
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+    // [END test_resource_name_oneof_core]
+  }
+  // [END test_resource_name_oneof]
+
+  public static void main(String[] args) {
+    sampleGetBookFromAbsolutelyAnywhere();
+  }
+}
 ============== file: samples/src/main/java/com/google/example/examples/library/v1/ThisTagShouldBeTheNameOfTheFile.java ==============
 /*
  * Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
@@ -365,6 +365,18 @@ interfaces:
         retry_codes_name: idempotent
         retry_params_name: default
         timeout_millis: 10000
+        sample_value_sets:
+        - id: test_resource_name_oneof
+          parameters:
+            defaults:
+            - name%archive_path="The archive to search for the book"
+            - name%book_id="The ID of the book"
+          on_success:
+          - print: ["Book found."]
+        samples:
+          standalone:
+          - region_tag: test_resource_name_oneof
+            value_sets: [test_resource_name_oneof]
       - name: UpdateBookIndex
         retry_codes_name: idempotent
         retry_params_name: default

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
@@ -372,11 +372,20 @@ interfaces:
             - name%archive_path="The archive to search for the book"
             - name%book_id="The ID of the book"
           on_success:
-          - print: ["Book found."]
+          - print: ["Archived book found."]
+        - id: test_resource_name_oneof_2
+          parameters:
+            defaults:
+            - name%shelf_id="The Shelf to search for the book"
+            - name%book_id="The ID of the book"
+          on_success:
+          - print: ["Book on shelf found."]
         samples:
           standalone:
           - region_tag: test_resource_name_oneof
             value_sets: [test_resource_name_oneof]
+          - region_tag: test_resource_name_oneof_2
+            value_sets: [test_resource_name_oneof_2]
       - name: UpdateBookIndex
         retry_codes_name: idempotent
         retry_params_name: default

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -1342,7 +1342,7 @@ function sampleGetBookFromAbsolutelyAnywhere() {
   client.getBookFromAbsolutelyAnywhere({name: formattedName})
     .then(responses => {
       const response = responses[0];
-      console.log(`Book found.`);
+      console.log(`Archived book found.`);
     })
     .catch(err => {
       console.error(err);
@@ -1352,6 +1352,34 @@ function sampleGetBookFromAbsolutelyAnywhere() {
 
 // [END test_resource_name_oneof_core]
 // [END test_resource_name_oneof]
+// tslint:disable-next-line:no-any
+
+sampleGetBookFromAbsolutelyAnywhere();
+============== file: samples/v1/test_resource_name_oneof_2.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
+'use strict';
+
+// [START test_resource_name_oneof_2]
+// [START test_resource_name_oneof_2_core]
+
+const library = require('@google-cloud/library').v1;
+
+function sampleGetBookFromAbsolutelyAnywhere() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  client.getBookFromAbsolutelyAnywhere({name: formattedName})
+    .then(responses => {
+      const response = responses[0];
+      console.log(`Book on shelf found.`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END test_resource_name_oneof_2_core]
+// [END test_resource_name_oneof_2]
 // tslint:disable-next-line:no-any
 
 sampleGetBookFromAbsolutelyAnywhere();

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -1327,6 +1327,34 @@ function sampleListShelves() {
 // tslint:disable-next-line:no-any
 
 sampleListShelves();
+============== file: samples/v1/test_resource_name_oneof.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
+'use strict';
+
+// [START test_resource_name_oneof]
+// [START test_resource_name_oneof_core]
+
+const library = require('@google-cloud/library').v1;
+
+function sampleGetBookFromAbsolutelyAnywhere() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  client.getBookFromAbsolutelyAnywhere({name: formattedName})
+    .then(responses => {
+      const response = responses[0];
+      console.log(`Book found.`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+
+// [END test_resource_name_oneof_core]
+// [END test_resource_name_oneof]
+// tslint:disable-next-line:no-any
+
+sampleGetBookFromAbsolutelyAnywhere();
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.js ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "wap")
 'use strict';

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -1710,7 +1710,7 @@ function sampleGetBookFromAbsolutelyAnywhere()
 
     try {
         $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
-        printf("Book found." . PHP_EOL);
+        printf("Archived book found." . PHP_EOL);
     } finally {
         $libraryServiceClient->close();
     }
@@ -1718,6 +1718,53 @@ function sampleGetBookFromAbsolutelyAnywhere()
     // [END test_resource_name_oneof_core]
 }
 // [END test_resource_name_oneof]
+
+sampleGetBookFromAbsolutelyAnywhere();
+============== file: samples/V1/TestResourceNameOneof2.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
+ */
+
+// [START test_resource_name_oneof_2]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+function sampleGetBookFromAbsolutelyAnywhere()
+{
+    // [START test_resource_name_oneof_2_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
+        printf("Book on shelf found." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END test_resource_name_oneof_2_core]
+}
+// [END test_resource_name_oneof_2]
 
 sampleGetBookFromAbsolutelyAnywhere();
 ============== file: samples/V1/ThisTagShouldBeTheNameOfTheFile.php ==============

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -1673,6 +1673,53 @@ function sampleListShelves()
 // [END test_default_calling_form_for_paging]
 
 sampleListShelves();
+============== file: samples/V1/TestResourceNameOneof.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
+ */
+
+// [START test_resource_name_oneof]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+function sampleGetBookFromAbsolutelyAnywhere()
+{
+    // [START test_resource_name_oneof_core]
+
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
+        printf("Book found." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+
+    // [END test_resource_name_oneof_core]
+}
+// [END test_resource_name_oneof]
+
+sampleGetBookFromAbsolutelyAnywhere();
 ============== file: samples/V1/ThisTagShouldBeTheNameOfTheFile.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -6048,6 +6048,52 @@ def main():
 
 if __name__ == '__main__':
   main()
+============== file: samples/v1/test_resource_name_oneof.py ==============
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-library
+
+import sys
+
+# [START test_resource_name_oneof]
+
+from google.cloud.example import library_v1
+
+def sample_get_book_from_absolutely_anywhere():
+  # [START test_resource_name_oneof_core]
+
+  client = library_v1.LibraryServiceClient()
+
+  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+
+  response = client.get_book_from_absolutely_anywhere(name)
+  print('Book found.')
+
+  # [END test_resource_name_oneof_core]
+# [END test_resource_name_oneof]
+
+def main():
+  sample_get_book_from_absolutely_anywhere()
+
+if __name__ == '__main__':
+  main()
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.py ==============
 # -*- coding: utf-8 -*-
 #

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -6084,10 +6084,56 @@ def sample_get_book_from_absolutely_anywhere():
   name = client.book_path('[BOOK_SHELF]', '[BOOK]')
 
   response = client.get_book_from_absolutely_anywhere(name)
-  print('Book found.')
+  print('Archived book found.')
 
   # [END test_resource_name_oneof_core]
 # [END test_resource_name_oneof]
+
+def main():
+  sample_get_book_from_absolutely_anywhere()
+
+if __name__ == '__main__':
+  main()
+============== file: samples/v1/test_resource_name_oneof_2.py ==============
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-library
+
+import sys
+
+# [START test_resource_name_oneof_2]
+
+from google.cloud.example import library_v1
+
+def sample_get_book_from_absolutely_anywhere():
+  # [START test_resource_name_oneof_2_core]
+
+  client = library_v1.LibraryServiceClient()
+
+  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+
+  response = client.get_book_from_absolutely_anywhere(name)
+  print('Book on shelf found.')
+
+  # [END test_resource_name_oneof_2_core]
+# [END test_resource_name_oneof_2]
 
 def main():
   sample_get_book_from_absolutely_anywhere()

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -6394,6 +6394,47 @@ require "optparse"
 if $0 == __FILE__
   sample_list_shelves
 end
+============== file: samples/v1/test_resource_name_oneof.rb ==============
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
+
+require "library"
+
+# [START test_resource_name_oneof]
+
+def sample_get_book_from_absolutely_anywhere
+  # [START test_resource_name_oneof_core]
+  # Instantiate a client
+  library_client = Library::Library.new version: :v1
+
+  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+
+  response = library_client.get_book_from_absolutely_anywhere(formatted_name)
+  puts "Book found."
+
+  # [END test_resource_name_oneof_core]
+end
+# [END test_resource_name_oneof]
+
+
+require "optparse"
+
+if $0 == __FILE__
+  sample_get_book_from_absolutely_anywhere
+end
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.rb ==============
 # Copyright 2019 Google LLC
 #

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -6423,11 +6423,52 @@ def sample_get_book_from_absolutely_anywhere
   formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
 
   response = library_client.get_book_from_absolutely_anywhere(formatted_name)
-  puts "Book found."
+  puts "Archived book found."
 
   # [END test_resource_name_oneof_core]
 end
 # [END test_resource_name_oneof]
+
+
+require "optparse"
+
+if $0 == __FILE__
+  sample_get_book_from_absolutely_anywhere
+end
+============== file: samples/v1/test_resource_name_oneof_2.rb ==============
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
+
+require "library"
+
+# [START test_resource_name_oneof_2]
+
+def sample_get_book_from_absolutely_anywhere
+  # [START test_resource_name_oneof_2_core]
+  # Instantiate a client
+  library_client = Library::Library.new version: :v1
+
+  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+
+  response = library_client.get_book_from_absolutely_anywhere(formatted_name)
+  puts "Book on shelf found."
+
+  # [END test_resource_name_oneof_2_core]
+end
+# [END test_resource_name_oneof_2]
 
 
 require "optparse"

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -603,6 +603,18 @@ interfaces:
     header_request_params:
       - name
       - alt_book_name
+    sample_value_sets:
+    - id: test_resource_name_oneof
+      parameters:
+        defaults:
+        - name%archive_path="The archive to search for the book"
+        - name%book_id="The ID of the book"
+      on_success:
+      - print: ["Book found."]
+    samples:
+      standalone:
+      - region_tag: test_resource_name_oneof
+        value_sets: [test_resource_name_oneof]
   - name: UpdateBookIndex
     flattening:
       groups:

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -610,11 +610,20 @@ interfaces:
         - name%archive_path="The archive to search for the book"
         - name%book_id="The ID of the book"
       on_success:
-      - print: ["Book found."]
+      - print: ["Archived book found."]
+    - id: test_resource_name_oneof_2
+      parameters:
+        defaults:
+        - name%shelf_id="The Shelf to search for the book"
+        - name%book_id="The ID of the book"
+      on_success:
+      - print: ["Book on shelf found."]
     samples:
       standalone:
       - region_tag: test_resource_name_oneof
         value_sets: [test_resource_name_oneof]
+      - region_tag: test_resource_name_oneof_2
+        value_sets: [test_resource_name_oneof_2]
   - name: UpdateBookIndex
     flattening:
       groups:


### PR DESCRIPTION
Fix #2719.

Try to find a resource name that matches exactly the initial values configured in gapic.yaml for Oneof resource names. If none is found, pick a random one and use boilerplate values.

Generated talent samples: [here](https://github.com/hzyi-google/sample-staging/tree/master/20190531).