### PR TITLE
Parse resource name annotations from imported protos too

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -278,7 +278,11 @@ public abstract class GapicProductConfig implements ProductConfig {
 
       messageConfigs =
           ResourceNameMessageConfigs.createFromAnnotations(
-              diagCollector, model.getFiles(), protoParser, descriptorConfigMap);
+              diagCollector,
+              model.getFiles(),
+              resourceNameConfigs,
+              protoParser,
+              descriptorConfigMap);
     } else {
       resourceNameConfigs =
           createResourceNameConfigsFromGapicConfigOnly(

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -278,7 +278,7 @@ public abstract class GapicProductConfig implements ProductConfig {
 
       messageConfigs =
           ResourceNameMessageConfigs.createFromAnnotations(
-              diagCollector, sourceProtos, protoParser, descriptorConfigMap);
+              diagCollector, model.getFiles(), protoParser, descriptorConfigMap);
     } else {
       resourceNameConfigs =
           createResourceNameConfigsFromGapicConfigOnly(

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -52,6 +52,7 @@ public abstract class ResourceNameMessageConfigs {
   static ResourceNameMessageConfigs createFromAnnotations(
       DiagCollector diagCollector,
       List<ProtoFile> protoFiles,
+      Map<String, ResourceNameConfig> resourceNameConfigs,
       ProtoParser parser,
       Map<String, ResourceDescriptorConfig> descriptorConfigMap) {
     ImmutableMap.Builder<String, ResourceNameMessageConfig> builder = ImmutableMap.builder();
@@ -77,6 +78,7 @@ public abstract class ResourceNameMessageConfigs {
                   message,
                   resourceField);
           if (Strings.isNullOrEmpty(entityName)) continue;
+          if (!resourceNameConfigs.containsKey(entityName)) continue;
           fieldEntityMapBuilder.put(resourceField.getSimpleName(), entityName);
         }
 

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -77,8 +77,12 @@ public abstract class ResourceNameMessageConfigs {
                   resourceDescriptor.getType(),
                   message,
                   resourceField);
-          if (Strings.isNullOrEmpty(entityName)) continue;
-          if (!resourceNameConfigs.containsKey(entityName)) continue;
+          if (Strings.isNullOrEmpty(entityName)) {
+            continue;
+          }
+          if (!resourceNameConfigs.containsKey(entityName)) {
+            continue;
+          }
           fieldEntityMapBuilder.put(resourceField.getSimpleName(), entityName);
         }
 

--- a/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceNameMessageConfigsTest.java
@@ -28,6 +28,7 @@ import com.google.api.codegen.MethodConfigProto;
 import com.google.api.codegen.ResourceNameMessageConfigProto;
 import com.google.api.codegen.ResourceNameTreatment;
 import com.google.api.codegen.common.TargetLanguage;
+import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.ProtoParser;
 import com.google.api.tools.framework.model.BoundedDiagCollector;
 import com.google.api.tools.framework.model.Diag;
@@ -210,9 +211,18 @@ public class ResourceNameMessageConfigsTest {
         .getResourceReference(shelfName);
     Mockito.doReturn(true).when(protoParser).hasResourceReference(shelfName);
 
+    // For testing purposes, we don't care about the actual config; we just need an entry in the map
+    ResourceNameConfig dummyConfig =
+        SingleResourceNameConfig.newBuilder()
+            .setNamePattern("")
+            .setEntityId("")
+            .setEntityName(Name.from("entity"))
+            .build();
+    Map<String, ResourceNameConfig> resourceNameConfigs =
+        ImmutableMap.of("Book", dummyConfig, "Shelf", dummyConfig);
     ResourceNameMessageConfigs messageConfigs =
         ResourceNameMessageConfigs.createFromAnnotations(
-            null, sourceProtoFiles, protoParser, resourceDescriptorConfigMap);
+            null, sourceProtoFiles, resourceNameConfigs, protoParser, resourceDescriptorConfigMap);
 
     assertThat(messageConfigs.getResourceTypeConfigMap().size()).isEqualTo(2);
     ResourceNameMessageConfig bookMessageConfig =
@@ -361,9 +371,6 @@ public class ResourceNameMessageConfigsTest {
             .build();
 
     DiagCollector diagCollector = new BoundedDiagCollector();
-    ResourceNameMessageConfigs messageConfigs =
-        ResourceNameMessageConfigs.createFromAnnotations(
-            diagCollector, sourceProtoFiles, protoParser, resourceDescriptorConfigMap);
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
 
     ImmutableMap<String, ResourceNameConfig> resourceNameConfigs =
@@ -377,6 +384,13 @@ public class ResourceNameMessageConfigsTest {
             resourceDescriptorConfigMap.keySet(),
             ImmutableSet.of());
     assertThat(diagCollector.getErrorCount()).isEqualTo(0);
+    ResourceNameMessageConfigs messageConfigs =
+        ResourceNameMessageConfigs.createFromAnnotations(
+            diagCollector,
+            sourceProtoFiles,
+            resourceNameConfigs,
+            protoParser,
+            resourceDescriptorConfigMap);
 
     List<FlatteningConfig> flatteningConfigs =
         new ArrayList<>(

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -6911,7 +6911,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                Resource = "",
+                ResourceAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
                 Label = "",
             };
             // Make the request
@@ -6928,7 +6928,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                Resource = "",
+                ResourceAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
                 Label = "",
             };
             // Make the request

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -3901,10 +3901,10 @@ func TestLabelerAddLabel(t *testing.T) {
 
     mockLabeler.resps = append(mockLabeler.resps[:0], expectedResponse)
 
-    var resource string = "resource-341064690"
+    var formattedResource string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
     var label string = "label102727412"
     var request = &taggerpb.AddLabelRequest{
-        Resource: resource,
+        Resource: formattedResource,
         Label: label,
     }
 
@@ -3932,10 +3932,10 @@ func TestLabelerAddLabelError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLabeler.err = gstatus.Error(errCode, "test error")
 
-    var resource string = "resource-341064690"
+    var formattedResource string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
     var label string = "label102727412"
     var request = &taggerpb.AddLabelRequest{
-        Resource: resource,
+        Resource: formattedResource,
         Label: label,
     }
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -7068,10 +7068,10 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   String resource = "";
+   *   BookName resource = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
-   *     .setResource(resource)
+   *     .setResource(resource.toString())
    *     .setLabel(label)
    *     .build();
    *   AddLabelResponse response = libraryClient.addLabel(request);
@@ -7093,10 +7093,10 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   String resource = "";
+   *   BookName resource = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
-   *     .setResource(resource)
+   *     .setResource(resource.toString())
    *     .setLabel(label)
    *     .build();
    *   ApiFuture&lt;AddLabelResponse&gt; future = libraryClient.addLabelCallable().futureCall(request);

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -2554,10 +2554,66 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String resource = "";
+   *   ResourceName resource = ArchiveBookName.of("[ARCHIVE]", "[BOOK]");
+   *   String tag = "";
+   *   AddTagResponse response = libraryServiceClient.addTag(resource, tag);
+   * }
+   * </code></pre>
+   *
+   * @param resource REQUIRED: The resource which the tag is being added to.
+   * In the form "shelves/{shelf_id}/books/{book_id}".
+   * @param tag REQUIRED: The tag to add.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final AddTagResponse addTag(ResourceName resource, String tag) {
+
+    AddTagRequest request =
+        AddTagRequest.newBuilder()
+        .setResource(resource == null ? null : resource.toString())
+        .setTag(tag)
+        .build();
+    return addTag(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Adds a tag to the book. This RPC is a mixin.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ResourceName resource = ArchiveBookName.of("[ARCHIVE]", "[BOOK]");
+   *   String tag = "";
+   *   AddTagResponse response = libraryServiceClient.addTag(resource.toString(), tag);
+   * }
+   * </code></pre>
+   *
+   * @param resource REQUIRED: The resource which the tag is being added to.
+   * In the form "shelves/{shelf_id}/books/{book_id}".
+   * @param tag REQUIRED: The tag to add.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final AddTagResponse addTag(String resource, String tag) {
+
+    AddTagRequest request =
+        AddTagRequest.newBuilder()
+        .setResource(resource)
+        .setTag(tag)
+        .build();
+    return addTag(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Adds a tag to the book. This RPC is a mixin.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ResourceName resource = ArchiveBookName.of("[ARCHIVE]", "[BOOK]");
    *   String tag = "";
    *   AddTagRequest request = AddTagRequest.newBuilder()
-   *     .setResource(resource)
+   *     .setResource(resource.toString())
    *     .setTag(tag)
    *     .build();
    *   AddTagResponse response = libraryServiceClient.addTag(request);
@@ -2578,10 +2634,10 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String resource = "";
+   *   ResourceName resource = ArchiveBookName.of("[ARCHIVE]", "[BOOK]");
    *   String tag = "";
    *   AddTagRequest request = AddTagRequest.newBuilder()
-   *     .setResource(resource)
+   *     .setResource(resource.toString())
    *     .setTag(tag)
    *     .build();
    *   ApiFuture&lt;AddTagResponse&gt; future = libraryServiceClient.addTagCallable().futureCall(request);
@@ -8788,6 +8844,8 @@ import com.google.protobuf.Timestamp;
 import com.google.protobuf.UInt32Value;
 import com.google.protobuf.UInt64Value;
 import com.google.protobuf.Value;
+import com.google.tagger.v1.TaggerProto.AddTagRequest;
+import com.google.tagger.v1.TaggerProto.AddTagResponse;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -10108,6 +10166,48 @@ public class LibraryServiceClientTest {
       List<String> formattedShelves = new ArrayList<>();
 
       client.findRelatedBooks(formattedNames, formattedShelves);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addTagTest() {
+    AddTagResponse expectedResponse = AddTagResponse.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    ResourceName resource = com.google.tagger.v1.ArchiveBookName.of("[ARCHIVE]", "[BOOK]");
+    String tag = "tag114586";
+
+    AddTagResponse actualResponse =
+        client.addTag(resource, tag);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    AddTagRequest actualRequest = (AddTagRequest)actualRequests.get(0);
+
+    Assert.assertEquals(Objects.toString(resource), Objects.toString(actualRequest.getResource()));
+    Assert.assertEquals(tag, actualRequest.getTag());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addTagExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      ResourceName resource = com.google.tagger.v1.ArchiveBookName.of("[ARCHIVE]", "[BOOK]");
+      String tag = "tag114586";
+
+      client.addTag(resource, tag);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -7068,10 +7068,10 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   String resource = "";
+   *   BookName resource = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
-   *     .setResource(resource)
+   *     .setResource(resource.toString())
    *     .setLabel(label)
    *     .build();
    *   AddLabelResponse response = libraryClient.addLabel(request);
@@ -7093,10 +7093,10 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   String resource = "";
+   *   BookName resource = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
-   *     .setResource(resource)
+   *     .setResource(resource.toString())
    *     .setLabel(label)
    *     .build();
    *   ApiFuture&lt;AddLabelResponse&gt; future = libraryClient.addLabelCallable().futureCall(request);

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -7031,10 +7031,10 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const resource = '';
+   * const formattedResource = client.bookPath('[BOOK_SHELF]', '[BOOK]');
    * const label = '';
    * const request = {
-   *   resource: resource,
+   *   resource: formattedResource,
    *   label: label,
    * };
    * client.addLabel(request)
@@ -9940,10 +9940,10 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const resource = 'resource-341064690';
+      const formattedResource = client.bookPath('[BOOK_SHELF]', '[BOOK]');
       const label = 'label102727412';
       const request = {
-        resource: resource,
+        resource: formattedResource,
         label: label,
       };
 
@@ -9970,10 +9970,10 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const resource = 'resource-341064690';
+      const formattedResource = client.bookPath('[BOOK_SHELF]', '[BOOK]');
       const label = 'label102727412';
       const request = {
-        resource: resource,
+        resource: formattedResource,
         label: label,
       };
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -4197,9 +4197,9 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $resource = '';
+     *     $formattedResource = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
      *     $label = '';
-     *     $response = $libraryServiceClient->addLabel($resource, $label);
+     *     $response = $libraryServiceClient->addLabel($formattedResource, $label);
      * } finally {
      *     $libraryServiceClient->close();
      * }
@@ -7878,10 +7878,10 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $resource = 'resource-341064690';
+        $formattedResource = $client->bookName('[BOOK_SHELF]', '[BOOK]');
         $label = 'label102727412';
 
-        $response = $client->addLabel($resource, $label);
+        $response = $client->addLabel($formattedResource, $label);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -7891,7 +7891,7 @@ class LibraryServiceClientTest extends GeneratedTest
 
         $actualValue = $actualRequestObject->getResource();
 
-        $this->assertProtobufEquals($resource, $actualValue);
+        $this->assertProtobufEquals($formattedResource, $actualValue);
         $actualValue = $actualRequestObject->getLabel();
 
         $this->assertProtobufEquals($label, $actualValue);
@@ -7922,11 +7922,11 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $resource = 'resource-341064690';
+        $formattedResource = $client->bookName('[BOOK_SHELF]', '[BOOK]');
         $label = 'label102727412';
 
         try {
-            $client->addLabel($resource, $label);
+            $client->addLabel($formattedResource, $label);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -4197,9 +4197,9 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $resource = '';
+     *     $formattedResource = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
      *     $label = '';
-     *     $response = $libraryServiceClient->addLabel($resource, $label);
+     *     $response = $libraryServiceClient->addLabel($formattedResource, $label);
      * } finally {
      *     $libraryServiceClient->close();
      * }
@@ -7903,10 +7903,10 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $resource = 'resource-341064690';
+        $formattedResource = $client->bookName('[BOOK_SHELF]', '[BOOK]');
         $label = 'label102727412';
 
-        $response = $client->addLabel($resource, $label);
+        $response = $client->addLabel($formattedResource, $label);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -7916,7 +7916,7 @@ class LibraryServiceClientTest extends GeneratedTest
 
         $actualValue = $actualRequestObject->getResource();
 
-        $this->assertProtobufEquals($resource, $actualValue);
+        $this->assertProtobufEquals($formattedResource, $actualValue);
         $actualValue = $actualRequestObject->getLabel();
 
         $this->assertProtobufEquals($label, $actualValue);
@@ -7947,11 +7947,11 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $resource = 'resource-341064690';
+        $formattedResource = $client->bookName('[BOOK_SHELF]', '[BOOK]');
         $label = 'label102727412';
 
         try {
-            $client->addLabel($resource, $label);
+            $client->addLabel($formattedResource, $label);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -3025,8 +3025,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> # TODO: Initialize `resource`:
-            >>> resource = ''
+            >>> resource = client.book_path('[BOOK_SHELF]', '[BOOK]')
             >>>
             >>> # TODO: Initialize `label`:
             >>> label = ''
@@ -7961,7 +7960,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        resource = 'resource-341064690'
+        resource = client.book_path('[BOOK_SHELF]', '[BOOK]')
         label = 'label102727412'
 
         response = client.add_label(resource, label)
@@ -7981,7 +7980,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        resource = 'resource-341064690'
+        resource = client.book_path('[BOOK_SHELF]', '[BOOK]')
         label = 'label102727412'
 
         with pytest.raises(CustomException):

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -4430,13 +4430,11 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #
-      #   # TODO: Initialize `resource`:
-      #   resource = ''
+      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
       #
       #   # TODO: Initialize `label`:
       #   label = ''
-      #   response = library_client.add_label(resource, label)
+      #   response = library_client.add_label(formatted_resource, label)
 
       def add_label \
           resource,
@@ -9257,7 +9255,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label without error' do
       # Create request parameters
-      resource = ''
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
       label = ''
 
       # Create expected grpc response
@@ -9267,7 +9265,7 @@ describe Library::V1::LibraryServiceClient do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Tagger::V1::AddLabelRequest, request)
-        assert_equal(resource, request.resource)
+        assert_equal(formatted_resource, request.resource)
         assert_equal(label, request.label)
         OpenStruct.new(execute: expected_response)
       end
@@ -9281,13 +9279,13 @@ describe Library::V1::LibraryServiceClient do
           client = Library::Library.new(version: :v1)
 
           # Call method
-          response = client.add_label(resource, label)
+          response = client.add_label(formatted_resource, label)
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.add_label(resource, label) do |response, operation|
+          client.add_label(formatted_resource, label) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -9298,13 +9296,13 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label with error' do
       # Create request parameters
-      resource = ''
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
       label = ''
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Tagger::V1::AddLabelRequest, request)
-        assert_equal(resource, request.resource)
+        assert_equal(formatted_resource, request.resource)
         assert_equal(label, request.label)
         raise custom_error
       end
@@ -9319,7 +9317,7 @@ describe Library::V1::LibraryServiceClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.add_label(resource, label)
+            client.add_label(formatted_resource, label)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/testsrc/common/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library.proto
@@ -225,6 +225,7 @@ service LibraryService {
   // Adds a tag to the book. This RPC is a mixin.
   rpc AddTag(google.tagger.v1.AddTagRequest) returns (google.tagger.v1.AddTagResponse) {
     option (google.api.http) = { post: "/v1/{resource=bookShelves/*/books/*}:addTag" body: "*" };
+    option (google.api.method_signature) = "resource,tag";
   }
 
   // AddLabel intentionally left out to test the reroute_to_grpc_interface feature

--- a/src/test/java/com/google/api/codegen/testsrc/common/tagger.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/tagger.proto
@@ -37,7 +37,7 @@ message AddTagRequest {
   // In the form "shelves/{shelf_id}/books/{book_id}".
   string resource = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "library.googleapis.com/Book"];
+    (google.api.resource_reference).type = "*"];
 
   // REQUIRED: The tag to add.
   string tag = 2  [


### PR DESCRIPTION
So far we only parse resource name related annotations from source protos (proto files that we generate code for) but not imports. However this does not work for IAM. IAM request messages declare `resource_reference.type = "*"`, but the request object is an import instead of a source proto for a certain API.

Also slightly tweak the method `addTag` (add `method_signature` and change `resource_reference.type` to `"*"`) to mimic IAM methods.