### PR TITLE
bazel: Support WORKSPACE-relative paths as command line arguments for the bazel BiuldFileGenerator.

### DIFF
--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BuildFileGenerator.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BuildFileGenerator.java
@@ -5,19 +5,19 @@ import java.nio.file.Files;
 
 // To run from bazel and overwrite existing BUILD.bazel files:
 //    bazel run //rules_gapic/bazel:build_file_generator -- \
-//        --src=rules_gapic/bazel/src/test/data/googleapis \
-//        --dest=rules_gapic/bazel/src/test/data/googleapis
+//        --src=rules_gapic/bazel/src/test/data/googleapis
 //
 // To compile and copy resources manually from the repository root directory (no bazel needed):
 //    javac -d . rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/*.java
 //    cp rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/*.mustache
-// com/google/api/codegen/bazel
 // Then to run manually:
-//    java -cp . com.google.api.codegen.bazel.BuildFileGenerator
+//    java -cp . com.google.api.codegen.bazel.BuildFileGenerator \
+//        --src=rules_gapic/bazel/src/test/data/googleapis
 public class BuildFileGenerator {
   public static void main(String[] args) throws IOException {
     BuildFileGenerator bfg = new BuildFileGenerator();
-    ApisVisitor visitor = new ArgsParser(args).createApisVisitor(null);
+    ApisVisitor visitor =
+        new ArgsParser(args).createApisVisitor(null, System.getenv("BUILD_WORKSPACE_DIRECTORY"));
     bfg.generateBuildFiles(visitor);
   }
 

--- a/rules_gapic/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
+++ b/rules_gapic/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
@@ -9,17 +9,18 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class BuildFileGeneratorTest {
-  private static final String SRC_DIR =
-      Paths.get("rules_gapic", "bazel", "src", "test", "data", "googleapis").toString();
+  private static final String SRC_DIR = Paths.get("googleapis").toString();
+  private static final String PATH_PREFIX =
+      Paths.get("rules_gapic", "bazel", "src", "test", "data").toString();
 
   @Test
   public void testGenerateBuildFiles() throws IOException {
 
-    ArgsParser args = new ArgsParser(new String[] {"--src=" + SRC_DIR, "--dest=" + SRC_DIR});
+    ArgsParser args = new ArgsParser(new String[] {"--src=" + SRC_DIR});
     FileWriter fw = new FileWriter();
-    new BuildFileGenerator().generateBuildFiles(args.createApisVisitor(fw));
+    new BuildFileGenerator().generateBuildFiles(args.createApisVisitor(fw, PATH_PREFIX));
 
-    Path fileBodyPathPrefix = Paths.get(SRC_DIR, "google", "example", "library");
+    Path fileBodyPathPrefix = Paths.get(PATH_PREFIX, SRC_DIR, "google", "example", "library");
     String gapicBuildFilePath =
         Paths.get(fileBodyPathPrefix.toString(), "v1", "BUILD.bazel").toString();
     String rawBuildFilePath = Paths.get(fileBodyPathPrefix.toString(), "BUILD.bazel").toString();


### PR DESCRIPTION
Also make `--dest` argument optional (by default it will be equal to `--src`, meaning that the generator will overwrite `BUILD.bazel` file in the `--src` directory (most common scenario)).

The `BUILD_WORKSPACE_DIRECTORY` environment variable is set automatically by bazel for all targets ran as `bazel run`. The value of the env varible is the path to the root folder of the repository.