### PR TITLE
Python: Update URL for 'requests' Sphinx inventory.

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/docs/conf.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/docs/conf.py.snip
@@ -332,7 +332,7 @@
       'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
       'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
       'grpc': ('https://grpc.io/grpc/python/', None),
-      'requests': ('https://2.python-requests.org/en/master/', None),
+      'requests': ('https://requests.kennethreitz.org/en/master/', None),
       'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),
       'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
   }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -637,7 +637,7 @@ intersphinx_mapping = {
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
     'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
-    'requests': ('https://2.python-requests.org/en/master/', None),
+    'requests': ('https://requests.kennethreitz.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
 }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -618,7 +618,7 @@ intersphinx_mapping = {
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
     'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
-    'requests': ('https://2.python-requests.org/en/master/', None),
+    'requests': ('https://requests.kennethreitz.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
 }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -618,7 +618,7 @@ intersphinx_mapping = {
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
     'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
-    'requests': ('https://2.python-requests.org/en/master/', None),
+    'requests': ('https://requests.kennethreitz.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
 }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
@@ -637,7 +637,7 @@ intersphinx_mapping = {
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
     'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
-    'requests': ('https://2.python-requests.org/en/master/', None),
+    'requests': ('https://requests.kennethreitz.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
 }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -637,7 +637,7 @@ intersphinx_mapping = {
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
     'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
-    'requests': ('https://2.python-requests.org/en/master/', None),
+    'requests': ('https://requests.kennethreitz.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
 }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
@@ -4670,7 +4670,7 @@ intersphinx_mapping = {
     'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
     'google.api_core': ('https://googleapis.dev/python/google-api-core/latest', None),
     'grpc': ('https://grpc.io/grpc/python/', None),
-    'requests': ('https://2.python-requests.org/en/master/', None),
+    'requests': ('https://requests.kennethreitz.org/en/master/', None),
     'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
 }


### PR DESCRIPTION
Preserve fix added in https://github.com/googleapis/google-cloud-python/pull/9294.