### PR TITLE
Support _virtual_imports in path of proto_library targets.

### DIFF
--- a/rules_gapic/gapic.bzl
+++ b/rules_gapic/gapic.bzl
@@ -244,6 +244,9 @@ unzipped_srcjar = rule(
 # Private helper functions
 #
 def _path_ignoring_repository(f):
+    virtual_imports = "/_virtual_imports/"
+    if virtual_imports in f.path:
+        return f.path.split(virtual_imports)[1].split("/", 1)[1]
     if f.owner.workspace_root:
         return f.path[f.path.find(f.owner.workspace_root) + len(f.owner.workspace_root) + 1:]
     return f.short_path


### PR DESCRIPTION
This is a new feature introduced recently (somewhere around bazel 0.28.0), where it adds `_virtual_imports` into the paths for all proto_library targets which use `strip_import_prefix` and/or `import_prefix` arguments (see [proto_library documentation](https://docs.bazel.build/versions/master/be/protocol-buffer.html#proto_library).

Probotuf repository, which exposes all the "well known protos" (like `descriptor.proto` or `anotation.proto`) recently started using those arguments in their build (https://github.com/protocolbuffers/protobuf/commit/a03d332aca5d33c5d4b2cd25037c9e37d57eff02), and since almost everything depends on at least one well known proto, not supporting `_virtual_imports` in the path breaks pretty much everythin in googleapis.

It looks like other grpc-specific rules hit similar issue recently.

grpc/grpc repo had to fix it: https://github.com/grpc/grpc/commit/e2ba3aa07009292617c3cabe734e8e44099b22ac
grpc-java had to fix it as well:  https://github.com/grpc/grpc-java/commit/b22017851560197a41015acd90f443f7b9519984

This PR effectively copies the grpc-java fix.