### PR TITLE
bazel: Replace native `maven_jar` rule with `jvm_maven_import_external`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,7 @@ jobs:
     working_directory: /tmp/
     environment:
       TEST_REPORTS_DIR: /tmp/workspace/bazel/reports/gapic-generator
-      BAZEL_VERSION: 0.28.1
+      BAZEL_VERSION: 2.0.0
       PYTHON_VERSION: 3.5.2
     machine: true
     steps:

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 load("@com_google_api_codegen_properties//:dependencies.properties.bzl", "PROPERTIES")
 
 def com_google_api_codegen_repositories():
     # Import dependencies shared between Gradle and Bazel (i.e. maven dependencies)
     for name, artifact in PROPERTIES.items():
         _maybe(
-            native.maven_jar,
+            jvm_maven_import_external,
             name = name,
             strip_repo_prefix = "maven.",
             artifact = _fix_bazel_artifact_format(artifact),
+            server_urls = ["https://repo.maven.apache.org/maven2/", "http://repo1.maven.org/maven2/"],
+            licenses = ["notice", "reciprocal"]
         )
 
     # Import Bazel-only dependencies (Gradle version will import maven artifacts of same
@@ -41,9 +43,11 @@ def com_google_api_codegen_repositories():
     )
 
     _maybe(
-        native.maven_jar,
+        jvm_maven_import_external,
         name = "google_java_format_all_deps",
         artifact = "com.google.googlejavaformat:google-java-format:jar:all-deps:%s" % PROPERTIES["version.google_java_format"],
+        server_urls = ["https://repo.maven.apache.org/maven2/", "http://repo1.maven.org/maven2/"],
+        licenses = ["notice", "reciprocal"]
     )
 
     _maybe(
@@ -83,9 +87,11 @@ def com_google_api_codegen_repositories():
     )
 
     _maybe(
-        native.maven_jar,
+        jvm_maven_import_external,
         name = "error_prone_annotations_maven",
         artifact = "com.google.errorprone:error_prone_annotations:2.3.2",
+        server_urls = ["https://repo.maven.apache.org/maven2/", "http://repo1.maven.org/maven2/"],
+        licenses = ["notice", "reciprocal"]
     )
 
     _maybe(


### PR DESCRIPTION
The native `maven_jar` was removed in bazel 2.x, this fix is needed to fix build for bazel 2.0.
The build remains backward compatible with bazel 1.x.