### PR TITLE
Python: Use googleapis.dev URL in intersphinx mapping for google-api-core.

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/docs/conf.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/docs/conf.py.snip
@@ -330,7 +330,7 @@
       'gax': ('https://gax-python.readthedocs.org/en/latest/', None),
       'google-auth': ('https://google-auth.readthedocs.io/en/stable', None),
       'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
-      'google.api_core': ('https://googleapis.github.io/google-cloud-python/latest', None),
+      'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
       'grpc': ('https://grpc.io/grpc/python/', None),
       'requests': ('https://2.python-requests.org/en/master/', None),
       'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -635,7 +635,7 @@ intersphinx_mapping = {
     'gax': ('https://gax-python.readthedocs.org/en/latest/', None),
     'google-auth': ('https://google-auth.readthedocs.io/en/stable', None),
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
-    'google.api_core': ('https://googleapis.github.io/google-cloud-python/latest', None),
+    'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
     'requests': ('https://2.python-requests.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -616,7 +616,7 @@ intersphinx_mapping = {
     'gax': ('https://gax-python.readthedocs.org/en/latest/', None),
     'google-auth': ('https://google-auth.readthedocs.io/en/stable', None),
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
-    'google.api_core': ('https://googleapis.github.io/google-cloud-python/latest', None),
+    'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
     'requests': ('https://2.python-requests.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -616,7 +616,7 @@ intersphinx_mapping = {
     'gax': ('https://gax-python.readthedocs.org/en/latest/', None),
     'google-auth': ('https://google-auth.readthedocs.io/en/stable', None),
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
-    'google.api_core': ('https://googleapis.github.io/google-cloud-python/latest', None),
+    'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
     'requests': ('https://2.python-requests.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
@@ -635,7 +635,7 @@ intersphinx_mapping = {
     'gax': ('https://gax-python.readthedocs.org/en/latest/', None),
     'google-auth': ('https://google-auth.readthedocs.io/en/stable', None),
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
-    'google.api_core': ('https://googleapis.github.io/google-cloud-python/latest', None),
+    'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
     'requests': ('https://2.python-requests.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -635,7 +635,7 @@ intersphinx_mapping = {
     'gax': ('https://gax-python.readthedocs.org/en/latest/', None),
     'google-auth': ('https://google-auth.readthedocs.io/en/stable', None),
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
-    'google.api_core': ('https://googleapis.github.io/google-cloud-python/latest', None),
+    'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
     'requests': ('https://2.python-requests.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
@@ -4668,7 +4668,7 @@ intersphinx_mapping = {
     'gax': ('https://gax-python.readthedocs.org/en/latest/', None),
     'google-auth': ('https://google-auth.readthedocs.io/en/stable', None),
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
-    'google.api_core': ('https://googleapis.github.io/google-cloud-python/latest', None),
+    'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
     'requests': ('https://2.python-requests.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),


### PR DESCRIPTION
Closes #2952.