### PR TITLE
SampleGen: generate multi-line descriptions in sample metadata

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleTransformer.java
@@ -261,6 +261,17 @@ public abstract class SampleTransformer {
                     .build())
             .build();
 
+    ImmutableList<String> metadataDescription =
+        ImmutableList.<String>builder()
+            .addAll(methodContext.getNamer().getWrappedDocLines(valueSet.getDescription(), false))
+            .build();
+
+    String descriptionLine = metadataDescription.isEmpty() ? "" : metadataDescription.get(0);
+    ImmutableList<String> additionalDescriptionLines =
+        metadataDescription.isEmpty()
+            ? ImmutableList.of()
+            : metadataDescription.subList(1, metadataDescription.size());
+
     return MethodSampleView.newBuilder()
         .callingForm(form)
         .valueSet(SampleValueSetView.of(valueSet))
@@ -277,7 +288,8 @@ public abstract class SampleTransformer {
             methodContext.getNamer().getSampleFunctionName(methodContext.getMethodModel()))
         .sampleFunctionDoc(sampleFunctionDocView)
         .title(config.valueSet().getTitle())
-        .description(config.valueSet().getDescription())
+        .descriptionLine(descriptionLine)
+        .additionalDescriptionLines(additionalDescriptionLines)
         .build();
   }
 

--- a/src/main/java/com/google/api/codegen/viewmodel/MethodSampleView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/MethodSampleView.java
@@ -52,7 +52,9 @@ public abstract class MethodSampleView {
 
   public abstract String title();
 
-  public abstract String description();
+  public abstract String descriptionLine();
+
+  public abstract ImmutableList<String> additionalDescriptionLines();
 
   public static Builder newBuilder() {
     return new AutoValue_MethodSampleView.Builder();
@@ -82,7 +84,9 @@ public abstract class MethodSampleView {
 
     public abstract Builder title(String val);
 
-    public abstract Builder description(String val);
+    public abstract Builder descriptionLine(String val);
+
+    public abstract Builder additionalDescriptionLines(ImmutableList<String> val);
 
     public abstract MethodSampleView build();
   }

--- a/src/main/resources/com/google/api/codegen/csharp/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/standalone_sample.snip
@@ -14,7 +14,9 @@
 
             // sample-metadata
             //   title: {@sample.title}
-            //   description: {@sample.description}
+            @if sample.descriptionLine
+                {@descriptionLines("//", sample.descriptionLine, sample.additionalDescriptionLines)}
+            @end
             //   usage: dotnet run {@commandlineArgumentList(sample.sampleInitCode.argDefaultParams)}
 
             // [START {@sample.regionTag}]

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -11,7 +11,9 @@
     // DO NOT EDIT! This is a generated sample ("{@sample.callingForm}",  "{@sample.valueSet.id}")
     // sample-metadata:
     //   title: {@sample.title}
-    //   description: {@sample.description}
+    @if sample.descriptionLine
+      {@descriptionLines("//", sample.descriptionLine, sample.additionalDescriptionLines)}
+    @end
     @if sample.sampleInitCode.argDefaultParams 
       //   usage: gradle run -PmainClass={@sampleFile.fileHeader.examplePackageName}.{@sampleFile.classView.name} [--args='{@commandlineArgumentList(sample.sampleInitCode.argDefaultParams)}']
     @else

--- a/src/main/resources/com/google/api/codegen/metadatagen/samplegen.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/samplegen.snip
@@ -3,3 +3,12 @@
   	[--{@arg.cliFlagName} {@arg.cliFlagDefaultValue}]
   @end
 @end
+
+@snippet descriptionLines(commentDelimiter, descriptionLine, additionalDescriptionLines)
+	{@commentDelimiter}   description: {@descriptionLine}
+	@if additionalDescriptionLines
+		@join line : additionalDescriptionLines
+		  {@commentDelimiter}     {@line}
+		@end
+	@end
+@end

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -10,7 +10,9 @@
 
       // sample-metadata:
       //   title: {@sample.title}
-      //   description: {@sample.description}
+      @if sample.descriptionLine
+        {@descriptionLines("//", sample.descriptionLine, sample.additionalDescriptionLines)}
+      @end
       //   usage: node {@sampleFile.outputPath} {@commandlineArgumentList(sample.sampleInitCode.argDefaultParams)}
 
       // [START {@sample.regionTag}]

--- a/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
@@ -16,7 +16,9 @@
 
     // sample-metadata
     //   title: {@sample.title}
-    //   description: {@sample.description}
+    @if sample.descriptionLine
+        {@descriptionLines("//", sample.descriptionLine, sample.additionalDescriptionLines)}
+    @end
     //   usage: php {@sampleFile.outputPath} {@commandlineArgumentList(sample.sampleInitCode.argDefaultParams)}
     // [START {@sample.regionTag}]
     require {@sampleFile.extraInfo.autoloadPath};

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -14,7 +14,9 @@
 
       @# sample-metadata
       @#   title: {@sample.title}
-      @#   description: {@sample.description}
+      @if sample.descriptionLine
+        {@descriptionLines("#", sample.descriptionLine, sample.additionalDescriptionLines)}
+      @end
       @#   usage: python3 {@sampleFile.outputPath} {@commandlineArgumentList(sample.sampleInitCode.argDefaultParams)}
       {@standaloneSample(apiMethod, sample)}
     @end

--- a/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
@@ -11,7 +11,9 @@
       
       @# sample-metadata
       @#   title: {@sample.title}
-      @#   description: {@sample.description}
+      @if sample.descriptionLine
+        {@descriptionLines("#", sample.descriptionLine, sample.additionalDescriptionLines)}
+      @end
       @#   bundle exec ruby {@sampleFile.outputPath} {@commandlineArgumentList(sample.sampleInitCode.argDefaultParams)}
 
       require "{@apiMethod.initCode.topLevelIndexFileImportName}"

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -1203,7 +1203,8 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: dotnet run
 
 // [START sample]
@@ -1214,6 +1215,10 @@ namespace Google.Example.Library.V1.Samples
 
     public class GetBookAsyncFlattenedAsyncTestOnSuccessMap
     {
+        /// <summary>
+        /// When there is a very long description for a sample file we can split
+        /// the description into multiple lines and the samples will be just fine
+        /// </summary>
         public static async Task SampleGetBookAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
@@ -1249,7 +1254,8 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: dotnet run
 
 // [START sample]
@@ -1260,6 +1266,10 @@ namespace Google.Example.Library.V1.Samples
 
     public class GetBookAsyncRequestAsyncTestOnSuccessMap
     {
+        /// <summary>
+        /// When there is a very long description for a sample file we can split
+        /// the description into multiple lines and the samples will be just fine
+        /// </summary>
         public static async Task SampleGetBookAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
@@ -1298,7 +1308,8 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: dotnet run
 
 // [START sample]
@@ -1308,6 +1319,10 @@ namespace Google.Example.Library.V1.Samples
 
     public class GetBookFlattenedTestOnSuccessMap
     {
+        /// <summary>
+        /// When there is a very long description for a sample file we can split
+        /// the description into multiple lines and the samples will be just fine
+        /// </summary>
         public static void SampleGetBook()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
@@ -1343,7 +1358,8 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: dotnet run
 
 // [START sample]
@@ -1353,6 +1369,10 @@ namespace Google.Example.Library.V1.Samples
 
     public class GetBookRequestTestOnSuccessMap
     {
+        /// <summary>
+        /// When there is a very long description for a sample file we can split
+        /// the description into multiple lines and the samples will be just fine
+        /// </summary>
         public static void SampleGetBook()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
@@ -2131,7 +2151,6 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title:
-//   description:
 //   usage: dotnet run
 
 // [START test_resource_name_oneof]
@@ -2179,7 +2198,6 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title:
-//   description:
 //   usage: dotnet run
 
 // [START test_resource_name_oneof_2]

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -2243,7 +2243,8 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
 // DO NOT EDIT! This is a generated sample ("Callable",  "test_on_success_map")
 // sample-metadata:
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: gradle run -PmainClass=com.google.example.examples.library.v1.GetBookCallableCallableTestOnSuccessMap
 
 package com.google.example.examples.library.v1;
@@ -2311,7 +2312,8 @@ public class GetBookCallableCallableTestOnSuccessMap {
 // DO NOT EDIT! This is a generated sample ("Flattened",  "test_on_success_map")
 // sample-metadata:
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: gradle run -PmainClass=com.google.example.examples.library.v1.GetBookFlattenedTestOnSuccessMap
 
 package com.google.example.examples.library.v1;
@@ -2368,7 +2370,8 @@ public class GetBookFlattenedTestOnSuccessMap {
 // DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
 // sample-metadata:
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: gradle run -PmainClass=com.google.example.examples.library.v1.GetBookRequestTestOnSuccessMap
 
 package com.google.example.examples.library.v1;
@@ -3481,7 +3484,6 @@ public class TestDefaultCallingFormForPaging {
 // DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
 // sample-metadata:
 //   title:
-//   description:
 //   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestResourceNameOneof
 
 package com.google.example.examples.library.v1;
@@ -3543,7 +3545,6 @@ public class TestResourceNameOneof {
 // DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
 // sample-metadata:
 //   title:
-//   description:
 //   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestResourceNameOneof2
 
 package com.google.example.examples.library.v1;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -962,7 +962,8 @@ sampleGetBigNothing();
 
 // sample-metadata:
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: node samples/v1/get_book_request_test_on_success_map.js
 
 // [START sample]
@@ -1383,7 +1384,6 @@ sampleListShelves();
 
 // sample-metadata:
 //   title:
-//   description:
 //   usage: node samples/v1/test_resource_name_oneof.js
 
 // [START test_resource_name_oneof]
@@ -1413,7 +1413,6 @@ sampleGetBookFromAbsolutelyAnywhere();
 
 // sample-metadata:
 //   title:
-//   description:
 //   usage: node samples/v1/test_resource_name_oneof_2.js
 
 // [START test_resource_name_oneof_2]

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -1039,7 +1039,8 @@ sampleGetBigNothing();
 
 // sample-metadata
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: php samples/V1/GetBookRequestTestOnSuccessMap.php
 // [START sample]
 require __DIR__ . '/../../vendor/autoload.php';
@@ -1689,7 +1690,6 @@ sampleListShelves();
 
 // sample-metadata
 //   title:
-//   description:
 //   usage: php samples/V1/TestResourceNameOneof.php
 // [START test_resource_name_oneof]
 require __DIR__ . '/../../vendor/autoload.php';
@@ -1736,7 +1736,6 @@ sampleGetBookFromAbsolutelyAnywhere();
 
 // sample-metadata
 //   title:
-//   description:
 //   usage: php samples/V1/TestResourceNameOneof2.php
 // [START test_resource_name_oneof_2]
 require __DIR__ . '/../../vendor/autoload.php';

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -5525,7 +5525,8 @@ if __name__ == '__main__':
 
 # sample-metadata
 #   title: test maps in response handling
-#   description:
+#   description: When there is a very long description for a sample file we can split
+#     the description into multiple lines and the samples will be just fine
 #   usage: python3 samples/v1/get_book_request_test_on_success_map.py
 import sys
 
@@ -6082,7 +6083,6 @@ if __name__ == '__main__':
 
 # sample-metadata
 #   title:
-#   description:
 #   usage: python3 samples/v1/test_resource_name_oneof.py
 import sys
 
@@ -6129,7 +6129,6 @@ if __name__ == '__main__':
 
 # sample-metadata
 #   title:
-#   description:
 #   usage: python3 samples/v1/test_resource_name_oneof_2.py
 import sys
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -5954,7 +5954,8 @@ end
 
 # sample-metadata
 #   title: test maps in response handling
-#   description:
+#   description: When there is a very long description for a sample file we can split
+#     the description into multiple lines and the samples will be just fine
 #   bundle exec ruby samples/v1/get_book_request_test_on_success_map.rb
 
 require "library"
@@ -6489,7 +6490,6 @@ end
 
 # sample-metadata
 #   title:
-#   description:
 #   bundle exec ruby samples/v1/test_resource_name_oneof.rb
 
 require "library"
@@ -6533,7 +6533,6 @@ end
 
 # sample-metadata
 #   title:
-#   description:
 #   bundle exec ruby samples/v1/test_resource_name_oneof_2.rb
 
 require "library"

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -1203,7 +1203,8 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: dotnet run
 
 // [START sample]
@@ -1214,6 +1215,10 @@ namespace Google.Example.Library.V1.Samples
 
     public class GetBookAsyncFlattenedAsyncTestOnSuccessMap
     {
+        /// <summary>
+        /// When there is a very long description for a sample file we can split
+        /// the description into multiple lines and the samples will be just fine
+        /// </summary>
         public static async Task SampleGetBookAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
@@ -1249,7 +1254,8 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: dotnet run
 
 // [START sample]
@@ -1260,6 +1266,10 @@ namespace Google.Example.Library.V1.Samples
 
     public class GetBookAsyncRequestAsyncTestOnSuccessMap
     {
+        /// <summary>
+        /// When there is a very long description for a sample file we can split
+        /// the description into multiple lines and the samples will be just fine
+        /// </summary>
         public static async Task SampleGetBookAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
@@ -1298,7 +1308,8 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: dotnet run
 
 // [START sample]
@@ -1308,6 +1319,10 @@ namespace Google.Example.Library.V1.Samples
 
     public class GetBookFlattenedTestOnSuccessMap
     {
+        /// <summary>
+        /// When there is a very long description for a sample file we can split
+        /// the description into multiple lines and the samples will be just fine
+        /// </summary>
         public static void SampleGetBook()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
@@ -1343,7 +1358,8 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: dotnet run
 
 // [START sample]
@@ -1353,6 +1369,10 @@ namespace Google.Example.Library.V1.Samples
 
     public class GetBookRequestTestOnSuccessMap
     {
+        /// <summary>
+        /// When there is a very long description for a sample file we can split
+        /// the description into multiple lines and the samples will be just fine
+        /// </summary>
         public static void SampleGetBook()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
@@ -2131,7 +2151,6 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title:
-//   description:
 //   usage: dotnet run [--param_float 1.2345]
 
 // [START test_float]
@@ -2218,7 +2237,6 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title:
-//   description:
 //   usage: dotnet run
 
 // [START test_resource_name_oneof]
@@ -2266,7 +2284,6 @@ namespace Google.Example.Library.V1.Samples
 
 // sample-metadata
 //   title:
-//   description:
 //   usage: dotnet run
 
 // [START test_resource_name_oneof_2]

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -2295,7 +2295,8 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
 // DO NOT EDIT! This is a generated sample ("Callable",  "test_on_success_map")
 // sample-metadata:
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: gradle run -PmainClass=com.google.example.examples.library.v1.GetBookCallableCallableTestOnSuccessMap
 
 package com.google.example.examples.library.v1;
@@ -2365,7 +2366,8 @@ public class GetBookCallableCallableTestOnSuccessMap {
 // DO NOT EDIT! This is a generated sample ("Flattened",  "test_on_success_map")
 // sample-metadata:
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: gradle run -PmainClass=com.google.example.examples.library.v1.GetBookFlattenedTestOnSuccessMap
 
 package com.google.example.examples.library.v1;
@@ -2424,7 +2426,8 @@ public class GetBookFlattenedTestOnSuccessMap {
 // DO NOT EDIT! This is a generated sample ("Request",  "test_on_success_map")
 // sample-metadata:
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: gradle run -PmainClass=com.google.example.examples.library.v1.GetBookRequestTestOnSuccessMap
 
 package com.google.example.examples.library.v1;
@@ -3541,7 +3544,6 @@ public class TestDefaultCallingFormForPaging {
 // DO NOT EDIT! This is a generated sample ("Request",  "test_float")
 // sample-metadata:
 //   title:
-//   description:
 //   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestFloat [--args='[--param_float 1.2345]']
 
 package com.google.example.examples.library.v1;
@@ -3687,7 +3689,6 @@ public class TestFloat {
 // DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
 // sample-metadata:
 //   title:
-//   description:
 //   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestResourceNameOneof
 
 package com.google.example.examples.library.v1;
@@ -3747,7 +3748,6 @@ public class TestResourceNameOneof {
 // DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof_2")
 // sample-metadata:
 //   title:
-//   description:
 //   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestResourceNameOneof2
 
 package com.google.example.examples.library.v1;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
@@ -293,6 +293,9 @@ interfaces:
                 - name="Unreal book"
           - id: test_on_success_map
             title: "test maps in response handling"
+            description: |
+              When there is a very long description for a sample file we can split
+              the description into multiple lines and the samples will be just fine
             parameters:
               defaults:
                 - name="test_on_success_map"

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -968,7 +968,8 @@ sampleGetBigNothing();
 
 // sample-metadata:
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: node samples/v1/get_book_request_test_on_success_map.js
 
 // [START sample]
@@ -1389,7 +1390,6 @@ sampleListShelves();
 
 // sample-metadata:
 //   title:
-//   description:
 //   usage: node samples/v1/test_float.js [--param_float 1.2345]
 
 // [START test_float]
@@ -1485,7 +1485,6 @@ sampleTestOptionalRequiredFlatteningParams(argv.param_float);
 
 // sample-metadata:
 //   title:
-//   description:
 //   usage: node samples/v1/test_resource_name_oneof.js
 
 // [START test_resource_name_oneof]
@@ -1515,7 +1514,6 @@ sampleGetBookFromAbsolutelyAnywhere();
 
 // sample-metadata:
 //   title:
-//   description:
 //   usage: node samples/v1/test_resource_name_oneof_2.js
 
 // [START test_resource_name_oneof_2]

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -1047,7 +1047,8 @@ sampleGetBigNothing();
 
 // sample-metadata
 //   title: test maps in response handling
-//   description:
+//   description: When there is a very long description for a sample file we can split
+//     the description into multiple lines and the samples will be just fine
 //   usage: php samples/V1/GetBookRequestTestOnSuccessMap.php
 // [START sample]
 require __DIR__ . '/../../vendor/autoload.php';
@@ -1697,7 +1698,6 @@ sampleListShelves();
 
 // sample-metadata
 //   title:
-//   description:
 //   usage: php samples/V1/TestFloat.php [--param_float 1.2345]
 // [START test_float]
 require __DIR__ . '/../../vendor/autoload.php';
@@ -1787,7 +1787,6 @@ sampleTestOptionalRequiredFlatteningParams($paramFloat);
 
 // sample-metadata
 //   title:
-//   description:
 //   usage: php samples/V1/TestResourceNameOneof.php
 // [START test_resource_name_oneof]
 require __DIR__ . '/../../vendor/autoload.php';
@@ -1834,7 +1833,6 @@ sampleGetBookFromAbsolutelyAnywhere();
 
 // sample-metadata
 //   title:
-//   description:
 //   usage: php samples/V1/TestResourceNameOneof2.php
 // [START test_resource_name_oneof_2]
 require __DIR__ . '/../../vendor/autoload.php';

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -5520,7 +5520,8 @@ if __name__ == '__main__':
 
 # sample-metadata
 #   title: test maps in response handling
-#   description:
+#   description: When there is a very long description for a sample file we can split
+#     the description into multiple lines and the samples will be just fine
 #   usage: python3 samples/v1/get_book_request_test_on_success_map.py
 import sys
 
@@ -6077,7 +6078,6 @@ if __name__ == '__main__':
 
 # sample-metadata
 #   title:
-#   description:
 #   usage: python3 samples/v1/test_float.py [--param_float 1.2345]
 import sys
 
@@ -6159,7 +6159,6 @@ if __name__ == '__main__':
 
 # sample-metadata
 #   title:
-#   description:
 #   usage: python3 samples/v1/test_resource_name_oneof.py
 import sys
 
@@ -6206,7 +6205,6 @@ if __name__ == '__main__':
 
 # sample-metadata
 #   title:
-#   description:
 #   usage: python3 samples/v1/test_resource_name_oneof_2.py
 import sys
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -5940,7 +5940,8 @@ end
 
 # sample-metadata
 #   title: test maps in response handling
-#   description:
+#   description: When there is a very long description for a sample file we can split
+#     the description into multiple lines and the samples will be just fine
 #   bundle exec ruby samples/v1/get_book_request_test_on_success_map.rb
 
 require "library"
@@ -6475,7 +6476,6 @@ end
 
 # sample-metadata
 #   title:
-#   description:
 #   bundle exec ruby samples/v1/test_float.rb [--param_float 1.2345]
 
 require "library"
@@ -6556,7 +6556,6 @@ end
 
 # sample-metadata
 #   title:
-#   description:
 #   bundle exec ruby samples/v1/test_resource_name_oneof.rb
 
 require "library"
@@ -6600,7 +6599,6 @@ end
 
 # sample-metadata
 #   title:
-#   description:
 #   bundle exec ruby samples/v1/test_resource_name_oneof_2.rb
 
 require "library"

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -420,6 +420,9 @@ interfaces:
         - name="Unreal book"
     - id: test_on_success_map
       title: "test maps in response handling"
+      description: |
+        When there is a very long description for a sample file we can split
+        the description into multiple lines and the samples will be just fine
       parameters:
         defaults:
         - name="test_on_success_map"


### PR DESCRIPTION
To not break when a a sample has a long long description, like [speech](https://github.com/googleapis/googleapis/blob/4145cd9e644de069b17a17cefd3364d351214b18/google/cloud/speech/v1p1beta1/samples/speech_transcribe_diarization_beta.yaml#L5)