### PR TITLE
Ruby standalone sample syntax updates 

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/response.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/response.snip
@@ -22,6 +22,7 @@
 @end
 
 @private processCommentView(view)
+
   {@toComments(view.lines)}
 @end
 

--- a/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
@@ -17,7 +17,6 @@
       @#   bundle exec ruby {@sampleFile.outputPath} {@commandlineArgumentList(sample.sampleInitCode.argDefaultParams)}
 
       @# {@sample.descriptionLine}
-
       {@standaloneSample(apiMethod, sample)}
 
     @end
@@ -136,7 +135,6 @@
   @else
     {@methodCallSampleCode(apiMethod, sample)}
     @if sample.outputs
-      
       {@processOutputViews(sample.outputs)}
     @end
   @end

--- a/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
@@ -26,7 +26,7 @@
 
 @private standaloneSample(apiMethod, sample)
   @if sample.sampleInitCode.argDefaultParams.size
-    def {@sample.sampleFunctionName} {@formalArgs(sample.sampleInitCode.argDefaultParams)}
+    def {@sample.sampleFunctionName} {@formalArgsWithDefaultValues(sample.sampleInitCode.argDefaultParams)}
   @else
     def {@sample.sampleFunctionName}
   @end
@@ -228,10 +228,15 @@
     @end
     opts.parse!
   end
-
 @end
 
 @private formalArgs(params)
+  @join param : params on ", "
+    {@param.identifier}
+  @end
+@end
+
+@private formalArgsWithDefaultValues(params)
   @join param : params on ", "
     {@param.identifier} = {@renderInitValue(param.initValue)}
   @end
@@ -241,8 +246,9 @@
 # in setting up resource names from incode samples.
 @private initCode(initCodeSpec)
   @if initCodeSpec.argDefaultLines
+    @# TODO(developer): Uncomment these variables before running the sample.
     @join line : util.pretty(initCodeLines(initCodeSpec.argDefaultLines))
-      {@line}
+      @# {@line}
     @end
 
 

--- a/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
@@ -25,8 +25,6 @@
 @end
 
 @private standaloneSample(apiMethod, sample)
-
-  @# Wrap code sample in parameterized method (to call with arg parsing below)
   @if sample.sampleInitCode.argDefaultParams.size
     def {@sample.sampleFunctionName} {@formalArgs(sample.sampleInitCode.argDefaultParams)}
   @else
@@ -49,7 +47,6 @@
     # Construct request
     @if sample.sampleInitCode.lines
       {@initCode(sample.sampleInitCode)}
-
     @end
     @switch sample.callingForm
     @case "Request"
@@ -74,7 +71,7 @@
     @end
   end
   
-  # Code below processes command-line arguments to execute this code sample.
+  @# Code below processes command-line arguments to execute this code sample.
 
   require "optparse"
 
@@ -133,6 +130,7 @@
   @if apiMethod.hasReturnValue
     response = {@methodCallSampleCode(apiMethod, sample)}
     @if sample.outputs
+
       {@processOutputViews(sample.outputs)}
     @end
   @else
@@ -261,14 +259,10 @@
 @private initCodeLinesWithDescriptions(lines)
   @join line : lines
     @if line.descriptions
-
       {@toComments(line.descriptions)}
 
     @end
     {@initCodeLine(line)}
-    @if line.descriptions
-
-    @end
   @end
 @end
 
@@ -276,14 +270,19 @@
   @switch line.lineType.toString
   @case "StructureInitLine"
     {@initLineStructure(line)}
+
   @case "ListInitLine"
     {@initLineList(line)}
+
   @case "MapInitLine"
     {@initLineMap(line)}
+
   @case "SimpleInitLine"
     {@initLineSimple(line)}
+
   @case "ReadFileInitLine"
     {@initLineReadFile(line)}
+
   @default
     $unhandledCase: {@line.lineType.toString}$
   @end

--- a/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
@@ -16,7 +16,7 @@
       @end
       @#   bundle exec ruby {@sampleFile.outputPath} {@commandlineArgumentList(sample.sampleInitCode.argDefaultParams)}
 
-      require "{@sample.sampleInitCode.topLevelIndexFileImportName}"
+      @# {@sample.descriptionLine}
 
       {@standaloneSample(apiMethod, sample)}
 
@@ -25,16 +25,20 @@
 @end
 
 @private standaloneSample(apiMethod, sample)
-  @# [START {@sample.regionTag}]
-  
-  @if not(sample.sampleFunctionDoc.isEmpty)
-    {@processSampleFunctionDoc(sample.sampleFunctionDoc)}
-  @end
+
+  @# Wrap code sample in parameterized method (to call with arg parsing below)
   @if sample.sampleInitCode.argDefaultParams.size
     def {@sample.sampleFunctionName} {@formalArgs(sample.sampleInitCode.argDefaultParams)}
   @else
     def {@sample.sampleFunctionName}
   @end
+    @if sample.regionTag
+      @# [START {@sample.regionTag}]
+    @end
+
+    @# Import client library
+    require "{@sample.sampleInitCode.topLevelIndexFileImportName}"
+
     @# Instantiate a client
     @if apiMethod.hasApiVersion
       {@apiMethod.apiVariableName} = {@apiMethod.topLevelAliasedApiClassName}.new version: :{@apiMethod.apiVersion.toLowerCase}
@@ -65,8 +69,10 @@
     @default
       $unhandledCallingForm: {@sample.callingForm} in sample "{@apiMethod.getClass.getSimpleName}"$
     @end
+    @if sample.regionTag
+      @# [END {@sample.regionTag}]
+    @end
   end
-  @# [END {@sample.regionTag}]
   
   # Code below processes command-line arguments to execute this code sample.
 
@@ -238,7 +244,7 @@
 @private initCode(initCodeSpec)
   @if initCodeSpec.argDefaultLines
     @join line : util.pretty(initCodeLines(initCodeSpec.argDefaultLines))
-      @# {@line}
+      {@line}
     @end
 
 
@@ -260,6 +266,9 @@
 
     @end
     {@initCodeLine(line)}
+    @if line.descriptions
+
+    @end
   @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/standalone_sample.snip
@@ -30,10 +30,10 @@
   @else
     def {@sample.sampleFunctionName}
   @end
+
     @if sample.regionTag
       @# [START {@sample.regionTag}]
     @end
-
     @# Import client library
     require "{@sample.sampleInitCode.topLevelIndexFileImportName}"
 
@@ -233,7 +233,7 @@
 
 @private formalArgs(params)
   @join param : params on ", "
-    {@param.identifier}
+    {@param.identifier} = {@renderInitValue(param.initValue)}
   @end
 @end
 


### PR DESCRIPTION
Refactors generated Ruby samples to render using syntax suggested from this code review PR:
 - https://github.com/googleapis/google-cloud-ruby/pull/4264

[WIP] to first get +1 on https://github.com/googleapis/google-cloud-ruby/pull/4264 for these changes (which shows rendered Ruby code samples)

@googleapis/samplegen 