### PR TITLE
PHP: add deprecation message to resource helpers generated from deprecated_collection in gapic v2

### DIFF
--- a/src/main/resources/com/google/api/codegen/php/client_impl.snip
+++ b/src/main/resources/com/google/api/codegen/php/client_impl.snip
@@ -168,7 +168,12 @@
         {@""} * @@param string ${@param.name}
     @end
      * @@return string The formatted {@function.entityName} resource.
-     * @@experimental
+    @if function.isResourceNameDeprecated 
+     {@""} * @@deprecated Multi-pattern resource names will have unified formatting functions.
+     {@""} *             This helper function will be deleted in the next major version.
+    @else
+     {@""} * @@experimental
+    @end
      */
     public static function {@function.name}(\
             {@formatResourceFunctionParams(function.resourceIdParams)})

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -2628,7 +2628,8 @@ class LibraryServiceGapicClient
      * @param string $archive
      * @param string $book
      * @return string The formatted book_from_archive resource.
-     * @experimental
+     * @deprecated Multi-pattern resource names will have unified formatting functions.
+     *             This helper function will be deleted in the next major version.
      */
     public static function bookFromArchiveName($archive, $book)
     {
@@ -2692,7 +2693,8 @@ class LibraryServiceGapicClient
      * @param string $project
      * @param string $book
      * @return string The formatted project_book resource.
-     * @experimental
+     * @deprecated Multi-pattern resource names will have unified formatting functions.
+     *             This helper function will be deleted in the next major version.
      */
     public static function projectBookName($project, $book)
     {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -2628,7 +2628,8 @@ class LibraryServiceGapicClient
      * @param string $archive
      * @param string $book
      * @return string The formatted book_from_archive resource.
-     * @experimental
+     * @deprecated Multi-pattern resource names will have unified formatting functions.
+     *             This helper function will be deleted in the next major version.
      */
     public static function bookFromArchiveName($archive, $book)
     {
@@ -2692,7 +2693,8 @@ class LibraryServiceGapicClient
      * @param string $project
      * @param string $book
      * @return string The formatted project_book resource.
-     * @experimental
+     * @deprecated Multi-pattern resource names will have unified formatting functions.
+     *             This helper function will be deleted in the next major version.
      */
     public static function projectBookName($project, $book)
     {


### PR DESCRIPTION
Follow up of #3016. Add `@deprecated` to resource name helper functions generated from `deprecated_collections` in gapic v2.