### PR TITLE
node: simplify inner call initialization

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -240,18 +240,16 @@
           @end
         ];
         for (const methodName of {@stub.stubMethodsArrayName}) {
+          const innerCallPromise = {@stub.name}.then(
+            stub => (...args) => {
+              return stub[methodName].apply(stub, args);
+            },
+            err => () => {
+              throw err;
+            }
+          );
           this._innerApiCalls[methodName] = gax.createApiCall(
-            {@stub.name}.then(
-              stub =>
-                function() {
-                  const args = Array.prototype.slice.call(arguments, 0);
-                  return stub[methodName].apply(stub, args);
-                },
-              err =>
-                function() {
-                  throw err;
-                }
-            ),
+            innerCallPromise,
             defaults[methodName],
             {@getDescriptors(xapi)}
           );

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -4398,18 +4398,16 @@ class LibraryServiceClient {
       'privateListShelves',
     ];
     for (const methodName of libraryServiceStubMethods) {
+      const innerCallPromise = libraryServiceStub.then(
+        stub => (...args) => {
+          return stub[methodName].apply(stub, args);
+        },
+        err => () => {
+          throw err;
+        }
+      );
       this._innerApiCalls[methodName] = gax.createApiCall(
-        libraryServiceStub.then(
-          stub =>
-            function() {
-              const args = Array.prototype.slice.call(arguments, 0);
-              return stub[methodName].apply(stub, args);
-            },
-          err =>
-            function() {
-              throw err;
-            }
-        ),
+        innerCallPromise,
         defaults[methodName],
         this._descriptors.page[methodName] || this._descriptors.batching[methodName] || this._descriptors.stream[methodName] || this._descriptors.longrunning[methodName]
       );
@@ -4428,18 +4426,16 @@ class LibraryServiceClient {
       'addLabel',
     ];
     for (const methodName of labelerStubMethods) {
+      const innerCallPromise = labelerStub.then(
+        stub => (...args) => {
+          return stub[methodName].apply(stub, args);
+        },
+        err => () => {
+          throw err;
+        }
+      );
       this._innerApiCalls[methodName] = gax.createApiCall(
-        labelerStub.then(
-          stub =>
-            function() {
-              const args = Array.prototype.slice.call(arguments, 0);
-              return stub[methodName].apply(stub, args);
-            },
-          err =>
-            function() {
-              throw err;
-            }
-        ),
+        innerCallPromise,
         defaults[methodName],
         this._descriptors.page[methodName] || this._descriptors.batching[methodName] || this._descriptors.stream[methodName] || this._descriptors.longrunning[methodName]
       );
@@ -7150,18 +7146,16 @@ class MyProtoClient {
       'myMethod',
     ];
     for (const methodName of myProtoStubMethods) {
+      const innerCallPromise = myProtoStub.then(
+        stub => (...args) => {
+          return stub[methodName].apply(stub, args);
+        },
+        err => () => {
+          throw err;
+        }
+      );
       this._innerApiCalls[methodName] = gax.createApiCall(
-        myProtoStub.then(
-          stub =>
-            function() {
-              const args = Array.prototype.slice.call(arguments, 0);
-              return stub[methodName].apply(stub, args);
-            },
-          err =>
-            function() {
-              throw err;
-            }
-        ),
+        innerCallPromise,
         defaults[methodName],
         null
       );

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -300,18 +300,16 @@ class DecrementerServiceClient {
       'decrement',
     ];
     for (const methodName of decrementerServiceStubMethods) {
+      const innerCallPromise = decrementerServiceStub.then(
+        stub => (...args) => {
+          return stub[methodName].apply(stub, args);
+        },
+        err => () => {
+          throw err;
+        }
+      );
       this._innerApiCalls[methodName] = gax.createApiCall(
-        decrementerServiceStub.then(
-          stub =>
-            function() {
-              const args = Array.prototype.slice.call(arguments, 0);
-              return stub[methodName].apply(stub, args);
-            },
-          err =>
-            function() {
-              throw err;
-            }
-        ),
+        innerCallPromise,
         defaults[methodName],
         this._descriptors.stream[methodName]
       );
@@ -628,18 +626,16 @@ class IncrementerServiceClient {
       'increment',
     ];
     for (const methodName of incrementerServiceStubMethods) {
+      const innerCallPromise = incrementerServiceStub.then(
+        stub => (...args) => {
+          return stub[methodName].apply(stub, args);
+        },
+        err => () => {
+          throw err;
+        }
+      );
       this._innerApiCalls[methodName] = gax.createApiCall(
-        incrementerServiceStub.then(
-          stub =>
-            function() {
-              const args = Array.prototype.slice.call(arguments, 0);
-              return stub[methodName].apply(stub, args);
-            },
-          err =>
-            function() {
-              throw err;
-            }
-        ),
+        innerCallPromise,
         defaults[methodName],
         null
       );

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -284,18 +284,16 @@ class NoTemplatesApiServiceClient {
       'increment',
     ];
     for (const methodName of noTemplatesApiServiceStubMethods) {
+      const innerCallPromise = noTemplatesApiServiceStub.then(
+        stub => (...args) => {
+          return stub[methodName].apply(stub, args);
+        },
+        err => () => {
+          throw err;
+        }
+      );
       this._innerApiCalls[methodName] = gax.createApiCall(
-        noTemplatesApiServiceStub.then(
-          stub =>
-            function() {
-              const args = Array.prototype.slice.call(arguments, 0);
-              return stub[methodName].apply(stub, args);
-            },
-          err =>
-            function() {
-              throw err;
-            }
-        ),
+        innerCallPromise,
         defaults[methodName],
         null
       );

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -4494,18 +4494,16 @@ class LibraryServiceClient {
       'privateListShelves',
     ];
     for (const methodName of libraryServiceStubMethods) {
+      const innerCallPromise = libraryServiceStub.then(
+        stub => (...args) => {
+          return stub[methodName].apply(stub, args);
+        },
+        err => () => {
+          throw err;
+        }
+      );
       this._innerApiCalls[methodName] = gax.createApiCall(
-        libraryServiceStub.then(
-          stub =>
-            function() {
-              const args = Array.prototype.slice.call(arguments, 0);
-              return stub[methodName].apply(stub, args);
-            },
-          err =>
-            function() {
-              throw err;
-            }
-        ),
+        innerCallPromise,
         defaults[methodName],
         this._descriptors.page[methodName] || this._descriptors.batching[methodName] || this._descriptors.stream[methodName] || this._descriptors.longrunning[methodName]
       );
@@ -4524,18 +4522,16 @@ class LibraryServiceClient {
       'addLabel',
     ];
     for (const methodName of labelerStubMethods) {
+      const innerCallPromise = labelerStub.then(
+        stub => (...args) => {
+          return stub[methodName].apply(stub, args);
+        },
+        err => () => {
+          throw err;
+        }
+      );
       this._innerApiCalls[methodName] = gax.createApiCall(
-        labelerStub.then(
-          stub =>
-            function() {
-              const args = Array.prototype.slice.call(arguments, 0);
-              return stub[methodName].apply(stub, args);
-            },
-          err =>
-            function() {
-              throw err;
-            }
-        ),
+        innerCallPromise,
         defaults[methodName],
         this._descriptors.page[methodName] || this._descriptors.batching[methodName] || this._descriptors.stream[methodName] || this._descriptors.longrunning[methodName]
       );
@@ -7255,18 +7251,16 @@ class MyProtoClient {
       'myMethod',
     ];
     for (const methodName of myProtoStubMethods) {
+      const innerCallPromise = myProtoStub.then(
+        stub => (...args) => {
+          return stub[methodName].apply(stub, args);
+        },
+        err => () => {
+          throw err;
+        }
+      );
       this._innerApiCalls[methodName] = gax.createApiCall(
-        myProtoStub.then(
-          stub =>
-            function() {
-              const args = Array.prototype.slice.call(arguments, 0);
-              return stub[methodName].apply(stub, args);
-            },
-          err =>
-            function() {
-              throw err;
-            }
-        ),
+        innerCallPromise,
         defaults[methodName],
         null
       );


### PR DESCRIPTION
This PR makes initialization of `this._innerApiCalls` just a little bit more readable by replacing `arguments` with a rest parameter syntax (`...args`). No changes in behavior intended.

Note: more changes to the generation code will follow, this one is just the first and the most minor one.