### PR TITLE
SampleGen: generates sample manifest file for Java samples

### DIFF
--- a/src/main/java/com/google/api/codegen/gapic/GapicGeneratorFactory.java
+++ b/src/main/java/com/google/api/codegen/gapic/GapicGeneratorFactory.java
@@ -226,6 +226,8 @@ public class GapicGeneratorFactory {
             generators.add(newJavaGenerator.apply(new JavaGapicSamplesTransformer()));
             generators.add(
                 newJavaGenerator.apply(new JavaGapicSamplesPackageTransformer(packageConfig)));
+            generators.add(
+                newJavaGenerator.apply(JavaGapicSamplesTransformer.createManifestTransformer()));
           }
         }
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSampleMetadataNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSampleMetadataNamer.java
@@ -40,11 +40,11 @@ public class JavaSampleMetadataNamer implements SampleMetadataNamer {
   }
 
   public String getBin() {
-    return "gradle run";
+    return "mvn exec:java";
   }
 
   public String getInvocation() {
-    return "{bin} -PmainClass={class} --args='@args'";
+    return "{bin} -Dexec.mainClass={class} -Dexec.args='@args'";
   }
 
   public String getSamplePath(String uniqueSampleId) {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -2034,6 +2034,138 @@ public class Turing {
     sampleDiscussBook(imageFileName, stage);
   }
 }
+============== file: samples/src/main/java/com/google/example/examples/library/v1/library-example.java.20190801.120000.manifest.yaml ==============
+---
+type: manifest/samples
+schema_version: 3
+java: &java
+  environment: java
+  bin: mvn exec:java
+  base_path: samples/src/main/java/com/google/example/examples/library/v1
+  package: com.google.example.examples.library.v1
+  invocation: {bin} -Dexec.mainClass={class} -Dexec.args='@args'
+samples:
+- <<: *java
+  sample: "sample_get_shelf"
+  path: "{base_path}/SampleGetShelf.java"
+  class: {package}.SampleGetShelf
+  region_tag: "sample_get_shelf"
+- <<: *java
+  sample: "test_setting_up_empty_objects_in_request"
+  path: "{base_path}/TestSettingUpEmptyObjectsInRequest.java"
+  class: {package}.TestSettingUpEmptyObjectsInRequest
+  region_tag: "test_setting_up_empty_objects_in_request"
+- <<: *java
+  sample: "test_default_calling_form_for_paging"
+  path: "{base_path}/TestDefaultCallingFormForPaging.java"
+  class: {package}.TestDefaultCallingFormForPaging
+  region_tag: "test_default_calling_form_for_paging"
+- <<: *java
+  sample: "delete_shelf_request_empty_response_type_with_response_handling"
+  path: "{base_path}/DeleteShelfRequestEmptyResponseTypeWithResponseHandling.java"
+  class: {package}.DeleteShelfRequestEmptyResponseTypeWithResponseHandling
+  region_tag: "sample"
+- <<: *java
+  sample: "delete_shelf_request_empty_response_type_without_response_handling"
+  path: "{base_path}/DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling.java"
+  class: {package}.DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling
+  region_tag: "sample"
+- <<: *java
+  sample: "testing_map"
+  path: "{base_path}/TestingMap.java"
+  class: {package}.TestingMap
+  region_tag: "testing_map"
+- <<: *java
+  sample: "publish_series_request_pi_version"
+  path: "{base_path}/PublishSeriesRequestPiVersion.java"
+  class: {package}.PublishSeriesRequestPiVersion
+  region_tag: "canonical"
+- <<: *java
+  sample: "publish_series_request_second_edition"
+  path: "{base_path}/PublishSeriesRequestSecondEdition.java"
+  class: {package}.PublishSeriesRequestSecondEdition
+  region_tag: "canonical"
+- <<: *java
+  sample: "publish_series_test_request_object_field_comments"
+  path: "{base_path}/PublishSeriesTestRequestObjectFieldComments.java"
+  class: {package}.PublishSeriesTestRequestObjectFieldComments
+  region_tag: "publish_series_test_request_object_field_comments"
+- <<: *java
+  sample: "publish_series_test_write_to_file"
+  path: "{base_path}/PublishSeriesTestWriteToFile.java"
+  class: {package}.PublishSeriesTestWriteToFile
+  region_tag: "publish_series_test_write_to_file"
+- <<: *java
+  sample: "get_book_request_test_on_success_map"
+  path: "{base_path}/GetBookRequestTestOnSuccessMap.java"
+  class: {package}.GetBookRequestTestOnSuccessMap
+  region_tag: "sample"
+- <<: *java
+  sample: "test_resource_name_oneof"
+  path: "{base_path}/TestResourceNameOneof.java"
+  class: {package}.TestResourceNameOneof
+  region_tag: "test_resource_name_oneof"
+- <<: *java
+  sample: "test_resource_name_oneof_2"
+  path: "{base_path}/TestResourceNameOneof2.java"
+  class: {package}.TestResourceNameOneof2
+  region_tag: "test_resource_name_oneof_2"
+- <<: *java
+  sample: "babbage"
+  path: "{base_path}/Babbage.java"
+  class: {package}.Babbage
+  region_tag: "babbage"
+- <<: *java
+  sample: "turing"
+  path: "{base_path}/Turing.java"
+  class: {package}.Turing
+  region_tag: "turing"
+- <<: *java
+  sample: "sample_monolog_about_book"
+  path: "{base_path}/SampleMonologAboutBook.java"
+  class: {package}.SampleMonologAboutBook
+  region_tag: "sample_monolog_about_book"
+- <<: *java
+  sample: "babble_about_book_1"
+  path: "{base_path}/BabbleAboutBook1.java"
+  class: {package}.BabbleAboutBook1
+  region_tag: "babble_about_book_1"
+- <<: *java
+  sample: "babble_about_book_2"
+  path: "{base_path}/BabbleAboutBook2.java"
+  class: {package}.BabbleAboutBook2
+  region_tag: "babble_about_book_2"
+- <<: *java
+  sample: "find_related_books_odyssey"
+  path: "{base_path}/FindRelatedBooksOdyssey.java"
+  class: {package}.FindRelatedBooksOdyssey
+  region_tag: "find_related_books_odyssey"
+- <<: *java
+  sample: "hopper"
+  path: "{base_path}/Hopper.java"
+  class: {package}.Hopper
+  region_tag: "hopper"
+- <<: *java
+  sample: "this_tag_should_be_the_name_of_the_file"
+  path: "{base_path}/ThisTagShouldBeTheNameOfTheFile.java"
+  class: {package}.ThisTagShouldBeTheNameOfTheFile
+  region_tag: "this_tag_should_be_the_name_of_the_file"
+- <<: *java
+  sample: "empty_response_type_with_response_handling"
+  path: "{base_path}/EmptyResponseTypeWithResponseHandling.java"
+  class: {package}.EmptyResponseTypeWithResponseHandling
+  region_tag: "empty_response_type_with_response_handling"
+- <<: *java
+  sample: "empty_response_type_without_response_handling"
+  path: "{base_path}/EmptyResponseTypeWithoutResponseHandling.java"
+  class: {package}.EmptyResponseTypeWithoutResponseHandling
+  region_tag: "empty_response_type_without_response_handling"
+- <<: *java
+  sample: "test_float_and_int64"
+  path: "{base_path}/TestFloatAndInt64.java"
+  class: {package}.TestFloatAndInt64
+  region_tag: "test_float_and_int64"
+
 ============== file: src/main/java/com/google/example/library/v1/LibraryClient.java ==============
 /*
  * Copyright 2019 Google LLC


### PR DESCRIPTION
Also changed invocation from gradle to maven, we know that this is how client libraries are set up and we are not using gradle right now anyway.

Running `sample-tester sample/test/v1` from repo root directory works for speech (tested locally).