### PR TITLE
SampleGen: Update Java templates

### DIFF
--- a/src/main/resources/com/google/api/codegen/java/build_gapic_samples.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/java/build_gapic_samples.gradle.snip
@@ -23,9 +23,6 @@
   javadoc.options.encoding = 'UTF-8'
 
   dependencies {
-    compile 'com.google.api:gax:{@metadata.gaxVersionBound.lower}'
-    compile 'com.google.api:gax-grpc:{@metadata.gaxVersionBound.lower}'
-    compile 'io.grpc:grpc-netty-shaded:{@metadata.grpcVersionBound.lower}'
     @join dep : metadata.additionalDependencies
       compile '{@dep.group}:{@dep.name}:{@dep.versionBound.lower}'
     @end
@@ -44,7 +41,7 @@
     delete 'all-jars'
   }
 
-  task run {
+  run {
     mainClassName = getProperty('mainClass')
   }
 

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -306,6 +306,11 @@
             cl.getOptionValue("{@param.cliFlagName}") != null
                 ? Float.parseFloat(cl.getOptionValue("{@param.cliFlagName}"))
                 : {@renderInitValue(param.initValue)};
+      @case "long"
+        long {@param.identifier} =
+            cl.getOptionValue("{@param.cliFlagName}") != null
+                ? Long.parseLong(cl.getOptionValue("{@param.cliFlagName}"))
+                : {@renderInitValue(param.initValue)};
       @default
         $unhandledCase: {@param.typeName}$
       @end

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -2268,6 +2268,97 @@ namespace Google.Example.Library.V1.Samples
         }
     }
 }
+============== file: Google.Example.Library.V1/Google.Example.Library.V1.Samples/TestFloatAndInt64.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Request", "test_float_and_int64")
+
+// sample-metadata
+//   title:
+//   usage: dotnet run [--param_float 1.2345] [--param_long 67890]
+
+// [START test_float_and_int64]
+namespace Google.Example.Library.V1.Samples
+{
+    using Google.Example.Library.V1;
+    using Google.Protobuf;
+    using System;
+    using System.Collections.Generic;
+
+    public class TestFloatAndInt64
+    {
+        public static void SampleTestOptionalRequiredFlatteningParams(float paramFloat, long paramLong)
+        {
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // float paramFloat = 1.2345f
+            // long paramLong = 67890L
+            TestOptionalRequiredFlatteningParamsRequest request = new TestOptionalRequiredFlatteningParamsRequest
+            {
+                RequiredSingularInt32 = 0,
+                RequiredSingularInt64 = 67890L,
+                RequiredSingularFloat = 1.2345f,
+                RequiredSingularDouble = 0.0,
+                RequiredSingularBool = false,
+                RequiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum.Zero,
+                RequiredSingularString = "",
+                RequiredSingularBytes = ByteString.Empty,
+                RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
+                RequiredSingularFixed32 = 0,
+                RequiredSingularFixed64 = 0L,
+                RequiredRepeatedInt32 = { },
+                RequiredRepeatedInt64 = { },
+                RequiredRepeatedFloat = { },
+                RequiredRepeatedDouble = { },
+                RequiredRepeatedBool = { },
+                RequiredRepeatedEnum = { },
+                RequiredRepeatedString = { },
+                RequiredRepeatedBytes = { },
+                RequiredRepeatedMessage = { },
+                RequiredRepeatedResourceNameAsBookNames = { },
+                RequiredRepeatedResourceNameOneofAsBookNameOneofs = { },
+                RequiredRepeatedResourceNameCommonAsProjectNames = { },
+                RequiredRepeatedFixed32 = { },
+                RequiredRepeatedFixed64 = { },
+                RequiredMap = { },
+            };
+            TestOptionalRequiredFlatteningParamsResponse response = libraryServiceClient.TestOptionalRequiredFlatteningParams(request);
+            Console.WriteLine(response);
+        }
+        // [END test_float_and_int64]
+        public static void Main(string[] args)
+        {
+            new Parser(with => with.CaseInsensitiveEnumValues = true).ParseArguments<Options>(args)
+                .WithParsed<Options>(opts =>
+                    SampleTestOptionalRequiredFlatteningParams(opts.ParamFloat, opts.ParamLong));
+        }
+
+        public class Options
+        {
+            [Option("param_float", Default = 1.2345f)]
+            public float ParamFloat { get; set; }
+
+            [Option("param_long", Default = 67890L)]
+            public long ParamLong { get; set; }
+        }
+    }
+}
 ============== file: Google.Example.Library.V1/Google.Example.Library.V1.Samples/TestResourceNameOneof.cs ==============
 // Copyright 2019 Google LLC
 //

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -101,9 +101,6 @@ compileJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
 
 dependencies {
-  compile 'com.google.api:gax:1.0.0'
-  compile 'com.google.api:gax-grpc:1.0.0'
-  compile 'io.grpc:grpc-netty-shaded:1.9.0'
   compile 'com.google.api:api-common:0.0.2'
   compile 'commons-cli:commons-cli:1.4'
   compile project(':gapic-google-cloud-library-v1')
@@ -121,7 +118,7 @@ clean {
   delete 'all-jars'
 }
 
-task run {
+run {
   mainClassName = getProperty('mainClass')
 }
 
@@ -3463,6 +3460,163 @@ public class TestDefaultCallingFormForPaging {
 
   public static void main(String[] args) {
     sampleListShelves();
+  }
+}
+============== file: samples/src/main/java/com/google/example/examples/library/v1/TestFloatAndInt64.java ==============
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// DO NOT EDIT! This is a generated sample ("Request",  "test_float_and_int64")
+// sample-metadata:
+//   title:
+//   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestFloatAndInt64 [--args='[--param_float 1.2345] [--param_long 67890]']
+
+package com.google.example.examples.library.v1;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import com.google.cloud.ProjectName;
+import com.google.example.library.v1.BookName;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
+import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestFloatAndInt64 {
+  // [START test_float_and_int64]
+  /*
+   * Please include the following imports to run this sample.
+   *
+   * import com.google.cloud.ProjectName;
+   * import com.google.example.library.v1.BookName;
+   * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
+   * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
+   * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
+   * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
+   * import com.google.protobuf.ByteString;
+   * import java.util.ArrayList;
+   * import java.util.HashMap;
+   * import java.util.List;
+   * import java.util.Map;
+   */
+
+  public static void sampleTestOptionalRequiredFlatteningParams(float paramFloat, long paramLong) {
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      // paramFloat = 1.2345F;
+      // paramLong = 67890L;
+      int requiredSingularInt32 = 0;
+      double requiredSingularDouble = 0.0;
+      boolean requiredSingularBool = false;
+      TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+      String requiredSingularString = "";
+      ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
+      TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
+      ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
+      int requiredSingularFixed32 = 0;
+      long requiredSingularFixed64 = 0L;
+      List<Integer> requiredRepeatedInt32 = new ArrayList<>();
+      List<Long> requiredRepeatedInt64 = new ArrayList<>();
+      List<Float> requiredRepeatedFloat = new ArrayList<>();
+      List<Double> requiredRepeatedDouble = new ArrayList<>();
+      List<Boolean> requiredRepeatedBool = new ArrayList<>();
+      List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum = new ArrayList<>();
+      List<String> requiredRepeatedString = new ArrayList<>();
+      List<ByteString> requiredRepeatedBytes = new ArrayList<>();
+      List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage = new ArrayList<>();
+      List<ShelfBookName> requiredRepeatedResourceName = new ArrayList<>();
+      List<BookName> requiredRepeatedResourceNameOneof = new ArrayList<>();
+      List<ProjectName> requiredRepeatedResourceNameCommon = new ArrayList<>();
+      List<Integer> requiredRepeatedFixed32 = new ArrayList<>();
+      List<Long> requiredRepeatedFixed64 = new ArrayList<>();
+      Map<Integer, String> requiredMap = new HashMap<>();
+      TestOptionalRequiredFlatteningParamsRequest request = TestOptionalRequiredFlatteningParamsRequest.newBuilder()
+        .setRequiredSingularInt32(requiredSingularInt32)
+        .setRequiredSingularInt64(paramLong)
+        .setRequiredSingularFloat(paramFloat)
+        .setRequiredSingularDouble(requiredSingularDouble)
+        .setRequiredSingularBool(requiredSingularBool)
+        .setRequiredSingularEnum(requiredSingularEnum)
+        .setRequiredSingularString(requiredSingularString)
+        .setRequiredSingularBytes(requiredSingularBytes)
+        .setRequiredSingularMessage(requiredSingularMessage)
+        .setRequiredSingularResourceName(requiredSingularResourceName.toString())
+        .setRequiredSingularResourceNameOneof(requiredSingularResourceNameOneof.toString())
+        .setRequiredSingularResourceNameCommon(requiredSingularResourceNameCommon.toString())
+        .setRequiredSingularFixed32(requiredSingularFixed32)
+        .setRequiredSingularFixed64(requiredSingularFixed64)
+        .addAllRequiredRepeatedInt32(requiredRepeatedInt32)
+        .addAllRequiredRepeatedInt64(requiredRepeatedInt64)
+        .addAllRequiredRepeatedFloat(requiredRepeatedFloat)
+        .addAllRequiredRepeatedDouble(requiredRepeatedDouble)
+        .addAllRequiredRepeatedBool(requiredRepeatedBool)
+        .addAllRequiredRepeatedEnum(requiredRepeatedEnum)
+        .addAllRequiredRepeatedString(requiredRepeatedString)
+        .addAllRequiredRepeatedBytes(requiredRepeatedBytes)
+        .addAllRequiredRepeatedMessage(requiredRepeatedMessage)
+        .addAllRequiredRepeatedResourceName(ShelfBookName.toStringList(requiredRepeatedResourceName))
+        .addAllRequiredRepeatedResourceNameOneof(BookName.toStringList(requiredRepeatedResourceNameOneof))
+        .addAllRequiredRepeatedResourceNameCommon(ProjectName.toStringList(requiredRepeatedResourceNameCommon))
+        .addAllRequiredRepeatedFixed32(requiredRepeatedFixed32)
+        .addAllRequiredRepeatedFixed64(requiredRepeatedFixed64)
+        .putAllRequiredMap(requiredMap)
+        .build();
+      TestOptionalRequiredFlatteningParamsResponse response = libraryClient.testOptionalRequiredFlatteningParams(request);
+      System.out.println(response);
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+  }
+  // [END test_float_and_int64]
+
+  public static void main(String[] args) throws Exception {
+    Options options = new Options();
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("param_float")
+          .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("param_long")
+          .build());
+
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    float paramFloat =
+        cl.getOptionValue("param_float") != null
+            ? Float.parseFloat(cl.getOptionValue("param_float"))
+            : 1.2345F;
+    long paramLong =
+        cl.getOptionValue("param_long") != null
+            ? Long.parseLong(cl.getOptionValue("param_long"))
+            : 67890L;
+
+    sampleTestOptionalRequiredFlatteningParams(paramFloat, paramLong);
   }
 }
 ============== file: samples/src/main/java/com/google/example/examples/library/v1/TestResourceNameOneof.java ==============

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -1378,6 +1378,105 @@ function sampleListShelves() {
 // tslint:disable-next-line:no-any
 
 sampleListShelves();
+============== file: samples/v1/test_float_and_int64.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_float_and_int64")
+'use strict';
+
+// sample-metadata:
+//   title:
+//   usage: node samples/v1/test_float_and_int64.js [--param_float 1.2345] [--param_long 67890]
+
+// [START test_float_and_int64]
+
+const library = require('@google-cloud/library').v1;
+
+function sampleTestOptionalRequiredFlatteningParams(paramFloat, paramLong) {
+  const client = new library.LibraryServiceClient();
+  // const paramFloat = 1.2345;
+  // const paramLong = 67890;
+  const requiredSingularInt32 = 0;
+  const requiredSingularDouble = 0.0;
+  const requiredSingularBool = false;
+  const requiredSingularEnum = 'ZERO';
+  const requiredSingularString = '';
+  const requiredSingularBytes = Buffer.from('');
+  const requiredSingularMessage = {};
+  const formattedRequiredSingularResourceName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedRequiredSingularResourceNameCommon = client.projectPath('[PROJECT]');
+  const requiredSingularFixed32 = 0;
+  const requiredSingularFixed64 = 0;
+  const requiredRepeatedInt32 = [];
+  const requiredRepeatedInt64 = [];
+  const requiredRepeatedFloat = [];
+  const requiredRepeatedDouble = [];
+  const requiredRepeatedBool = [];
+  const requiredRepeatedEnum = [];
+  const requiredRepeatedString = [];
+  const requiredRepeatedBytes = [];
+  const requiredRepeatedMessage = [];
+  const formattedRequiredRepeatedResourceName = [];
+  const formattedRequiredRepeatedResourceNameOneof = [];
+  const formattedRequiredRepeatedResourceNameCommon = [];
+  const requiredRepeatedFixed32 = [];
+  const requiredRepeatedFixed64 = [];
+  const requiredMap = {};
+  const request = {
+    requiredSingularInt32: requiredSingularInt32,
+    requiredSingularInt64: paramLong,
+    requiredSingularFloat: paramFloat,
+    requiredSingularDouble: requiredSingularDouble,
+    requiredSingularBool: requiredSingularBool,
+    requiredSingularEnum: requiredSingularEnum,
+    requiredSingularString: requiredSingularString,
+    requiredSingularBytes: requiredSingularBytes,
+    requiredSingularMessage: requiredSingularMessage,
+    requiredSingularResourceName: formattedRequiredSingularResourceName,
+    requiredSingularResourceNameOneof: formattedRequiredSingularResourceNameOneof,
+    requiredSingularResourceNameCommon: formattedRequiredSingularResourceNameCommon,
+    requiredSingularFixed32: requiredSingularFixed32,
+    requiredSingularFixed64: requiredSingularFixed64,
+    requiredRepeatedInt32: requiredRepeatedInt32,
+    requiredRepeatedInt64: requiredRepeatedInt64,
+    requiredRepeatedFloat: requiredRepeatedFloat,
+    requiredRepeatedDouble: requiredRepeatedDouble,
+    requiredRepeatedBool: requiredRepeatedBool,
+    requiredRepeatedEnum: requiredRepeatedEnum,
+    requiredRepeatedString: requiredRepeatedString,
+    requiredRepeatedBytes: requiredRepeatedBytes,
+    requiredRepeatedMessage: requiredRepeatedMessage,
+    requiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
+    requiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
+    requiredRepeatedResourceNameCommon: formattedRequiredRepeatedResourceNameCommon,
+    requiredRepeatedFixed32: requiredRepeatedFixed32,
+    requiredRepeatedFixed64: requiredRepeatedFixed64,
+    requiredMap: requiredMap,
+  };
+  client.testOptionalRequiredFlatteningParams(request)
+    .then(responses => {
+      const response = responses[0];
+      console.log(response);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+// [END test_float_and_int64]
+// tslint:disable-next-line:no-any
+
+const argv = require(`yargs`)
+  .option('param_float', {
+    default: 1.2345,
+    number: true
+  })
+  .option('param_long', {
+    default: 67890,
+    number: true
+  })
+  .argv;
+
+sampleTestOptionalRequiredFlatteningParams(argv.param_float, argv.param_long);
 ============== file: samples/v1/test_resource_name_oneof.js ==============
 // DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
 'use strict';

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -1666,6 +1666,98 @@ function sampleListShelves()
 // [END test_default_calling_form_for_paging]
 
 sampleListShelves();
+============== file: samples/V1/TestFloatAndInt64.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_float_and_int64")
+ */
+
+// sample-metadata
+//   title:
+//   usage: php samples/V1/TestFloatAndInt64.php [--param_float 1.2345] [--param_long 67890]
+// [START test_float_and_int64]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\TestOptionalRequiredFlatteningParamsRequest\InnerEnum;
+use Google\Example\Library\V1\TestOptionalRequiredFlatteningParamsRequest\InnerMessage;
+
+function sampleTestOptionalRequiredFlatteningParams($paramFloat, $paramLong)
+{
+    $libraryServiceClient = new LibraryServiceClient();
+
+    // $paramFloat = 1.2345;
+    // $paramLong = 67890;
+    $requiredSingularInt32 = 0;
+    $requiredSingularDouble = 0.0;
+    $requiredSingularBool = false;
+    $requiredSingularEnum = InnerEnum::ZERO;
+    $requiredSingularString = '';
+    $requiredSingularBytes = '';
+    $requiredSingularMessage = new InnerMessage();
+    $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedRequiredSingularResourceNameCommon = $libraryServiceClient->projectName('[PROJECT]');
+    $requiredSingularFixed32 = 0;
+    $requiredSingularFixed64 = 0;
+    $requiredRepeatedInt32 = [];
+    $requiredRepeatedInt64 = [];
+    $requiredRepeatedFloat = [];
+    $requiredRepeatedDouble = [];
+    $requiredRepeatedBool = [];
+    $requiredRepeatedEnum = [];
+    $requiredRepeatedString = [];
+    $requiredRepeatedBytes = [];
+    $requiredRepeatedMessage = [];
+    $formattedRequiredRepeatedResourceName = [];
+    $formattedRequiredRepeatedResourceNameOneof = [];
+    $formattedRequiredRepeatedResourceNameCommon = [];
+    $requiredRepeatedFixed32 = [];
+    $requiredRepeatedFixed64 = [];
+    $requiredMap = [];
+
+    try {
+        $response = $libraryServiceClient->testOptionalRequiredFlatteningParams($requiredSingularInt32, $paramLong, $paramFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $formattedRequiredSingularResourceName, $formattedRequiredSingularResourceNameOneof, $formattedRequiredSingularResourceNameCommon, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $formattedRequiredRepeatedResourceName, $formattedRequiredRepeatedResourceNameOneof, $formattedRequiredRepeatedResourceNameCommon, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap);
+        printf("%s" . PHP_EOL, print_r($response, true));
+    } finally {
+        $libraryServiceClient->close();
+    }
+}
+// [END test_float_and_int64]
+
+$opts = [
+    'param_float::',
+    'param_long::',
+];
+
+$defaultOptions = [
+    'param_float' => 1.2345,
+    'param_long' => 67890,
+];
+
+$options = getopt('', $opts);
+$options += $defaultOptions;
+
+$paramFloat = $options['param_float'];
+$paramLong = $options['param_long'];
+
+sampleTestOptionalRequiredFlatteningParams($paramFloat, $paramLong);
 ============== file: samples/V1/TestResourceNameOneof.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -6059,6 +6059,88 @@ def main():
 
 if __name__ == '__main__':
   main()
+============== file: samples/v1/test_float_and_int64.py ==============
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_float_and_int64")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-library
+
+# sample-metadata
+#   title:
+#   usage: python3 samples/v1/test_float_and_int64.py [--param_float 1.2345] [--param_long 67890]
+import sys
+
+# [START test_float_and_int64]
+
+from google.cloud.example import library_v1
+from google.cloud.example.library_v1 import enums
+
+def sample_test_optional_required_flattening_params(param_float, param_long):
+
+  client = library_v1.LibraryServiceClient()
+
+  # param_float = 1.2345
+  # param_long = 67890
+  required_singular_int32 = 0
+  required_singular_double = 0.0
+  required_singular_bool = False
+  required_singular_enum = enums.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO
+  required_singular_string = ''
+  required_singular_bytes = b''
+  required_singular_message = {}
+  required_singular_resource_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  required_singular_resource_name_oneof = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  required_singular_resource_name_common = client.project_path('[PROJECT]')
+  required_singular_fixed32 = 0
+  required_singular_fixed64 = 0
+  required_repeated_int32 = []
+  required_repeated_int64 = []
+  required_repeated_float = []
+  required_repeated_double = []
+  required_repeated_bool = []
+  required_repeated_enum = []
+  required_repeated_string = []
+  required_repeated_bytes = []
+  required_repeated_message = []
+  required_repeated_resource_name = []
+  required_repeated_resource_name_oneof = []
+  required_repeated_resource_name_common = []
+  required_repeated_fixed32 = []
+  required_repeated_fixed64 = []
+  required_map = {}
+
+  response = client.test_optional_required_flattening_params(required_singular_int32, param_long, param_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
+  print(response)
+# [END test_float_and_int64]
+
+def main():
+  import argparse
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--param_float', type=float, default=1.2345)
+  parser.add_argument('--param_long', type=long, default=67890)
+  args = parser.parse_args()
+
+  sample_test_optional_required_flattening_params(args.param_float, args.param_long)
+
+if __name__ == '__main__':
+  main()
 ============== file: samples/v1/test_resource_name_oneof.py ==============
 # -*- coding: utf-8 -*-
 #

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -6471,6 +6471,88 @@ if $PROGRAM_NAME == __FILE__
   sample_list_shelves
 end
 
+============== file: samples/v1/test_float_and_int64.rb ==============
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_float_and_int64")
+
+# sample-metadata
+#   title:
+#   bundle exec ruby samples/v1/test_float_and_int64.rb [--param_float 1.2345] [--param_long 67890]
+
+require "library"
+
+# [START test_float_and_int64]
+
+def sample_test_optional_required_flattening_params param_float, param_long
+  # Instantiate a client
+  library_client = Library::Library.new version: :v1
+
+  # param_float = 1.2345
+  # param_long = 67890
+  required_singular_int32 = 0
+  required_singular_double = 0.0
+  required_singular_bool = false
+  required_singular_enum = :ZERO
+  required_singular_string = ''
+  required_singular_bytes = ''
+  required_singular_message = {}
+  formatted_required_singular_resource_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_required_singular_resource_name_oneof = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_required_singular_resource_name_common = library_client.class.project_path("[PROJECT]")
+  required_singular_fixed32 = 0
+  required_singular_fixed64 = 0
+  required_repeated_int32 = []
+  required_repeated_int64 = []
+  required_repeated_float = []
+  required_repeated_double = []
+  required_repeated_bool = []
+  required_repeated_enum = []
+  required_repeated_string = []
+  required_repeated_bytes = []
+  required_repeated_message = []
+  formatted_required_repeated_resource_name = []
+  formatted_required_repeated_resource_name_oneof = []
+  formatted_required_repeated_resource_name_common = []
+  required_repeated_fixed32 = []
+  required_repeated_fixed64 = []
+  required_map = {}
+
+  response = library_client.test_optional_required_flattening_params(required_singular_int32, param_long, param_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, formatted_required_singular_resource_name, formatted_required_singular_resource_name_oneof, formatted_required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, formatted_required_repeated_resource_name, formatted_required_repeated_resource_name_oneof, formatted_required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
+  puts response.inspect
+end
+# [END test_float_and_int64]
+
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+
+  param_float = 1.2345
+  param_long = 67890
+
+  ARGV.options do |opts|
+    opts.on("--param_float=val") { |val| param_float = val }
+    opts.on("--param_long=val") { |val| param_long = val }
+    opts.parse!
+  end
+
+
+  sample_test_optional_required_flattening_params(param_float, param_long)
+end
+
 ============== file: samples/v1/test_resource_name_oneof.rb ==============
 # Copyright 2019 Google LLC
 #

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -2268,7 +2268,7 @@ namespace Google.Example.Library.V1.Samples
         }
     }
 }
-============== file: Google.Example.Library.V1/Google.Example.Library.V1.Samples/TestFloat.cs ==============
+============== file: Google.Example.Library.V1/Google.Example.Library.V1.Samples/TestFloatAndInt64.cs ==============
 // Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -2285,13 +2285,13 @@ namespace Google.Example.Library.V1.Samples
 
 // Generated code. DO NOT EDIT!
 
-// This is a generated sample ("Request", "test_float")
+// This is a generated sample ("Request", "test_float_and_int64")
 
 // sample-metadata
 //   title:
-//   usage: dotnet run [--param_float 1.2345]
+//   usage: dotnet run [--param_float 1.2345] [--param_long 67890]
 
-// [START test_float]
+// [START test_float_and_int64]
 namespace Google.Example.Library.V1.Samples
 {
     using Google.Example.Library.V1;
@@ -2299,16 +2299,17 @@ namespace Google.Example.Library.V1.Samples
     using System;
     using System.Collections.Generic;
 
-    public class TestFloat
+    public class TestFloatAndInt64
     {
-        public static void SampleTestOptionalRequiredFlatteningParams(float paramFloat)
+        public static void SampleTestOptionalRequiredFlatteningParams(float paramFloat, long paramLong)
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // float paramFloat = 1.2345f
+            // long paramLong = 67890L
             TestOptionalRequiredFlatteningParamsRequest request = new TestOptionalRequiredFlatteningParamsRequest
             {
                 RequiredSingularInt32 = 0,
-                RequiredSingularInt64 = 0L,
+                RequiredSingularInt64 = 67890L,
                 RequiredSingularFloat = 1.2345f,
                 RequiredSingularDouble = 0.0,
                 RequiredSingularBool = false,
@@ -2340,18 +2341,21 @@ namespace Google.Example.Library.V1.Samples
             TestOptionalRequiredFlatteningParamsResponse response = libraryServiceClient.TestOptionalRequiredFlatteningParams(request);
             Console.WriteLine(response);
         }
-        // [END test_float]
+        // [END test_float_and_int64]
         public static void Main(string[] args)
         {
             new Parser(with => with.CaseInsensitiveEnumValues = true).ParseArguments<Options>(args)
                 .WithParsed<Options>(opts =>
-                    SampleTestOptionalRequiredFlatteningParams(opts.ParamFloat));
+                    SampleTestOptionalRequiredFlatteningParams(opts.ParamFloat, opts.ParamLong));
         }
 
         public class Options
         {
             [Option("param_float", Default = 1.2345f)]
             public float ParamFloat { get; set; }
+
+            [Option("param_long", Default = 67890L)]
+            public long ParamLong { get; set; }
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -101,9 +101,6 @@ compileJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
 
 dependencies {
-  compile 'com.google.api:gax:1.0.0'
-  compile 'com.google.api:gax-grpc:1.0.0'
-  compile 'io.grpc:grpc-netty-shaded:1.9.0'
   compile 'com.google.api:api-common:0.0.2'
   compile 'commons-cli:commons-cli:1.4'
   compile project(':gapic-google-cloud-library-v1')
@@ -121,7 +118,7 @@ clean {
   delete 'all-jars'
 }
 
-task run {
+run {
   mainClassName = getProperty('mainClass')
 }
 
@@ -3525,7 +3522,7 @@ public class TestDefaultCallingFormForPaging {
     sampleListShelves();
   }
 }
-============== file: samples/src/main/java/com/google/example/examples/library/v1/TestFloat.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/TestFloatAndInt64.java ==============
 /*
  * Copyright 2019 Google LLC
  *
@@ -3541,10 +3538,10 @@ public class TestDefaultCallingFormForPaging {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// DO NOT EDIT! This is a generated sample ("Request",  "test_float")
+// DO NOT EDIT! This is a generated sample ("Request",  "test_float_and_int64")
 // sample-metadata:
 //   title:
-//   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestFloat [--args='[--param_float 1.2345]']
+//   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestFloatAndInt64 [--args='[--param_float 1.2345] [--param_long 67890]']
 
 package com.google.example.examples.library.v1;
 
@@ -3564,8 +3561,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class TestFloat {
-  // [START test_float]
+public class TestFloatAndInt64 {
+  // [START test_float_and_int64]
   /*
    * Please include the following imports to run this sample.
    *
@@ -3582,11 +3579,11 @@ public class TestFloat {
    * import java.util.Map;
    */
 
-  public static void sampleTestOptionalRequiredFlatteningParams(float paramFloat) {
+  public static void sampleTestOptionalRequiredFlatteningParams(float paramFloat, long paramLong) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
       // paramFloat = 1.2345F;
+      // paramLong = 67890L;
       int requiredSingularInt32 = 0;
-      long requiredSingularInt64 = 0L;
       double requiredSingularDouble = 0.0;
       boolean requiredSingularBool = false;
       TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum = TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
@@ -3615,7 +3612,7 @@ public class TestFloat {
       Map<Integer, String> requiredMap = new HashMap<>();
       TestOptionalRequiredFlatteningParamsRequest request = TestOptionalRequiredFlatteningParamsRequest.newBuilder()
         .setRequiredSingularInt32(requiredSingularInt32)
-        .setRequiredSingularInt64(requiredSingularInt64)
+        .setRequiredSingularInt64(paramLong)
         .setRequiredSingularFloat(paramFloat)
         .setRequiredSingularDouble(requiredSingularDouble)
         .setRequiredSingularBool(requiredSingularBool)
@@ -3650,7 +3647,7 @@ public class TestFloat {
       System.err.println("Failed to create the client due to: " + exception);
     }
   }
-  // [END test_float]
+  // [END test_float_and_int64]
 
   public static void main(String[] args) throws Exception {
     Options options = new Options();
@@ -3660,14 +3657,24 @@ public class TestFloat {
           .hasArg(true)
           .longOpt("param_float")
           .build());
+    options.addOption(
+        Option.builder("")
+          .required(false)
+          .hasArg(true)
+          .longOpt("param_long")
+          .build());
 
     CommandLine cl = (new DefaultParser()).parse(options, args);
     float paramFloat =
         cl.getOptionValue("param_float") != null
             ? Float.parseFloat(cl.getOptionValue("param_float"))
             : 1.2345F;
+    long paramLong =
+        cl.getOptionValue("param_long") != null
+            ? Long.parseLong(cl.getOptionValue("param_long"))
+            : 67890L;
 
-    sampleTestOptionalRequiredFlatteningParams(paramFloat);
+    sampleTestOptionalRequiredFlatteningParams(paramFloat, paramLong);
   }
 }
 ============== file: samples/src/main/java/com/google/example/examples/library/v1/TestResourceNameOneof.java ==============

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
@@ -690,16 +690,19 @@ interfaces:
       - name: TestOptionalRequiredFlatteningParams
         samples:
           standalone:
-          - value_sets: [test_float]
-            region_tag: test_float
+          - value_sets: [test_float_and_int64]
+            region_tag: test_float_and_int64
         sample_value_sets:
-        - id: test_float
+        - id: test_float_and_int64
           parameters:
             defaults: 
             - required_singular_float=1.2345
+            - required_singular_int64=67890
             attributes:
             - parameter: required_singular_float
               sample_argument_name: param_float
+            - parameter: required_singular_int64
+              sample_argument_name: param_long
         retry_params_name: default
     # Intentionally leave out PrivateGetBook method from GAPIC config.
 # Force Java client to have the formatting string functions.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -1384,23 +1384,23 @@ function sampleListShelves() {
 // tslint:disable-next-line:no-any
 
 sampleListShelves();
-============== file: samples/v1/test_float.js ==============
-// DO NOT EDIT! This is a generated sample ("Request",  "test_float")
+============== file: samples/v1/test_float_and_int64.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_float_and_int64")
 'use strict';
 
 // sample-metadata:
 //   title:
-//   usage: node samples/v1/test_float.js [--param_float 1.2345]
+//   usage: node samples/v1/test_float_and_int64.js [--param_float 1.2345] [--param_long 67890]
 
-// [START test_float]
+// [START test_float_and_int64]
 
 const library = require('@google-cloud/library').v1;
 
-function sampleTestOptionalRequiredFlatteningParams(paramFloat) {
+function sampleTestOptionalRequiredFlatteningParams(paramFloat, paramLong) {
   const client = new library.LibraryServiceClient();
   // const paramFloat = 1.2345;
+  // const paramLong = 67890;
   const requiredSingularInt32 = 0;
-  const requiredSingularInt64 = 0;
   const requiredSingularDouble = 0.0;
   const requiredSingularBool = false;
   const requiredSingularEnum = 'ZERO';
@@ -1429,7 +1429,7 @@ function sampleTestOptionalRequiredFlatteningParams(paramFloat) {
   const requiredMap = {};
   const request = {
     requiredSingularInt32: requiredSingularInt32,
-    requiredSingularInt64: requiredSingularInt64,
+    requiredSingularInt64: paramLong,
     requiredSingularFloat: paramFloat,
     requiredSingularDouble: requiredSingularDouble,
     requiredSingularBool: requiredSingularBool,
@@ -1468,7 +1468,7 @@ function sampleTestOptionalRequiredFlatteningParams(paramFloat) {
     });
 }
 
-// [END test_float]
+// [END test_float_and_int64]
 // tslint:disable-next-line:no-any
 
 const argv = require(`yargs`)
@@ -1476,9 +1476,13 @@ const argv = require(`yargs`)
     default: 1.2345,
     number: true
   })
+  .option('param_long', {
+    default: 67890,
+    number: true
+  })
   .argv;
 
-sampleTestOptionalRequiredFlatteningParams(argv.param_float);
+sampleTestOptionalRequiredFlatteningParams(argv.param_float, argv.param_long);
 ============== file: samples/v1/test_resource_name_oneof.js ==============
 // DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
 'use strict';

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -1674,7 +1674,7 @@ function sampleListShelves()
 // [END test_default_calling_form_for_paging]
 
 sampleListShelves();
-============== file: samples/V1/TestFloat.php ==============
+============== file: samples/V1/TestFloatAndInt64.php ==============
 <?php
 /*
  * Copyright 2019 Google LLC
@@ -1693,26 +1693,26 @@ sampleListShelves();
  */
 
 /*
- * DO NOT EDIT! This is a generated sample ("Request",  "test_float")
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_float_and_int64")
  */
 
 // sample-metadata
 //   title:
-//   usage: php samples/V1/TestFloat.php [--param_float 1.2345]
-// [START test_float]
+//   usage: php samples/V1/TestFloatAndInt64.php [--param_float 1.2345] [--param_long 67890]
+// [START test_float_and_int64]
 require __DIR__ . '/../../vendor/autoload.php';
 
 use Google\Cloud\Example\Library\V1\LibraryServiceClient;
 use Google\Example\Library\V1\TestOptionalRequiredFlatteningParamsRequest\InnerEnum;
 use Google\Example\Library\V1\TestOptionalRequiredFlatteningParamsRequest\InnerMessage;
 
-function sampleTestOptionalRequiredFlatteningParams($paramFloat)
+function sampleTestOptionalRequiredFlatteningParams($paramFloat, $paramLong)
 {
     $libraryServiceClient = new LibraryServiceClient();
 
     // $paramFloat = 1.2345;
+    // $paramLong = 67890;
     $requiredSingularInt32 = 0;
-    $requiredSingularInt64 = 0;
     $requiredSingularDouble = 0.0;
     $requiredSingularBool = false;
     $requiredSingularEnum = InnerEnum::ZERO;
@@ -1741,28 +1741,31 @@ function sampleTestOptionalRequiredFlatteningParams($paramFloat)
     $requiredMap = [];
 
     try {
-        $response = $libraryServiceClient->testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $paramFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $formattedRequiredSingularResourceName, $formattedRequiredSingularResourceNameOneof, $requiredSingularResourceNameCommon, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $formattedRequiredRepeatedResourceName, $formattedRequiredRepeatedResourceNameOneof, $requiredRepeatedResourceNameCommon, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap);
+        $response = $libraryServiceClient->testOptionalRequiredFlatteningParams($requiredSingularInt32, $paramLong, $paramFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $formattedRequiredSingularResourceName, $formattedRequiredSingularResourceNameOneof, $requiredSingularResourceNameCommon, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $formattedRequiredRepeatedResourceName, $formattedRequiredRepeatedResourceNameOneof, $requiredRepeatedResourceNameCommon, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap);
         printf("%s" . PHP_EOL, print_r($response, true));
     } finally {
         $libraryServiceClient->close();
     }
 }
-// [END test_float]
+// [END test_float_and_int64]
 
 $opts = [
     'param_float::',
+    'param_long::',
 ];
 
 $defaultOptions = [
     'param_float' => 1.2345,
+    'param_long' => 67890,
 ];
 
 $options = getopt('', $opts);
 $options += $defaultOptions;
 
 $paramFloat = $options['param_float'];
+$paramLong = $options['param_long'];
 
-sampleTestOptionalRequiredFlatteningParams($paramFloat);
+sampleTestOptionalRequiredFlatteningParams($paramFloat, $paramLong);
 ============== file: samples/V1/TestResourceNameOneof.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -6054,7 +6054,7 @@ def main():
 
 if __name__ == '__main__':
   main()
-============== file: samples/v1/test_float.py ==============
+============== file: samples/v1/test_float_and_int64.py ==============
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 Google LLC
@@ -6071,28 +6071,28 @@ if __name__ == '__main__':
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# DO NOT EDIT! This is a generated sample ("Request",  "test_float")
+# DO NOT EDIT! This is a generated sample ("Request",  "test_float_and_int64")
 
 # To install the latest published package dependency, execute the following:
 #   pip install google-cloud-library
 
 # sample-metadata
 #   title:
-#   usage: python3 samples/v1/test_float.py [--param_float 1.2345]
+#   usage: python3 samples/v1/test_float_and_int64.py [--param_float 1.2345] [--param_long 67890]
 import sys
 
-# [START test_float]
+# [START test_float_and_int64]
 
 from google.cloud.example import library_v1
 from google.cloud.example.library_v1 import enums
 
-def sample_test_optional_required_flattening_params(param_float):
+def sample_test_optional_required_flattening_params(param_float, param_long):
 
   client = library_v1.LibraryServiceClient()
 
   # param_float = 1.2345
+  # param_long = 67890
   required_singular_int32 = 0
-  required_singular_int64 = 0
   required_singular_double = 0.0
   required_singular_bool = False
   required_singular_enum = enums.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO
@@ -6120,18 +6120,19 @@ def sample_test_optional_required_flattening_params(param_float):
   required_repeated_fixed64 = []
   required_map = {}
 
-  response = client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, param_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
+  response = client.test_optional_required_flattening_params(required_singular_int32, param_long, param_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
   print(response)
-# [END test_float]
+# [END test_float_and_int64]
 
 def main():
   import argparse
 
   parser = argparse.ArgumentParser()
   parser.add_argument('--param_float', type=float, default=1.2345)
+  parser.add_argument('--param_long', type=long, default=67890)
   args = parser.parse_args()
 
-  sample_test_optional_required_flattening_params(args.param_float)
+  sample_test_optional_required_flattening_params(args.param_float, args.param_long)
 
 if __name__ == '__main__':
   main()

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -6457,7 +6457,7 @@ if $PROGRAM_NAME == __FILE__
   sample_list_shelves
 end
 
-============== file: samples/v1/test_float.rb ==============
+============== file: samples/v1/test_float_and_int64.rb ==============
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -6472,23 +6472,23 @@ end
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# DO NOT EDIT! This is a generated sample ("Request",  "test_float")
+# DO NOT EDIT! This is a generated sample ("Request",  "test_float_and_int64")
 
 # sample-metadata
 #   title:
-#   bundle exec ruby samples/v1/test_float.rb [--param_float 1.2345]
+#   bundle exec ruby samples/v1/test_float_and_int64.rb [--param_float 1.2345] [--param_long 67890]
 
 require "library"
 
-# [START test_float]
+# [START test_float_and_int64]
 
-def sample_test_optional_required_flattening_params param_float
+def sample_test_optional_required_flattening_params param_float, param_long
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
   # param_float = 1.2345
+  # param_long = 67890
   required_singular_int32 = 0
-  required_singular_int64 = 0
   required_singular_double = 0.0
   required_singular_bool = false
   required_singular_enum = :ZERO
@@ -6516,10 +6516,10 @@ def sample_test_optional_required_flattening_params param_float
   required_repeated_fixed64 = []
   required_map = {}
 
-  response = library_client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, param_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, formatted_required_singular_resource_name, formatted_required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, formatted_required_repeated_resource_name, formatted_required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
+  response = library_client.test_optional_required_flattening_params(required_singular_int32, param_long, param_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, formatted_required_singular_resource_name, formatted_required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, formatted_required_repeated_resource_name, formatted_required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
   puts response.inspect
 end
-# [END test_float]
+# [END test_float_and_int64]
 
 
 require "optparse"
@@ -6527,14 +6527,16 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   param_float = 1.2345
+  param_long = 67890
 
   ARGV.options do |opts|
     opts.on("--param_float=val") { |val| param_float = val }
+    opts.on("--param_long=val") { |val| param_long = val }
     opts.parse!
   end
 
 
-  sample_test_optional_required_flattening_params(param_float)
+  sample_test_optional_required_flattening_params(param_float, param_long)
 end
 
 ============== file: samples/v1/test_resource_name_oneof.rb ==============

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -1167,6 +1167,21 @@ interfaces:
       optional_repeated_resource_name_oneof: book_oneof
       optional_repeated_resource_name_common: project
     timeout_millis: 60000
+    samples:
+      standalone:
+      - value_sets: [test_float_and_int64]
+        region_tag: test_float_and_int64
+    sample_value_sets:
+    - id: test_float_and_int64
+      parameters:
+        defaults: 
+        - required_singular_float=1.2345
+        - required_singular_int64=67890
+        attributes:
+        - parameter: required_singular_float
+          sample_argument_name: param_float
+        - parameter: required_singular_int64
+          sample_argument_name: param_long
   # Intentionally leave out PrivateListShelves method from GAPIC config.
 resource_name_generation:
 - message_name: Book


### PR DESCRIPTION
- Correctly parse `int64` fields into `long` values through CLI
- Remove unnecessary dependencies from build.gradle of the sample package
- Remove the `task` in build.gradle