### PR TITLE
Assign the proto file where the method is defined 

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -19,6 +19,8 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.MethodContext;
+import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.config.ProtoTypeRef;
 import com.google.api.codegen.config.ResourceNameConfig;
 import com.google.api.codegen.config.ResourceNameOneofConfig;
@@ -57,6 +59,7 @@ import com.google.api.codegen.viewmodel.SimpleInitValueView;
 import com.google.api.codegen.viewmodel.StructureInitCodeLineView;
 import com.google.api.codegen.viewmodel.testing.ClientTestAssertView;
 import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.tools.framework.model.ProtoFile;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
@@ -771,6 +774,10 @@ public class InitCodeTransformer {
         // TODO(michaelbausor): handle case where there are no other resource names at all...
         singleResourceNameConfig =
             Iterables.get(context.getProductConfig().getSingleResourceNameConfigs(), 0);
+        MethodModel methodModel = context.getMethodModel();
+        ProtoFile protoFile = ((ProtoMethodModel) methodModel).getProtoMethod().getFile();
+        singleResourceNameConfig =
+            singleResourceNameConfig.toBuilder().setAssignedProtoFile(protoFile).build();
         FieldConfig anyResourceNameFieldConfig =
             fieldConfig.withResourceNameConfig(singleResourceNameConfig);
         return createResourceNameInitValueView(context, anyResourceNameFieldConfig, item)

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -775,9 +775,11 @@ public class InitCodeTransformer {
         singleResourceNameConfig =
             Iterables.get(context.getProductConfig().getSingleResourceNameConfigs(), 0);
         MethodModel methodModel = context.getMethodModel();
-        ProtoFile protoFile = ((ProtoMethodModel) methodModel).getProtoMethod().getFile();
-        singleResourceNameConfig =
-            singleResourceNameConfig.toBuilder().setAssignedProtoFile(protoFile).build();
+        if (methodModel instanceof ProtoMethodModel) {
+          ProtoFile protoFile = ((ProtoMethodModel) methodModel).getProtoMethod().getFile();
+          singleResourceNameConfig =
+              singleResourceNameConfig.toBuilder().setAssignedProtoFile(protoFile).build();
+        }
         FieldConfig anyResourceNameFieldConfig =
             fieldConfig.withResourceNameConfig(singleResourceNameConfig);
         return createResourceNameInitValueView(context, anyResourceNameFieldConfig, item)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -10223,7 +10223,7 @@ public class LibraryServiceClientTest {
     AddTagResponse expectedResponse = AddTagResponse.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ResourceName resource = com.google.tagger.v1.ArchiveBookName.of("[ARCHIVE]", "[BOOK]");
+    ResourceName resource = ArchiveBookName.of("[ARCHIVE]", "[BOOK]");
     String tag = "tag114586";
 
     AddTagResponse actualResponse =
@@ -10249,7 +10249,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ResourceName resource = com.google.tagger.v1.ArchiveBookName.of("[ARCHIVE]", "[BOOK]");
+      ResourceName resource = ArchiveBookName.of("[ARCHIVE]", "[BOOK]");
       String tag = "tag114586";
 
       client.addTag(resource, tag);


### PR DESCRIPTION
When picking a `SingleResourceNameConfig` for an `AnyResourceNameConfig`, assign the proto file of where the method is defined to it so that it has the correct package.