### PR TITLE
node: fix webpack config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -638,6 +638,11 @@ jobs:
             npm test
             npm run browser-test
       - run:
+          name: Test webpack
+          command: |
+            cd workspace/gapic-generator/showcase/nodejs
+            npx webpack
+      - run:
           name: Prepare to test Pubsub
           command: |
             echo 'export TEST_API="pubsub-v1"' >> $BASH_ENV

--- a/src/main/resources/com/google/api/codegen/nodejs/webpack.config.js.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/webpack.config.js.snip
@@ -1,6 +1,4 @@
 @snippet generate(metadata)
-const path = require('path');
-  
 module.exports = {
     entry: './src/browser.js',
     output: {
@@ -18,24 +16,20 @@ module.exports = {
     module: {
       rules: [
         {
-          test: /node_modules[\\\/]retry-request[\\\/]/,
-          use: 'null-loader',
-        },
-        {
-          test: /node_modules[\\\/]retry-request/,
+          test: /node_modules[\\/]retry-request[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]https-proxy-agent/,
+          test: /node_modules[\\/]https-proxy-agent[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]gtoken/,
+          test: /node_modules[\\/]gtoken[\\/]/,
           use: 'null-loader'
         },
       ]
     },
     mode: 'production'
-}
+};
 
 @end

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -10564,8 +10564,6 @@ function mockLongRunningGrpcMethod(expectedRequest, response, error) {
 }
 
 ============== file: webpack.config.js ==============
-const path = require('path');
-
 module.exports = {
     entry: './src/browser.js',
     output: {
@@ -10583,23 +10581,19 @@ module.exports = {
     module: {
       rules: [
         {
-          test: /node_modules[\\\/]retry-request[\\\/]/,
-          use: 'null-loader',
-        },
-        {
-          test: /node_modules[\\\/]retry-request/,
+          test: /node_modules[\\/]retry-request[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]https-proxy-agent/,
+          test: /node_modules[\\/]https-proxy-agent[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]gtoken/,
+          test: /node_modules[\\/]gtoken[\\/]/,
           use: 'null-loader'
         },
       ]
     },
     mode: 'production'
-}
+};
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -1039,8 +1039,6 @@ function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
 }
 
 ============== file: webpack.config.js ==============
-const path = require('path');
-
 module.exports = {
     entry: './src/browser.js',
     output: {
@@ -1058,23 +1056,19 @@ module.exports = {
     module: {
       rules: [
         {
-          test: /node_modules[\\\/]retry-request[\\\/]/,
-          use: 'null-loader',
-        },
-        {
-          test: /node_modules[\\\/]retry-request/,
+          test: /node_modules[\\/]retry-request[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]https-proxy-agent/,
+          test: /node_modules[\\/]https-proxy-agent[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]gtoken/,
+          test: /node_modules[\\/]gtoken[\\/]/,
           use: 'null-loader'
         },
       ]
     },
     mode: 'production'
-}
+};
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -535,8 +535,6 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
 }
 
 ============== file: webpack.config.js ==============
-const path = require('path');
-
 module.exports = {
     entry: './src/browser.js',
     output: {
@@ -554,23 +552,19 @@ module.exports = {
     module: {
       rules: [
         {
-          test: /node_modules[\\\/]retry-request[\\\/]/,
-          use: 'null-loader',
-        },
-        {
-          test: /node_modules[\\\/]retry-request/,
+          test: /node_modules[\\/]retry-request[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]https-proxy-agent/,
+          test: /node_modules[\\/]https-proxy-agent[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]gtoken/,
+          test: /node_modules[\\/]gtoken[\\/]/,
           use: 'null-loader'
         },
       ]
     },
     mode: 'production'
-}
+};
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
@@ -9575,8 +9575,6 @@ function mockLongRunningGrpcMethod(expectedRequest, response, error) {
 }
 
 ============== file: webpack.config.js ==============
-const path = require('path');
-
 module.exports = {
     entry: './src/browser.js',
     output: {
@@ -9594,23 +9592,19 @@ module.exports = {
     module: {
       rules: [
         {
-          test: /node_modules[\\\/]retry-request[\\\/]/,
-          use: 'null-loader',
-        },
-        {
-          test: /node_modules[\\\/]retry-request/,
+          test: /node_modules[\\/]retry-request[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]https-proxy-agent/,
+          test: /node_modules[\\/]https-proxy-agent[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]gtoken/,
+          test: /node_modules[\\/]gtoken[\\/]/,
           use: 'null-loader'
         },
       ]
     },
     mode: 'production'
-}
+};
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -10515,8 +10515,6 @@ function mockLongRunningGrpcMethod(expectedRequest, response, error) {
 }
 
 ============== file: webpack.config.js ==============
-const path = require('path');
-
 module.exports = {
     entry: './src/browser.js',
     output: {
@@ -10534,23 +10532,19 @@ module.exports = {
     module: {
       rules: [
         {
-          test: /node_modules[\\\/]retry-request[\\\/]/,
-          use: 'null-loader',
-        },
-        {
-          test: /node_modules[\\\/]retry-request/,
+          test: /node_modules[\\/]retry-request[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]https-proxy-agent/,
+          test: /node_modules[\\/]https-proxy-agent[\\/]/,
           use: 'null-loader'
         },
         {
-          test: /node_modules[\\\/]gtoken/,
+          test: /node_modules[\\/]gtoken[\\/]/,
           use: 'null-loader'
         },
       ]
     },
     mode: 'production'
-}
+};
 


### PR DESCRIPTION
Node.js `eslint` linter disliked the generated `webpack.config.js` (for a reason). Fixing it.