### PR TITLE
Hiding methods from generation violates AIP

### DIFF
--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -662,6 +662,9 @@ message SurfaceTreatmentProto {
   repeated string include_languages = 1;
 
   // The visibility of the surface.
+  // (-- aip.dev/not-precedent AIPs do not support hiding specific RPCs from generation.
+  //     The option to hide methods from generation will not be supported in micro
+  //     generators that are AIP-compliant. --)
   VisibilityProto visibility = 2;
 
   // Whether the method is deprecated.


### PR DESCRIPTION
Fixes #2761 by adding a comment to `config.proto`. Not that anyone will ever read that but...