### PR TITLE
go: remove encoding on header request param key

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -442,14 +442,14 @@
     @end
     ",
     @join headerRequestParam : headerRequestParams on ", "
-        "{@headerRequestParam.fullyQualifiedName}", req.{@requestParamGetter(headerRequestParam.gettersChain)}
+        "{@headerRequestParam.fullyQualifiedName}", url.QueryEscape(req.{@requestParamGetter(headerRequestParam.gettersChain)})
     @end
     )
 @end
 
 @private mergeMetadata(method)
     @if method.headerRequestParams
-        md := metadata.Pairs("x-goog-request-params", url.QueryEscape({@headerRequestParamString(method.headerRequestParams)}))
+        md := metadata.Pairs("x-goog-request-params", {@headerRequestParamString(method.headerRequestParams)})
         ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     @else
         ctx = insertMetadata(ctx, c.xGoogMetadata)

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -408,7 +408,7 @@ func (c *LibClient) CreateShelf(ctx context.Context, req *librarypb.CreateShelfR
 
 // GetShelf gets a shelf.
 func (c *LibClient) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetShelf[0:len(c.CallOptions.GetShelf):len(c.CallOptions.GetShelf)], opts...)
     var resp *librarypb.Shelf
@@ -463,7 +463,7 @@ func (c *LibClient) ListShelves(ctx context.Context, req *librarypb.ListShelvesR
 
 // DeleteShelf deletes a shelf.
 func (c *LibClient) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest, opts ...gax.CallOption) error {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.DeleteShelf[0:len(c.CallOptions.DeleteShelf):len(c.CallOptions.DeleteShelf)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -478,7 +478,7 @@ func (c *LibClient) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfR
 // other_shelf_name to shelf name, and deletes
 // other_shelf_name. Returns the updated shelf.
 func (c *LibClient) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.MergeShelves[0:len(c.CallOptions.MergeShelves):len(c.CallOptions.MergeShelves)], opts...)
     var resp *librarypb.Shelf
@@ -495,7 +495,7 @@ func (c *LibClient) MergeShelves(ctx context.Context, req *librarypb.MergeShelve
 
 // CreateBook creates a book.
 func (c *LibClient) CreateBook(ctx context.Context, req *librarypb.CreateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.CreateBook[0:len(c.CallOptions.CreateBook):len(c.CallOptions.CreateBook)], opts...)
     var resp *librarypb.Book
@@ -512,7 +512,7 @@ func (c *LibClient) CreateBook(ctx context.Context, req *librarypb.CreateBookReq
 
 // PublishSeries creates a series of books.
 func (c *LibClient) PublishSeries(ctx context.Context, req *librarypb.PublishSeriesRequest, opts ...gax.CallOption) (*librarypb.PublishSeriesResponse, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "shelf.name", req.GetShelf().GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "shelf.name", url.QueryEscape(req.GetShelf().GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.PublishSeries[0:len(c.CallOptions.PublishSeries):len(c.CallOptions.PublishSeries)], opts...)
     var resp *librarypb.PublishSeriesResponse
@@ -529,7 +529,7 @@ func (c *LibClient) PublishSeries(ctx context.Context, req *librarypb.PublishSer
 
 // GetBook gets a book.
 func (c *LibClient) GetBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetBook[0:len(c.CallOptions.GetBook):len(c.CallOptions.GetBook)], opts...)
     var resp *librarypb.Book
@@ -546,7 +546,7 @@ func (c *LibClient) GetBook(ctx context.Context, req *librarypb.GetBookRequest, 
 
 // ListBooks lists books in a shelf.
 func (c *LibClient) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest, opts ...gax.CallOption) *BookIterator {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.ListBooks[0:len(c.CallOptions.ListBooks):len(c.CallOptions.ListBooks)], opts...)
     it := &BookIterator{}
@@ -585,7 +585,7 @@ func (c *LibClient) ListBooks(ctx context.Context, req *librarypb.ListBooksReque
 
 // DeleteBook deletes a book.
 func (c *LibClient) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest, opts ...gax.CallOption) error {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.DeleteBook[0:len(c.CallOptions.DeleteBook):len(c.CallOptions.DeleteBook)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -598,7 +598,7 @@ func (c *LibClient) DeleteBook(ctx context.Context, req *librarypb.DeleteBookReq
 
 // UpdateBook updates a book.
 func (c *LibClient) UpdateBook(ctx context.Context, req *librarypb.UpdateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.UpdateBook[0:len(c.CallOptions.UpdateBook):len(c.CallOptions.UpdateBook)], opts...)
     var resp *librarypb.Book
@@ -615,7 +615,7 @@ func (c *LibClient) UpdateBook(ctx context.Context, req *librarypb.UpdateBookReq
 
 // MoveBook moves a book to another shelf, and returns the new book.
 func (c *LibClient) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.MoveBook[0:len(c.CallOptions.MoveBook):len(c.CallOptions.MoveBook)], opts...)
     var resp *librarypb.Book
@@ -670,7 +670,7 @@ func (c *LibClient) ListStrings(ctx context.Context, req *librarypb.ListStringsR
 
 // AddComments adds comments to a book
 func (c *LibClient) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest, opts ...gax.CallOption) error {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.AddComments[0:len(c.CallOptions.AddComments):len(c.CallOptions.AddComments)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -683,7 +683,7 @@ func (c *LibClient) AddComments(ctx context.Context, req *librarypb.AddCommentsR
 
 // GetBookFromAnywhere gets a book from a shelf or archive.
 func (c *LibClient) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBookFromAnywhereRequest, opts ...gax.CallOption) (*librarypb.BookFromAnywhere, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetBookFromAnywhere[0:len(c.CallOptions.GetBookFromAnywhere):len(c.CallOptions.GetBookFromAnywhere)], opts...)
     var resp *librarypb.BookFromAnywhere
@@ -700,7 +700,7 @@ func (c *LibClient) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetB
 
 // GetBookFromAbsolutelyAnywhere test proper OneOf-Any resource name mapping
 func (c *LibClient) GetBookFromAbsolutelyAnywhere(ctx context.Context, req *librarypb.GetBookFromAbsolutelyAnywhereRequest, opts ...gax.CallOption) (*librarypb.BookFromAnywhere, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "name", req.GetName(), "alt_book_name", req.GetAltBookName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "name", url.QueryEscape(req.GetName()), "alt_book_name", url.QueryEscape(req.GetAltBookName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetBookFromAbsolutelyAnywhere[0:len(c.CallOptions.GetBookFromAbsolutelyAnywhere):len(c.CallOptions.GetBookFromAbsolutelyAnywhere)], opts...)
     var resp *librarypb.BookFromAnywhere
@@ -717,7 +717,7 @@ func (c *LibClient) GetBookFromAbsolutelyAnywhere(ctx context.Context, req *libr
 
 // UpdateBookIndex updates the index of a book.
 func (c *LibClient) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest, opts ...gax.CallOption) error {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.UpdateBookIndex[0:len(c.CallOptions.UpdateBookIndex):len(c.CallOptions.UpdateBookIndex)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -851,7 +851,7 @@ func (c *LibClient) FindRelatedBooks(ctx context.Context, req *librarypb.FindRel
 
 // addLabel adds a label to the entity.
 func (c *LibClient) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest, opts ...gax.CallOption) (*taggerpb.AddLabelResponse, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "resource", req.GetResource())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "resource", url.QueryEscape(req.GetResource())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.AddLabel[0:len(c.CallOptions.AddLabel):len(c.CallOptions.AddLabel)], opts...)
     var resp *taggerpb.AddLabelResponse
@@ -868,7 +868,7 @@ func (c *LibClient) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest,
 
 // GetBigBook test long-running operations
 func (c *LibClient) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigBookOperation, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetBigBook[0:len(c.CallOptions.GetBigBook):len(c.CallOptions.GetBigBook)], opts...)
     var resp *longrunningpb.Operation
@@ -887,7 +887,7 @@ func (c *LibClient) GetBigBook(ctx context.Context, req *librarypb.GetBookReques
 
 // GetBigNothing test long-running operations with empty return type.
 func (c *LibClient) GetBigNothing(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigNothingOperation, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetBigNothing[0:len(c.CallOptions.GetBigNothing):len(c.CallOptions.GetBigNothing)], opts...)
     var resp *longrunningpb.Operation

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -408,7 +408,7 @@ func (c *LibClient) CreateShelf(ctx context.Context, req *librarypb.CreateShelfR
 
 // GetShelf gets a shelf.
 func (c *LibClient) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetShelf[0:len(c.CallOptions.GetShelf):len(c.CallOptions.GetShelf)], opts...)
     var resp *librarypb.Shelf
@@ -463,7 +463,7 @@ func (c *LibClient) ListShelves(ctx context.Context, req *librarypb.ListShelvesR
 
 // DeleteShelf deletes a shelf.
 func (c *LibClient) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest, opts ...gax.CallOption) error {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.DeleteShelf[0:len(c.CallOptions.DeleteShelf):len(c.CallOptions.DeleteShelf)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -478,7 +478,7 @@ func (c *LibClient) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfR
 // other_shelf_name to shelf name, and deletes
 // other_shelf_name. Returns the updated shelf.
 func (c *LibClient) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.MergeShelves[0:len(c.CallOptions.MergeShelves):len(c.CallOptions.MergeShelves)], opts...)
     var resp *librarypb.Shelf
@@ -495,7 +495,7 @@ func (c *LibClient) MergeShelves(ctx context.Context, req *librarypb.MergeShelve
 
 // CreateBook creates a book.
 func (c *LibClient) CreateBook(ctx context.Context, req *librarypb.CreateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.CreateBook[0:len(c.CallOptions.CreateBook):len(c.CallOptions.CreateBook)], opts...)
     var resp *librarypb.Book
@@ -512,7 +512,7 @@ func (c *LibClient) CreateBook(ctx context.Context, req *librarypb.CreateBookReq
 
 // PublishSeries creates a series of books.
 func (c *LibClient) PublishSeries(ctx context.Context, req *librarypb.PublishSeriesRequest, opts ...gax.CallOption) (*librarypb.PublishSeriesResponse, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "shelf.name", req.GetShelf().GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "shelf.name", url.QueryEscape(req.GetShelf().GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.PublishSeries[0:len(c.CallOptions.PublishSeries):len(c.CallOptions.PublishSeries)], opts...)
     var resp *librarypb.PublishSeriesResponse
@@ -529,7 +529,7 @@ func (c *LibClient) PublishSeries(ctx context.Context, req *librarypb.PublishSer
 
 // GetBook gets a book.
 func (c *LibClient) GetBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetBook[0:len(c.CallOptions.GetBook):len(c.CallOptions.GetBook)], opts...)
     var resp *librarypb.Book
@@ -546,7 +546,7 @@ func (c *LibClient) GetBook(ctx context.Context, req *librarypb.GetBookRequest, 
 
 // ListBooks lists books in a shelf.
 func (c *LibClient) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest, opts ...gax.CallOption) *BookIterator {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.ListBooks[0:len(c.CallOptions.ListBooks):len(c.CallOptions.ListBooks)], opts...)
     it := &BookIterator{}
@@ -585,7 +585,7 @@ func (c *LibClient) ListBooks(ctx context.Context, req *librarypb.ListBooksReque
 
 // DeleteBook deletes a book.
 func (c *LibClient) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest, opts ...gax.CallOption) error {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.DeleteBook[0:len(c.CallOptions.DeleteBook):len(c.CallOptions.DeleteBook)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -598,7 +598,7 @@ func (c *LibClient) DeleteBook(ctx context.Context, req *librarypb.DeleteBookReq
 
 // UpdateBook updates a book.
 func (c *LibClient) UpdateBook(ctx context.Context, req *librarypb.UpdateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.UpdateBook[0:len(c.CallOptions.UpdateBook):len(c.CallOptions.UpdateBook)], opts...)
     var resp *librarypb.Book
@@ -615,7 +615,7 @@ func (c *LibClient) UpdateBook(ctx context.Context, req *librarypb.UpdateBookReq
 
 // MoveBook moves a book to another shelf, and returns the new book.
 func (c *LibClient) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.MoveBook[0:len(c.CallOptions.MoveBook):len(c.CallOptions.MoveBook)], opts...)
     var resp *librarypb.Book
@@ -670,7 +670,7 @@ func (c *LibClient) ListStrings(ctx context.Context, req *librarypb.ListStringsR
 
 // AddComments adds comments to a book
 func (c *LibClient) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest, opts ...gax.CallOption) error {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.AddComments[0:len(c.CallOptions.AddComments):len(c.CallOptions.AddComments)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -683,7 +683,7 @@ func (c *LibClient) AddComments(ctx context.Context, req *librarypb.AddCommentsR
 
 // GetBookFromAnywhere gets a book from a shelf or archive.
 func (c *LibClient) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBookFromAnywhereRequest, opts ...gax.CallOption) (*librarypb.BookFromAnywhere, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetBookFromAnywhere[0:len(c.CallOptions.GetBookFromAnywhere):len(c.CallOptions.GetBookFromAnywhere)], opts...)
     var resp *librarypb.BookFromAnywhere
@@ -700,7 +700,7 @@ func (c *LibClient) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetB
 
 // GetBookFromAbsolutelyAnywhere test proper OneOf-Any resource name mapping
 func (c *LibClient) GetBookFromAbsolutelyAnywhere(ctx context.Context, req *librarypb.GetBookFromAbsolutelyAnywhereRequest, opts ...gax.CallOption) (*librarypb.BookFromAnywhere, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "name", req.GetName(), "alt_book_name", req.GetAltBookName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "name", url.QueryEscape(req.GetName()), "alt_book_name", url.QueryEscape(req.GetAltBookName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetBookFromAbsolutelyAnywhere[0:len(c.CallOptions.GetBookFromAbsolutelyAnywhere):len(c.CallOptions.GetBookFromAbsolutelyAnywhere)], opts...)
     var resp *librarypb.BookFromAnywhere
@@ -717,7 +717,7 @@ func (c *LibClient) GetBookFromAbsolutelyAnywhere(ctx context.Context, req *libr
 
 // UpdateBookIndex updates the index of a book.
 func (c *LibClient) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest, opts ...gax.CallOption) error {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.UpdateBookIndex[0:len(c.CallOptions.UpdateBookIndex):len(c.CallOptions.UpdateBookIndex)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -851,7 +851,7 @@ func (c *LibClient) FindRelatedBooks(ctx context.Context, req *librarypb.FindRel
 
 // addLabel adds a label to the entity.
 func (c *LibClient) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest, opts ...gax.CallOption) (*taggerpb.AddLabelResponse, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "resource", req.GetResource())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "resource", url.QueryEscape(req.GetResource())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.AddLabel[0:len(c.CallOptions.AddLabel):len(c.CallOptions.AddLabel)], opts...)
     var resp *taggerpb.AddLabelResponse
@@ -868,7 +868,7 @@ func (c *LibClient) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest,
 
 // GetBigBook test long-running operations
 func (c *LibClient) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigBookOperation, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetBigBook[0:len(c.CallOptions.GetBigBook):len(c.CallOptions.GetBigBook)], opts...)
     var resp *longrunningpb.Operation
@@ -887,7 +887,7 @@ func (c *LibClient) GetBigBook(ctx context.Context, req *librarypb.GetBookReques
 
 // GetBigNothing test long-running operations with empty return type.
 func (c *LibClient) GetBigNothing(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigNothingOperation, error) {
-    md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v", "name", req.GetName())))
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "name", url.QueryEscape(req.GetName())))
     ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.GetBigNothing[0:len(c.CallOptions.GetBigNothing):len(c.CallOptions.GetBigNothing)], opts...)
     var resp *longrunningpb.Operation


### PR DESCRIPTION
Removes URL encoding of the header request param keys from the snippets and only encodes the value instead.

Needing to encode the key will be decided later (if we actually need it at all). The chance a field name is non-ASCII is very very low.

Similar PR in https://github.com/googleapis/gapic-generator-go/pull/145