### PR TITLE
samplegen: fix Java manifest file

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -131,25 +131,6 @@ public abstract class GapicProductConfig implements ProductConfig {
         getGenerationTimestamp());
   }
 
-  public GapicProductConfig withGenerationTimestamp(Date timestamp) {
-    return new AutoValue_GapicProductConfig(
-        getInterfaceConfigMap(),
-        getPackageName(),
-        getDomainLayerLocation(),
-        getReleaseLevel(),
-        getResourceNameMessageConfigs(),
-        getCopyrightLines(),
-        getLicenseLines(),
-        getResourceNameConfigs(),
-        getProtoParser(),
-        getTransportProtocol(),
-        getDefaultResourceNameFieldConfigMap(),
-        getConfigSchemaVersion(),
-        enableStringFormattingFunctionsOverride(),
-        getSampleConfigTable(),
-        timestamp);
-  }
-
   @Nullable
   public static GapicProductConfig create(
       Model model, ConfigProto configProto, TargetLanguage language) {

--- a/src/main/java/com/google/api/codegen/transformer/SampleManifestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleManifestTransformer.java
@@ -25,7 +25,6 @@ import com.google.api.codegen.viewmodel.metadata.SampleManifestView;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -118,10 +117,6 @@ public class SampleManifestTransformer implements ModelToViewTransformer<ProtoAp
     fileName.append(serviceName);
     fileName.append(".");
     fileName.append(metadataNamer.getEnvironment());
-    fileName.append(".");
-    fileName.append(
-        new SimpleDateFormat("yyyyMMdd.hhmmss").format(productConfig.getGenerationTimestamp()));
-    fileName.append(".manifest.yaml");
     return Paths.get(pathMapper.getOutputPath(null, productConfig), fileName.toString()).toString();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/SampleManifestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SampleManifestTransformer.java
@@ -20,8 +20,10 @@ import com.google.api.codegen.config.InterfaceContext;
 import com.google.api.codegen.config.ProtoApiModel;
 import com.google.api.codegen.config.SampleContext;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
+import com.google.api.codegen.util.VersionMatcher;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.codegen.viewmodel.metadata.SampleManifestView;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import java.nio.file.Paths;
@@ -116,7 +118,18 @@ public class SampleManifestTransformer implements ModelToViewTransformer<ProtoAp
     }
     fileName.append(serviceName);
     fileName.append(".");
+
+    // Trying to find API version from the proto package name. If unsuccessful, ignore.
+    for (String segment : Splitter.on('.').split(productConfig.getPackageName())) {
+      if (VersionMatcher.isVersion(segment)) {
+        fileName.append(segment);
+        fileName.append(".");
+        break;
+      }
+    }
+
     fileName.append(metadataNamer.getEnvironment());
+    fileName.append(".yaml");
     return Paths.get(pathMapper.getOutputPath(null, productConfig), fileName.toString()).toString();
   }
 }

--- a/src/main/resources/com/google/api/codegen/metadatagen/sample_manifest.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/sample_manifest.snip
@@ -5,20 +5,20 @@
   type: manifest/samples
   schema_version: {@manifest.schemaVersion}
   {@manifest.environment}: &{@manifest.environment}
-    environment: {@manifest.environment}
-    bin: {@manifest.bin}
-    base_path: {@manifest.basePath}
+    environment: "{@manifest.environment}"
+    bin: "{@manifest.bin}"
+    base_path: "{@manifest.basePath}"
     @if manifest.packageName
-      package: {@manifest.packageName}
+      package: "{@manifest.packageName}"
     @end
-    invocation: {@manifest.invocation}
+    invocation: "{@manifest.invocation}"
   samples:
   @join entry : manifest.sampleEntries
     - <<: *{@manifest.environment}
       sample: "{@entry.sample}"
       path: "{@entry.path}"
       @if entry.className
-        class: {@entry.className}
+        class: "{@entry.className}"
       @end
       region_tag: "{@entry.regionTag}"
   @end

--- a/src/test/java/com/google/api/codegen/gapic/GapicTestBase2.java
+++ b/src/test/java/com/google/api/codegen/gapic/GapicTestBase2.java
@@ -41,8 +41,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -50,8 +48,6 @@ import javax.annotation.Nullable;
 
 /** Base class for code generator baseline tests. */
 public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
-
-  private static final Date frozenTimestamp = new GregorianCalendar(2019, 7, 1).getTime();
 
   // Wiring
   // ======
@@ -289,7 +285,6 @@ public abstract class GapicTestBase2 extends ConfigBaselineTestCase {
             language,
             grpcServiceConfig);
 
-    productConfig = productConfig.withGenerationTimestamp(frozenTimestamp);
     if (productConfig == null) {
       for (Diag diag : model.getDiagReporter().getDiagCollector().getDiags()) {
         System.err.println(diag.toString());

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -2039,131 +2039,131 @@ public class Turing {
 type: manifest/samples
 schema_version: 3
 java: &java
-  environment: java
-  bin: mvn exec:java
-  base_path: samples/src/main/java/com/google/example/examples/library/v1
-  package: com.google.example.examples.library.v1
-  invocation: {bin} -Dexec.mainClass={class} -Dexec.args='@args'
+  environment: "java"
+  bin: "mvn exec:java"
+  base_path: "samples/src/main/java/com/google/example/examples/library/v1"
+  package: "com.google.example.examples.library.v1"
+  invocation: "{bin} -Dexec.mainClass={class} -Dexec.args='@args'"
 samples:
 - <<: *java
   sample: "sample_get_shelf"
   path: "{base_path}/SampleGetShelf.java"
-  class: {package}.SampleGetShelf
+  class: "{package}.SampleGetShelf"
   region_tag: "sample_get_shelf"
 - <<: *java
   sample: "test_setting_up_empty_objects_in_request"
   path: "{base_path}/TestSettingUpEmptyObjectsInRequest.java"
-  class: {package}.TestSettingUpEmptyObjectsInRequest
+  class: "{package}.TestSettingUpEmptyObjectsInRequest"
   region_tag: "test_setting_up_empty_objects_in_request"
 - <<: *java
   sample: "test_default_calling_form_for_paging"
   path: "{base_path}/TestDefaultCallingFormForPaging.java"
-  class: {package}.TestDefaultCallingFormForPaging
+  class: "{package}.TestDefaultCallingFormForPaging"
   region_tag: "test_default_calling_form_for_paging"
 - <<: *java
   sample: "delete_shelf_request_empty_response_type_with_response_handling"
   path: "{base_path}/DeleteShelfRequestEmptyResponseTypeWithResponseHandling.java"
-  class: {package}.DeleteShelfRequestEmptyResponseTypeWithResponseHandling
+  class: "{package}.DeleteShelfRequestEmptyResponseTypeWithResponseHandling"
   region_tag: "sample"
 - <<: *java
   sample: "delete_shelf_request_empty_response_type_without_response_handling"
   path: "{base_path}/DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling.java"
-  class: {package}.DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling
+  class: "{package}.DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling"
   region_tag: "sample"
 - <<: *java
   sample: "testing_map"
   path: "{base_path}/TestingMap.java"
-  class: {package}.TestingMap
+  class: "{package}.TestingMap"
   region_tag: "testing_map"
 - <<: *java
   sample: "publish_series_request_pi_version"
   path: "{base_path}/PublishSeriesRequestPiVersion.java"
-  class: {package}.PublishSeriesRequestPiVersion
+  class: "{package}.PublishSeriesRequestPiVersion"
   region_tag: "canonical"
 - <<: *java
   sample: "publish_series_request_second_edition"
   path: "{base_path}/PublishSeriesRequestSecondEdition.java"
-  class: {package}.PublishSeriesRequestSecondEdition
+  class: "{package}.PublishSeriesRequestSecondEdition"
   region_tag: "canonical"
 - <<: *java
   sample: "publish_series_test_request_object_field_comments"
   path: "{base_path}/PublishSeriesTestRequestObjectFieldComments.java"
-  class: {package}.PublishSeriesTestRequestObjectFieldComments
+  class: "{package}.PublishSeriesTestRequestObjectFieldComments"
   region_tag: "publish_series_test_request_object_field_comments"
 - <<: *java
   sample: "publish_series_test_write_to_file"
   path: "{base_path}/PublishSeriesTestWriteToFile.java"
-  class: {package}.PublishSeriesTestWriteToFile
+  class: "{package}.PublishSeriesTestWriteToFile"
   region_tag: "publish_series_test_write_to_file"
 - <<: *java
   sample: "get_book_request_test_on_success_map"
   path: "{base_path}/GetBookRequestTestOnSuccessMap.java"
-  class: {package}.GetBookRequestTestOnSuccessMap
+  class: "{package}.GetBookRequestTestOnSuccessMap"
   region_tag: "sample"
 - <<: *java
   sample: "test_resource_name_oneof"
   path: "{base_path}/TestResourceNameOneof.java"
-  class: {package}.TestResourceNameOneof
+  class: "{package}.TestResourceNameOneof"
   region_tag: "test_resource_name_oneof"
 - <<: *java
   sample: "test_resource_name_oneof_2"
   path: "{base_path}/TestResourceNameOneof2.java"
-  class: {package}.TestResourceNameOneof2
+  class: "{package}.TestResourceNameOneof2"
   region_tag: "test_resource_name_oneof_2"
 - <<: *java
   sample: "babbage"
   path: "{base_path}/Babbage.java"
-  class: {package}.Babbage
+  class: "{package}.Babbage"
   region_tag: "babbage"
 - <<: *java
   sample: "turing"
   path: "{base_path}/Turing.java"
-  class: {package}.Turing
+  class: "{package}.Turing"
   region_tag: "turing"
 - <<: *java
   sample: "sample_monolog_about_book"
   path: "{base_path}/SampleMonologAboutBook.java"
-  class: {package}.SampleMonologAboutBook
+  class: "{package}.SampleMonologAboutBook"
   region_tag: "sample_monolog_about_book"
 - <<: *java
   sample: "babble_about_book_1"
   path: "{base_path}/BabbleAboutBook1.java"
-  class: {package}.BabbleAboutBook1
+  class: "{package}.BabbleAboutBook1"
   region_tag: "babble_about_book_1"
 - <<: *java
   sample: "babble_about_book_2"
   path: "{base_path}/BabbleAboutBook2.java"
-  class: {package}.BabbleAboutBook2
+  class: "{package}.BabbleAboutBook2"
   region_tag: "babble_about_book_2"
 - <<: *java
   sample: "find_related_books_odyssey"
   path: "{base_path}/FindRelatedBooksOdyssey.java"
-  class: {package}.FindRelatedBooksOdyssey
+  class: "{package}.FindRelatedBooksOdyssey"
   region_tag: "find_related_books_odyssey"
 - <<: *java
   sample: "hopper"
   path: "{base_path}/Hopper.java"
-  class: {package}.Hopper
+  class: "{package}.Hopper"
   region_tag: "hopper"
 - <<: *java
   sample: "this_tag_should_be_the_name_of_the_file"
   path: "{base_path}/ThisTagShouldBeTheNameOfTheFile.java"
-  class: {package}.ThisTagShouldBeTheNameOfTheFile
+  class: "{package}.ThisTagShouldBeTheNameOfTheFile"
   region_tag: "this_tag_should_be_the_name_of_the_file"
 - <<: *java
   sample: "empty_response_type_with_response_handling"
   path: "{base_path}/EmptyResponseTypeWithResponseHandling.java"
-  class: {package}.EmptyResponseTypeWithResponseHandling
+  class: "{package}.EmptyResponseTypeWithResponseHandling"
   region_tag: "empty_response_type_with_response_handling"
 - <<: *java
   sample: "empty_response_type_without_response_handling"
   path: "{base_path}/EmptyResponseTypeWithoutResponseHandling.java"
-  class: {package}.EmptyResponseTypeWithoutResponseHandling
+  class: "{package}.EmptyResponseTypeWithoutResponseHandling"
   region_tag: "empty_response_type_without_response_handling"
 - <<: *java
   sample: "test_float_and_int64"
   path: "{base_path}/TestFloatAndInt64.java"
-  class: {package}.TestFloatAndInt64
+  class: "{package}.TestFloatAndInt64"
   region_tag: "test_float_and_int64"
 
 ============== file: src/main/java/com/google/example/library/v1/LibraryClient.java ==============

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -2034,7 +2034,7 @@ public class Turing {
     sampleDiscussBook(imageFileName, stage);
   }
 }
-============== file: samples/src/main/java/com/google/example/examples/library/v1/library-example.java ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/library-example.v1.java.yaml ==============
 ---
 type: manifest/samples
 schema_version: 3

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -2034,7 +2034,7 @@ public class Turing {
     sampleDiscussBook(imageFileName, stage);
   }
 }
-============== file: samples/src/main/java/com/google/example/examples/library/v1/library-example.java.20190801.120000.manifest.yaml ==============
+============== file: samples/src/main/java/com/google/example/examples/library/v1/library-example.java ==============
 ---
 type: manifest/samples
 schema_version: 3


### PR DESCRIPTION
To conform to the standard of manifest file format: `api.version.lang.yaml`
- Remove timestamp
- Add version 

Also quote all entries to be safe with `{}`s.