### PR TITLE
Fix string literal character escaping in Ruby generator

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyModelTypeNameConverter.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.transformer.ruby;
 
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.transformer.ModelTypeNameConverter;
+import com.google.api.codegen.util.EscaperFactory;
 import com.google.api.codegen.util.NamePath;
 import com.google.api.codegen.util.TypeName;
 import com.google.api.codegen.util.TypeNameConverter;
@@ -162,7 +163,7 @@ public class RubyModelTypeNameConverter extends ModelTypeNameConverter {
         return value.toLowerCase();
       case TYPE_STRING:
       case TYPE_BYTES:
-        return "\"" + value + "\"";
+        return "\"" + EscaperFactory.getDoubleQuoteEscaper().escape(value) + "\"";
       default:
         // Types that do not need to be modified (e.g. TYPE_INT32) are handled
         // here

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -5707,8 +5707,7 @@ def sample_get_big_book shelf
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  # shelf = "Novel\"`	
-  # "
+  # shelf = "Novel\\\"`\b\t\n\r"
   formatted_name = library_client.class.book_path(shelf, "War and Peace")
 
   # Make the long-running operation request
@@ -5746,8 +5745,7 @@ require "optparse"
 
 if $PROGRAM_NAME == __FILE__
 
-  shelf = "Novel\"`	
-"
+  shelf = "Novel\\\"`\b\t\n\r"
 
   ARGV.options do |opts|
     opts.on("--shelf=val") { |val| shelf = val }
@@ -6721,8 +6719,7 @@ def sample_get_big_book shelf
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  # shelf = "Novel\"`	
-  # "
+  # shelf = "Novel\\\"`\b\t\n\r"
   formatted_name = library_client.class.book_path(shelf, "War and Peace")
 
   # Make the long-running operation request
@@ -6760,8 +6757,7 @@ require "optparse"
 
 if $PROGRAM_NAME == __FILE__
 
-  shelf = "Novel\"`	
-"
+  shelf = "Novel\\\"`\b\t\n\r"
 
   ARGV.options do |opts|
     opts.on("--shelf=val") { |val| shelf = val }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -5693,8 +5693,7 @@ def sample_get_big_book shelf
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  # shelf = "Novel\"`	
-  # "
+  # shelf = "Novel\\\"`\b\t\n\r"
   formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
 
   # Make the long-running operation request
@@ -5732,8 +5731,7 @@ require "optparse"
 
 if $PROGRAM_NAME == __FILE__
 
-  shelf = "Novel\"`	
-"
+  shelf = "Novel\\\"`\b\t\n\r"
 
   ARGV.options do |opts|
     opts.on("--shelf=val") { |val| shelf = val }
@@ -6707,8 +6705,7 @@ def sample_get_big_book shelf
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  # shelf = "Novel\"`	
-  # "
+  # shelf = "Novel\\\"`\b\t\n\r"
   formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
 
   # Make the long-running operation request
@@ -6746,8 +6743,7 @@ require "optparse"
 
 if $PROGRAM_NAME == __FILE__
 
-  shelf = "Novel\"`	
-"
+  shelf = "Novel\\\"`\b\t\n\r"
 
   ARGV.options do |opts|
     opts.on("--shelf=val") { |val| shelf = val }


### PR DESCRIPTION
This seems like missing part of https://github.com/googleapis/gapic-generator/pull/2782. 

Note, the left part of the diff (i.e. file before this PR) for `ruby_library.baseline` file contains non-printable whitespaces.