### PR TITLE
fix: use string literals in samples for an any resource name if there are no other resources

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -771,9 +771,11 @@ public class InitCodeTransformer {
     SingleResourceNameConfig singleResourceNameConfig;
     switch (fieldConfig.getResourceNameType()) {
       case ANY:
-        // TODO(michaelbausor): handle case where there are no other resource names at all...
-        singleResourceNameConfig =
-            Iterables.get(context.getProductConfig().getSingleResourceNameConfigs(), 0);
+        Iterable<SingleResourceNameConfig> singleResourceNameConfigs = context.getProductConfig().getSingleResourceNameConfigs();
+        if (!singleResourceNameConfigs.hasNext()) {
+          
+        }
+        singleResourceNameConfig = singleResourceNameConfigs.next();
         MethodModel methodModel = context.getMethodModel();
         if (methodModel instanceof ProtoMethodModel) {
           ProtoFile protoFile = ((ProtoMethodModel) methodModel).getProtoMethod().getFile();

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -771,11 +771,8 @@ public class InitCodeTransformer {
     SingleResourceNameConfig singleResourceNameConfig;
     switch (fieldConfig.getResourceNameType()) {
       case ANY:
-        Iterable<SingleResourceNameConfig> singleResourceNameConfigs = context.getProductConfig().getSingleResourceNameConfigs();
-        if (!singleResourceNameConfigs.hasNext()) {
-          
-        }
-        singleResourceNameConfig = singleResourceNameConfigs.next();
+        singleResourceNameConfig =
+            Iterables.get(context.getProductConfig().getSingleResourceNameConfigs(), 0);
         MethodModel methodModel = context.getMethodModel();
         if (methodModel instanceof ProtoMethodModel) {
           ProtoFile protoFile = ((ProtoMethodModel) methodModel).getProtoMethod().getFile();

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
@@ -47,6 +47,15 @@ public abstract class JavaFeatureConfig extends DefaultFeatureConfig {
       return false;
     }
 
+    // For an any resource name, we choose one single resource name defined in the API for
+    // sample generation. If there are no single resource names in the API, we do not use
+    // resource name format option.
+    boolean apiHasSingleResources =
+        context.getProductConfig().getSingleResourceNameConfigs().iterator().hasNext();
+    if (fieldConfig.getResourceNameType() == ResourceNameType.ANY && !apiHasSingleResources) {
+      return false;
+    }
+
     // TODO: support creating resource name strings in tests and samples using creation methods
     // in the new multi-pattern resource classes.
     //

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
@@ -49,7 +49,7 @@ public abstract class JavaFeatureConfig extends DefaultFeatureConfig {
 
     // For an any resource name, we choose a random single resource name defined in the API for
     // sample generation. If there are no single resource names at all in the API, we set this
-    // value to false and use a string literal to instantiate a resource name string. 
+    // value to false and use a string literal to instantiate a resource name string.
     boolean apiHasSingleResources =
         context.getProductConfig().getSingleResourceNameConfigs().iterator().hasNext();
     if (fieldConfig.getResourceNameType() == ResourceNameType.ANY && !apiHasSingleResources) {

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
@@ -47,9 +47,9 @@ public abstract class JavaFeatureConfig extends DefaultFeatureConfig {
       return false;
     }
 
-    // For an any resource name, we choose one single resource name defined in the API for
-    // sample generation. If there are no single resource names in the API, we do not use
-    // resource name format option.
+    // For an any resource name, we choose a random single resource name defined in the API for
+    // sample generation. If there are no single resource names at all in the API, we set this
+    // value to false and use a string literal to instantiate a resource name string. 
     boolean apiHasSingleResources =
         context.getProductConfig().getSingleResourceNameConfigs().iterator().hasNext();
     if (fieldConfig.getResourceNameType() == ResourceNameType.ANY && !apiHasSingleResources) {

--- a/src/main/resources/com/google/api/codegen/java/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/java/initcode.snip
@@ -114,7 +114,6 @@
 @end
 
 @private renderResourceName(initValue)
-  @if {@initValue.}
   @if {@initValue.convertToString}
     {@initValue.resourceTypeName}.format({@argList(initValue.formatArgs)})
   @else

--- a/src/main/resources/com/google/api/codegen/java/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/java/initcode.snip
@@ -114,6 +114,7 @@
 @end
 
 @private renderResourceName(initValue)
+  @if {@initValue.}
   @if {@initValue.convertToString}
     {@initValue.resourceTypeName}.format({@argList(initValue.formatArgs)})
   @else


### PR DESCRIPTION
It's hard to demonstrate the change in baseline since we do have other resources. See [this](https://github.com/hzyi-google/sample-staging/blob/ae03c7d75df202a060ab25c1b114dcb7ed5e5e5f/20200108/java/gapic-google-cloud-containeranalysis-v1/src/main/java/com/google/cloud/devtools/containeranalysis/v1/ContainerAnalysisClient.java#L54-L56) for what the generated code looks like. 