### PR TITLE
[feat] SampleGen: Parse empty object literals

### DIFF
--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public class FieldStructureParser {
   private static final String PROJECT_ID_TOKEN = "$PROJECT_ID";
-  private static final String EMPTY_OBJECT = "{}";
+  private static final String EMPTY_OBJECT = "$EMPTY_OBJECT";
 
   /** Update {@code root} with configuration in {@code initFieldConfigString}. */
   public static void parse(InitCodeNode root, String initFieldConfigString) {
@@ -245,9 +245,14 @@ public class FieldStructureParser {
   }
 
   /**
-   * Parses the value of configs (i.e. the RHS of the '='). If the value is a double-quoted string
-   * literal we return it unquoted. If the value is `{}` we return Otherwise we strip leading spaces
-   * and return the rest of value as a string for backward compatibility.
+   * Parses the value of configs (i.e. the RHS of the '=').
+   *
+   * <ul>
+   *   <li>If the value is a double-quoted string literal we return it unquoted.
+   *   <li>If the value is `{}` we return FieldStructureParser.EMPTY_OBJECT.
+   *   <li>Otherwise we strip leading spaces and return the rest of value as a string for backward
+   *       compatibility.
+   * </ul>
    */
   private static String parseValue(Scanner scanner) {
     int token = scanner.scan();

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -78,7 +78,7 @@ public class FieldStructureParser {
   // path = ident pathElem*
   // pathElem = ('.' ident) | ('[' int ']') | ('{' value '}');
   // value = int | string | ident | emptyObject;
-  // emptyObject = {}
+  // emptyObject = {};
   //
   // For compatibility with the previous parser, when ident is used as a value, the value is
   // the name of the ident. Eg, if the ident is "x", the value is simply "x", not the content

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -2364,6 +2364,61 @@ namespace Google.Example.Library.V1.Samples
         }
     }
 }
+============== file: Google.Example.Library.V1/Google.Example.Library.V1.Samples/TestSettingUpEmptyObjectsInRequest.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Request", "test_setting_up_empty_objects_in_request")
+
+// sample-metadata
+//   title: test_setting_up_empty_objects_in_request
+//   description: Test setting up empty objects in the request objects.
+//   usage: dotnet run
+
+// [START test_setting_up_empty_objects_in_request]
+namespace Google.Example.Library.V1.Samples
+{
+    using Google.Example.Library.V1;
+    using System;
+
+    public class TestSettingUpEmptyObjectsInRequest
+    {
+        /// <summary>
+        /// Test setting up empty objects in the request objects.
+        /// </summary>
+        public static void SampleGetShelf()
+        {
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            GetShelfRequest request = new GetShelfRequest
+            {
+                ShelfName = new ShelfName("my-shelf"),
+                Options = "",
+                Message = new SomeMessage(),
+                StringBuilder = new StringBuilder(),
+            };
+            Shelf response = libraryServiceClient.GetShelf(request);
+            Console.WriteLine("Shelf found.");
+        }
+        // [END test_setting_up_empty_objects_in_request]
+        public static void Main(string[] args)
+        {
+            SampleGetShelf();
+        }
+    }
+}
 ============== file: Google.Example.Library.V1/Google.Example.Library.V1.SmokeTests/Google.Example.Library.V1.SmokeTests.csproj ==============
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -3587,6 +3587,73 @@ public class TestResourceNameOneof2 {
     sampleGetBookFromAbsolutelyAnywhere();
   }
 }
+============== file: samples/src/main/java/com/google/example/examples/library/v1/TestSettingUpEmptyObjectsInRequest.java ==============
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// DO NOT EDIT! This is a generated sample ("Request",  "test_setting_up_empty_objects_in_request")
+// sample-metadata:
+//   title: test_setting_up_empty_objects_in_request
+//   description: Test setting up empty objects in the request objects.
+//   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestSettingUpEmptyObjectsInRequest
+
+package com.google.example.examples.library.v1;
+
+import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.Shelf;
+import com.google.example.library.v1.ShelfName;
+import com.google.example.library.v1.SomeMessage;
+
+public class TestSettingUpEmptyObjectsInRequest {
+  // [START test_setting_up_empty_objects_in_request]
+  /*
+   * Please include the following imports to run this sample.
+   *
+   * import com.google.example.library.v1.GetShelfRequest;
+   * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.Shelf;
+   * import com.google.example.library.v1.ShelfName;
+   * import com.google.example.library.v1.SomeMessage;
+   */
+
+  /** Test setting up empty objects in the request objects. */
+  public static void sampleGetShelf() {
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfName name = ShelfName.of("my-shelf");
+      String options = "";
+      SomeMessage message = SomeMessage.newBuilder().build();
+      com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
+      GetShelfRequest request = GetShelfRequest.newBuilder()
+        .setName(name.toString())
+        .setOptions(options)
+        .setMessage(message)
+        .setStringBuilder(stringBuilder)
+        .build();
+      Shelf response = libraryClient.getShelf(request);
+      System.out.println("Shelf found.");
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+  }
+  // [END test_setting_up_empty_objects_in_request]
+
+  public static void main(String[] args) {
+    sampleGetShelf();
+  }
+}
 ============== file: samples/src/main/java/com/google/example/examples/library/v1/ThisTagShouldBeTheNameOfTheFile.java ==============
 /*
  * Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -3634,6 +3634,8 @@ public class TestSettingUpEmptyObjectsInRequest {
     try (LibraryClient libraryClient = LibraryClient.create()) {
       ShelfName name = ShelfName.of("my-shelf");
       String options = "";
+
+      // we can set up this empty nested object now
       SomeMessage message = SomeMessage.newBuilder().build();
       com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
       GetShelfRequest request = GetShelfRequest.newBuilder()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -1396,6 +1396,8 @@ function sampleGetShelf() {
   const client = new library.LibraryServiceClient();
   const formattedName = client.shelfPath('my-shelf');
   const options = '';
+
+  // we can set up this empty nested object now
   const message = {};
   const stringBuilder = {};
   const request = {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -1378,6 +1378,46 @@ function sampleGetBookFromAbsolutelyAnywhere() {
 // tslint:disable-next-line:no-any
 
 sampleGetBookFromAbsolutelyAnywhere();
+============== file: samples/v1/test_setting_up_empty_objects_in_request.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_setting_up_empty_objects_in_request")
+'use strict';
+
+// sample-metadata:
+//   title: test_setting_up_empty_objects_in_request
+//   description: Test setting up empty objects in the request objects.
+//   usage: node samples/v1/test_setting_up_empty_objects_in_request.js
+
+// [START test_setting_up_empty_objects_in_request]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test setting up empty objects in the request objects. */
+function sampleGetShelf() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.shelfPath('my-shelf');
+  const options = '';
+  const message = {};
+  const stringBuilder = {};
+  const request = {
+    name: formattedName,
+    options: options,
+    message: message,
+    stringBuilder: stringBuilder,
+  };
+  client.getShelf(request)
+    .then(responses => {
+      const response = responses[0];
+      console.log(`Shelf found.`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+// [END test_setting_up_empty_objects_in_request]
+// tslint:disable-next-line:no-any
+
+sampleGetShelf();
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.js ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "wap")
 'use strict';

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -1798,6 +1798,8 @@ function sampleGetShelf()
 
     $formattedName = $libraryServiceClient->shelfName('my-shelf');
     $options = '';
+
+    // we can set up this empty nested object now
     $message = new SomeMessage();
     $stringBuilder = new StringBuilder();
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -1758,6 +1758,59 @@ function sampleGetBookFromAbsolutelyAnywhere()
 // [END test_resource_name_oneof_2]
 
 sampleGetBookFromAbsolutelyAnywhere();
+============== file: samples/V1/TestSettingUpEmptyObjectsInRequest.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_setting_up_empty_objects_in_request")
+ */
+
+// sample-metadata
+//   title: test_setting_up_empty_objects_in_request
+//   description: Test setting up empty objects in the request objects.
+//   usage: php samples/V1/TestSettingUpEmptyObjectsInRequest.php
+// [START test_setting_up_empty_objects_in_request]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\SomeMessage;
+use Google\Example\Library\V1\StringBuilder;
+
+/** Test setting up empty objects in the request objects. */
+function sampleGetShelf()
+{
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->shelfName('my-shelf');
+    $options = '';
+    $message = new SomeMessage();
+    $stringBuilder = new StringBuilder();
+
+    try {
+        $response = $libraryServiceClient->getShelf($formattedName, $options);
+        printf("Shelf found." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+}
+// [END test_setting_up_empty_objects_in_request]
+
+sampleGetShelf();
 ============== file: samples/V1/ThisTagShouldBeTheNameOfTheFile.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -6159,6 +6159,57 @@ def main():
 
 if __name__ == '__main__':
   main()
+============== file: samples/v1/test_setting_up_empty_objects_in_request.py ==============
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_setting_up_empty_objects_in_request")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-library
+
+# sample-metadata
+#   title: test_setting_up_empty_objects_in_request
+#   description: Test setting up empty objects in the request objects.
+#   usage: python3 samples/v1/test_setting_up_empty_objects_in_request.py
+import sys
+
+# [START test_setting_up_empty_objects_in_request]
+
+from google.cloud.example import library_v1
+
+def sample_get_shelf():
+  """Test setting up empty objects in the request objects."""
+
+  client = library_v1.LibraryServiceClient()
+
+  name = client.shelf_path('my-shelf')
+  options_ = ''
+  message = {}
+  string_builder = {}
+
+  response = client.get_shelf(name, options_, message=message, string_builder=string_builder)
+  print(u'Shelf found.')
+# [END test_setting_up_empty_objects_in_request]
+
+def main():
+  sample_get_shelf()
+
+if __name__ == '__main__':
+  main()
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.py ==============
 # -*- coding: utf-8 -*-
 #

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -6198,6 +6198,8 @@ def sample_get_shelf():
 
   name = client.shelf_path('my-shelf')
   options_ = ''
+
+  # we can set up this empty nested object now
   message = {}
   string_builder = {}
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -6590,6 +6590,8 @@ def sample_get_shelf
 
   formatted_name = library_client.class.shelf_path("my-shelf")
   options_ = ''
+
+  # we can set up this empty nested object now
   message = {}
   string_builder = {}
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -6557,6 +6557,54 @@ if $PROGRAM_NAME == __FILE__
   sample_get_book_from_absolutely_anywhere
 end
 
+============== file: samples/v1/test_setting_up_empty_objects_in_request.rb ==============
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_setting_up_empty_objects_in_request")
+
+# sample-metadata
+#   title: test_setting_up_empty_objects_in_request
+#   description: Test setting up empty objects in the request objects.
+#   bundle exec ruby samples/v1/test_setting_up_empty_objects_in_request.rb
+
+require "library"
+
+# [START test_setting_up_empty_objects_in_request]
+
+# Test setting up empty objects in the request objects.
+def sample_get_shelf
+  # Instantiate a client
+  library_client = Library::Library.new version: :v1
+
+  formatted_name = library_client.class.shelf_path("my-shelf")
+  options_ = ''
+  message = {}
+  string_builder = {}
+
+  response = library_client.get_shelf(formatted_name, options_)
+  puts "Shelf found."
+end
+# [END test_setting_up_empty_objects_in_request]
+
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_get_shelf
+end
+
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.rb ==============
 # Copyright 2019 Google LLC
 #

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -2451,6 +2451,61 @@ namespace Google.Example.Library.V1.Samples
         }
     }
 }
+============== file: Google.Example.Library.V1/Google.Example.Library.V1.Samples/TestSettingUpEmptyObjectsInRequest.cs ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+// This is a generated sample ("Request", "test_setting_up_empty_objects_in_request")
+
+// sample-metadata
+//   title: test_setting_up_empty_objects_in_request
+//   description: Test setting up empty objects in the request objects.
+//   usage: dotnet run
+
+// [START test_setting_up_empty_objects_in_request]
+namespace Google.Example.Library.V1.Samples
+{
+    using Google.Example.Library.V1;
+    using System;
+
+    public class TestSettingUpEmptyObjectsInRequest
+    {
+        /// <summary>
+        /// Test setting up empty objects in the request objects.
+        /// </summary>
+        public static void SampleGetShelf()
+        {
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            GetShelfRequest request = new GetShelfRequest
+            {
+                ShelfName = new ShelfName("my-shelf"),
+                Options = "",
+                Message = new SomeMessage(),
+                StringBuilder = new StringBuilder(),
+            };
+            Shelf response = libraryServiceClient.GetShelf(request);
+            Console.WriteLine("Shelf found.");
+        }
+        // [END test_setting_up_empty_objects_in_request]
+        public static void Main(string[] args)
+        {
+            SampleGetShelf();
+        }
+    }
+}
 ============== file: Google.Example.Library.V1/Google.Example.Library.V1.SmokeTests/Google.Example.Library.V1.SmokeTests.csproj ==============
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -3835,6 +3835,8 @@ public class TestSettingUpEmptyObjectsInRequest {
     try (LibraryClient libraryClient = LibraryClient.create()) {
       ShelfName name = ShelfName.of("my-shelf");
       String options = "";
+
+      // we can set up this empty nested object now
       SomeMessage message = SomeMessage.newBuilder().build();
       com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
       GetShelfRequest request = GetShelfRequest.newBuilder()

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -3788,6 +3788,73 @@ public class TestResourceNameOneof2 {
     sampleGetBookFromAbsolutelyAnywhere();
   }
 }
+============== file: samples/src/main/java/com/google/example/examples/library/v1/TestSettingUpEmptyObjectsInRequest.java ==============
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// DO NOT EDIT! This is a generated sample ("Request",  "test_setting_up_empty_objects_in_request")
+// sample-metadata:
+//   title: test_setting_up_empty_objects_in_request
+//   description: Test setting up empty objects in the request objects.
+//   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestSettingUpEmptyObjectsInRequest
+
+package com.google.example.examples.library.v1;
+
+import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.Shelf;
+import com.google.example.library.v1.ShelfName;
+import com.google.example.library.v1.SomeMessage;
+
+public class TestSettingUpEmptyObjectsInRequest {
+  // [START test_setting_up_empty_objects_in_request]
+  /*
+   * Please include the following imports to run this sample.
+   *
+   * import com.google.example.library.v1.GetShelfRequest;
+   * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.Shelf;
+   * import com.google.example.library.v1.ShelfName;
+   * import com.google.example.library.v1.SomeMessage;
+   */
+
+  /** Test setting up empty objects in the request objects. */
+  public static void sampleGetShelf() {
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfName name = ShelfName.of("my-shelf");
+      String options = "";
+      SomeMessage message = SomeMessage.newBuilder().build();
+      com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
+      GetShelfRequest request = GetShelfRequest.newBuilder()
+        .setName(name.toString())
+        .setOptions(options)
+        .setMessage(message)
+        .setStringBuilder(stringBuilder)
+        .build();
+      Shelf response = libraryClient.getShelf(request);
+      System.out.println("Shelf found.");
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+  }
+  // [END test_setting_up_empty_objects_in_request]
+
+  public static void main(String[] args) {
+    sampleGetShelf();
+  }
+}
 ============== file: samples/src/main/java/com/google/example/examples/library/v1/ThisTagShouldBeTheNameOfTheFile.java ==============
 /*
  * Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
@@ -93,6 +93,9 @@ interfaces:
             - name%shelf_id="my-shelf"
             - message={}
             - string_builder={}
+            attributes:
+            - parameter: message
+              description: "we can set up this empty nested object now"
           on_success:
           - print:
             - "Shelf found."

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
@@ -85,10 +85,23 @@ interfaces:
           - print:
               - "The theme of the shelf is: %s"
               - $resp.theme
+        - id: test_setting_up_empty_objects_in_request
+          title: test_setting_up_empty_objects_in_request
+          description: "Test setting up empty objects in the request objects."
+          parameters:
+            defaults:
+            - name%shelf_id="my-shelf"
+            - message={}
+            - string_builder={}
+          on_success:
+          - print:
+            - "Shelf found."
         samples:
           standalone:
           - region_tag: sample_get_shelf
             value_sets: test_default_calling_form_unary
+          - region_tag: test_setting_up_empty_objects_in_request
+            value_sets: test_setting_up_empty_objects_in_request
       - name: ListShelves
         page_streaming:
           request:

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -1479,6 +1479,46 @@ function sampleGetBookFromAbsolutelyAnywhere() {
 // tslint:disable-next-line:no-any
 
 sampleGetBookFromAbsolutelyAnywhere();
+============== file: samples/v1/test_setting_up_empty_objects_in_request.js ==============
+// DO NOT EDIT! This is a generated sample ("Request",  "test_setting_up_empty_objects_in_request")
+'use strict';
+
+// sample-metadata:
+//   title: test_setting_up_empty_objects_in_request
+//   description: Test setting up empty objects in the request objects.
+//   usage: node samples/v1/test_setting_up_empty_objects_in_request.js
+
+// [START test_setting_up_empty_objects_in_request]
+
+const library = require('@google-cloud/library').v1;
+
+/** Test setting up empty objects in the request objects. */
+function sampleGetShelf() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.shelfPath('my-shelf');
+  const options = '';
+  const message = {};
+  const stringBuilder = {};
+  const request = {
+    name: formattedName,
+    options: options,
+    message: message,
+    stringBuilder: stringBuilder,
+  };
+  client.getShelf(request)
+    .then(responses => {
+      const response = responses[0];
+      console.log(`Shelf found.`);
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+// [END test_setting_up_empty_objects_in_request]
+// tslint:disable-next-line:no-any
+
+sampleGetShelf();
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.js ==============
 // DO NOT EDIT! This is a generated sample ("LongRunningPromiseAwait",  "wap")
 'use strict';

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -1497,6 +1497,8 @@ function sampleGetShelf() {
   const client = new library.LibraryServiceClient();
   const formattedName = client.shelfPath('my-shelf');
   const options = '';
+
+  // we can set up this empty nested object now
   const message = {};
   const stringBuilder = {};
   const request = {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -1895,6 +1895,8 @@ function sampleGetShelf()
 
     $formattedName = $libraryServiceClient->shelfName('my-shelf');
     $options = '';
+
+    // we can set up this empty nested object now
     $message = new SomeMessage();
     $stringBuilder = new StringBuilder();
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -1855,6 +1855,59 @@ function sampleGetBookFromAbsolutelyAnywhere()
 // [END test_resource_name_oneof_2]
 
 sampleGetBookFromAbsolutelyAnywhere();
+============== file: samples/V1/TestSettingUpEmptyObjectsInRequest.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("Request",  "test_setting_up_empty_objects_in_request")
+ */
+
+// sample-metadata
+//   title: test_setting_up_empty_objects_in_request
+//   description: Test setting up empty objects in the request objects.
+//   usage: php samples/V1/TestSettingUpEmptyObjectsInRequest.php
+// [START test_setting_up_empty_objects_in_request]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+use Google\Example\Library\V1\SomeMessage;
+use Google\Example\Library\V1\StringBuilder;
+
+/** Test setting up empty objects in the request objects. */
+function sampleGetShelf()
+{
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->shelfName('my-shelf');
+    $options = '';
+    $message = new SomeMessage();
+    $stringBuilder = new StringBuilder();
+
+    try {
+        $response = $libraryServiceClient->getShelf($formattedName, $options);
+        printf("Shelf found." . PHP_EOL);
+    } finally {
+        $libraryServiceClient->close();
+    }
+}
+// [END test_setting_up_empty_objects_in_request]
+
+sampleGetShelf();
 ============== file: samples/V1/ThisTagShouldBeTheNameOfTheFile.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -6235,6 +6235,57 @@ def main():
 
 if __name__ == '__main__':
   main()
+============== file: samples/v1/test_setting_up_empty_objects_in_request.py ==============
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_setting_up_empty_objects_in_request")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-library
+
+# sample-metadata
+#   title: test_setting_up_empty_objects_in_request
+#   description: Test setting up empty objects in the request objects.
+#   usage: python3 samples/v1/test_setting_up_empty_objects_in_request.py
+import sys
+
+# [START test_setting_up_empty_objects_in_request]
+
+from google.cloud.example import library_v1
+
+def sample_get_shelf():
+  """Test setting up empty objects in the request objects."""
+
+  client = library_v1.LibraryServiceClient()
+
+  name = client.shelf_path('my-shelf')
+  options_ = ''
+  message = {}
+  string_builder = {}
+
+  response = client.get_shelf(name, options_, message=message, string_builder=string_builder)
+  print(u'Shelf found.')
+# [END test_setting_up_empty_objects_in_request]
+
+def main():
+  sample_get_shelf()
+
+if __name__ == '__main__':
+  main()
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.py ==============
 # -*- coding: utf-8 -*-
 #

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -6274,6 +6274,8 @@ def sample_get_shelf():
 
   name = client.shelf_path('my-shelf')
   options_ = ''
+
+  # we can set up this empty nested object now
   message = {}
   string_builder = {}
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -6656,6 +6656,8 @@ def sample_get_shelf
 
   formatted_name = library_client.class.shelf_path("my-shelf")
   options_ = ''
+
+  # we can set up this empty nested object now
   message = {}
   string_builder = {}
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -6623,6 +6623,54 @@ if $PROGRAM_NAME == __FILE__
   sample_get_book_from_absolutely_anywhere
 end
 
+============== file: samples/v1/test_setting_up_empty_objects_in_request.rb ==============
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "test_setting_up_empty_objects_in_request")
+
+# sample-metadata
+#   title: test_setting_up_empty_objects_in_request
+#   description: Test setting up empty objects in the request objects.
+#   bundle exec ruby samples/v1/test_setting_up_empty_objects_in_request.rb
+
+require "library"
+
+# [START test_setting_up_empty_objects_in_request]
+
+# Test setting up empty objects in the request objects.
+def sample_get_shelf
+  # Instantiate a client
+  library_client = Library::Library.new version: :v1
+
+  formatted_name = library_client.class.shelf_path("my-shelf")
+  options_ = ''
+  message = {}
+  string_builder = {}
+
+  response = library_client.get_shelf(formatted_name, options_)
+  puts "Shelf found."
+end
+# [END test_setting_up_empty_objects_in_request]
+
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_get_shelf
+end
+
 ============== file: samples/v1/this_tag_should_be_the_name_of_the_file.rb ==============
 # Copyright 2019 Google LLC
 #

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -150,10 +150,23 @@ interfaces:
       - print:
           - "The theme of the shelf is: %s"
           - $resp.theme
+    - id: test_setting_up_empty_objects_in_request
+      title: test_setting_up_empty_objects_in_request
+      description: "Test setting up empty objects in the request objects."
+      parameters:
+        defaults:
+        - name%shelf_id="my-shelf"
+        - message={}
+        - string_builder={}
+      on_success:
+      - print:
+        - "Shelf found."
     samples:
       standalone:
       - region_tag: sample_get_shelf
         value_sets: test_default_calling_form_unary
+      - region_tag: test_setting_up_empty_objects_in_request
+        value_sets: test_setting_up_empty_objects_in_request
   - name: ListShelves
     page_streaming:
       request:

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -158,6 +158,9 @@ interfaces:
         - name%shelf_id="my-shelf"
         - message={}
         - string_builder={}
+        attributes:
+        - parameter: message
+          description: "we can set up this empty nested object now"
       on_success:
       - print:
         - "Shelf found."


### PR DESCRIPTION
This PR allows setting up a field of the request object as an empty object using `{}`.