### PR TITLE
[Do not merge] initial commit to add project as a well-known resource name config

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -195,7 +195,9 @@ public abstract class GapicProductConfig implements ProductConfig {
     }
 
     List<ProtoFile> sourceProtos =
-        model.getFiles().stream()
+        model
+            .getFiles()
+            .stream()
             .filter(f -> f.getProto().getPackage().equals(defaultPackage))
             .collect(Collectors.toList());
 
@@ -238,7 +240,8 @@ public abstract class GapicProductConfig implements ProductConfig {
           protoParser.getResourceDescriptorConfigMap(sourceProtos, diagCollector);
 
       Set<String> configsWithChildTypeReferences =
-          sourceProtos.stream()
+          sourceProtos
+              .stream()
               .flatMap(protoFile -> protoFile.getMessages().stream())
               .flatMap(messageType -> messageType.getFields().stream())
               .filter(protoParser::hasResourceReference)
@@ -522,7 +525,8 @@ public abstract class GapicProductConfig implements ProductConfig {
         diagCollector,
         language,
         protoInterfaces.values(),
-        interfaceConfigProtosList.stream()
+        interfaceConfigProtosList
+            .stream()
             .collect(Collectors.toMap(InterfaceConfigProto::getName, Function.identity())));
   }
 
@@ -544,7 +548,9 @@ public abstract class GapicProductConfig implements ProductConfig {
       Interface apiInterface = symbolTable.lookupInterface(interfaceConfigProto.getName());
       if (apiInterface == null) {
         List<String> interfaces =
-            symbolTable.getInterfaces().stream()
+            symbolTable
+                .getInterfaces()
+                .stream()
                 .map(ProtoElement::getFullName)
                 .collect(Collectors.toList());
         String interfacesString = String.join(",", interfaces);
@@ -652,11 +658,14 @@ public abstract class GapicProductConfig implements ProductConfig {
                 SimpleLocation.TOPLEVEL, "method not found: %s", methodConfigProto.getName()));
         continue;
       }
-      if (methodConfigProto.getSurfaceTreatmentsList().stream()
+      if (methodConfigProto
+          .getSurfaceTreatmentsList()
+          .stream()
           .anyMatch(
               s ->
                   s.getVisibility().equals(VisibilityProto.DISABLED)
-                      && s.getIncludeLanguagesList().stream()
+                      && s.getIncludeLanguagesList()
+                          .stream()
                           .anyMatch(lang -> lang.equalsIgnoreCase(targetLanguage.name())))) {
         gapicDisabledMethods.add(protoMethod);
         continue;
@@ -782,20 +791,21 @@ public abstract class GapicProductConfig implements ProductConfig {
             diagCollector, allCollectionConfigProtos, sampleProtoFile, language);
 
     HashMap<String, ResourceNameConfig> annotationResourceNameConfigs = new HashMap<>();
-    resourceDescriptorConfigs.values().stream()
+    resourceDescriptorConfigs
+        .values()
+        .stream()
         .flatMap(
             r ->
-                r
-                    .buildResourceNameConfigs(
-                        diagCollector, singleResourceNameConfigsFromGapicConfig)
+                r.buildResourceNameConfigs(diagCollector, singleResourceNameConfigsFromGapicConfig)
                     .stream())
         .forEach(config -> annotationResourceNameConfigs.put(config.getEntityId(), config));
-    resourceDescriptorConfigs.values().stream()
+    resourceDescriptorConfigs
+        .values()
+        .stream()
         .filter(c -> typesWithChildReferences.contains(c.getUnifiedResourceType()))
         .flatMap(
             r ->
-                r
-                    .buildParentResourceNameConfigs(
+                r.buildParentResourceNameConfigs(
                         diagCollector, singleResourceNameConfigsFromGapicConfig)
                     .stream())
         .forEach(config -> annotationResourceNameConfigs.put(config.getEntityId(), config));
@@ -846,7 +856,9 @@ public abstract class GapicProductConfig implements ProductConfig {
 
     ImmutableMap.Builder<String, ResourceNameConfig> resourceNameConfigs =
         new ImmutableSortedMap.Builder<>(Comparator.naturalOrder());
-    wellKnownResourceNames.getReferencedResourceNameConfigs().stream()
+    wellKnownResourceNames
+        .getReferencedResourceNameConfigs()
+        .stream()
         .forEach(r -> resourceNameConfigs.put(r.getEntityId(), r));
     resourceNameConfigs.putAll(annotationResourceNameConfigs);
     resourceNameConfigs.putAll(finalFixedResourceNameConfigs);
@@ -1123,7 +1135,9 @@ public abstract class GapicProductConfig implements ProductConfig {
   }
 
   public List<LongRunningConfig> getAllLongRunningConfigs() {
-    return getInterfaceConfigMap().values().stream()
+    return getInterfaceConfigMap()
+        .values()
+        .stream()
         .flatMap(i -> i.getMethodConfigs().stream())
         .map(MethodConfig::getLroConfig)
         .filter(Objects::nonNull)
@@ -1133,7 +1147,9 @@ public abstract class GapicProductConfig implements ProductConfig {
   private static Map<CollectionConfigProto, Interface> getAllCollectionConfigProtos(
       @Nullable Model model, ConfigProto configProto) {
     Map<CollectionConfigProto, Interface> allCollectionConfigProtos =
-        configProto.getCollectionsList().stream()
+        configProto
+            .getCollectionsList()
+            .stream()
             .collect(HashMap::new, (map, config) -> map.put(config, null), HashMap::putAll);
     configProto
         .getInterfacesList()

--- a/src/main/java/com/google/api/codegen/config/WellKnownResourceNames.java
+++ b/src/main/java/com/google/api/codegen/config/WellKnownResourceNames.java
@@ -1,0 +1,98 @@
+/* Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.config;
+
+import com.google.api.codegen.util.Name;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.tools.framework.model.ProtoFile;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents definition of 5 well-known resource name types: project, location, org, folder,
+ * billingAccount.
+ */
+public class WellKnownResourceNames {
+
+  private static final SingleResourceNameConfig.Builder PROJECT =
+      SingleResourceNameConfig.newBuilder()
+          .setNamePattern("project/{project}")
+          .setNameTemplate(PathTemplate.create("project/{project}"))
+          .setEntityId("project")
+          .setEntityName(Name.anyLower("project"));
+
+  private final Map<String, ResourceNameConfig> RESOURCE_NAMES;
+  private final ProtoFile sourceProtoFile;
+  private final Set<ResourceNameConfig> referencedResourceNames;
+  private final Map<String, String> entityNameTypeNameMap;
+
+  // Because we don't have resource definitions for these well-known resource name types,
+  // we need to assign a source file to them so that we know how to calculate a consistent
+  // for them.
+  public WellKnownResourceNames(ProtoFile sourceProtoFile) {
+    this.sourceProtoFile = sourceProtoFile;
+    this.referencedResourceNames = new HashSet<>();
+    RESOURCE_NAMES =
+        ImmutableMap.<String, ResourceNameConfig>builder()
+            .put(
+                "cloudresourcemanager.googleapis.com/Project",
+                PROJECT.setAssignedProtoFile(sourceProtoFile).build())
+            .build();
+    this.entityNameTypeNameMap = ImmutableMap.of("project", "cloudresourcemanager.googleapis.com/Project");
+  }
+
+  public boolean containsType(String type) {
+    return RESOURCE_NAMES.containsKey(type);
+  }
+
+  public boolean containsTypeWithEntityName(String entityName) {
+    return entityNameTypeNameMap.containsKey(entityName);
+  }
+
+  public List<ResourceNameConfig> getReferencedResourceNameConfigs() {
+    return ImmutableList.<ResourceNameConfig>builder().addAll(referencedResourceNames).build();
+  }
+
+  /**
+   * Gets a ResourceNameConfig based on the type, mark it as referenced and returns it. We need to
+   * keep track of the all the referenced resource names because we need to generate resource name
+   * classes or formatting helper methods for them.
+   */
+  public ResourceNameConfig reference(String type) {
+    Preconditions.checkArgument(containsType(type), "not a well-known resource type: %s", type);
+    ResourceNameConfig resource = RESOURCE_NAMES.get(type);
+    referencedResourceNames.add(resource);
+    return resource;
+  }
+
+  /**
+   * Gets a ResourceNameConfig based on the type, mark it as referenced and returns it. We need to
+   * keep track of the all the referenced resource names because we need to generate resource name
+   * classes or formatting helper methods for them.
+   */
+  public ResourceNameConfig referenceByEntityName(String entityName) {
+    Preconditions.checkArgument(
+        containsTypeWithEntityName(entityName), "not a well-known resource type entity name: %s", entityName);
+    ResourceNameConfig resource = RESOURCE_NAMES.get(entityNameTypeNameMap.get(entityName));
+    referencedResourceNames.add(resource);
+    return resource;
+  }
+}

--- a/src/main/java/com/google/api/codegen/config/WellKnownResourceNames.java
+++ b/src/main/java/com/google/api/codegen/config/WellKnownResourceNames.java
@@ -20,7 +20,6 @@ import com.google.api.tools.framework.model.ProtoFile;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +55,8 @@ public class WellKnownResourceNames {
                 "cloudresourcemanager.googleapis.com/Project",
                 PROJECT.setAssignedProtoFile(sourceProtoFile).build())
             .build();
-    this.entityNameTypeNameMap = ImmutableMap.of("project", "cloudresourcemanager.googleapis.com/Project");
+    this.entityNameTypeNameMap =
+        ImmutableMap.of("project", "cloudresourcemanager.googleapis.com/Project");
   }
 
   public boolean containsType(String type) {
@@ -90,7 +90,9 @@ public class WellKnownResourceNames {
    */
   public ResourceNameConfig referenceByEntityName(String entityName) {
     Preconditions.checkArgument(
-        containsTypeWithEntityName(entityName), "not a well-known resource type entity name: %s", entityName);
+        containsTypeWithEntityName(entityName),
+        "not a well-known resource type entity name: %s",
+        entityName);
     ResourceNameConfig resource = RESOURCE_NAMES.get(entityNameTypeNameMap.get(entityName));
     referencedResourceNames.add(resource);
     return resource;

--- a/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
@@ -210,9 +210,14 @@ public class ResourceNameMessageConfigsTest {
         .getResourceReference(shelfName);
     Mockito.doReturn(true).when(protoParser).hasResourceReference(shelfName);
 
+    WellKnownResourceNames wellKnownResourceNames = new WellKnownResourceNames(protoFile);
     ResourceNameMessageConfigs messageConfigs =
         ResourceNameMessageConfigs.createFromAnnotations(
-            null, sourceProtoFiles, protoParser, resourceDescriptorConfigMap);
+            null,
+            sourceProtoFiles,
+            protoParser,
+            resourceDescriptorConfigMap,
+            wellKnownResourceNames);
 
     assertThat(messageConfigs.getResourceTypeConfigMap().size()).isEqualTo(2);
     ResourceNameMessageConfig bookMessageConfig =
@@ -273,6 +278,7 @@ public class ResourceNameMessageConfigsTest {
   public void testCreateResourceNameConfigs() {
     DiagCollector diagCollector = new BoundedDiagCollector();
 
+    WellKnownResourceNames wellKnownResourceNames = new WellKnownResourceNames(protoFile);
     Map<String, ResourceNameConfig> resourceNameConfigs =
         GapicProductConfig.createResourceNameConfigsFromAnnotationsAndGapicConfig(
             null,
@@ -281,6 +287,7 @@ public class ResourceNameMessageConfigsTest {
             protoFile,
             TargetLanguage.CSHARP,
             resourceDescriptorConfigMap,
+            wellKnownResourceNames,
             ImmutableSet.of());
 
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
@@ -360,9 +367,14 @@ public class ResourceNameMessageConfigsTest {
             .build();
 
     DiagCollector diagCollector = new BoundedDiagCollector();
+    WellKnownResourceNames wellKnownResourceNames = new WellKnownResourceNames(protoFile);
     ResourceNameMessageConfigs messageConfigs =
         ResourceNameMessageConfigs.createFromAnnotations(
-            diagCollector, sourceProtoFiles, protoParser, resourceDescriptorConfigMap);
+            diagCollector,
+            sourceProtoFiles,
+            protoParser,
+            resourceDescriptorConfigMap,
+            wellKnownResourceNames);
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
 
     ImmutableMap<String, ResourceNameConfig> resourceNameConfigs =
@@ -373,6 +385,7 @@ public class ResourceNameMessageConfigsTest {
             protoFile,
             TargetLanguage.CSHARP,
             resourceDescriptorConfigMap,
+            wellKnownResourceNames,
             ImmutableSet.of());
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
 


### PR DESCRIPTION
Fix https://github.com/googleapis/gapic-generator/issues/2972

Please do not submit for now because this PR contains a bunch of hacks which I intend to clean up/add more tests when I have more time to get a better understanding about resource name configurations in both v1 and v2 gapic config.

This PR shall make generating GAPICs for all languages but Java for APIs annotated with `cloudresourcemanager.googleapis.com/Project` work.

The reason why Java gapic generation won't work is that Java resource name classes are generated by a separate plugin. We need to update that to understand the `cloudresourcemanager.googleapis.com/Project` annotation to unblock Java.

Some more thoughts: for one second I believed that add annotations to the actual message of `Project` is the better solution, but I realized it isn't going to work: the message `Project` will most likely live in the API of `cloudresourcemanager`, and the generated Java/C# resource name classes (`ProjectName`) will have its package/namespace derived from the proto package of the `cloudresourcemanager` API, rather than the actual API that we are generating GAPICs from. This would have been a backward-incompatible change.



