### PR TITLE
Add sample_config.proto to the config_java_proto BUILD target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -76,7 +76,7 @@ java_proto_library(
     name = "config_java_proto",
     deps = [":config_proto",
             ":config_v2_proto",
-	    ":sample_config_proto"],
+            ":sample_config_proto"],
 )
 
 java_binary(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -66,10 +66,17 @@ proto_library(
     deps = ["@com_google_protobuf//:wrappers_proto"],
 )
 
+proto_library(
+    name = "sample_config_proto",
+    srcs = ["src/main/proto/com/google/api/codegen/samplegen/v1/sample_config_v1.proto"],
+    deps = ["@com_google_protobuf//:wrappers_proto"],
+)
+
 java_proto_library(
     name = "config_java_proto",
     deps = [":config_proto",
-            ":config_v2_proto"],
+            ":config_v2_proto",
+	    ":sample_config_proto"],
 )
 
 java_binary(


### PR DESCRIPTION
We accidentally omitted this in #2828 