### PR TITLE
Improvement: explicitly error out when an optional is empty

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -750,7 +750,8 @@ public class JavaSurfaceTransformer {
         .map(InterfaceModel::getFullName)
         .findFirst()
         .map(name -> pathMapper.getOutputPath(name, productConfig))
-        .ifPresent(path -> packageInfo.outputPath(path + File.separator + "package-info.java"));
+        .map(path -> packageInfo.outputPath(path + File.separator + "package-info.java"))
+        .orElseThrow(() -> new IllegalStateException("found no configured interface."));
     packageInfo.releaseLevel(productConfig.getReleaseLevel());
 
     return packageInfo.build();


### PR DESCRIPTION
kudos to @msridhar who found this unhandled code path in #2892. Thanks again!

Fix #2892 