### PR TITLE
add PagedExpand to showcase gapic config

### DIFF
--- a/src/test/java/com/google/api/codegen/testsrc/showcase/showcase_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/showcase/showcase_gapic.yaml
@@ -126,6 +126,17 @@ interfaces:
     retry_codes_name: idempotent
     retry_params_name: default
     timeout_millis: 60000
+  - name: PagedExpand
+    page_streaming:
+      request:
+        page_size_field: page_size
+        token_field: page_token
+      response:
+        token_field: next_page_token
+        resources_field: responses
+    retry_codes_name: idempotent
+    retry_params_name: default
+    timeout_millis: 60000
   - name: Collect
     retry_codes_name: non_idempotent
     retry_params_name: default


### PR DESCRIPTION
For some reason, `PagedExpand` is missing from the gapic config that is used for Showcase testing in gapic-generator. Adding it back.