### PR TITLE
[feat]SampleGen: new calling form that cancels the LRO at the end of the sample

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -61,6 +61,10 @@ public class DynamicLangApiMethodTransformer {
     this.sampleTransformer = sampleTransformer;
   }
 
+  public SampleTransformer getSampleTransformer() {
+    return sampleTransformer;
+  }
+
   /** Generates method views for all methods in an interface. */
   public List<OptionalArrayMethodView> generateApiMethods(InterfaceContext context) {
     return Streams.stream(context.getSupportedMethods())
@@ -74,7 +78,7 @@ public class DynamicLangApiMethodTransformer {
         context,
         null,
         context.getSurfaceInterfaceContext().getApiModel().hasMultipleServices(),
-        context.getNamer().getCallingForms(context));
+        context.getNamer().getCallingForms(context, sampleTransformer.sampleType()));
   }
 
   private OptionalArrayMethodView generateApiMethod(

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -28,6 +28,7 @@ import com.google.api.codegen.config.OneofConfig;
 import com.google.api.codegen.config.PageStreamingConfig;
 import com.google.api.codegen.config.ResourceNameConfig;
 import com.google.api.codegen.config.ResourceNameType;
+import com.google.api.codegen.config.SampleSpec;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.TransportProtocol;
 import com.google.api.codegen.config.TypeModel;
@@ -1663,6 +1664,9 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   public String getSampleResponseVarName(MethodContext context, CallingForm form) {
     MethodConfig config = context.getMethodConfig();
+    if (form == CallingForm.LongRunningStartThenCancel) {
+      return "operation";
+    }
     if (config.getPageStreaming() != null) {
       return "responseItem";
     }
@@ -1690,7 +1694,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
   // TODO(hzyi): this method doesn't fit very well in SurfaceNamer. So far we don't have a
   // better place for this logic but consider moving this out when we implement default
   // calling forms.
-  public List<CallingForm> getCallingForms(MethodContext context) {
+  public List<CallingForm> getCallingForms(
+      MethodContext context, SampleSpec.SampleType sampleType) {
     return Collections.singletonList(CallingForm.Generic);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaMethodViewGenerator.java
@@ -150,7 +150,8 @@ public class JavaMethodViewGenerator {
         apiMethods.add(
             clientMethodTransformer.generateOperationCallableMethod(
                 requestMethodContext.withCallingForms(
-                    Collections.singletonList(CallingForm.LongRunningCallable))));
+                    ImmutableList.of(
+                        CallingForm.LongRunningCallable, CallingForm.LongRunningStartThenCancel))));
         apiMethods.add(
             clientMethodTransformer.generateCallableMethod(
                 requestMethodContext.withCallingForms(

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSampleImportTransformer.java
@@ -79,6 +79,7 @@ public class JavaSampleImportTransformer extends StandardSampleImportTransformer
         typeTable.getAndSaveNicknameFor(namer.getGenericAwareResponseTypeName(context));
         break;
       case LongRunningCallable:
+      case LongRunningStartThenCancel:
         typeTable.saveNicknameFor(OPERATION_FUTURE);
         saveResponseTypeNameForLongRunningMethod(context);
         saveMetadataTypeNameForLongRunningMethod(context);

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -29,6 +29,7 @@ import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.config.ProtoTypeRef;
 import com.google.api.codegen.config.ResourceNameConfig;
 import com.google.api.codegen.config.ResourceNameType;
+import com.google.api.codegen.config.SampleSpec;
 import com.google.api.codegen.config.TransportProtocol;
 import com.google.api.codegen.config.TypeModel;
 import com.google.api.codegen.metacode.InitFieldConfig;
@@ -421,8 +422,9 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public List<CallingForm> getCallingForms(MethodContext context) {
-    return CallingForm.getCallingForms(context, TargetLanguage.JAVA);
+  public List<CallingForm> getCallingForms(
+      MethodContext context, SampleSpec.SampleType sampleType) {
+    return CallingForm.getCallingForms(context, TargetLanguage.JAVA, sampleType);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSMethodViewGenerator.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSMethodViewGenerator.java
@@ -69,10 +69,10 @@ public class NodeJSMethodViewGenerator {
               methodContext,
               initContext,
               packageHasMultipleServices,
-              Arrays.asList(
-                  CallingForm.LongRunningPromise,
-                  CallingForm.LongRunningEventEmitter,
-                  CallingForm.LongRunningPromiseAwait));
+              methodContext
+                  .getNamer()
+                  .getCallingForms(
+                      methodContext, clientMethodTransformer.getSampleTransformer().sampleType()));
     } else {
       List<CallingForm> callingForms;
       GrpcStreamingType streamingType = methodContext.getMethodConfig().getGrpcStreamingType();

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -25,6 +25,7 @@ import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodContext;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProtoTypeRef;
+import com.google.api.codegen.config.SampleSpec;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.TypeModel;
 import com.google.api.codegen.config.VisibilityConfig;
@@ -629,14 +630,17 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
       case LongRunningEventEmitter:
       case LongRunningPromise:
         return "result";
+      case LongRunningStartThenCancel:
+        return "operation";
       default:
         throw new IllegalArgumentException("illegal calling form for Node.js: " + form);
     }
   }
 
   @Override
-  public List<CallingForm> getCallingForms(MethodContext context) {
-    return CallingForm.getCallingForms(context, TargetLanguage.NODEJS);
+  public List<CallingForm> getCallingForms(
+      MethodContext context, SampleSpec.SampleType sampleType) {
+    return CallingForm.getCallingForms(context, TargetLanguage.NODEJS, sampleType);
   }
 
   @Override
@@ -646,6 +650,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
 
   @Override
   public boolean usesAsyncAwaitPattern(CallingForm form) {
-    return form == CallingForm.LongRunningPromiseAwait;
+    return form == CallingForm.LongRunningPromiseAwait
+        || form == CallingForm.LongRunningStartThenCancel;
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpMethodViewGenerator.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpMethodViewGenerator.java
@@ -64,7 +64,10 @@ public class PhpMethodViewGenerator {
               methodContext,
               initContext,
               false,
-              Arrays.asList(CallingForm.LongRunningRequest, CallingForm.LongRunningRequestAsync));
+              methodContext
+                  .getNamer()
+                  .getCallingForms(
+                      methodContext, clientMethodTransformer.getSampleTransformer().sampleType()));
     } else {
       List<CallingForm> callingForms;
       GrpcStreamingType streamingType = methodContext.getMethodConfig().getGrpcStreamingType();

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -22,6 +22,7 @@ import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodContext;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProtoTypeRef;
+import com.google.api.codegen.config.SampleSpec;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.TypeModel;
 import com.google.api.codegen.config.VisibilityConfig;
@@ -321,8 +322,9 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public List<CallingForm> getCallingForms(MethodContext context) {
-    return CallingForm.getCallingForms(context, TargetLanguage.PHP);
+  public List<CallingForm> getCallingForms(
+      MethodContext context, SampleSpec.SampleType sampleType) {
+    return CallingForm.getCallingForms(context, TargetLanguage.PHP, sampleType);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -25,6 +25,7 @@ import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodContext;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProtoTypeRef;
+import com.google.api.codegen.config.SampleSpec;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.TypeModel;
 import com.google.api.codegen.config.VisibilityConfig;
@@ -552,8 +553,9 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public List<CallingForm> getCallingForms(MethodContext context) {
-    return CallingForm.getCallingForms(context, TargetLanguage.PYTHON);
+  public List<CallingForm> getCallingForms(
+      MethodContext context, SampleSpec.SampleType sampleType) {
+    return CallingForm.getCallingForms(context, TargetLanguage.PYTHON, sampleType);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -23,6 +23,7 @@ import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodContext;
 import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.SampleSpec;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.TypeModel;
 import com.google.api.codegen.config.VisibilityConfig;
@@ -464,8 +465,9 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public List<CallingForm> getCallingForms(MethodContext context) {
-    return CallingForm.getCallingForms(context, TargetLanguage.RUBY);
+  public List<CallingForm> getCallingForms(
+      MethodContext context, SampleSpec.SampleType sampleType) {
+    return CallingForm.getCallingForms(context, TargetLanguage.RUBY, sampleType);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/viewmodel/CallingForm.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/CallingForm.java
@@ -83,7 +83,7 @@ public enum CallingForm {
   LongRunningPromiseAwait, // used by: nodejs
   LongRunningRequest, // used by: php
   LongRunningRequestAsync, // used by: java php ruby
-  LongRunningStartThenCancel, // used by: java, python, php, ruby, nodejs
+  LongRunningStartThenCancel, // used by: java nodejs php py ruby
 
   // TODO: the following calling forms should be added for csharp. They are
   // currently removed to turn off generating samples in these calling forms

--- a/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/standalone_sample.snip
@@ -112,6 +112,8 @@
     @if sample.outputs
       {@processResponse(sample)}
     @end
+  @case "LongRunningStartThenCancel"
+    {@LongRunningStartThenCancelMethodSampleCode(apiMethod, sample)}
   @default
     $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
   @end
@@ -211,6 +213,18 @@
   @else
     future.get();
   @end
+@end
+
+@private LongRunningStartThenCancelMethodSampleCode(apiMethod, sample)
+  {@initCode(sample.sampleInitCode)}
+  OperationFuture<{@apiMethod.responseTypeName}, \
+    {@apiMethod.operationMethod.metadataTypeName}> operation = \
+    {@sampleFutureMethodCall(apiMethod)};
+  @if sample.outputs
+    
+    {@processResponse(sample)}
+  @end
+  {@apiMethod.apiVariableName}.getOperationsClient().cancelOperation(operation.getName());
 @end
 
 @private streamingCallableMethodSampleCode(apiMethod, sample)

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -85,6 +85,8 @@
       {@methodCallSampleCodeLongrunningPromise(apiMethod, sample)}
     @case "LongRunningPromiseAwait"
       {@methodCallSampleCodeLongRunningPromiseAwait(apiMethod, sample)}
+    @case "LongRunningStartThenCancel"
+      {@methodCallSampleCodeLongRunningStartThenCancel(apiMethod, sample)}
     @default
       $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
     @end
@@ -268,6 +270,15 @@
     .catch(err => {
       console.error(err);
     });
+@end
+
+@private methodCallSampleCodeLongRunningStartThenCancel(apiMethod, sample)
+  {@initCode(apiMethod, sample.sampleInitCode)}
+
+  @if sample.outputs
+    {@processResponse(sample)}
+  @end
+  await client.operationsClient.cancelOperation({name: operation.name});
 @end
 
 @private methodCallSampleCodeLongrunningPromise(apiMethod, sample)

--- a/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/standalone_sample.snip
@@ -274,8 +274,9 @@
 
 @private methodCallSampleCodeLongRunningStartThenCancel(apiMethod, sample)
   {@initCode(apiMethod, sample.sampleInitCode)}
-
+  const [operation] = await {@methodCallSampleCodePrefix(apiMethod, sample.sampleInitCode)};
   @if sample.outputs
+
     {@processResponse(sample)}
   @end
   await client.operationsClient.cancelOperation({name: operation.name});

--- a/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/php/standalone_sample.snip
@@ -59,6 +59,8 @@
                 {@longRunningSampleCode(sample, apiMethod)}
             @case "LongRunningRequestAsync"
                 {@longRunningAsyncSampleCode(sample, apiMethod)}
+            @case "LongRunningStartThenCancel"
+                {@LongRunningStartThenCancelSampleCode(sample, apiMethod)}
             @case "Request"
                 {@requestSampleCode(sample, apiMethod)}
             @case "RequestPaged"
@@ -212,6 +214,15 @@
       $error = $newOperationResponse->getError();
       // handleError($error)
     }
+@end
+
+@private LongRunningStartThenCancelSampleCode(sample, apiMethod)
+    $operation = {@methodCallSampleCode(apiMethod)};
+    
+    @if sample.outputs
+        {@processResponse(sample)}
+    @end
+    ${@apiMethod.apiVariableName}.getOperationsClient()->cancelOperation($operation->getName());
 @end
 
 @private requestSampleCode(sample, apiMethod)

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -67,6 +67,8 @@
       {@optionalArrayMethodSampleCodeServerStreaming(apiMethod, sample)}
     @case "LongRunningPromise"
       {@lroSampleCode(apiMethod, sample)}
+    @case "LongRunningStartThenCancel"
+      {@lroCancelSampleCode(apiMethod, sample)}
     @default
       $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
     @end
@@ -172,6 +174,14 @@
 
   print(u'Waiting for operation to complete...')
   response = operation.result()
+
+  @if sample.outputs
+    {@processResponse(sample)}
+  @end
+@end
+
+@private lroCancelSampleCode(apiMethod, sample)
+  operation = {@methodCallSampleCode(apiMethod, sample.sampleInitCode)}.operation
 
   @if sample.outputs
     {@processResponse(sample)}

--- a/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/standalone_sample.snip
@@ -186,6 +186,7 @@
   @if sample.outputs
     {@processResponse(sample)}
   @end
+  client.transport._operations_client.cancel_operation(operation.name)
 @end
 
 @private singularResponseSampleCode(apiMethod, sampleInitCode)

--- a/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
@@ -128,11 +128,9 @@
 @private LongRunningStartThenCancelMethodSampleCode(apiMethod, sample)
   @# Make the long-running operation request
   operation = {@methodCallSampleCode(apiMethod, sample)}
-
   @if sample.outputs
 
     {@processOutputViews(sample.outputs)}
-
   @end
   operation.cancel
 @end

--- a/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
@@ -62,6 +62,8 @@
       {@optionalArrayMethodSampleCodeServerStreaming(apiMethod, sample)}
     @case "LongRunningRequestAsync"
       {@longRunningAsyncMethodSampleCode(apiMethod, sample)}
+    @case "LongRunningStartThenCancel"
+      {@LongRunningStartThenCancelMethodSampleCode(apiMethod, sample)}
     @default
       $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
     @end
@@ -121,6 +123,18 @@
 
     {@processOutputViews(sample.outputs)}
   @end
+@end
+
+@private LongRunningStartThenCancelMethodSampleCode(apiMethod, sample)
+  @# Make the long-running operation request
+  operation = {@methodCallSampleCode(apiMethod, sample)}
+
+  @if sample.outputs
+
+    {@processOutputViews(sample.outputs)}
+
+  @end
+  operation.cancel
 @end
 
 @private optionalArrayMethodSampleCodeNonStreaming(apiMethod, sample)

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -3643,6 +3643,9 @@ public class TestFloatAndInt64 {
 
 package com.google.example.examples.library.v1;
 
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
@@ -3652,6 +3655,9 @@ public class TestLongRunningStartThenCancelCallingForm {
   /*
    * Please include the following imports to run this sample.
    *
+   * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
    * import com.google.example.library.v1.ShelfBookName;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -3465,6 +3465,67 @@ public class TestDefaultCallingFormForPaging {
     sampleListShelves();
   }
 }
+============== file: samples/src/main/java/com/google/example/examples/library/v1/TestLongRunningStartThenCancelCallingForm.java ==============
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// DO NOT EDIT! This is a generated sample ("LongRunningStartThenCancel",  "test_long_running_start_then_cancel_calling_form")
+// sample-metadata:
+//   title: kick off, retrieve name, and cancel
+//   description: Kick off the LRO and cancel it.
+//   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestLongRunningStartThenCancelCallingForm
+
+package com.google.example.examples.library.v1;
+
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class TestLongRunningStartThenCancelCallingForm {
+  // [START test_long_running_start_then_cancel_calling_form]
+  /*
+   * Please include the following imports to run this sample.
+   *
+   * import com.google.example.library.v1.GetBookRequest;
+   * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
+   */
+
+  /** Kick off the LRO and cancel it. */
+  public static void sampleGetBigBook() {
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      ShelfBookName name = ShelfBookName.of("Novel", "War and Peace");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      OperationFuture<Book, GetBigBookMetadata> operation = libraryClient.getBigBookOperationCallable().futureCall(request);
+
+      // You'll want to save this for later to retrieve your completed operation.
+      System.out.printf("Operation Name: %s\n", operation.getName());
+      // Cancel the operation to avoid charges when testing.
+      libraryClient.getOperationsClient().cancelOperation(operation.getName());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+  }
+  // [END test_long_running_start_then_cancel_calling_form]
+
+  public static void main(String[] args) {
+    sampleGetBigBook();
+  }
+}
 ============== file: samples/src/main/java/com/google/example/examples/library/v1/TestResourceNameOneof.java ==============
 /*
  * Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -1320,6 +1320,34 @@ function sampleListShelves() {
 // tslint:disable-next-line:no-any
 
 sampleListShelves();
+============== file: samples/v1/test_long_running_start_then_cancel_calling_form.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningStartThenCancel",  "test_long_running_start_then_cancel_calling_form")
+'use strict';
+
+// sample-metadata:
+//   title: kick off, retrieve name, and cancel
+//   description: Kick off the LRO and cancel it.
+//   usage: node samples/v1/test_long_running_start_then_cancel_calling_form.js
+
+// [START test_long_running_start_then_cancel_calling_form]
+
+const library = require('@google-cloud/library').v1;
+
+/** Kick off the LRO and cancel it. */
+async function sampleGetBigBook() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('Novel', 'War and Peace');
+
+  // You'll want to save this for later to retrieve your completed operation.
+  console.log(`Operation Name: ${operation.name}`);
+  // Cancel the operation to avoid charges when testing.
+  await client.operationsClient.cancelOperation({name: operation.name});
+}
+
+// [END test_long_running_start_then_cancel_calling_form]
+// tslint:disable-next-line:no-any
+
+sampleGetBigBook();
 ============== file: samples/v1/test_resource_name_oneof.js ==============
 // DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
 'use strict';

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -1436,6 +1436,7 @@ const library = require('@google-cloud/library').v1;
 async function sampleGetBigBook() {
   const client = new library.LibraryServiceClient();
   const formattedName = client.bookPath('Novel', 'War and Peace');
+  const [operation] = await client.getBigBook({name: formattedName});
 
   // You'll want to save this for later to retrieve your completed operation.
   console.log(`Operation Name: ${operation.name}`);

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -1666,6 +1666,58 @@ function sampleListShelves()
 // [END test_default_calling_form_for_paging]
 
 sampleListShelves();
+============== file: samples/V1/TestLongRunningStartThenCancelCallingForm.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningStartThenCancel",  "test_long_running_start_then_cancel_calling_form")
+ */
+
+// sample-metadata
+//   title: kick off, retrieve name, and cancel
+//   description: Kick off the LRO and cancel it.
+//   usage: php samples/V1/TestLongRunningStartThenCancelCallingForm.php
+// [START test_long_running_start_then_cancel_calling_form]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Kick off the LRO and cancel it. */
+function sampleGetBigBook()
+{
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('Novel', 'War and Peace');
+
+    try {
+        $operation = $libraryServiceClient->getBigBook($formattedName);
+
+        // You'll want to save this for later to retrieve your completed operation.
+        printf("Operation Name: %s" . PHP_EOL, $operation->getName());
+        // Cancel the operation to avoid charges when testing.
+        $libraryServiceClient.getOperationsClient()->cancelOperation($operation->getName());
+    } finally {
+        $libraryServiceClient->close();
+    }
+}
+// [END test_long_running_start_then_cancel_calling_form]
+
+sampleGetBigBook();
 ============== file: samples/V1/TestResourceNameOneof.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -6193,6 +6193,7 @@ def sample_get_big_book():
   # You'll want to save this for later to retrieve your completed operation.
   print(u'Operation Name: {}'.format(operation.name))
   # Cancel the operation to avoid charges when testing.
+  client.transport._operations_client.cancel_operation(operation.name)
 # [END test_long_running_start_then_cancel_calling_form]
 
 def main():

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -6067,6 +6067,57 @@ def main():
 
 if __name__ == '__main__':
   main()
+============== file: samples/v1/test_long_running_start_then_cancel_calling_form.py ==============
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("LongRunningStartThenCancel",  "test_long_running_start_then_cancel_calling_form")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-library
+
+# sample-metadata
+#   title: kick off, retrieve name, and cancel
+#   description: Kick off the LRO and cancel it.
+#   usage: python3 samples/v1/test_long_running_start_then_cancel_calling_form.py
+import sys
+
+# [START test_long_running_start_then_cancel_calling_form]
+
+from google.cloud.example import library_v1
+
+def sample_get_big_book():
+  """Kick off the LRO and cancel it."""
+
+  client = library_v1.LibraryServiceClient()
+
+  name = client.book_path('Novel', 'War and Peace')
+
+  operation = client.get_big_book(name).operation
+
+  # You'll want to save this for later to retrieve your completed operation.
+  print(u'Operation Name: {}'.format(operation.name))
+  # Cancel the operation to avoid charges when testing.
+# [END test_long_running_start_then_cancel_calling_form]
+
+def main():
+  sample_get_big_book()
+
+if __name__ == '__main__':
+  main()
 ============== file: samples/v1/test_resource_name_oneof.py ==============
 # -*- coding: utf-8 -*-
 #

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -6471,6 +6471,58 @@ if $PROGRAM_NAME == __FILE__
   sample_list_shelves
 end
 
+============== file: samples/v1/test_long_running_start_then_cancel_calling_form.rb ==============
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("LongRunningStartThenCancel",  "test_long_running_start_then_cancel_calling_form")
+
+# sample-metadata
+#   title: kick off, retrieve name, and cancel
+#   description: Kick off the LRO and cancel it.
+#   bundle exec ruby samples/v1/test_long_running_start_then_cancel_calling_form.rb
+
+require "library"
+
+# [START test_long_running_start_then_cancel_calling_form]
+
+# Kick off the LRO and cancel it.
+def sample_get_big_book
+  # Instantiate a client
+  library_client = Library::Library.new version: :v1
+
+  formatted_name = library_client.class.book_path("Novel", "War and Peace")
+
+  # Make the long-running operation request
+  operation = library_client.get_big_book(formatted_name)
+
+
+  # You'll want to save this for later to retrieve your completed operation.
+  puts "Operation Name: #{response.name}"
+  # Cancel the operation to avoid charges when testing.
+
+  operation.cancel
+end
+# [END test_long_running_start_then_cancel_calling_form]
+
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_get_big_book
+end
+
 ============== file: samples/v1/test_resource_name_oneof.rb ==============
 # Copyright 2019 Google LLC
 #

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -6589,11 +6589,9 @@ def sample_get_big_book
   # Make the long-running operation request
   operation = library_client.get_big_book(formatted_name)
 
-
   # You'll want to save this for later to retrieve your completed operation.
   puts "Operation Name: #{response.name}"
   # Cancel the operation to avoid charges when testing.
-
   operation.cancel
 end
 # [END test_long_running_start_then_cancel_calling_form]

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -3701,7 +3701,10 @@ public class TestFloatAndInt64 {
 
 package com.google.example.examples.library.v1;
 
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookName;
+import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
 import com.google.example.library.v1.ShelfBookName;
@@ -3711,7 +3714,10 @@ public class TestLongRunningStartThenCancelCallingForm {
   /*
    * Please include the following imports to run this sample.
    *
+   * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.Book;
    * import com.google.example.library.v1.BookName;
+   * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
    * import com.google.example.library.v1.ShelfBookName;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -3670,6 +3670,69 @@ public class TestFloat {
     sampleTestOptionalRequiredFlatteningParams(paramFloat);
   }
 }
+============== file: samples/src/main/java/com/google/example/examples/library/v1/TestLongRunningStartThenCancelCallingForm.java ==============
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// DO NOT EDIT! This is a generated sample ("LongRunningStartThenCancel",  "test_long_running_start_then_cancel_calling_form")
+// sample-metadata:
+//   title: kick off, retrieve name, and cancel
+//   description: Kick off the LRO and cancel it.
+//   usage: gradle run -PmainClass=com.google.example.examples.library.v1.TestLongRunningStartThenCancelCallingForm
+
+package com.google.example.examples.library.v1;
+
+import com.google.example.library.v1.BookName;
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
+
+public class TestLongRunningStartThenCancelCallingForm {
+  // [START test_long_running_start_then_cancel_calling_form]
+  /*
+   * Please include the following imports to run this sample.
+   *
+   * import com.google.example.library.v1.BookName;
+   * import com.google.example.library.v1.GetBookRequest;
+   * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
+   */
+
+  /** Kick off the LRO and cancel it. */
+  public static void sampleGetBigBook() {
+    try (LibraryClient libraryClient = LibraryClient.create()) {
+      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      GetBookRequest request = GetBookRequest.newBuilder()
+        .setName(name.toString())
+        .build();
+      OperationFuture<Book, GetBigBookMetadata> operation = libraryClient.getBigBookOperationCallable().futureCall(request);
+
+      // You'll want to save this for later to retrieve your completed operation.
+      System.out.printf("Operation Name: %s\n", operation.getName());
+      // Cancel the operation to avoid charges when testing.
+      libraryClient.getOperationsClient().cancelOperation(operation.getName());
+    } catch (Exception exception) {
+      System.err.println("Failed to create the client due to: " + exception);
+    }
+  }
+  // [END test_long_running_start_then_cancel_calling_form]
+
+  public static void main(String[] args) {
+    sampleGetBigBook();
+  }
+}
 ============== file: samples/src/main/java/com/google/example/examples/library/v1/TestResourceNameOneof.java ==============
 /*
  * Copyright 2019 Google LLC

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/library_v2_gapic.yaml
@@ -673,13 +673,36 @@ interfaces:
                 - parameter: name%book_id
                   sample_argument_name: big_book_name
                   description: "The name of the book."
+          - id: test_long_running_start_then_cancel_calling_form
+            title: "kick off, retrieve name, and cancel"
+            description: "Kick off the LRO and cancel it."
+            parameters:
+              defaults:
+              - name%shelf_id=Novel
+              - name%book_id="War and Peace"
+            on_success:
+            - comment: [You'll want to save this for later to retrieve your completed operation.]
+            - print: ["Operation Name: %s", $resp.name]
+            - comment: [Cancel the operation to avoid charges when testing.]
         samples:
           standalone:
-            - calling_forms: ".*"
-              value_sets: ".*"
-              region_tag: hopper
-            - value_sets: wap
-              region_tag: "this_tag_should_be_the_name_of_the_file"
+          - calling_forms: 
+            - long_running_callable
+            - long_running_event_emitter
+            - long_running_flattened
+            - long_running_flattened_async
+            - long_running_promise
+            - long_running_promise_await
+            - long_running_request
+            - long_running_request_async
+            - callable
+            value_sets: [wap, wap2]
+            region_tag: hopper
+          - value_sets: wap
+            region_tag: "this_tag_should_be_the_name_of_the_file"
+          - value_sets: [test_long_running_start_then_cancel_calling_form]
+            calling_forms: [long_running_start_then_cancel]
+            region_tag: test_long_running_start_then_cancel_calling_form
       - name: GetBigNothing
         retry_codes_name: non_idempotent
         retry_params_name: default
@@ -701,8 +724,17 @@ interfaces:
             description: "Test default response handling is turned off for methods that return empty"
         samples:
           standalone:
-            - calling_forms: ".*"
-              value_sets: [empty_response_type_with_response_handling, empty_response_type_without_response_handling]
+          - calling_forms: 
+            - long_running_callable
+            - long_running_event_emitter
+            - long_running_flattened
+            - long_running_flattened_async
+            - long_running_promise
+            - long_running_promise_await
+            - long_running_request
+            - long_running_request_async
+            - callable
+            value_sets: [empty_response_type_with_response_handling, empty_response_type_without_response_handling]
       - name: TestOptionalRequiredFlatteningParams
         samples:
           standalone:

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -1442,6 +1442,7 @@ const library = require('@google-cloud/library').v1;
 async function sampleGetBigBook() {
   const client = new library.LibraryServiceClient();
   const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const [operation] = await client.getBigBook({name: formattedName});
 
   // You'll want to save this for later to retrieve your completed operation.
   console.log(`Operation Name: ${operation.name}`);

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -1421,6 +1421,34 @@ const argv = require(`yargs`)
   .argv;
 
 sampleTestOptionalRequiredFlatteningParams(argv.param_float);
+============== file: samples/v1/test_long_running_start_then_cancel_calling_form.js ==============
+// DO NOT EDIT! This is a generated sample ("LongRunningStartThenCancel",  "test_long_running_start_then_cancel_calling_form")
+'use strict';
+
+// sample-metadata:
+//   title: kick off, retrieve name, and cancel
+//   description: Kick off the LRO and cancel it.
+//   usage: node samples/v1/test_long_running_start_then_cancel_calling_form.js
+
+// [START test_long_running_start_then_cancel_calling_form]
+
+const library = require('@google-cloud/library').v1;
+
+/** Kick off the LRO and cancel it. */
+async function sampleGetBigBook() {
+  const client = new library.LibraryServiceClient();
+  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+
+  // You'll want to save this for later to retrieve your completed operation.
+  console.log(`Operation Name: ${operation.name}`);
+  // Cancel the operation to avoid charges when testing.
+  await client.operationsClient.cancelOperation({name: operation.name});
+}
+
+// [END test_long_running_start_then_cancel_calling_form]
+// tslint:disable-next-line:no-any
+
+sampleGetBigBook();
 ============== file: samples/v1/test_resource_name_oneof.js ==============
 // DO NOT EDIT! This is a generated sample ("Request",  "test_resource_name_oneof")
 'use strict';

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -1763,6 +1763,58 @@ $options += $defaultOptions;
 $paramFloat = $options['param_float'];
 
 sampleTestOptionalRequiredFlatteningParams($paramFloat);
+============== file: samples/V1/TestLongRunningStartThenCancelCallingForm.php ==============
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DO NOT EDIT! This is a generated sample ("LongRunningStartThenCancel",  "test_long_running_start_then_cancel_calling_form")
+ */
+
+// sample-metadata
+//   title: kick off, retrieve name, and cancel
+//   description: Kick off the LRO and cancel it.
+//   usage: php samples/V1/TestLongRunningStartThenCancelCallingForm.php
+// [START test_long_running_start_then_cancel_calling_form]
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Google\Cloud\Example\Library\V1\LibraryServiceClient;
+
+/** Kick off the LRO and cancel it. */
+function sampleGetBigBook()
+{
+    $libraryServiceClient = new LibraryServiceClient();
+
+    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+
+    try {
+        $operation = $libraryServiceClient->getBigBook($formattedName);
+
+        // You'll want to save this for later to retrieve your completed operation.
+        printf("Operation Name: %s" . PHP_EOL, $operation->getName());
+        // Cancel the operation to avoid charges when testing.
+        $libraryServiceClient.getOperationsClient()->cancelOperation($operation->getName());
+    } finally {
+        $libraryServiceClient->close();
+    }
+}
+// [END test_long_running_start_then_cancel_calling_form]
+
+sampleGetBigBook();
 ============== file: samples/V1/TestResourceNameOneof.php ==============
 <?php
 /*

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -6188,6 +6188,7 @@ def sample_get_big_book():
   # You'll want to save this for later to retrieve your completed operation.
   print(u'Operation Name: {}'.format(operation.name))
   # Cancel the operation to avoid charges when testing.
+  client.transport._operations_client.cancel_operation(operation.name)
 # [END test_long_running_start_then_cancel_calling_form]
 
 def main():

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -6143,6 +6143,57 @@ def main():
 
 if __name__ == '__main__':
   main()
+============== file: samples/v1/test_long_running_start_then_cancel_calling_form.py ==============
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("LongRunningStartThenCancel",  "test_long_running_start_then_cancel_calling_form")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-library
+
+# sample-metadata
+#   title: kick off, retrieve name, and cancel
+#   description: Kick off the LRO and cancel it.
+#   usage: python3 samples/v1/test_long_running_start_then_cancel_calling_form.py
+import sys
+
+# [START test_long_running_start_then_cancel_calling_form]
+
+from google.cloud.example import library_v1
+
+def sample_get_big_book():
+  """Kick off the LRO and cancel it."""
+
+  client = library_v1.LibraryServiceClient()
+
+  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+
+  operation = client.get_big_book(name).operation
+
+  # You'll want to save this for later to retrieve your completed operation.
+  print(u'Operation Name: {}'.format(operation.name))
+  # Cancel the operation to avoid charges when testing.
+# [END test_long_running_start_then_cancel_calling_form]
+
+def main():
+  sample_get_big_book()
+
+if __name__ == '__main__':
+  main()
 ============== file: samples/v1/test_resource_name_oneof.py ==============
 # -*- coding: utf-8 -*-
 #

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -6537,6 +6537,58 @@ if $PROGRAM_NAME == __FILE__
   sample_test_optional_required_flattening_params(param_float)
 end
 
+============== file: samples/v1/test_long_running_start_then_cancel_calling_form.rb ==============
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("LongRunningStartThenCancel",  "test_long_running_start_then_cancel_calling_form")
+
+# sample-metadata
+#   title: kick off, retrieve name, and cancel
+#   description: Kick off the LRO and cancel it.
+#   bundle exec ruby samples/v1/test_long_running_start_then_cancel_calling_form.rb
+
+require "library"
+
+# [START test_long_running_start_then_cancel_calling_form]
+
+# Kick off the LRO and cancel it.
+def sample_get_big_book
+  # Instantiate a client
+  library_client = Library::Library.new version: :v1
+
+  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+
+  # Make the long-running operation request
+  operation = library_client.get_big_book(formatted_name)
+
+
+  # You'll want to save this for later to retrieve your completed operation.
+  puts "Operation Name: #{response.name}"
+  # Cancel the operation to avoid charges when testing.
+
+  operation.cancel
+end
+# [END test_long_running_start_then_cancel_calling_form]
+
+
+require "optparse"
+
+if $PROGRAM_NAME == __FILE__
+  sample_get_big_book
+end
+
 ============== file: samples/v1/test_resource_name_oneof.rb ==============
 # Copyright 2019 Google LLC
 #

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -6575,11 +6575,9 @@ def sample_get_big_book
   # Make the long-running operation request
   operation = library_client.get_big_book(formatted_name)
 
-
   # You'll want to save this for later to retrieve your completed operation.
   puts "Operation Name: #{response.name}"
   # Cancel the operation to avoid charges when testing.
-
   operation.cancel
 end
 # [END test_long_running_start_then_cancel_calling_form]

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -1003,6 +1003,11 @@ interfaces:
           sample_argument_name: big_book_name
           description: "The name of the book."
     - id: test_long_running_start_then_cancel_calling_form
+      # callingFormCheck: test_long_running_start_then_cancel_calling_form java: LongRunningStartThenCancel
+      # callingFormCheck: test_long_running_start_then_cancel_calling_form python: LongRunningStartThenCancel
+      # callingFormCheck: test_long_running_start_then_cancel_calling_form ruby: LongRunningStartThenCancel
+      # callingFormCheck: test_long_running_start_then_cancel_calling_form php: LongRunningStartThenCancel
+      # callingFormCheck: test_long_running_start_then_cancel_calling_form nodejs: LongRunningStartThenCancel
       title: "kick off, retrieve name, and cancel"
       description: "Kick off the LRO and cancel it."
       parameters:

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -1004,9 +1004,7 @@ interfaces:
           description: "The name of the book."
     - id: test_long_running_start_then_cancel_calling_form
       # callingFormCheck: test_long_running_start_then_cancel_calling_form java: LongRunningStartThenCancel
-      # callingFormCheck: test_long_running_start_then_cancel_calling_form python: LongRunningStartThenCancel
       # callingFormCheck: test_long_running_start_then_cancel_calling_form ruby: LongRunningStartThenCancel
-      # callingFormCheck: test_long_running_start_then_cancel_calling_form php: LongRunningStartThenCancel
       # callingFormCheck: test_long_running_start_then_cancel_calling_form nodejs: LongRunningStartThenCancel
       title: "kick off, retrieve name, and cancel"
       description: "Kick off the LRO and cancel it."

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -1002,13 +1002,36 @@ interfaces:
         - parameter: name%book_id
           sample_argument_name: big_book_name
           description: "The name of the book."
+    - id: test_long_running_start_then_cancel_calling_form
+      title: "kick off, retrieve name, and cancel"
+      description: "Kick off the LRO and cancel it."
+      parameters:
+        defaults:
+        - name%shelf_id=Novel
+        - name%book_id="War and Peace"
+      on_success:
+      - comment: [You'll want to save this for later to retrieve your completed operation.]
+      - print: ["Operation Name: %s", $resp.name]
+      - comment: [Cancel the operation to avoid charges when testing.]
     samples:
       standalone:
-      - calling_forms: ".*"
-        value_sets: ".*"
+      - calling_forms: 
+        - long_running_callable
+        - long_running_event_emitter
+        - long_running_flattened
+        - long_running_flattened_async
+        - long_running_promise
+        - long_running_promise_await
+        - long_running_request
+        - long_running_request_async
+        - callable
+        value_sets: [wap, wap2]
         region_tag: hopper
       - value_sets: wap
         region_tag: "this_tag_should_be_the_name_of_the_file"
+      - value_sets: [test_long_running_start_then_cancel_calling_form]
+        calling_forms: [long_running_start_then_cancel]
+        region_tag: test_long_running_start_then_cancel_calling_form
   - name: GetBigNothing
     flattening:
       groups:
@@ -1040,7 +1063,16 @@ interfaces:
       description: "Test default response handling is turned off for methods that return empty"
     samples:
       standalone:
-      - calling_forms: ".*"
+      - calling_forms: 
+        - long_running_callable
+        - long_running_event_emitter
+        - long_running_flattened
+        - long_running_flattened_async
+        - long_running_promise
+        - long_running_promise_await
+        - long_running_request
+        - long_running_request_async
+        - callable
         value_sets: [empty_response_type_with_response_handling, empty_response_type_without_response_handling]
   - name: TestOptionalRequiredFlatteningParams
     flattening:


### PR DESCRIPTION
Generated samples using AutoML API: https://github.com/hzyi-google/sample-staging/tree/master/20190619

(I tried to run the samples but I found no easy way to create a dataset that the API was satisfied with. But at least the Java sample compiled)