### PR TITLE
fix(nodejs): drop dependency on through2

### DIFF
--- a/showcase/nodejs/package.json
+++ b/showcase/nodejs/package.json
@@ -7,7 +7,6 @@
   "devDependencies": {
     "grpc": "^1.12.1",
     "mocha": "^5.2.0",
-    "showcase": "file:../../artman-genfiles/js/showcase-v1beta1",
-    "through2": "^2.0.3"
+    "showcase": "file:../../artman-genfiles/js/showcase-v1beta1"
   }
 }

--- a/src/main/resources/com/google/api/codegen/nodejs/package.json.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/package.json.snip
@@ -32,8 +32,7 @@
       "google-gax": "^1.1.0"
     },
     "devDependencies": {
-      "mocha": "^5.2.0",
-      "through2": "^2.0.3"
+      "mocha": "^5.2.0"
     },
     "scripts": {
       "smoke-test": "mocha smoke-test/*.js --timeout 5000",

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -48,7 +48,7 @@
 @private header(apiTest)
   const assert = require('assert');
   @if apiTest.hasGrpcStreaming
-    const through2 = require('through2');
+    const {PassThrough} = require('stream');
   @end
 
   const {@apiTest.localPackageName}Module = require('../src');
@@ -76,12 +76,15 @@
     function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
       return actualRequest => {
         assert.deepStrictEqual(actualRequest, expectedRequest);
-        const mockStream = through2.obj((chunk, enc, callback) => {
-          if (error) {
-            callback(error);
-          }
-          else {
-            callback(null, response);
+        const mockStream = new PassThrough({
+          objectMode: true,
+          transform: (chunk, enc, callback) => {
+            if (error) {
+              callback(error);
+            }
+            else {
+              callback(null, response);
+            }
           }
         });
         return mockStream;
@@ -92,13 +95,16 @@
 
     function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
       return () => {
-        const mockStream = through2.obj((chunk, enc, callback) => {
-          assert.deepStrictEqual(chunk, expectedRequest);
-          if (error) {
-            callback(error);
-          }
-          else {
-            callback(null, response);
+        const mockStream = new PassThrough({
+          objectMode: true,
+          transform: (chunk, enc, callback) => {
+            assert.deepStrictEqual(chunk, expectedRequest);
+            if (error) {
+              callback(error);
+            }
+            else {
+              callback(null, response);
+            }
           }
         });
         return mockStream;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -35,8 +35,7 @@ This is a generated README.md placeholder. Put your own documentation here.
     "google-gax": "^1.1.0"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
-    "through2": "^2.0.3"
+    "mocha": "^5.2.0"
   },
   "scripts": {
     "smoke-test": "mocha smoke-test/*.js --timeout 5000",
@@ -7502,7 +7501,7 @@ module.exports = MyProtoClient;
 'use strict';
 
 const assert = require('assert');
-const through2 = require('through2');
+const {PassThrough} = require('stream');
 
 const libraryModule = require('../src');
 
@@ -9483,12 +9482,15 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
 function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
   return actualRequest => {
     assert.deepStrictEqual(actualRequest, expectedRequest);
-    const mockStream = through2.obj((chunk, enc, callback) => {
-      if (error) {
-        callback(error);
-      }
-      else {
-        callback(null, response);
+    const mockStream = new PassThrough({
+      objectMode: true,
+      transform: (chunk, enc, callback) => {
+        if (error) {
+          callback(error);
+        }
+        else {
+          callback(null, response);
+        }
       }
     });
     return mockStream;
@@ -9497,13 +9499,16 @@ function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
 
 function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
   return () => {
-    const mockStream = through2.obj((chunk, enc, callback) => {
-      assert.deepStrictEqual(chunk, expectedRequest);
-      if (error) {
-        callback(error);
-      }
-      else {
-        callback(null, response);
+    const mockStream = new PassThrough({
+      objectMode: true,
+      transform: (chunk, enc, callback) => {
+        assert.deepStrictEqual(chunk, expectedRequest);
+        if (error) {
+          callback(error);
+        }
+        else {
+          callback(null, response);
+        }
       }
     });
     return mockStream;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -34,8 +34,7 @@ This is a generated README.md placeholder. Put your own documentation here.
     "google-gax": "^1.1.0"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
-    "through2": "^2.0.3"
+    "mocha": "^5.2.0"
   },
   "scripts": {
     "smoke-test": "mocha smoke-test/*.js --timeout 5000",
@@ -775,7 +774,7 @@ module.exports.DecrementerServiceClient = DecrementerServiceClient;
 'use strict';
 
 const assert = require('assert');
-const through2 = require('through2');
+const {PassThrough} = require('stream');
 
 const multipleServicesModule = require('../src');
 
@@ -938,13 +937,16 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
 
 function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
   return () => {
-    const mockStream = through2.obj((chunk, enc, callback) => {
-      assert.deepStrictEqual(chunk, expectedRequest);
-      if (error) {
-        callback(error);
-      }
-      else {
-        callback(null, response);
+    const mockStream = new PassThrough({
+      objectMode: true,
+      transform: (chunk, enc, callback) => {
+        assert.deepStrictEqual(chunk, expectedRequest);
+        if (error) {
+          callback(error);
+        }
+        else {
+          callback(null, response);
+        }
       }
     });
     return mockStream;

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -33,8 +33,7 @@ This is a generated README.md placeholder. Put your own documentation here.
     "google-gax": "^1.1.0"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
-    "through2": "^2.0.3"
+    "mocha": "^5.2.0"
   },
   "scripts": {
     "smoke-test": "mocha smoke-test/*.js --timeout 5000",

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
@@ -35,8 +35,7 @@ This is a generated README.md placeholder. Put your own documentation here.
     "google-gax": "^1.1.0"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
-    "through2": "^2.0.3"
+    "mocha": "^5.2.0"
   },
   "scripts": {
     "smoke-test": "mocha smoke-test/*.js --timeout 5000",
@@ -6873,7 +6872,7 @@ module.exports = MyProtoClient;
 'use strict';
 
 const assert = require('assert');
-const through2 = require('through2');
+const {PassThrough} = require('stream');
 
 const libraryModule = require('../src');
 
@@ -8854,12 +8853,15 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
 function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
   return actualRequest => {
     assert.deepStrictEqual(actualRequest, expectedRequest);
-    const mockStream = through2.obj((chunk, enc, callback) => {
-      if (error) {
-        callback(error);
-      }
-      else {
-        callback(null, response);
+    const mockStream = new PassThrough({
+      objectMode: true,
+      transform: (chunk, enc, callback) => {
+        if (error) {
+          callback(error);
+        }
+        else {
+          callback(null, response);
+        }
       }
     });
     return mockStream;
@@ -8868,13 +8870,16 @@ function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
 
 function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
   return () => {
-    const mockStream = through2.obj((chunk, enc, callback) => {
-      assert.deepStrictEqual(chunk, expectedRequest);
-      if (error) {
-        callback(error);
-      }
-      else {
-        callback(null, response);
+    const mockStream = new PassThrough({
+      objectMode: true,
+      transform: (chunk, enc, callback) => {
+        assert.deepStrictEqual(chunk, expectedRequest);
+        if (error) {
+          callback(error);
+        }
+        else {
+          callback(null, response);
+        }
       }
     });
     return mockStream;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -35,8 +35,7 @@ This is a generated README.md placeholder. Put your own documentation here.
     "google-gax": "^1.1.0"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
-    "through2": "^2.0.3"
+    "mocha": "^5.2.0"
   },
   "scripts": {
     "smoke-test": "mocha smoke-test/*.js --timeout 5000",
@@ -7453,7 +7452,7 @@ module.exports = MyProtoClient;
 'use strict';
 
 const assert = require('assert');
-const through2 = require('through2');
+const {PassThrough} = require('stream');
 
 const libraryModule = require('../src');
 
@@ -9434,12 +9433,15 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
 function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
   return actualRequest => {
     assert.deepStrictEqual(actualRequest, expectedRequest);
-    const mockStream = through2.obj((chunk, enc, callback) => {
-      if (error) {
-        callback(error);
-      }
-      else {
-        callback(null, response);
+    const mockStream = new PassThrough({
+      objectMode: true,
+      transform: (chunk, enc, callback) => {
+        if (error) {
+          callback(error);
+        }
+        else {
+          callback(null, response);
+        }
       }
     });
     return mockStream;
@@ -9448,13 +9450,16 @@ function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
 
 function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
   return () => {
-    const mockStream = through2.obj((chunk, enc, callback) => {
-      assert.deepStrictEqual(chunk, expectedRequest);
-      if (error) {
-        callback(error);
-      }
-      else {
-        callback(null, response);
+    const mockStream = new PassThrough({
+      objectMode: true,
+      transform: (chunk, enc, callback) => {
+        assert.deepStrictEqual(chunk, expectedRequest);
+        if (error) {
+          callback(error);
+        }
+        else {
+          callback(null, response);
+        }
       }
     });
     return mockStream;


### PR DESCRIPTION
The gapic generated tests for nodejs often take a dependency on the `through2` module.  Oftentimes... it's not actually needed!  This is in pursuit of dropping the total number of dependencies in our projects to improve security and reliability.