### PR TITLE
Fix lro initial call settings

### DIFF
--- a/src/main/resources/com/google/api/codegen/java/stub_settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/stub_settings.snip
@@ -542,8 +542,8 @@
           .{@settings.settingsGetFunction}()
           .setInitialCallSettings(
               UnaryCallSettings.<{@settings.requestTypeName}, OperationSnapshot>newUnaryCallSettingsBuilder()
-                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
-                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("{@settings.retryCodesName}"))
+                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("{@settings.retryParamsName}"))
                   .build())
           .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create({@settings.operationMethod.operationPayloadTypeName}.class))
           .setMetadataTransformer(ProtoOperationTransformers.MetadataTransformer.create({@settings.operationMethod.metadataTypeName}.class))

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -12271,7 +12271,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .getBigBookOperationSettings()
           .setInitialCallSettings(
               UnaryCallSettings.<GetBookRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
-                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
                   .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
                   .build())
           .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create(Book.class))
@@ -12291,7 +12291,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .getBigNothingOperationSettings()
           .setInitialCallSettings(
               UnaryCallSettings.<GetBookRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
-                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
                   .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
                   .build())
           .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create(Empty.class))

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -10142,7 +10142,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .getBigBookOperationSettings()
           .setInitialCallSettings(
               UnaryCallSettings.<GetBookRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
-                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
                   .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
                   .build())
           .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create(Book.class))
@@ -10162,7 +10162,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .getBigNothingOperationSettings()
           .setInitialCallSettings(
               UnaryCallSettings.<GetBookRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
-                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
                   .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
                   .build())
           .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create(Empty.class))

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -12264,7 +12264,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .getBigBookOperationSettings()
           .setInitialCallSettings(
               UnaryCallSettings.<GetBookRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
-                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
                   .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
                   .build())
           .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create(Book.class))
@@ -12284,7 +12284,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .getBigNothingOperationSettings()
           .setInitialCallSettings(
               UnaryCallSettings.<GetBookRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
-                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
                   .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
                   .build())
           .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create(Empty.class))


### PR DESCRIPTION
Fixes #2877

When generating LRO stub settings, make sure to respect the initial call setting's RetrySettings