### PR TITLE
test: use artman image v0.26.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,7 +398,7 @@ jobs:
           path: reports/gapic-generator
   generate-clients:
     docker:
-      - image: googleapis/artman:0.16.25
+      - image: googleapis/artman:0.26.0
     working_directory: /tmp/
     environment:
       <<: *anchor_artman_vars
@@ -718,7 +718,7 @@ jobs:
     environment:
       ARTMAN_USER_CONFIG: /tmp/workspace/gapic-generator/.circleci/artman_config.yaml
     docker:
-      - image: googleapis/artman:0.16.25
+      - image: googleapis/artman:0.26.0
     steps:
       - attach_workspace:
           at: workspace


### PR DESCRIPTION
Using artman v0.26.0 for running smoke tests. Looks like the protoc version update made the CI fail https://circleci.com/gh/googleapis/gapic-generator/28531#artifacts/containers/0 and I just guess this version bump might solve the problem.