### PR TITLE
[bazel]: Fix "proto" provider regression

### DIFF
--- a/rules_gapic/csharp/csharp_gapic_pkg.bzl
+++ b/rules_gapic/csharp/csharp_gapic_pkg.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//rules_gapic:gapic.bzl", "gapic_srcjar", "proto_custom_library", "GapicInfo")
+load("//rules_gapic:gapic.bzl", "CustomProtoInfo", "gapic_srcjar", "proto_custom_library", "GapicInfo")
 load("//rules_gapic:gapic_pkg.bzl", "construct_package_dir_paths")
 
 def _csharp_gapic_src_pkg_impl(ctx):
@@ -21,7 +21,7 @@ def _csharp_gapic_src_pkg_impl(ctx):
     gapic_srcs = []
 
     for dep in ctx.attr.deps:
-        if(hasattr(dep, "proto")):
+        if ProtoInfo in dep or CustomProtoInfo in dep:
             proto_grpc_srcs.extend(dep.files.to_list())
         elif GapicInfo in dep:
             gapic_srcs.append(dep[GapicInfo].test)

--- a/rules_gapic/gapic.bzl
+++ b/rules_gapic/gapic.bzl
@@ -84,7 +84,7 @@ gapic_srcjar = rule(
     implementation = _gapic_srcjar_impl,
 )
 
-_ProtoInfo = provider(
+CustomProtoInfo = provider(
     fields = [
         "direct_sources",
         "check_deps_sources",
@@ -101,7 +101,7 @@ def _proto_custom_library_impl(ctx):
     check_dep_sources_list = []
 
     for dep in ctx.attr.deps:
-        prov = ProtoInfo if ProtoInfo in dep else _ProtoInfo
+        prov = ProtoInfo if ProtoInfo in dep else CustomProtoInfo
         src = dep[prov].check_deps_sources
         srcs_list.append(src)
         check_dep_sources_list.append(src)
@@ -175,7 +175,7 @@ def _proto_custom_library_impl(ctx):
     #   - transitive_imports
     #   - transitive_descriptor_sets
     return [
-        _ProtoInfo(
+        CustomProtoInfo(
             direct_sources = check_dep_sources,
             check_deps_sources = check_dep_sources,
             transitive_imports = imports,
@@ -185,7 +185,11 @@ def _proto_custom_library_impl(ctx):
 
 proto_custom_library = rule(
     attrs = {
-        "deps": attr.label_list(mandatory = True, allow_empty = False, providers = [[ProtoInfo], [_ProtoInfo]]),
+        "deps": attr.label_list(
+            mandatory = True,
+            allow_empty = False,
+            providers = [[ProtoInfo], [CustomProtoInfo]],
+        ),
         "plugin": attr.label(mandatory = False, executable = True, cfg = "host"),
         "plugin_file_args": attr.label_keyed_string_dict(
             mandatory = False,
@@ -328,6 +332,7 @@ def _calculate_import_prefix(strip_import_prefix):
     tokens_len = len(tokens)
     for i in range(1, tokens_len):
         t = tokens[i]
+
         # This logic is executed only if import_prefix is not specified by
         # a user explicitly (so there is no enforced coupling to google cloud
         # domain, it serves only as a convenient default value).

--- a/rules_gapic/nodejs/nodejs_gapic_pkg.bzl
+++ b/rules_gapic/nodejs/nodejs_gapic_pkg.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//rules_gapic:gapic.bzl", "CustomProtoInfo")
 load("//rules_gapic:gapic_pkg.bzl", "construct_package_dir_paths")
 
 def _nodejs_gapic_src_pkg_impl(ctx):
@@ -21,8 +22,8 @@ def _nodejs_gapic_src_pkg_impl(ctx):
     for dep in ctx.attr.deps:
         if ProtoInfo in dep:
             proto_srcs.extend(dep[ProtoInfo].check_deps_sources.to_list())
-        elif hasattr(dep, "proto"):
-            proto_srcs.extend(dep.proto.check_deps_sources.to_list())
+        elif CustomProtoInfo in dep:
+            proto_srcs.extend(dep[CustomProtoInfo].check_deps_sources.to_list())
         else:
             gapic_srcs.extend(dep.files.to_list())
 

--- a/rules_gapic/php/php_gapic_pkg.bzl
+++ b/rules_gapic/php/php_gapic_pkg.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//rules_gapic:gapic.bzl", "gapic_srcjar", "proto_custom_library")
+load("//rules_gapic:gapic.bzl", "CustomProtoInfo", "gapic_srcjar", "proto_custom_library")
 load("//rules_gapic:gapic_pkg.bzl", "construct_package_dir_paths")
 
 def _php_gapic_src_pkg_impl(ctx):
@@ -20,7 +20,7 @@ def _php_gapic_src_pkg_impl(ctx):
     gapic_srcs = []
 
     for dep in ctx.attr.deps:
-        if(hasattr(dep, "proto")):
+        if ProtoInfo in dep or CustomProtoInfo in dep:
             proto_grpc_srcs.extend(dep.files.to_list())
         else:
             gapic_srcs.extend(dep.files.to_list())

--- a/rules_gapic/ruby/ruby_gapic_pkg.bzl
+++ b/rules_gapic/ruby/ruby_gapic_pkg.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//rules_gapic:gapic.bzl", "gapic_srcjar", "proto_custom_library")
+load("//rules_gapic:gapic.bzl", "CustomProtoInfo", "gapic_srcjar", "proto_custom_library")
 load("//rules_gapic:gapic_pkg.bzl", "construct_package_dir_paths")
 
 def _ruby_gapic_src_pkg_impl(ctx):
@@ -20,7 +20,7 @@ def _ruby_gapic_src_pkg_impl(ctx):
     gapic_srcs = []
 
     for dep in ctx.attr.deps:
-        if(hasattr(dep, "proto")):
+        if ProtoInfo in dep or CustomProtoInfo in dep:
             proto_grpc_srcs.extend(dep.files.to_list())
         else:
             gapic_srcs.extend(dep.files.to_list())


### PR DESCRIPTION
`custom_proto_plugin` was migrated to use custom (new) provider instead of using `struct()` (deprecated). The depending (languge-specific) rules where not updated. This PR fixes that.