### PR TITLE
Update generated java tests to use a unique InProcessChannel name

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
@@ -418,6 +418,7 @@ public class JavaSurfaceTestTransformer<ApiModelT extends ApiModel>
         typeTable.saveNicknameFor("java.util.ArrayList");
         typeTable.saveNicknameFor("java.util.Objects");
         typeTable.saveNicknameFor("java.util.concurrent.ExecutionException");
+        typeTable.saveNicknameFor("java.util.UUID");
         typeTable.saveNicknameFor("org.junit.Before");
         break;
       case HTTP:

--- a/src/main/resources/com/google/api/codegen/java/grpc_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/grpc_test.snip
@@ -18,7 +18,7 @@
       @join mockService : xapiTest.testClass.mockServices
         {@mockService.varName} = new {@mockService.className}();
       @end
-      serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList({@mockServiceArgs(xapiTest.testClass.mockServices)}));
+      serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList({@mockServiceArgs(xapiTest.testClass.mockServices)}));
       serviceHelper.start();
     }
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -13687,6 +13687,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -13709,7 +13710,7 @@ public class LibraryClientTest {
     mockLibraryService = new MockLibraryService();
     mockLabeler = new MockLabeler();
     mockMyProto = new MockMyProto();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
     serviceHelper.start();
   }
 
@@ -16599,6 +16600,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -16621,7 +16623,7 @@ public class MyProtoClientTest {
     mockLibraryService = new MockLibraryService();
     mockLabeler = new MockLabeler();
     mockMyProto = new MockMyProto();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
     serviceHelper.start();
   }
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
@@ -2018,6 +2018,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -2038,7 +2039,7 @@ public class DecrementerServiceClientTest {
   public static void startStaticServer() {
     mockIncrementerService = new MockIncrementerService();
     mockDecrementerService = new MockDecrementerService();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockIncrementerService, mockDecrementerService));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockIncrementerService, mockDecrementerService));
     serviceHelper.start();
   }
 
@@ -2148,6 +2149,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -2168,7 +2170,7 @@ public class IncrementerServiceClientTest {
   public static void startStaticServer() {
     mockIncrementerService = new MockIncrementerService();
     mockDecrementerService = new MockDecrementerService();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockIncrementerService, mockDecrementerService));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockIncrementerService, mockDecrementerService));
     serviceHelper.start();
   }
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_my_streaming_proto.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_my_streaming_proto.baseline
@@ -1338,6 +1338,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -1356,7 +1357,7 @@ public class MyStreamingServiceClientTest {
   @BeforeClass
   public static void startStaticServer() {
     mockMyStreamingService = new MockMyStreamingService();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockMyStreamingService));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockMyStreamingService));
     serviceHelper.start();
   }
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -1228,6 +1228,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -1246,7 +1247,7 @@ public class NoTemplatesApiServiceClientTest {
   @BeforeClass
   public static void startStaticServer() {
     mockNoTemplatesAPIService = new MockNoTemplatesAPIService();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockNoTemplatesAPIService));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockNoTemplatesAPIService));
     serviceHelper.start();
   }
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -11175,6 +11175,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -11197,7 +11198,7 @@ public class LibraryClientTest {
     mockLibraryService = new MockLibraryService();
     mockLabeler = new MockLabeler();
     mockMyProto = new MockMyProto();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
     serviceHelper.start();
   }
 
@@ -13982,6 +13983,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -14004,7 +14006,7 @@ public class MyProtoClientTest {
     mockLibraryService = new MockLibraryService();
     mockLabeler = new MockLabeler();
     mockMyProto = new MockMyProto();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
     serviceHelper.start();
   }
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -13843,6 +13843,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -13865,7 +13866,7 @@ public class LibraryClientTest {
     mockLibraryService = new MockLibraryService();
     mockLabeler = new MockLabeler();
     mockMyProto = new MockMyProto();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
     serviceHelper.start();
   }
 
@@ -16716,6 +16717,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -16738,7 +16740,7 @@ public class MyProtoClientTest {
     mockLibraryService = new MockLibraryService();
     mockLabeler = new MockLabeler();
     mockMyProto = new MockMyProto();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
     serviceHelper.start();
   }
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -8897,6 +8897,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -8917,7 +8918,7 @@ public class LibraryServiceClientTest {
   public static void startStaticServer() {
     mockLibraryService = new MockLibraryService();
     mockMyProto = new MockMyProto();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockLibraryService, mockMyProto));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockLibraryService, mockMyProto));
     serviceHelper.start();
   }
 
@@ -11580,6 +11581,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -11600,7 +11602,7 @@ public class MyProtoClientTest {
   public static void startStaticServer() {
     mockLibraryService = new MockLibraryService();
     mockMyProto = new MockMyProto();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockLibraryService, mockMyProto));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockLibraryService, mockMyProto));
     serviceHelper.start();
   }
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -13847,6 +13847,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -13869,7 +13870,7 @@ public class LibraryClientTest {
     mockLibraryService = new MockLibraryService();
     mockLabeler = new MockLabeler();
     mockMyProto = new MockMyProto();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
     serviceHelper.start();
   }
 
@@ -16720,6 +16721,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -16742,7 +16744,7 @@ public class MyProtoClientTest {
     mockLibraryService = new MockLibraryService();
     mockLabeler = new MockLabeler();
     mockMyProto = new MockMyProto();
-    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
+    serviceHelper = new MockServiceHelper(UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockLibraryService, mockLabeler, mockMyProto));
     serviceHelper.start();
   }
 


### PR DESCRIPTION
This should allow unit tests in generated clients to run concurrently