### PR TITLE
Allow samplegen without sample configs

### DIFF
--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
@@ -203,8 +203,9 @@ public class GapicGeneratorApp extends ToolDriverBase {
       return;
     }
 
-    // TODO(hzyi-google): Once we switch to sample configs, require an additional check to generate
-    // samples: `sampleConfigProto != null`
+    // TODO(hzyi-google): Once we switch to sample configs, require an
+    // additional check to generate samples:
+    // `sampleConfigProto != null`
     ArtifactFlags artifactFlags =
         new ArtifactFlags(
             options.get(ENABLED_ARTIFACTS),

--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
@@ -207,10 +207,7 @@ public class GapicGeneratorApp extends ToolDriverBase {
     // additional check to generate samples:
     // `sampleConfigProto != null`
     ArtifactFlags artifactFlags =
-        new ArtifactFlags(
-            options.get(ENABLED_ARTIFACTS),
-            artifactType,
-            options.get(DEV_SAMPLES));
+        new ArtifactFlags(options.get(ENABLED_ARTIFACTS), artifactType, options.get(DEV_SAMPLES));
     List<CodeGenerator<?>> generators =
         GapicGeneratorFactory.create(language, model, productConfig, packageConfig, artifactFlags);
     ImmutableMap.Builder<String, GeneratedResult<?>> generatedResults = ImmutableMap.builder();

--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorApp.java
@@ -203,11 +203,13 @@ public class GapicGeneratorApp extends ToolDriverBase {
       return;
     }
 
+    // TODO(hzyi-google): Once we switch to sample configs, require an additional check to generate
+    // samples: `sampleConfigProto != null`
     ArtifactFlags artifactFlags =
         new ArtifactFlags(
             options.get(ENABLED_ARTIFACTS),
             artifactType,
-            options.get(DEV_SAMPLES) && sampleConfigProto != null);
+            options.get(DEV_SAMPLES));
     List<CodeGenerator<?>> generators =
         GapicGeneratorFactory.create(language, model, productConfig, packageConfig, artifactFlags);
     ImmutableMap.Builder<String, GeneratedResult<?>> generatedResults = ImmutableMap.builder();


### PR DESCRIPTION
We are not yet requiring sample configs because we only parse them but
do not use the results (and users have not yet converted from the
gapic configs). PR #2828 accidentally made having these sample configs
parsed a requirement for samplegen. This breaks users.

This PR ignores whether the sample configs have been parsed in order
to re-enable samplegen for the time being.