### PR TITLE
[bazel] Fix Bazel 1.0.0 incompatibility issue

### DIFF
--- a/repository_rules.bzl
+++ b/repository_rules.bzl
@@ -26,7 +26,7 @@ def _com_google_api_codegen_properties_impl(ctx):
         p = prop.strip()
         if len(p) <= 0 or p.startswith("#"):
             continue
-        key_value = p.split("=", maxsplit = 1)
+        key_value = p.split("=", 1)
         props_as_map[key_value[0]] = key_value[1]
 
     props_name = ctx.attr.file.name


### PR DESCRIPTION
Maxsplit is now a positional argument in string.split(). It seems like the only incompatibility issue between 0.28.1 and 1.0.0