### PR TITLE
Add GAPIC Bazel Extensions for Node.js

### DIFF
--- a/rules_gapic/README.md
+++ b/rules_gapic/README.md
@@ -50,7 +50,14 @@ The rules will call `gapic-generator` and do all the necessary pre- and post- ge
 
 4. **`php_gapic_library`** - PHP **macro**, which calls `php_gapic_srcjar` to generate and postprocess gapic library. 
 
-5. **`php_gapic_assembly_pkg`** - PHP **macro** which accepts the previously built `php_proto_library`, `php_grpc_library` and `php_gapic_library` artifacts and packages them into an idiomatic (for PHP) package which is ready for opensourcing and is independent from Bazel.
+5. **`php_gapic_assembly_pkg`** - PHP **macro** which accepts the previously built `php_proto_library`, `php_grpc_library` and `php_gapic_library` artifacts as arguments and packages them into an idiomatic (for PHP) package which is ready for opensourcing and is independent from Bazel.
+
+#### Node.js
+1. **`nodejs_gapic_srcjar`** - Node.js **macro**, which first calls `gapic_srcjar` to generate the source code, then calls an internal rule which does all the specific to Node.js postprocessing of the code (mainly just splitting the code into main, test, smoke test and packaging (`package.json`) `.srcjar` files (zip format)).
+
+2. **`nodejs_gapic_library`** - Node.js **macro**, which calls `nodejs_gapic_srcjar` to generate and postprocess gapic library. 
+
+3. **`nodejs_gapic_assembly_pkg`** - Node.js **macro** which accepts the previously built `nodejs_proto_library` and `proto_library` artifact as arguments and packages them into an idiomatic (for Node.js) package which is ready for opensourcing and is independent from Bazel. This rule does not need corresponding `nodejs_proto_library` input arguments, because the Node.js client does not use pregenerated protbuf/grpc stubs but does it in runtime (loading protobuf files directly, that is why a `proto_library` taget is expected as input to this rule).  
 
 ### Generated Artifacts Dependencies Resolution
 #### Java
@@ -61,3 +68,6 @@ The rules will call `gapic-generator` and do all the necessary pre- and post- ge
 
 #### PHP
 1. **`php/php_gapic_repositories.bzl`** - this file declares the PHP-specific dependencies of the generated output and is supposed to be included in the WORKSPACE file of the consuming workspace (for example in `googleapis`). This file also declares the `php` repository rule, which downloads and builds from sources the PHP interpreter (by using `gcc`, `make` and `autoconf` tools, so they are expected to be installed on the system).
+
+#### Node.js
+There are no any specific to Node.js dependencies at this moment (thay may be added in the future).

--- a/rules_gapic/nodejs/nodejs_gapic.bzl
+++ b/rules_gapic/nodejs/nodejs_gapic.bzl
@@ -1,0 +1,112 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//rules_gapic:gapic.bzl", "gapic_srcjar")
+
+def _nodejs_gapic_postprocessed_srcjar_impl(ctx):
+    gapic_srcjar = ctx.file.gapic_srcjar
+
+    output_main = ctx.outputs.main
+    output_test = ctx.outputs.test
+    output_smoke_test = ctx.outputs.smoke_test
+    output_pkg = ctx.outputs.pkg
+
+    output_dir_name = ctx.label.name
+    output_dir_path = "%s/%s" % (output_main.dirname, output_dir_name)
+
+    script = """
+    unzip -q {gapic_srcjar} -d {output_dir_path}
+    pushd {output_dir_path}
+    zip -q -r {output_dir_name}.srcjar src
+    zip -q -r {output_dir_name}-test.srcjar test
+    if [ -d "smoke-test" ]; then
+        zip -q -r {output_dir_name}-smoke-test.srcjar smoke-test
+    else
+        touch empty_file
+        zip -q -r {output_dir_name}-smoke-test.srcjar empty_file
+        zip -d {output_dir_name}-smoke-test.srcjar empty_file
+    fi
+    zip -q -r {output_dir_name}-pkg.srcjar . -i './*.json' './*.md'
+    popd
+    mv {output_dir_path}/{output_dir_name}.srcjar {output_main}
+    mv {output_dir_path}/{output_dir_name}-test.srcjar {output_test}
+    mv {output_dir_path}/{output_dir_name}-smoke-test.srcjar {output_smoke_test}
+    mv {output_dir_path}/{output_dir_name}-pkg.srcjar {output_pkg}
+    rm -rf {output_dir_path}
+    """.format(
+        gapic_srcjar = gapic_srcjar.path,
+        output_dir_path = output_dir_path,
+        output_dir_name = output_dir_name,
+        output_main = output_main.path,
+        output_test = output_test.path,
+        output_smoke_test = output_smoke_test.path,
+        output_pkg = output_pkg.path,
+    )
+
+    ctx.actions.run_shell(
+        inputs = [gapic_srcjar],
+        tools = [],
+        command = script,
+        outputs = [output_main, output_test, output_smoke_test, output_pkg],
+    )
+
+_nodejs_gapic_postprocessed_srcjar = rule(
+    _nodejs_gapic_postprocessed_srcjar_impl,
+    attrs = {
+        "gapic_srcjar": attr.label(mandatory = True, allow_single_file = True),
+    },
+    outputs = {
+        "main": "%{name}.srcjar",
+        "test": "%{name}-test.srcjar",
+        "smoke_test": "%{name}-smoke-test.srcjar",
+        "pkg": "%{name}-pkg.srcjar",
+    },
+)
+
+def nodejs_gapic_srcjar(name, src, gapic_yaml, service_yaml, **kwargs):
+    raw_srcjar_name = "%s_raw" % name
+
+    gapic_srcjar(
+        name = raw_srcjar_name,
+        src = src,
+        gapic_yaml = gapic_yaml,
+        service_yaml = service_yaml,
+        artifact_type = "GAPIC_CODE",
+        language = "nodejs",
+        **kwargs
+    )
+
+    _nodejs_gapic_postprocessed_srcjar(
+        name = name,
+        gapic_srcjar = ":%s" % raw_srcjar_name,
+        **kwargs
+    )
+
+def nodejs_gapic_library(name, src, gapic_yaml, service_yaml, deps = [], **kwargs):
+    srcjar_name = "%s_srcjar" % name
+
+    nodejs_gapic_srcjar(
+        name = srcjar_name,
+        src = src,
+        gapic_yaml = gapic_yaml,
+        service_yaml = service_yaml,
+        **kwargs
+    )
+
+    # Change with nodejs_library if it ever becomes a thing.
+    # See https://github.com/bazelbuild/rules_nodejs for nodejs_bazel rules.
+    native.alias(
+        name = name,
+        actual = ":%s" % srcjar_name,
+    )

--- a/rules_gapic/nodejs/nodejs_gapic_pkg.bzl
+++ b/rules_gapic/nodejs/nodejs_gapic_pkg.bzl
@@ -19,7 +19,9 @@ def _nodejs_gapic_src_pkg_impl(ctx):
     gapic_srcs = []
 
     for dep in ctx.attr.deps:
-        if(hasattr(dep, "proto")):
+        if ProtoInfo in dep:
+            proto_srcs.extend(dep[ProtoInfo].check_deps_sources.to_list())
+        elif(hasattr(dep, "proto")):
             proto_srcs.extend(dep.proto.check_deps_sources.to_list())
         else:
             gapic_srcs.extend(dep.files.to_list())

--- a/rules_gapic/nodejs/nodejs_gapic_pkg.bzl
+++ b/rules_gapic/nodejs/nodejs_gapic_pkg.bzl
@@ -1,0 +1,73 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//rules_gapic:gapic_pkg.bzl", "construct_package_dir_paths")
+
+def _nodejs_gapic_src_pkg_impl(ctx):
+    proto_srcs = []
+    gapic_srcs = []
+
+    for dep in ctx.attr.deps:
+        if(hasattr(dep, "proto")):
+            proto_srcs.extend(dep.proto.check_deps_sources.to_list())
+        else:
+            gapic_srcs.extend(dep.files.to_list())
+
+    paths = construct_package_dir_paths(ctx.attr.package_dir, ctx.outputs.pkg, ctx.label.name)
+
+    script = """
+    for gapic_src in {gapic_srcs}; do
+        mkdir -p {package_dir_path}
+        unzip -q -o $gapic_src -d {package_dir_path}
+    done
+    for proto_src in {proto_srcs}; do
+        mkdir -p {package_dir_path}/protos
+        cp -f --parents $proto_src {package_dir_path}/protos
+    done
+    cd {package_dir_path}
+    tar -zchpf {package_dir}.tar.gz {package_dir_expr}
+    cd -
+    mv {package_dir_path}/{package_dir}.tar.gz {pkg}
+    rm -rf {package_dir_path}
+    """.format(
+        gapic_srcs = " ".join(["'%s'" % f.path for f in gapic_srcs]),
+        proto_srcs = " ".join(["'%s'" % f.path for f in proto_srcs]),
+        package_dir_path = paths.package_dir_path,
+        package_dir = paths.package_dir,
+        pkg = ctx.outputs.pkg.path,
+        package_dir_expr = paths.package_dir_expr,
+    )
+
+    ctx.actions.run_shell(
+        inputs = proto_srcs + gapic_srcs,
+        command = script,
+        outputs = [ctx.outputs.pkg],
+    )
+
+_nodejs_gapic_src_pkg = rule(
+    attrs = {
+        "deps": attr.label_list(allow_files = True, mandatory = True, non_empty = True),
+        "package_dir": attr.string(mandatory = True),
+    },
+    outputs = {"pkg": "%{name}.tar.gz"},
+    implementation = _nodejs_gapic_src_pkg_impl,
+)
+
+def nodejs_gapic_assembly_pkg(name, deps):
+    _nodejs_gapic_src_pkg(
+        name = name,
+        deps = deps,
+        package_dir = name,
+    )
+

--- a/rules_gapic/nodejs/nodejs_gapic_pkg.bzl
+++ b/rules_gapic/nodejs/nodejs_gapic_pkg.bzl
@@ -21,7 +21,7 @@ def _nodejs_gapic_src_pkg_impl(ctx):
     for dep in ctx.attr.deps:
         if ProtoInfo in dep:
             proto_srcs.extend(dep[ProtoInfo].check_deps_sources.to_list())
-        elif(hasattr(dep, "proto")):
+        elif hasattr(dep, "proto"):
             proto_srcs.extend(dep.proto.check_deps_sources.to_list())
         else:
             gapic_srcs.extend(dep.files.to_list())
@@ -72,4 +72,3 @@ def nodejs_gapic_assembly_pkg(name, deps):
         deps = deps,
         package_dir = name,
     )
-


### PR DESCRIPTION
The extensions provide minimum level of functionality. 

They generate the output identical to what artman provides (i.e. have feature parity with artman).

It does not try to build and run the generated tests from withing bazel (like it does for Java and Go). This functionality may be added later.