### PR TITLE
node: minor fixes to Node.js generator

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -67,6 +67,7 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer<Pro
   private static final String VERSION_BROWSER_TEMPLATE_FILE = "nodejs/version_browser.snip";
   private static final String XAPI_TEMPLATE_FILENAME = "nodejs/main.snip";
   private static final String PROTO_LIST_TEMPLATE_FILENAME = "nodejs/protos.snip";
+  private static final String WEBPACK_CONFIG_TEMPLATE_FILENAME = "nodejs/webpack.config.js.snip";
 
   private final GapicCodePathMapper pathMapper;
   private final FileHeaderTransformer fileHeaderTransformer =
@@ -92,7 +93,8 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer<Pro
         VERSION_INDEX_TEMPLATE_FILE,
         VERSION_BROWSER_TEMPLATE_FILE,
         XAPI_TEMPLATE_FILENAME,
-        PROTO_LIST_TEMPLATE_FILENAME);
+        PROTO_LIST_TEMPLATE_FILENAME,
+        WEBPACK_CONFIG_TEMPLATE_FILENAME);
   }
 
   @Override
@@ -311,6 +313,18 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer<Pro
       indexViewbuilder.apiVersion(version);
     }
     indexViews.add(indexViewbuilder.build());
+
+    String webpackConfigOutputPath = "webpack.config.js";
+    VersionIndexView.Builder webpackConfigViewBuilder =
+        VersionIndexView.newBuilder()
+            .templateFileName(WEBPACK_CONFIG_TEMPLATE_FILENAME)
+            .outputPath(webpackConfigOutputPath)
+            .requireViews(requireViews)
+            .namespace(packageMetadataNamer.getServiceName())
+            .fileHeader(
+                fileHeaderTransformer.generateFileHeader(
+                    productConfig, ImportSectionView.newBuilder().build(), namer));
+    indexViews.add(webpackConfigViewBuilder.build());
 
     if (hasVersion) {
       String versionIndexOutputPath = "src/index.js";

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -51,8 +51,7 @@ import java.util.Objects;
 public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer<ProtoApiModel> {
   private static final String README_FILE = "nodejs/README.md.snip";
   private static final String README_OUTPUT_FILE = "README.md";
-  private static final List<String> TOP_LEVEL_FILES =
-      ImmutableList.of("nodejs/package.json.snip", "nodejs/webpack.config.js.snip");
+  private static final List<String> TOP_LEVEL_FILES = ImmutableList.of("nodejs/package.json.snip");
 
   private static final String GITHUB_DOC_HOST =
       "https://googlecloudplatform.github.io/google-cloud-node";

--- a/src/main/resources/com/google/api/codegen/nodejs/protos.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/protos.snip
@@ -4,6 +4,7 @@
       "{@protoPath(protoList)}/{@stub.protoFileName}"
     @end
   ]
+
 @end
 
 @private protoPath(protoList)

--- a/src/main/resources/com/google/api/codegen/nodejs/webpack.config.js.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/webpack.config.js.snip
@@ -1,9 +1,15 @@
-@snippet generate(metadata)
+@extends "nodejs/common.snip"
+
+@snippet generate(index)
+{@lineComments(index.fileHeader.copyrightLines)}
+//
+{@lineComments(index.fileHeader.licenseLines)}
+
 module.exports = {
     entry: './src/browser.js',
     output: {
-      library: "{@metadata.identifier}",
-      filename: "./{@metadata.identifier}.js"
+      library: "{@index.namespace}",
+      filename: "./{@index.namespace}.js"
     },
     node: {
       child_process: 'empty',

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -8006,6 +8006,7 @@ module.exports = LibraryServiceClient;
   "../../protos/library.proto",
   "../../protos/tagger.proto"
 ]
+
 ============== file: src/v1/my_proto_client.js ==============
 // Copyright 2019 Google LLC
 //
@@ -8374,6 +8375,7 @@ module.exports = MyProtoClient;
 [
   "../../protos/another_service.proto"
 ]
+
 ============== file: test/gapic-v1.js ==============
 // Copyright 2019 Google LLC
 //

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -10566,11 +10566,25 @@ function mockLongRunningGrpcMethod(expectedRequest, response, error) {
 }
 
 ============== file: webpack.config.js ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 module.exports = {
     entry: './src/browser.js',
     output: {
-      library: "@google-cloud/library",
-      filename: "./@google-cloud/library.js"
+      library: "library",
+      filename: "./library.js"
     },
     node: {
       child_process: 'empty',

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -1041,11 +1041,25 @@ function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
 }
 
 ============== file: webpack.config.js ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 module.exports = {
     entry: './src/browser.js',
     output: {
-      library: "@google-cloud/multiple-services",
-      filename: "./@google-cloud/multiple-services.js"
+      library: "multiple-services",
+      filename: "./multiple-services.js"
     },
     node: {
       child_process: 'empty',

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_multiple_services.baseline
@@ -450,6 +450,7 @@ module.exports = DecrementerServiceClient;
 [
   "../../protos/multiple_services.proto"
 ]
+
 ============== file: src/v1/doc/google/cloud/example/v1/foo/doc_multiple_services.js ==============
 // Copyright 2019 Google LLC
 //
@@ -808,6 +809,7 @@ module.exports = IncrementerServiceClient;
 [
   "../../protos/multiple_services.proto"
 ]
+
 ============== file: src/v1/index.js ==============
 // Copyright 2019 Google LLC
 //

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -424,6 +424,7 @@ module.exports = NoTemplatesApiServiceClient;
 [
   "../protos/no_path_templates.proto"
 ]
+
 ============== file: test/gapic.js ==============
 // Copyright 2019 Google LLC
 //

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -536,6 +536,20 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
 }
 
 ============== file: webpack.config.js ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 module.exports = {
     entry: './src/browser.js',
     output: {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
@@ -7145,6 +7145,7 @@ module.exports = LibraryServiceClient;
   "../../protos/library.proto",
   "../../protos/tagger.proto"
 ]
+
 ============== file: src/v1/my_proto_client.js ==============
 // Copyright 2019 Google LLC
 //
@@ -7513,6 +7514,7 @@ module.exports = MyProtoClient;
 [
   "../../protos/another_service.proto"
 ]
+
 ============== file: test/gapic-v1.js ==============
 // Copyright 2019 Google LLC
 //

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
@@ -9577,11 +9577,25 @@ function mockLongRunningGrpcMethod(expectedRequest, response, error) {
 }
 
 ============== file: webpack.config.js ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 module.exports = {
     entry: './src/browser.js',
     output: {
-      library: "@google-cloud/library",
-      filename: "./@google-cloud/library.js"
+      library: "library",
+      filename: "./library.js"
     },
     node: {
       child_process: 'empty',

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -10517,11 +10517,25 @@ function mockLongRunningGrpcMethod(expectedRequest, response, error) {
 }
 
 ============== file: webpack.config.js ==============
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 module.exports = {
     entry: './src/browser.js',
     output: {
-      library: "@google-cloud/library",
-      filename: "./@google-cloud/library.js"
+      library: "library",
+      filename: "./library.js"
     },
     node: {
       child_process: 'empty',

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -8025,6 +8025,7 @@ module.exports = LibraryServiceClient;
   "../../protos/library.proto",
   "../../protos/tagger.proto"
 ]
+
 ============== file: src/v1/my_proto_client.js ==============
 // Copyright 2019 Google LLC
 //
@@ -8325,6 +8326,7 @@ module.exports = MyProtoClient;
 [
   "../../protos/another_service.proto"
 ]
+
 ============== file: test/gapic-v1.js ==============
 // Copyright 2019 Google LLC
 //


### PR DESCRIPTION
The generated list of protos for Node.js does not have a newline at the end of file. Fixing that.

Also, adding license header to the generated `webpack.config.js`.