### PR TITLE
node: use Buffer as a type for protobuf bytes

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSModelTypeNameConverter.java
@@ -46,7 +46,7 @@ public class NodeJSModelTypeNameConverter extends ModelTypeNameConverter {
           .put(Type.TYPE_FIXED32, "number")
           .put(Type.TYPE_SFIXED32, "number")
           .put(Type.TYPE_STRING, "string")
-          .put(Type.TYPE_BYTES, "string")
+          .put(Type.TYPE_BYTES, "Buffer")
           .build();
 
   /** A map from primitive types in proto to zero value in NodeJS */
@@ -66,7 +66,7 @@ public class NodeJSModelTypeNameConverter extends ModelTypeNameConverter {
           .put(Type.TYPE_FIXED32, "0")
           .put(Type.TYPE_SFIXED32, "0")
           .put(Type.TYPE_STRING, "\'\'")
-          .put(Type.TYPE_BYTES, "\'\'")
+          .put(Type.TYPE_BYTES, "Buffer.from(\'\')")
           .build();
 
   private TypeNameConverter typeNameConverter;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -2308,7 +2308,7 @@ const PublishSeriesRequest = {
 };
 
 /**
- * @property {string} seriesBytes
+ * @property {Buffer} seriesBytes
  *
  * @property {string} seriesString
  *
@@ -2530,7 +2530,7 @@ const AddCommentsRequest = {
  * @property {string} userName
  *   won't be filled in by the sample generator
  *
- * @property {string} comment
+ * @property {Buffer} comment
  *   should be filled in by the sample generator
  *
  * @property {number} stage
@@ -2643,7 +2643,7 @@ const UpdateBookIndexRequest = {
  *
  *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
  *
- * @property {string} image
+ * @property {Buffer} image
  *
  * @typedef DiscussBookRequest
  * @memberof google.example.library.v1
@@ -2717,7 +2717,7 @@ const GetBigBookMetadata = {
  *
  * @property {string} requiredSingularString
  *
- * @property {string} requiredSingularBytes
+ * @property {Buffer} requiredSingularBytes
  *
  * @property {Object} requiredSingularMessage
  *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
@@ -2747,7 +2747,7 @@ const GetBigBookMetadata = {
  *
  * @property {string[]} requiredRepeatedString
  *
- * @property {string[]} requiredRepeatedBytes
+ * @property {Buffer[]} requiredRepeatedBytes
  *
  * @property {Object[]} requiredRepeatedMessage
  *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
@@ -2779,7 +2779,7 @@ const GetBigBookMetadata = {
  *
  * @property {string} optionalSingularString
  *
- * @property {string} optionalSingularBytes
+ * @property {Buffer} optionalSingularBytes
  *
  * @property {Object} optionalSingularMessage
  *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
@@ -2809,7 +2809,7 @@ const GetBigBookMetadata = {
  *
  * @property {string[]} optionalRepeatedString
  *
- * @property {string[]} optionalRepeatedBytes
+ * @property {Buffer[]} optionalRepeatedBytes
  *
  * @property {Object[]} optionalRepeatedMessage
  *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
@@ -3150,7 +3150,7 @@ const Operation = {
  *   Schemes other than `http`, `https` (or the empty scheme) might be
  *   used with implementation specific semantics.
  *
- * @property {string} value
+ * @property {Buffer} value
  *   Must be a valid serialized protocol buffer of the above specified type.
  *
  * @typedef Any
@@ -3904,7 +3904,7 @@ const StringValue = {
  *
  * The JSON representation for `BytesValue` is JSON string.
  *
- * @property {string} value
+ * @property {Buffer} value
  *   The bytes value.
  *
  * @typedef BytesValue
@@ -5550,7 +5550,7 @@ class LibraryServiceClient {
    * });
    *
    * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-   * const comment = '';
+   * const comment = Buffer.from('');
    * const stage = 'UNSET';
    * const alignment = 'CHAR';
    * const commentsElement = {
@@ -6423,7 +6423,7 @@ class LibraryServiceClient {
    * @param {number} request.requiredSingularEnum
    *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
    * @param {string} request.requiredSingularString
-   * @param {string} request.requiredSingularBytes
+   * @param {Buffer} request.requiredSingularBytes
    * @param {Object} request.requiredSingularMessage
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string} request.requiredSingularResourceName
@@ -6439,7 +6439,7 @@ class LibraryServiceClient {
    * @param {number[]} request.requiredRepeatedEnum
    *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
    * @param {string[]} request.requiredRepeatedString
-   * @param {string[]} request.requiredRepeatedBytes
+   * @param {Buffer[]} request.requiredRepeatedBytes
    * @param {Object[]} request.requiredRepeatedMessage
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string[]} request.requiredRepeatedResourceName
@@ -6456,7 +6456,7 @@ class LibraryServiceClient {
    * @param {number} [request.optionalSingularEnum]
    *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
    * @param {string} [request.optionalSingularString]
-   * @param {string} [request.optionalSingularBytes]
+   * @param {Buffer} [request.optionalSingularBytes]
    * @param {Object} [request.optionalSingularMessage]
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string} [request.optionalSingularResourceName]
@@ -6472,7 +6472,7 @@ class LibraryServiceClient {
    * @param {number[]} [request.optionalRepeatedEnum]
    *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
    * @param {string[]} [request.optionalRepeatedString]
-   * @param {string[]} [request.optionalRepeatedBytes]
+   * @param {Buffer[]} [request.optionalRepeatedBytes]
    * @param {Object[]} [request.optionalRepeatedMessage]
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string[]} [request.optionalRepeatedResourceName]
@@ -6571,7 +6571,7 @@ class LibraryServiceClient {
    * const requiredSingularBool = false;
    * const requiredSingularEnum = 'ZERO';
    * const requiredSingularString = '';
-   * const requiredSingularBytes = '';
+   * const requiredSingularBytes = Buffer.from('');
    * const requiredSingularMessage = {};
    * const formattedRequiredSingularResourceName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
    * const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF_ID]', '[BOOK_ID]');

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -1405,7 +1405,7 @@ function sampleTestOptionalRequiredFlatteningParams(paramFloat) {
   const requiredSingularBool = false;
   const requiredSingularEnum = 'ZERO';
   const requiredSingularString = '';
-  const requiredSingularBytes = '';
+  const requiredSingularBytes = Buffer.from('');
   const requiredSingularMessage = {};
   const formattedRequiredSingularResourceName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
   const formattedRequiredSingularResourceNameOneof = client.bookPath('[BOOK_SHELF]', '[BOOK]');
@@ -2405,7 +2405,7 @@ const PublishSeriesRequest = {
 };
 
 /**
- * @property {string} seriesBytes
+ * @property {Buffer} seriesBytes
  *
  * @property {string} seriesString
  *
@@ -2627,7 +2627,7 @@ const AddCommentsRequest = {
  * @property {string} userName
  *   won't be filled in by the sample generator
  *
- * @property {string} comment
+ * @property {Buffer} comment
  *   should be filled in by the sample generator
  *
  * @property {number} stage
@@ -2740,7 +2740,7 @@ const UpdateBookIndexRequest = {
  *
  *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
  *
- * @property {string} image
+ * @property {Buffer} image
  *
  * @typedef DiscussBookRequest
  * @memberof google.example.library.v1
@@ -2814,7 +2814,7 @@ const GetBigBookMetadata = {
  *
  * @property {string} requiredSingularString
  *
- * @property {string} requiredSingularBytes
+ * @property {Buffer} requiredSingularBytes
  *
  * @property {Object} requiredSingularMessage
  *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
@@ -2844,7 +2844,7 @@ const GetBigBookMetadata = {
  *
  * @property {string[]} requiredRepeatedString
  *
- * @property {string[]} requiredRepeatedBytes
+ * @property {Buffer[]} requiredRepeatedBytes
  *
  * @property {Object[]} requiredRepeatedMessage
  *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
@@ -2876,7 +2876,7 @@ const GetBigBookMetadata = {
  *
  * @property {string} optionalSingularString
  *
- * @property {string} optionalSingularBytes
+ * @property {Buffer} optionalSingularBytes
  *
  * @property {Object} optionalSingularMessage
  *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
@@ -2906,7 +2906,7 @@ const GetBigBookMetadata = {
  *
  * @property {string[]} optionalRepeatedString
  *
- * @property {string[]} optionalRepeatedBytes
+ * @property {Buffer[]} optionalRepeatedBytes
  *
  * @property {Object[]} optionalRepeatedMessage
  *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
@@ -3247,7 +3247,7 @@ const Operation = {
  *   Schemes other than `http`, `https` (or the empty scheme) might be
  *   used with implementation specific semantics.
  *
- * @property {string} value
+ * @property {Buffer} value
  *   Must be a valid serialized protocol buffer of the above specified type.
  *
  * @typedef Any
@@ -4001,7 +4001,7 @@ const StringValue = {
  *
  * The JSON representation for `BytesValue` is JSON string.
  *
- * @property {string} value
+ * @property {Buffer} value
  *   The bytes value.
  *
  * @typedef BytesValue
@@ -5647,7 +5647,7 @@ class LibraryServiceClient {
    * });
    *
    * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
-   * const comment = '';
+   * const comment = Buffer.from('');
    * const stage = 'UNSET';
    * const alignment = 'CHAR';
    * const commentsElement = {
@@ -6523,7 +6523,7 @@ class LibraryServiceClient {
    * @param {number} request.requiredSingularEnum
    *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
    * @param {string} request.requiredSingularString
-   * @param {string} request.requiredSingularBytes
+   * @param {Buffer} request.requiredSingularBytes
    * @param {Object} request.requiredSingularMessage
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string} request.requiredSingularResourceName
@@ -6539,7 +6539,7 @@ class LibraryServiceClient {
    * @param {number[]} request.requiredRepeatedEnum
    *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
    * @param {string[]} request.requiredRepeatedString
-   * @param {string[]} request.requiredRepeatedBytes
+   * @param {Buffer[]} request.requiredRepeatedBytes
    * @param {Object[]} request.requiredRepeatedMessage
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string[]} request.requiredRepeatedResourceName
@@ -6556,7 +6556,7 @@ class LibraryServiceClient {
    * @param {number} [request.optionalSingularEnum]
    *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
    * @param {string} [request.optionalSingularString]
-   * @param {string} [request.optionalSingularBytes]
+   * @param {Buffer} [request.optionalSingularBytes]
    * @param {Object} [request.optionalSingularMessage]
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string} [request.optionalSingularResourceName]
@@ -6572,7 +6572,7 @@ class LibraryServiceClient {
    * @param {number[]} [request.optionalRepeatedEnum]
    *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
    * @param {string[]} [request.optionalRepeatedString]
-   * @param {string[]} [request.optionalRepeatedBytes]
+   * @param {Buffer[]} [request.optionalRepeatedBytes]
    * @param {Object[]} [request.optionalRepeatedMessage]
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string[]} [request.optionalRepeatedResourceName]
@@ -6671,7 +6671,7 @@ class LibraryServiceClient {
    * const requiredSingularBool = false;
    * const requiredSingularEnum = 'ZERO';
    * const requiredSingularString = '';
-   * const requiredSingularBytes = '';
+   * const requiredSingularBytes = Buffer.from('');
    * const requiredSingularMessage = {};
    * const formattedRequiredSingularResourceName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
    * const formattedRequiredSingularResourceNameOneof = client.bookPath('[BOOK_SHELF]', '[BOOK]');


### PR DESCRIPTION
Documentation incorrectly shows `string` as a Node.js type for protobuf `bytes`. Changing that to `Buffer`. It won't be a breaking change for the generated clients since (a) `string` never worked in this case, and (b) it's just the documentation and samples, actual code does not change.