### PR TITLE
Switch to machine executor for Bazel builds (to fix tests flakiness)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,8 +352,8 @@ jobs:
     working_directory: /tmp/
     environment:
       TEST_REPORTS_DIR: /tmp/workspace/bazel/reports/gapic-generator
-    docker:
-      - image: l.gcr.io/google/bazel:0.23.1
+    machine:
+      - image: ubuntu-1604:201903-01
     steps:
       - checkout:
           path: gapic-generator
@@ -363,15 +363,14 @@ jobs:
           name: Make reports directory
           command: |
             mkdir -p ${TEST_REPORTS_DIR}
+            wget https://github.com/bazelbuild/bazel/releases/download/0.28.1/bazel-0.28.1-installer-linux-x86_64.sh -O bazel_installer.sh
+            chmod +x bazel_installer.sh
+            ./bazel_installer.sh
       - run:
           name: Run unit tests for gapic-generator
           command: |
             cd gapic-generator
-            bazel --host_jvm_args="-Xmx512m" \
-              test //... \
-              --jvmopt="-Xmx512m" \
-              --local_resources=3072,0.5,1.0 \
-              --experimental_enable_repo_mapping
+            bazel test //...
             find . -type f -regex ".*/bazel-testlogs/.*xml" -exec cp {} ${TEST_REPORTS_DIR} \;
       - store_test_results:
           path: bazel/reports/gapic-generator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ jobs:
             mkdir -p ${TEST_REPORTS_DIR}
             wget https://github.com/bazelbuild/bazel/releases/download/0.28.1/bazel-0.28.1-installer-linux-x86_64.sh -O bazel_installer.sh
             chmod +x bazel_installer.sh
-            ./bazel_installer.sh
+            ./bazel_installer.sh --user
       - run:
           name: Run unit tests for gapic-generator
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,9 +349,9 @@ jobs:
             go test testutils/check-lang-uses-form/*.go
             go run $(find testutils/check-lang-uses-form -type f | grep -v _test) -forms src/main/java/com/google/api/codegen/viewmodel/CallingForm.java src/test
   gapic-generator-bazel-test:
-    working_directory: /tmp/
-    environment:
-      TEST_REPORTS_DIR: /tmp/workspace/bazel/reports/gapic-generator
+#    working_directory: /tmp/
+#    environment:
+#      TEST_REPORTS_DIR: /tmp/workspace/bazel/reports/gapic-generator
     machine:
       - image: ubuntu-1604:201903-01
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,11 +349,10 @@ jobs:
             go test testutils/check-lang-uses-form/*.go
             go run $(find testutils/check-lang-uses-form -type f | grep -v _test) -forms src/main/java/com/google/api/codegen/viewmodel/CallingForm.java src/test
   gapic-generator-bazel-test:
-#    working_directory: /tmp/
-#    environment:
-#      TEST_REPORTS_DIR: /tmp/workspace/bazel/reports/gapic-generator
-    machine:
-      - image: ubuntu-1604:201903-01
+    working_directory: /tmp/
+    environment:
+      TEST_REPORTS_DIR: /tmp/workspace/bazel/reports/gapic-generator
+    machine: true
     steps:
       - checkout:
           path: gapic-generator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,6 +352,8 @@ jobs:
     working_directory: /tmp/
     environment:
       TEST_REPORTS_DIR: /tmp/workspace/bazel/reports/gapic-generator
+      BAZEL_VERSION: 0.28.1
+      PYTHON_VERSION: 3.5.2
     machine: true
     steps:
       - checkout:
@@ -359,12 +361,19 @@ jobs:
       - attach_workspace:
           at: workspace
       - run:
+          name: Set Python version
+          command: |
+            pyenv global ${PYTHON_VERSION}
+      - run:
+          name: Install Bazel
+          command: |
+            wget https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh -O bazel_installer.sh
+            chmod +x bazel_installer.sh
+            ./bazel_installer.sh --user
+      - run:
           name: Make reports directory
           command: |
             mkdir -p ${TEST_REPORTS_DIR}
-            wget https://github.com/bazelbuild/bazel/releases/download/0.28.1/bazel-0.28.1-installer-linux-x86_64.sh -O bazel_installer.sh
-            chmod +x bazel_installer.sh
-            ./bazel_installer.sh --user
       - run:
           name: Run unit tests for gapic-generator
           command: |


### PR DESCRIPTION
With a dedicated machine executor Bazel can determine properly the actual resources available (amount of CPUs and memory). 

When executed inside a Docker, Bazel sees the huge machine on which docker is running (i.e. stuff in `/protoc/cpuinfo` and `/proc/meminfo`) and assumes that all of those resources are available (while they are not, because Docker limits the access to them). 

As a result, when Bazel was executed from a Docker image, it tried to run tons of actions in parallel (assuming it had enough resources to do so), and circleci was simply killing it for consuming more resources than allowed. 

The previously employed `--local_resources` argument helped to mitigate the issue, but was not enough because it could control how much resources bazel and its direct tasks where allowed to consume, but the argument was not affecting subprocesses spawned by bazel's direct tasks (like javac Autovalue plugin, which was causing OutOfMemory exceptions and was the root cause of Bazel build tests flakiness).

With dedicated machine in place, all the tools used in build (Bazel itself and javac plugins) can see the real specs of the environment they are running on and "plan" accordingly (i.e. not fail with OutOfMemory and similar stuff).

Also upgrade bazel to the latest version (0.28.1).