### PR TITLE
chore: ignore a few dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "extends": "packages:linters",
       "groupName": "linters"
     }
-  ]
+  ],
   "ignoreDeps": [
     "com.google.protobuf:protobuf-java",
     "com.google.protobuf:protoc",

--- a/renovate.json
+++ b/renovate.json
@@ -15,4 +15,9 @@
       "groupName": "linters"
     }
   ]
+  "ignoreDeps": [
+    "com.google.protobuf:protobuf-java",
+    "com.google.protobuf:protoc",
+    "com.google.cloud:google-cloud-pubsub"
+  ]
 }


### PR DESCRIPTION
- PubSub was used only for benchmarking (which we don't not measure now)
- The bot isn't smart enough to correctly update protobuf's version (not even humans can understand a gradle script, please don't put that burden on a bot)