### PR TITLE
[bazel] Extend proto_custom_library to support files as key-value plugin arguments

### DIFF
--- a/rules_gapic/gapic.bzl
+++ b/rules_gapic/gapic.bzl
@@ -128,7 +128,8 @@ def _proto_custom_library_impl(ctx):
             for f in t.files.to_list():
                 extra_inputs.append(f)
                 plugin_file_args.append("%s=%s" % (k, f.path) if k else f.path)
-        output_paths = ctx.attr.plugin_args + plugin_file_args + output_paths
+        if ctx.attr.plugin_args or plugin_file_args:
+            output_paths.insert(0, ",".join(ctx.attr.plugin_args + plugin_file_args))
         calculated_args = [
             "--plugin=protoc-gen-%s=%s" % (output_type, plugin.path),
         ]

--- a/rules_gapic/java/java_gapic.bzl
+++ b/rules_gapic/java/java_gapic.bzl
@@ -77,7 +77,7 @@ def java_resource_name_proto_library(name, deps, gapic_yaml, visibility = None):
         name = srcjar_target_name,
         deps = deps,
         plugin = Label("@com_google_protoc_java_resource_names_plugin//:gapic_plugin"),
-        plugin_file_args = [gapic_yaml],
+        plugin_file_args = {gapic_yaml: ""},
         output_type = "resourcename",
         output_suffix = srcjar_output_suffix,
     )


### PR DESCRIPTION
This is to suport microgenerator custom arguments, like gRPC retry config.

To use it, provide the arguments which expect file paths as plugin_file_args dictionary:

```bzl
  proto_custom_library(
    name = name,
    deps = srcs,
    plugin = Label("//cmd/protoc-gen-go_gapic"),
    plugin_args = [
      "go-gapic-package="+importpath,
    ],
    plugin_file_args = {
      grpc_config: "grpc-service-config",
    }
    output_type = "go_gapic",
    output_suffix = ".zip",
    **kwargs
  )
```

Note, `grpc_config` in the example above must be **an actual label**, pointing to a file or to a taget which generates a file. If the file belongs to another package, it must be exported from there using `exports_files()` rule.