### PR TITLE
chore: update dependencies for Java

### DIFF
--- a/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
+++ b/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
@@ -32,7 +32,7 @@ grpc_version:
   ruby:
     lower: '1.0'
   java:
-    lower: '1.10.1'
+    lower: '1.24.1'
 
 gax_version:
   python:
@@ -43,13 +43,13 @@ gax_version:
   ruby:
     lower: '1.3'
   java:
-    lower: '1.43.0'
+    lower: '1.49.1'
 
 gax_grpc_version:
   csharp:
     lower: '2.3.0'
   java:
-    lower: '1.43.0'
+    lower: '1.49.1'
 
 gax_http_version:
   java:
@@ -64,7 +64,7 @@ proto_version:
   ruby:
     lower: '3.5'
   java:
-    lower: '3.7.1'
+    lower: '3.10.0'
 
 # Dependencies on gRPC/proto packages referenced in the proto_deps
 # field of the Artman config.
@@ -78,7 +78,7 @@ google-common-protos_version:
     name_override: googleapis-common-protos
     lower: '1.3.9'
   java:
-    lower: '1.15.0'
+    lower: '1.17.0'
 
 google-iam-v1_version:
   csharp:
@@ -92,7 +92,7 @@ google-iam-v1_version:
     name_override: grpc-google-iam-v1
     lower: '0.6.9'
   java:
-    lower: '0.12.0'
+    lower: '0.13.0'
 
 google-appengine-v1_version:
   java:
@@ -100,7 +100,7 @@ google-appengine-v1_version:
 
 api_common_version:
   java:
-    lower: '1.6.0'
+    lower: '1.8.1'
 
 # Dependencies of helper packages used by SampleGen only
 


### PR DESCRIPTION
Update dependencies to latest versions used by google-cloud-java.

Fix #2751