### PR TITLE
Make it possible to pass metadata to the operations client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,9 @@ anchor_run_ruby: &anchor_run_ruby
        name: Run Showcase Integration Tests
        command: |
          cd workspace/gapic-generator/showcase/ruby
-         bundle install
+         echo "gem 'google-gax', '~> 1.6.3'" >> Gemfile
+         bundle update --conservative google-gax
+         bundle
          bundle exec ruby showcase_integration_test.rb
 
 anchor_test_php: &anchor_test_php

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,8 +178,7 @@ anchor_run_ruby: &anchor_run_ruby
        name: Run Showcase Integration Tests
        command: |
          cd workspace/gapic-generator/showcase/ruby
-         echo "gem 'google-gax', '~> 1.6.3'" >> Gemfile
-         bundle update --conservative google-gax
+         bundle update
          bundle
          bundle exec ruby showcase_integration_test.rb
 

--- a/showcase/ruby/Gemfile
+++ b/showcase/ruby/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "google-showcase", "~> 0.1.0"
 gem "minitest", "~> 5.10"
+gem "google-gax", "~> 1.6"

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -168,6 +168,7 @@
         timeout: timeout,
         lib_name: lib_name,
         lib_version: lib_version,
+        metadata: metadata,
       )
 
     @end

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -3036,6 +3036,7 @@ module Library
           timeout: timeout,
           lib_name: lib_name,
           lib_version: lib_version,
+          metadata: metadata,
         )
 
         if credentials.is_a?(String) || credentials.is_a?(Hash)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -3034,6 +3034,7 @@ module Library
           timeout: timeout,
           lib_name: lib_name,
           lib_version: lib_version,
+          metadata: metadata,
         )
 
         if credentials.is_a?(String) || credentials.is_a?(Hash)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -2893,6 +2893,7 @@ module Library
           timeout: timeout,
           lib_name: lib_name,
           lib_version: lib_version,
+          metadata: metadata,
         )
 
         if credentials.is_a?(String) || credentials.is_a?(Hash)


### PR DESCRIPTION
For googleads we inject `developer-token` and `login-customer-id` to all
Reques)ts. Previously to this patch, we had used a [monkey patch](https://git.io/fjrda)
to inject them in to the right place. However, ths patch was built
against an old version of both gax and the generated code and no longer
works for the newly generated google ads v2 protos.

At the core of the requirement is that both the main API client and,
where generated, the long running operations client, have injecatable
metadata so that we can provide them for LROs without patches.

This patch passes the metadata value passed in to the constructed client
along to the Long Running Operations client, which was not happening
before.