### PR TITLE
Un-deprecate resource name functions for python GAPICs

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -61,9 +61,7 @@
             @join function : api.formatResourceFunctions
                 @@classmethod
                 def {@function.name}(cls, {@createResourceFunctionParams(function.resourceIdParams)}):
-                    """DEPRECATED. Return a fully-qualified {@function.entityName} string."""
-                    warnings.warn('Resource name helper functions are deprecated.',
-                        PendingDeprecationWarning, stacklevel=1)
+                    """Return a fully-qualified {@function.entityName} string."""
                     return google.api_core.path_template.expand(
                         '{@function.pattern}',
                         {@createRenderParams(function.resourceIdParams)}

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -1157,9 +1157,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def archived_book_path(cls, archive_path, book_id):
-        """DEPRECATED. Return a fully-qualified archived_book string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified archived_book string."""
         return google.api_core.path_template.expand(
             'archives/{archive_path}/books/{book_id=**}',
             archive_path=archive_path,
@@ -1168,9 +1166,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def book_path(cls, shelf_id, book_id):
-        """DEPRECATED. Return a fully-qualified book string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified book string."""
         return google.api_core.path_template.expand(
             'shelves/{shelf_id}/books/{book_id}',
             shelf_id=shelf_id,
@@ -1179,9 +1175,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def folder_path(cls, folder):
-        """DEPRECATED. Return a fully-qualified folder string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified folder string."""
         return google.api_core.path_template.expand(
             'folders/{folder}',
             folder=folder,
@@ -1189,9 +1183,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def location_path(cls, project, location):
-        """DEPRECATED. Return a fully-qualified location string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified location string."""
         return google.api_core.path_template.expand(
             'projects/{project}/locations/{location}',
             project=project,
@@ -1200,9 +1192,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def project_path(cls, project):
-        """DEPRECATED. Return a fully-qualified project string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified project string."""
         return google.api_core.path_template.expand(
             'projects/{project}',
             project=project,
@@ -1210,9 +1200,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def project_book_path(cls, project, book):
-        """DEPRECATED. Return a fully-qualified project_book string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified project_book string."""
         return google.api_core.path_template.expand(
             'projects/{project}/books/{book}',
             project=project,
@@ -1221,9 +1209,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def shelf_path(cls, shelf_id):
-        """DEPRECATED. Return a fully-qualified shelf string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified shelf string."""
         return google.api_core.path_template.expand(
             'shelves/{shelf_id}',
             shelf_id=shelf_id,
@@ -4314,9 +4300,7 @@ class MyProtoClient(object):
 
     @classmethod
     def return_path(cls, shelf, book, return_):
-        """DEPRECATED. Return a fully-qualified return string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified return string."""
         return google.api_core.path_template.expand(
             'shelves/{shelf}/books/{book}/returns/{return}',
             shelf=shelf,

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
@@ -1157,9 +1157,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def archived_book_path(cls, archive_path, book_id):
-        """DEPRECATED. Return a fully-qualified archived_book string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified archived_book string."""
         return google.api_core.path_template.expand(
             'archives/{archive_path}/books/{book_id=**}',
             archive_path=archive_path,
@@ -1168,9 +1166,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def book_path(cls, shelf_id, book_id):
-        """DEPRECATED. Return a fully-qualified book string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified book string."""
         return google.api_core.path_template.expand(
             'shelves/{shelf_id}/books/{book_id}',
             shelf_id=shelf_id,
@@ -1179,9 +1175,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def project_path(cls, project):
-        """DEPRECATED. Return a fully-qualified project string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified project string."""
         return google.api_core.path_template.expand(
             'projects/{project}',
             project=project,
@@ -1189,9 +1183,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def shelf_path(cls, shelf_id):
-        """DEPRECATED. Return a fully-qualified shelf string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified shelf string."""
         return google.api_core.path_template.expand(
             'shelves/{shelf_id}',
             shelf_id=shelf_id,
@@ -4183,9 +4175,7 @@ class MyProtoClient(object):
 
     @classmethod
     def return_path(cls, shelf, book, return_):
-        """DEPRECATED. Return a fully-qualified return string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified return string."""
         return google.api_core.path_template.expand(
             'shelves/{shelf}/books/{book}/returns/{return}',
             shelf=shelf,

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -1157,9 +1157,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def archive_book_path(cls, archive, book):
-        """DEPRECATED. Return a fully-qualified archive_book string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified archive_book string."""
         return google.api_core.path_template.expand(
             'archives/{archive}/books/{book}',
             archive=archive,
@@ -1168,9 +1166,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def archived_book_path(cls, archive, book):
-        """DEPRECATED. Return a fully-qualified archived_book string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified archived_book string."""
         return google.api_core.path_template.expand(
             'archives/{archive}/books/{book}',
             archive=archive,
@@ -1179,9 +1175,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def book_path(cls, book_shelf, book):
-        """DEPRECATED. Return a fully-qualified book string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified book string."""
         return google.api_core.path_template.expand(
             'bookShelves/{book_shelf}/books/{book}',
             book_shelf=book_shelf,
@@ -1190,9 +1184,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def book_from_archive_path(cls, archive, book):
-        """DEPRECATED. Return a fully-qualified book_from_archive string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified book_from_archive string."""
         return google.api_core.path_template.expand(
             'archives/{archive}/books/{book}',
             archive=archive,
@@ -1201,9 +1193,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def folder_path(cls, folder):
-        """DEPRECATED. Return a fully-qualified folder string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified folder string."""
         return google.api_core.path_template.expand(
             'folders/{folder}',
             folder=folder,
@@ -1211,9 +1201,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def location_path(cls, project, location):
-        """DEPRECATED. Return a fully-qualified location string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified location string."""
         return google.api_core.path_template.expand(
             'projects/{project}/locations/{location}',
             project=project,
@@ -1222,9 +1210,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def project_path(cls, project):
-        """DEPRECATED. Return a fully-qualified project string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified project string."""
         return google.api_core.path_template.expand(
             'projects/{project}',
             project=project,
@@ -1232,9 +1218,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def project_book_path(cls, project, book):
-        """DEPRECATED. Return a fully-qualified project_book string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified project_book string."""
         return google.api_core.path_template.expand(
             'projects/{project}/books/{book}',
             project=project,
@@ -1243,9 +1227,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def publisher_path(cls, project, location, publisher):
-        """DEPRECATED. Return a fully-qualified publisher string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified publisher string."""
         return google.api_core.path_template.expand(
             'projects/{project}/locations/{location}/publishers/{publisher}',
             project=project,
@@ -1255,9 +1237,7 @@ class LibraryServiceClient(object):
 
     @classmethod
     def shelf_path(cls, shelf_id):
-        """DEPRECATED. Return a fully-qualified shelf string."""
-        warnings.warn('Resource name helper functions are deprecated.',
-            PendingDeprecationWarning, stacklevel=1)
+        """Return a fully-qualified shelf string."""
         return google.api_core.path_template.expand(
             'shelves/{shelf_id}',
             shelf_id=shelf_id,


### PR DESCRIPTION
Resource name functions have been added back to the surface for microgenerated Python GAPIC libraries, so they should no longer be deprecated in the monolithic surface.