### PR TITLE
Update baseline proto files and gapic configs

### DIFF
--- a/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
@@ -665,6 +665,92 @@ interfaces:
       total_poll_timeout_millis: 300000
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  - name: MoveBooks
+    # FIXME: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - source
+        - destination
+        - publishers
+        - project
+    # FIXME: Configure which fields are required.
+    required_fields:
+    - source
+    - destination
+    - publishers
+    - project
+    # FIXME: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # FIXME: Configure the retryable params for this method.
+    retry_params_name: default
+    # FIXME: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: ArchiveBooks
+    # FIXME: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - source
+        - archive
+    # FIXME: Configure which fields are required.
+    required_fields:
+    - source
+    - archive
+    # FIXME: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # FIXME: Configure the retryable params for this method.
+    retry_params_name: default
+    # FIXME: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: LongRunningArchiveBooks
+    # FIXME: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - source
+        - archive
+    # FIXME: Configure which fields are required.
+    required_fields:
+    - source
+    - archive
+    # FIXME: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # FIXME: Configure the retryable params for this method.
+    retry_params_name: default
+    # FIXME: Configure long running operation.
+    long_running:
+      # FIXME: Configure return type.
+      return_type: google.protobuf.Empty
+      # FIXME: Configure metadata type.
+      metadata_type: google.protobuf.Struct
+      initial_poll_delay_millis: 500
+      poll_delay_multiplier: 1.5
+      max_poll_delay_millis: 5000
+      total_poll_timeout_millis: 300000
+    # FIXME: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: StreamingArchiveBooks
+    # FIXME: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - source
+        - archive
+    # FIXME: Configure which fields are required.
+    required_fields:
+    - source
+    - archive
+    # FIXME: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # FIXME: Configure the retryable params for this method.
+    retry_params_name: default
+    # FIXME: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: TestOptionalRequiredFlatteningParams
     # FIXME: Configure which fields are required.
     required_fields:

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -39,7 +39,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleDeleteShelfAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             await libraryServiceClient.DeleteShelfAsync(name);
             // Shelf deleted
             Console.WriteLine("Shelf deleted.");
@@ -97,7 +97,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleDeleteShelfAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             await libraryServiceClient.DeleteShelfAsync(name);
         }
     }
@@ -156,7 +156,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             await libraryServiceClient.DeleteShelfAsync(request);
             // Shelf deleted
@@ -217,7 +217,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             await libraryServiceClient.DeleteShelfAsync(request);
         }
@@ -274,7 +274,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleDeleteShelf()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             libraryServiceClient.DeleteShelf(name);
             // Shelf deleted
             Console.WriteLine("Shelf deleted.");
@@ -331,7 +331,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleDeleteShelf()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             libraryServiceClient.DeleteShelf(name);
         }
     }
@@ -389,7 +389,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             libraryServiceClient.DeleteShelf(request);
             // Shelf deleted
@@ -449,7 +449,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             libraryServiceClient.DeleteShelf(request);
         }
@@ -511,11 +511,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             IEnumerable<BookName> names = new[]
             {
-                new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                new BookName("[SHELF]", "[BOOK]"),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookName> response = await libraryServiceClient.FindRelatedBooksAsync(names, shelves);
             // Iterate over pages (of server-defined size), performing one RPC per page
@@ -583,11 +583,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             IEnumerable<BookName> names = new[]
             {
-                new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                new BookName("[SHELF]", "[BOOK]"),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookName> response = await libraryServiceClient.FindRelatedBooksAsync(names, shelves);
             // Iterate over all response items, lazily performing RPCs as required
@@ -657,11 +657,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             IEnumerable<BookName> names = new[]
             {
-                new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                new BookName("[SHELF]", "[BOOK]"),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookName> response = await libraryServiceClient.FindRelatedBooksAsync(names, shelves);
             // Retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
@@ -735,11 +735,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNames =
                 {
-                    new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    new BookName("[SHELF]", "[BOOK]"),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookName> response = await libraryServiceClient.FindRelatedBooksAsync(request);
@@ -810,11 +810,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNames =
                 {
-                    new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    new BookName("[SHELF]", "[BOOK]"),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookName> response = await libraryServiceClient.FindRelatedBooksAsync(request);
@@ -887,11 +887,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNames =
                 {
-                    new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    new BookName("[SHELF]", "[BOOK]"),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookName> response = await libraryServiceClient.FindRelatedBooksAsync(request);
@@ -963,11 +963,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             IEnumerable<BookName> names = new[]
             {
-                new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                new BookName("[SHELF]", "[BOOK]"),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedEnumerable<FindRelatedBooksResponse, BookName> response = libraryServiceClient.FindRelatedBooks(names, shelves);
             // Iterate over pages (of server-defined size), performing one RPC per page
@@ -1034,11 +1034,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             IEnumerable<BookName> names = new[]
             {
-                new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                new BookName("[SHELF]", "[BOOK]"),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedEnumerable<FindRelatedBooksResponse, BookName> response = libraryServiceClient.FindRelatedBooks(names, shelves);
             // Iterate over all response items, lazily performing RPCs as required
@@ -1108,11 +1108,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             IEnumerable<BookName> names = new[]
             {
-                new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                new BookName("[SHELF]", "[BOOK]"),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedEnumerable<FindRelatedBooksResponse, BookName> response = libraryServiceClient.FindRelatedBooks(names, shelves);
             // Retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
@@ -1185,11 +1185,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNames =
                 {
-                    new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    new BookName("[SHELF]", "[BOOK]"),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedEnumerable<FindRelatedBooksResponse, BookName> response = libraryServiceClient.FindRelatedBooks(request);
@@ -1259,11 +1259,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNames =
                 {
-                    new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    new BookName("[SHELF]", "[BOOK]"),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedEnumerable<FindRelatedBooksResponse, BookName> response = libraryServiceClient.FindRelatedBooks(request);
@@ -1336,11 +1336,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNames =
                 {
-                    new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    new BookName("[SHELF]", "[BOOK]"),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedEnumerable<FindRelatedBooksResponse, BookName> response = libraryServiceClient.FindRelatedBooks(request);
@@ -2057,7 +2057,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBigNothingAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(name);
             await operation.PollUntilCompletedAsync();
@@ -2117,7 +2117,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBigNothingAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(name);
             await operation.PollUntilCompletedAsync();
@@ -2178,7 +2178,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(request);
@@ -2241,7 +2241,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(request);
@@ -2300,7 +2300,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBigNothing()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(name).PollUntilCompleted();
             // Got nothing
@@ -2358,7 +2358,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBigNothing()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(name).PollUntilCompleted();
         }
@@ -2417,7 +2417,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(request).PollUntilCompleted();
@@ -2478,7 +2478,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(request).PollUntilCompleted();
@@ -2539,7 +2539,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBookAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book response = await libraryServiceClient.GetBookAsync(name);
             string intKeyVal = response.MapStringValue[123];
             string booleanKeyVal = response.MapBoolKey[true];
@@ -2605,7 +2605,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Book response = await libraryServiceClient.GetBookAsync(request);
             string intKeyVal = response.MapStringValue[123];
@@ -2669,7 +2669,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBook()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book response = libraryServiceClient.GetBook(name);
             string intKeyVal = response.MapStringValue[123];
             string booleanKeyVal = response.MapBoolKey[true];
@@ -2734,7 +2734,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Book response = libraryServiceClient.GetBook(request);
             string intKeyVal = response.MapStringValue[123];
@@ -3798,7 +3798,7 @@ namespace Google.Example.Library.V1.Samples
             while (!done)
             {
                 // Initialize a request
-                ShelfName name = new ShelfName("[SHELF_ID]");
+                ShelfName name = new ShelfName("[SHELF]");
                 // Stream a request to the server
                 await duplexStream.WriteAsync(request);
 
@@ -3865,7 +3865,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleStreamShelvesAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
 
             // Make the request, returning a streaming response
             LibraryServiceClient.StreamShelvesStream streamingResponse = libraryServiceClient.StreamShelves(name);
@@ -3959,7 +3959,7 @@ namespace Google.Example.Library.V1.Samples
                 // Initialize a request
                 StreamShelvesRequest request = new StreamShelvesRequest
                 {
-                    ShelfName = new ShelfName("[SHELF_ID]"),
+                    ShelfName = new ShelfName("[SHELF]"),
                 };
                 // Stream a request to the server
                 await duplexStream.WriteAsync(request);
@@ -4029,7 +4029,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             StreamShelvesRequest request = new StreamShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
 
             // Make the request, returning a streaming response
@@ -4168,8 +4168,8 @@ namespace Google.Example.Library.V1.Samples
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -4581,7 +4581,7 @@ namespace Google.Example.Library.V1.Samples
                 // Initialize a request
                 DiscussBookRequest request = new DiscussBookRequest
                 {
-                    BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    BookName = new BookName("[SHELF]", "[BOOK]"),
                     Comment = new Comment
                     {
                         Comment = ByteString.CopyFrom(File.ReadAllBytes("comment_file")),
@@ -4670,7 +4670,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             DiscussBookRequest request = new DiscussBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comment = new Comment
                 {
                     Comment = ByteString.CopyFrom(File.ReadAllBytes("comment_file")),
@@ -4918,7 +4918,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = await libraryServiceClient.GetShelfAsync(name);
             // End snippet
@@ -4931,7 +4931,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = libraryServiceClient.GetShelf(name);
             // End snippet
@@ -4945,7 +4945,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             // Make the request
             Shelf response = await libraryServiceClient.GetShelfAsync(name, message);
@@ -4959,7 +4959,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             // Make the request
             Shelf response = libraryServiceClient.GetShelf(name, message);
@@ -4974,7 +4974,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             // Make the request
@@ -4989,7 +4989,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             // Make the request
@@ -5007,7 +5007,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "",
             };
             // Make the request
@@ -5024,7 +5024,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "",
             };
             // Make the request
@@ -5212,7 +5212,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             await libraryServiceClient.DeleteShelfAsync(name);
             // End snippet
@@ -5225,7 +5225,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             libraryServiceClient.DeleteShelf(name);
             // End snippet
@@ -5241,7 +5241,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             await libraryServiceClient.DeleteShelfAsync(request);
@@ -5257,7 +5257,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             libraryServiceClient.DeleteShelf(request);
@@ -5272,8 +5272,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = await libraryServiceClient.MergeShelvesAsync(name, otherShelfName);
             // End snippet
@@ -5286,8 +5286,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = libraryServiceClient.MergeShelves(name, otherShelfName);
             // End snippet
@@ -5303,8 +5303,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Shelf response = await libraryServiceClient.MergeShelvesAsync(request);
@@ -5320,8 +5320,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Shelf response = libraryServiceClient.MergeShelves(request);
@@ -5336,7 +5336,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             // Make the request
             Book response = await libraryServiceClient.CreateBookAsync(name, book);
@@ -5350,7 +5350,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             // Make the request
             Book response = libraryServiceClient.CreateBook(name, book);
@@ -5367,7 +5367,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             // Make the request
@@ -5384,7 +5384,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             // Make the request
@@ -5482,7 +5482,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Book response = await libraryServiceClient.GetBookAsync(name);
             // End snippet
@@ -5495,7 +5495,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Book response = libraryServiceClient.GetBook(name);
             // End snippet
@@ -5511,7 +5511,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Book response = await libraryServiceClient.GetBookAsync(request);
@@ -5527,7 +5527,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Book response = libraryServiceClient.GetBook(request);
@@ -5541,7 +5541,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             string filter = "book-filter-string";
             // Make the request
             PagedAsyncEnumerable<ListBooksResponse, Book> response =
@@ -5586,7 +5586,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             string filter = "book-filter-string";
             // Make the request
             PagedEnumerable<ListBooksResponse, Book> response =
@@ -5633,7 +5633,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             ListBooksRequest request = new ListBooksRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Filter = "book-filter-string",
             };
             // Make the request
@@ -5681,7 +5681,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             ListBooksRequest request = new ListBooksRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Filter = "book-filter-string",
             };
             // Make the request
@@ -5728,7 +5728,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             await libraryServiceClient.DeleteBookAsync(name);
             // End snippet
@@ -5741,7 +5741,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             libraryServiceClient.DeleteBook(name);
             // End snippet
@@ -5757,7 +5757,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             await libraryServiceClient.DeleteBookAsync(request);
@@ -5773,7 +5773,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             libraryServiceClient.DeleteBook(request);
@@ -5788,7 +5788,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book book = new Book();
             // Make the request
             Book response = await libraryServiceClient.UpdateBookAsync(name, book);
@@ -5802,7 +5802,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book book = new Book();
             // Make the request
             Book response = libraryServiceClient.UpdateBook(name, book);
@@ -5817,7 +5817,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string optionalFoo = "";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -5834,7 +5834,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string optionalFoo = "";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -5854,7 +5854,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             // Make the request
@@ -5871,7 +5871,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             // Make the request
@@ -5887,8 +5887,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Book response = await libraryServiceClient.MoveBookAsync(name, otherShelfName);
             // End snippet
@@ -5901,8 +5901,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Book response = libraryServiceClient.MoveBook(name, otherShelfName);
             // End snippet
@@ -5918,8 +5918,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MoveBookRequest request = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Book response = await libraryServiceClient.MoveBookAsync(request);
@@ -5935,8 +5935,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MoveBookRequest request = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Book response = libraryServiceClient.MoveBook(request);
@@ -6034,7 +6034,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            IResourceName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            IResourceName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             // Make the request
             PagedAsyncEnumerable<ListStringsResponse, IResourceName> response =
                 libraryServiceClient.ListStringsAsync(name);
@@ -6078,7 +6078,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            IResourceName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            IResourceName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             // Make the request
             PagedEnumerable<ListStringsResponse, IResourceName> response =
                 libraryServiceClient.ListStrings(name);
@@ -6211,7 +6211,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -6233,7 +6233,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -6258,7 +6258,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -6283,7 +6283,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -6307,7 +6307,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             LocationParentNameOneof parent = LocationParentNameOneof.From(new ProjectName("[PROJECT]"));
             // Make the request
             BookFromArchive response = await libraryServiceClient.GetBookFromArchiveAsync(name, parent);
@@ -6321,7 +6321,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             LocationParentNameOneof parent = LocationParentNameOneof.From(new ProjectName("[PROJECT]"));
             // Make the request
             BookFromArchive response = libraryServiceClient.GetBookFromArchive(name, parent);
@@ -6338,7 +6338,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromArchiveRequest request = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 ParentAsLocationParentNameOneof = LocationParentNameOneof.From(new ProjectName("[PROJECT]")),
             };
             // Make the request
@@ -6355,7 +6355,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromArchiveRequest request = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 ParentAsLocationParentNameOneof = LocationParentNameOneof.From(new ProjectName("[PROJECT]")),
             };
             // Make the request
@@ -6371,8 +6371,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
-            BookName altBookName = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookName altBookName = new BookName("[SHELF]", "[BOOK]");
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             // Make the request
@@ -6387,8 +6387,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
-            BookName altBookName = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookName altBookName = new BookName("[SHELF]", "[BOOK]");
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             // Make the request
@@ -6406,8 +6406,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
@@ -6425,8 +6425,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
@@ -6443,7 +6443,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             BookFromAnywhere response = await libraryServiceClient.GetBookFromAbsolutelyAnywhereAsync(name);
             // End snippet
@@ -6456,7 +6456,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(name);
             // End snippet
@@ -6472,7 +6472,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             BookFromAnywhere response = await libraryServiceClient.GetBookFromAbsolutelyAnywhereAsync(request);
@@ -6488,7 +6488,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
@@ -6503,7 +6503,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -6521,7 +6521,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -6542,7 +6542,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -6563,7 +6563,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -6584,7 +6584,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument
             StreamShelvesRequest request = new StreamShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request, returning a streaming response
             LibraryServiceClient.StreamShelvesStream streamingResponse = libraryServiceClient.StreamShelves(request);
@@ -6656,7 +6656,7 @@ namespace Google.Example.Library.V1.Snippets
                 // Initialize a request
                 DiscussBookRequest request = new DiscussBookRequest
                 {
-                    BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    BookName = new BookName("[SHELF]", "[BOOK]"),
                 };
                 // Stream a request to the server
                 await duplexStream.WriteAsync(request);
@@ -6680,7 +6680,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             IEnumerable<BookName> names = new[]
             {
-                new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                new BookName("[SHELF]", "[BOOK]"),
             };
             IEnumerable<ShelfName> shelves = new List<ShelfName>();
             // Make the request
@@ -6728,7 +6728,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             IEnumerable<BookName> names = new[]
             {
-                new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                new BookName("[SHELF]", "[BOOK]"),
             };
             IEnumerable<ShelfName> shelves = new List<ShelfName>();
             // Make the request
@@ -6778,7 +6778,7 @@ namespace Google.Example.Library.V1.Snippets
             {
                 BookNames =
                 {
-                    new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    new BookName("[SHELF]", "[BOOK]"),
                 },
                 ShelvesAsShelfNames = { },
             };
@@ -6829,7 +6829,7 @@ namespace Google.Example.Library.V1.Snippets
             {
                 BookNames =
                 {
-                    new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    new BookName("[SHELF]", "[BOOK]"),
                 },
                 ShelvesAsShelfNames = { },
             };
@@ -6877,7 +6877,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            string formattedResource = new BookName("[SHELF_ID]", "[BOOK_ID]").ToString();
+            string formattedResource = new BookName("[SHELF]", "[BOOK]").ToString();
             string label = "";
             // Make the request
             AddLabelResponse response = await libraryServiceClient.AddLabelAsync(formattedResource, label);
@@ -6891,7 +6891,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            string formattedResource = new BookName("[SHELF_ID]", "[BOOK_ID]").ToString();
+            string formattedResource = new BookName("[SHELF]", "[BOOK]").ToString();
             string label = "";
             // Make the request
             AddLabelResponse response = libraryServiceClient.AddLabel(formattedResource, label);
@@ -6908,7 +6908,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                Resource = new BookName("[SHELF_ID]", "[BOOK_ID]").ToString(),
+                Resource = new BookName("[SHELF]", "[BOOK]").ToString(),
                 Label = "",
             };
             // Make the request
@@ -6925,7 +6925,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                Resource = new BookName("[SHELF_ID]", "[BOOK_ID]").ToString(),
+                Resource = new BookName("[SHELF]", "[BOOK]").ToString(),
                 Label = "",
             };
             // Make the request
@@ -6941,7 +6941,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
                 await libraryServiceClient.GetBigBookAsync(name);
@@ -6973,7 +6973,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
                 libraryServiceClient.GetBigBook(name);
@@ -7007,7 +7007,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
@@ -7042,7 +7042,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
@@ -7076,7 +7076,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
                 await libraryServiceClient.GetBigNothingAsync(name);
@@ -7106,7 +7106,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
                 libraryServiceClient.GetBigNothing(name);
@@ -7138,7 +7138,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
@@ -7171,7 +7171,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
@@ -7235,8 +7235,8 @@ namespace Google.Example.Library.V1.Snippets
             string requiredSingularString = "";
             ByteString requiredSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName requiredSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 0;
             long requiredSingularFixed64 = 0L;
@@ -7296,8 +7296,8 @@ namespace Google.Example.Library.V1.Snippets
             string optionalSingularString = "";
             ByteString optionalSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName optionalSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 0;
             long optionalSingularFixed64 = 0L;
@@ -7369,8 +7369,8 @@ namespace Google.Example.Library.V1.Snippets
             string requiredSingularString = "";
             ByteString requiredSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName requiredSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 0;
             long requiredSingularFixed64 = 0L;
@@ -7430,8 +7430,8 @@ namespace Google.Example.Library.V1.Snippets
             string optionalSingularString = "";
             ByteString optionalSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName optionalSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 0;
             long optionalSingularFixed64 = 0L;
@@ -7506,8 +7506,8 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -7582,8 +7582,8 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -7637,6 +7637,130 @@ namespace Google.Example.Library.V1.Snippets
             };
             // Make the request
             TestOptionalRequiredFlatteningParamsResponse response = libraryServiceClient.TestOptionalRequiredFlatteningParams(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MoveBooksAsync</summary>
+        public async Task MoveBooksAsync_RequestObject()
+        {
+            // Snippet: MoveBooksAsync(MoveBooksRequest,CallSettings)
+            // Additional: MoveBooksAsync(MoveBooksRequest,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            MoveBooksRequest request = new MoveBooksRequest();
+            // Make the request
+            MoveBooksResponse response = await libraryServiceClient.MoveBooksAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MoveBooks</summary>
+        public void MoveBooks_RequestObject()
+        {
+            // Snippet: MoveBooks(MoveBooksRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            MoveBooksRequest request = new MoveBooksRequest();
+            // Make the request
+            MoveBooksResponse response = libraryServiceClient.MoveBooks(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for ArchiveBooksAsync</summary>
+        public async Task ArchiveBooksAsync_RequestObject()
+        {
+            // Snippet: ArchiveBooksAsync(ArchiveBooksRequest,CallSettings)
+            // Additional: ArchiveBooksAsync(ArchiveBooksRequest,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            ArchiveBooksResponse response = await libraryServiceClient.ArchiveBooksAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for ArchiveBooks</summary>
+        public void ArchiveBooks_RequestObject()
+        {
+            // Snippet: ArchiveBooks(ArchiveBooksRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            ArchiveBooksResponse response = libraryServiceClient.ArchiveBooks(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for LongRunningArchiveBooksAsync</summary>
+        public async Task LongRunningArchiveBooksAsync_RequestObject()
+        {
+            // Snippet: LongRunningArchiveBooksAsync(ArchiveBooksRequest,CallSettings)
+            // Additional: LongRunningArchiveBooksAsync(ArchiveBooksRequest,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            Operation response = await libraryServiceClient.LongRunningArchiveBooksAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for LongRunningArchiveBooks</summary>
+        public void LongRunningArchiveBooks_RequestObject()
+        {
+            // Snippet: LongRunningArchiveBooks(ArchiveBooksRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            Operation response = libraryServiceClient.LongRunningArchiveBooks(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for StreamingArchiveBooks</summary>
+        public async Task StreamingArchiveBooks()
+        {
+            // Snippet: StreamingArchiveBooks(CallSettings,BidirectionalStreamingSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize streaming call, retrieving the stream object
+            LibraryServiceClient.StreamingArchiveBooksStream duplexStream = libraryServiceClient.StreamingArchiveBooks();
+
+            // Sending requests and retrieving responses can be arbitrarily interleaved.
+            // Exact sequence will depend on client/server behavior.
+
+            // Create task to do something with responses from server
+            Task responseHandlerTask = Task.Run(async () =>
+            {
+                IAsyncEnumerator<ArchiveBooksResponse> responseStream = duplexStream.ResponseStream;
+                while (await responseStream.MoveNext())
+                {
+                    ArchiveBooksResponse response = responseStream.Current;
+                    // Do something with streamed response
+                }
+                // The response stream has completed
+            });
+
+            // Send requests to the server
+            bool done = false;
+            while (!done)
+            {
+                // Initialize a request
+                ArchiveBooksRequest request = new ArchiveBooksRequest();
+                // Stream a request to the server
+                await duplexStream.WriteAsync(request);
+
+                // Set "done" to true when sending requests is complete
+            }
+            // Complete writing requests to the stream
+            await duplexStream.WriteCompleteAsync();
+            // Await the response handler.
+            // This will complete once all server responses have been processed.
+            await responseHandlerTask;
             // End snippet
         }
 
@@ -7811,7 +7935,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -7838,7 +7962,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -7865,7 +7989,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -7891,7 +8015,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -7913,18 +8037,18 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Shelf response = client.GetShelf(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -7940,18 +8064,18 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Shelf response = await client.GetShelfAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -7967,19 +8091,19 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             Shelf response = client.GetShelf(name, message);
             Assert.Same(expectedResponse, response);
@@ -7996,19 +8120,19 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             Shelf response = await client.GetShelfAsync(name, message);
             Assert.Same(expectedResponse, response);
@@ -8025,20 +8149,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
                 StringBuilder = new StringBuilder(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             Shelf response = client.GetShelf(name, message, stringBuilder);
@@ -8056,20 +8180,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
                 StringBuilder = new StringBuilder(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             Shelf response = await client.GetShelfAsync(name, message, stringBuilder);
@@ -8087,12 +8211,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "options-1249474914",
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -8114,12 +8238,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "options-1249474914",
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -8141,13 +8265,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest expectedRequest = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             client.DeleteShelf(name);
             mockGrpcClient.VerifyAll();
         }
@@ -8162,13 +8286,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest expectedRequest = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             await client.DeleteShelfAsync(name);
             mockGrpcClient.VerifyAll();
         }
@@ -8183,7 +8307,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelf(request, It.IsAny<CallOptions>()))
@@ -8203,7 +8327,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelfAsync(request, It.IsAny<CallOptions>()))
@@ -8223,20 +8347,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest expectedRequest = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.MergeShelves(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Shelf response = client.MergeShelves(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -8252,20 +8376,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest expectedRequest = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.MergeShelvesAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Shelf response = await client.MergeShelvesAsync(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -8281,12 +8405,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -8308,12 +8432,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -8335,12 +8459,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest expectedRequest = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8348,7 +8472,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.CreateBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             Book response = client.CreateBook(name, book);
             Assert.Same(expectedResponse, response);
@@ -8365,12 +8489,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest expectedRequest = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8378,7 +8502,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.CreateBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             Book response = await client.CreateBookAsync(name, book);
             Assert.Same(expectedResponse, response);
@@ -8395,12 +8519,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8423,12 +8547,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8595,11 +8719,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest expectedRequest = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8607,7 +8731,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book response = client.GetBook(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -8623,11 +8747,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest expectedRequest = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8635,7 +8759,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book response = await client.GetBookAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -8651,11 +8775,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8678,11 +8802,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8705,13 +8829,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest expectedRequest = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             client.DeleteBook(name);
             mockGrpcClient.VerifyAll();
         }
@@ -8726,13 +8850,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest expectedRequest = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             await client.DeleteBookAsync(name);
             mockGrpcClient.VerifyAll();
         }
@@ -8747,7 +8871,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBook(request, It.IsAny<CallOptions>()))
@@ -8767,7 +8891,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBookAsync(request, It.IsAny<CallOptions>()))
@@ -8787,12 +8911,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8800,7 +8924,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book book = new Book();
             Book response = client.UpdateBook(name, book);
             Assert.Same(expectedResponse, response);
@@ -8817,12 +8941,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8830,7 +8954,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book book = new Book();
             Book response = await client.UpdateBookAsync(name, book);
             Assert.Same(expectedResponse, response);
@@ -8847,7 +8971,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 OptionalFoo = "optionalFoo1822578535",
                 Book = new Book(),
                 UpdateMask = new FieldMask(),
@@ -8855,7 +8979,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8863,7 +8987,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string optionalFoo = "optionalFoo1822578535";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -8883,7 +9007,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 OptionalFoo = "optionalFoo1822578535",
                 Book = new Book(),
                 UpdateMask = new FieldMask(),
@@ -8891,7 +9015,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8899,7 +9023,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string optionalFoo = "optionalFoo1822578535";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -8919,12 +9043,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8947,12 +9071,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8975,12 +9099,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest expectedRequest = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8988,8 +9112,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.MoveBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Book response = client.MoveBook(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -9005,12 +9129,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest expectedRequest = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9018,8 +9142,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.MoveBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Book response = await client.MoveBookAsync(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -9035,12 +9159,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest request = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9063,12 +9187,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest request = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9091,7 +9215,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest expectedRequest = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -9106,7 +9230,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.AddComments(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -9130,7 +9254,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest expectedRequest = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -9145,7 +9269,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.AddCommentsAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -9169,7 +9293,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -9198,7 +9322,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -9227,12 +9351,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromArchiveRequest expectedRequest = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 ParentAsLocationParentNameOneof = LocationParentNameOneof.From(new ProjectName("[PROJECT]")),
             };
             BookFromArchive expectedResponse = new BookFromArchive
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9240,7 +9364,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromArchive(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             LocationParentNameOneof parent = LocationParentNameOneof.From(new ProjectName("[PROJECT]"));
             BookFromArchive response = client.GetBookFromArchive(name, parent);
             Assert.Same(expectedResponse, response);
@@ -9257,12 +9381,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromArchiveRequest expectedRequest = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 ParentAsLocationParentNameOneof = LocationParentNameOneof.From(new ProjectName("[PROJECT]")),
             };
             BookFromArchive expectedResponse = new BookFromArchive
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9270,7 +9394,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromArchiveAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<BookFromArchive>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             LocationParentNameOneof parent = LocationParentNameOneof.From(new ProjectName("[PROJECT]"));
             BookFromArchive response = await client.GetBookFromArchiveAsync(name, parent);
             Assert.Same(expectedResponse, response);
@@ -9287,12 +9411,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromArchiveRequest request = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 ParentAsLocationParentNameOneof = LocationParentNameOneof.From(new ProjectName("[PROJECT]")),
             };
             BookFromArchive expectedResponse = new BookFromArchive
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9315,12 +9439,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromArchiveRequest request = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 ParentAsLocationParentNameOneof = LocationParentNameOneof.From(new ProjectName("[PROJECT]")),
             };
             BookFromArchive expectedResponse = new BookFromArchive
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9343,14 +9467,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest expectedRequest = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9358,8 +9482,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAnywhere(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
-            BookName altBookName = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookName altBookName = new BookName("[SHELF]", "[BOOK]");
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             BookFromAnywhere response = client.GetBookFromAnywhere(name, altBookName, place, folder);
@@ -9377,14 +9501,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest expectedRequest = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9392,8 +9516,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAnywhereAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<BookFromAnywhere>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
-            BookName altBookName = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookName altBookName = new BookName("[SHELF]", "[BOOK]");
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             BookFromAnywhere response = await client.GetBookFromAnywhereAsync(name, altBookName, place, folder);
@@ -9411,14 +9535,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9441,14 +9565,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9471,11 +9595,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest expectedRequest = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9483,7 +9607,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAbsolutelyAnywhere(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             BookFromAnywhere response = client.GetBookFromAbsolutelyAnywhere(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -9499,11 +9623,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest expectedRequest = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9511,7 +9635,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAbsolutelyAnywhereAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<BookFromAnywhere>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             BookFromAnywhere response = await client.GetBookFromAbsolutelyAnywhereAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -9527,11 +9651,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9554,11 +9678,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9581,7 +9705,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest expectedRequest = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -9592,7 +9716,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookIndex(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -9612,7 +9736,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest expectedRequest = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -9623,7 +9747,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookIndexAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -9643,7 +9767,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -9668,7 +9792,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -9740,8 +9864,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -9801,8 +9925,8 @@ namespace Google.Example.Library.V1.Tests
                 OptionalSingularString = "optionalSingularString1852995162",
                 OptionalSingularBytes = ByteString.CopyFromUtf8("2"),
                 OptionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                OptionalSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                OptionalSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OptionalSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 OptionalSingularFixed32 = 1648847958,
                 OptionalSingularFixed64 = 1648847863,
@@ -9867,8 +9991,8 @@ namespace Google.Example.Library.V1.Tests
             string requiredSingularString = "requiredSingularString-1949894503";
             ByteString requiredSingularBytes = ByteString.CopyFromUtf8("-29");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName requiredSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 720656715;
             long requiredSingularFixed64 = 720656810;
@@ -9928,8 +10052,8 @@ namespace Google.Example.Library.V1.Tests
             string optionalSingularString = "optionalSingularString1852995162";
             ByteString optionalSingularBytes = ByteString.CopyFromUtf8("2");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName optionalSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 1648847958;
             long optionalSingularFixed64 = 1648847863;
@@ -10004,8 +10128,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -10065,8 +10189,8 @@ namespace Google.Example.Library.V1.Tests
                 OptionalSingularString = "optionalSingularString1852995162",
                 OptionalSingularBytes = ByteString.CopyFromUtf8("2"),
                 OptionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                OptionalSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                OptionalSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OptionalSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 OptionalSingularFixed32 = 1648847958,
                 OptionalSingularFixed64 = 1648847863,
@@ -10131,8 +10255,8 @@ namespace Google.Example.Library.V1.Tests
             string requiredSingularString = "requiredSingularString-1949894503";
             ByteString requiredSingularBytes = ByteString.CopyFromUtf8("-29");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName requiredSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 720656715;
             long requiredSingularFixed64 = 720656810;
@@ -10192,8 +10316,8 @@ namespace Google.Example.Library.V1.Tests
             string optionalSingularString = "optionalSingularString1852995162";
             ByteString optionalSingularBytes = ByteString.CopyFromUtf8("2");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName optionalSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 1648847958;
             long optionalSingularFixed64 = 1648847863;
@@ -10268,8 +10392,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -10349,8 +10473,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -10412,6 +10536,134 @@ namespace Google.Example.Library.V1.Tests
         }
 
         [Fact]
+        public void MoveBooks()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            MoveBooksRequest request = new MoveBooksRequest();
+            MoveBooksResponse expectedResponse = new MoveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.MoveBooks(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            MoveBooksResponse response = client.MoveBooks(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task MoveBooksAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            MoveBooksRequest request = new MoveBooksRequest();
+            MoveBooksResponse expectedResponse = new MoveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.MoveBooksAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<MoveBooksResponse>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            MoveBooksResponse response = await client.MoveBooksAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void ArchiveBooks()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            ArchiveBooksResponse expectedResponse = new ArchiveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.ArchiveBooks(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            ArchiveBooksResponse response = client.ArchiveBooks(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ArchiveBooksAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            ArchiveBooksResponse expectedResponse = new ArchiveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.ArchiveBooksAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<ArchiveBooksResponse>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            ArchiveBooksResponse response = await client.ArchiveBooksAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void LongRunningArchiveBooks()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            Operation expectedResponse = new Operation
+            {
+                Name = "name3373707",
+                Done = true,
+            };
+            mockGrpcClient.Setup(x => x.LongRunningArchiveBooks(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            Operation response = client.LongRunningArchiveBooks(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task LongRunningArchiveBooksAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            Operation expectedResponse = new Operation
+            {
+                Name = "name3373707",
+                Done = true,
+            };
+            mockGrpcClient.Setup(x => x.LongRunningArchiveBooksAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<Operation>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            Operation response = await client.LongRunningArchiveBooksAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
         public void PrivateListShelves()
         {
             Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
@@ -10422,7 +10674,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest request = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -10446,7 +10698,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest request = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -10671,6 +10923,11 @@ namespace Google.Example.Library.V1
             GetBigNothingSettings = existing.GetBigNothingSettings;
             GetBigNothingOperationsSettings = existing.GetBigNothingOperationsSettings?.Clone();
             TestOptionalRequiredFlatteningParamsSettings = existing.TestOptionalRequiredFlatteningParamsSettings;
+            MoveBooksSettings = existing.MoveBooksSettings;
+            ArchiveBooksSettings = existing.ArchiveBooksSettings;
+            LongRunningArchiveBooksSettings = existing.LongRunningArchiveBooksSettings;
+            StreamingArchiveBooksSettings = existing.StreamingArchiveBooksSettings;
+            StreamingArchiveBooksStreamingSettings = existing.StreamingArchiveBooksStreamingSettings;
             PrivateListShelvesSettings = existing.PrivateListShelvesSettings;
             OnCopy(existing);
         }
@@ -11499,6 +11756,112 @@ namespace Google.Example.Library.V1
                 totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.MoveBooks</c> and <c>LibraryServiceClient.MoveBooksAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.MoveBooks</c> and
+        /// <c>LibraryServiceClient.MoveBooksAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings MoveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.ArchiveBooks</c> and <c>LibraryServiceClient.ArchiveBooksAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.ArchiveBooks</c> and
+        /// <c>LibraryServiceClient.ArchiveBooksAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings ArchiveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.LongRunningArchiveBooks</c> and <c>LibraryServiceClient.LongRunningArchiveBooksAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.LongRunningArchiveBooks</c> and
+        /// <c>LibraryServiceClient.LongRunningArchiveBooksAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings LongRunningArchiveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for calls to <c>LibraryServiceClient.StreamingArchiveBooks</c>.
+        /// </summary>
+        /// <remarks>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings StreamingArchiveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::BidirectionalStreamingSettings"/> for calls to
+        /// <c>LibraryServiceClient.StreamingArchiveBooks</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default local send queue size is 100.
+        /// </remarks>
+        public gaxgrpc::BidirectionalStreamingSettings StreamingArchiveBooksStreamingSettings { get; set; } =
+            new gaxgrpc::BidirectionalStreamingSettings(100);
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -20406,6 +20769,200 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            MoveBooksRequest request,
+            st::CancellationToken cancellationToken) => MoveBooksAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MoveBooksResponse MoveBooks(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            st::CancellationToken cancellationToken) => ArchiveBooksAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual ArchiveBooksResponse ArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation> LongRunningArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation> LongRunningArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            st::CancellationToken cancellationToken) => LongRunningArchiveBooksAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual lro::Operation LongRunningArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <param name="streamingSettings">
+        /// If not null, applies streaming overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The client-server stream.
+        /// </returns>
+        public virtual StreamingArchiveBooksStream StreamingArchiveBooks(
+            gaxgrpc::CallSettings callSettings = null,
+            gaxgrpc::BidirectionalStreamingSettings streamingSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Bidirectional streaming methods for <c>StreamingArchiveBooks</c>.
+        /// </summary>
+        public abstract partial class StreamingArchiveBooksStream : gaxgrpc::BidirectionalStreamingBase<ArchiveBooksRequest, ArchiveBooksResponse>
+        {
+        }
+
+        /// <summary>
         /// This method is not exposed in the GAPIC config. It should be generated.
         /// </summary>
         /// <param name="request">
@@ -20494,6 +21051,10 @@ namespace Google.Example.Library.V1
         private readonly gaxgrpc::ApiCall<GetBookRequest, lro::Operation> _callGetBigBook;
         private readonly gaxgrpc::ApiCall<GetBookRequest, lro::Operation> _callGetBigNothing;
         private readonly gaxgrpc::ApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> _callTestOptionalRequiredFlatteningParams;
+        private readonly gaxgrpc::ApiCall<MoveBooksRequest, MoveBooksResponse> _callMoveBooks;
+        private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> _callArchiveBooks;
+        private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> _callLongRunningArchiveBooks;
+        private readonly gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> _callStreamingArchiveBooks;
         private readonly gaxgrpc::ApiCall<ListShelvesRequest, Book> _callPrivateListShelves;
 
         /// <summary>
@@ -20582,6 +21143,17 @@ namespace Google.Example.Library.V1
                 .WithGoogleRequestParam("name", request => request.Name);
             _callTestOptionalRequiredFlatteningParams = clientHelper.BuildApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>(
                 GrpcClient.TestOptionalRequiredFlatteningParamsAsync, GrpcClient.TestOptionalRequiredFlatteningParams, effectiveSettings.TestOptionalRequiredFlatteningParamsSettings);
+            _callMoveBooks = clientHelper.BuildApiCall<MoveBooksRequest, MoveBooksResponse>(
+                GrpcClient.MoveBooksAsync, GrpcClient.MoveBooks, effectiveSettings.MoveBooksSettings)
+                .WithGoogleRequestParam("source", request => request.Source);
+            _callArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, ArchiveBooksResponse>(
+                GrpcClient.ArchiveBooksAsync, GrpcClient.ArchiveBooks, effectiveSettings.ArchiveBooksSettings)
+                .WithGoogleRequestParam("source", request => request.Source);
+            _callLongRunningArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, lro::Operation>(
+                GrpcClient.LongRunningArchiveBooksAsync, GrpcClient.LongRunningArchiveBooks, effectiveSettings.LongRunningArchiveBooksSettings)
+                .WithGoogleRequestParam("source", request => request.Source);
+            _callStreamingArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, ArchiveBooksResponse>(
+                GrpcClient.StreamingArchiveBooks, effectiveSettings.StreamingArchiveBooksSettings, effectiveSettings.StreamingArchiveBooksStreamingSettings);
             _callPrivateListShelves = clientHelper.BuildApiCall<ListShelvesRequest, Book>(
                 GrpcClient.PrivateListShelvesAsync, GrpcClient.PrivateListShelves, effectiveSettings.PrivateListShelvesSettings);
             Modify_ApiCall(ref _callCreateShelf);
@@ -20636,6 +21208,14 @@ namespace Google.Example.Library.V1
             Modify_GetBigNothingApiCall(ref _callGetBigNothing);
             Modify_ApiCall(ref _callTestOptionalRequiredFlatteningParams);
             Modify_TestOptionalRequiredFlatteningParamsApiCall(ref _callTestOptionalRequiredFlatteningParams);
+            Modify_ApiCall(ref _callMoveBooks);
+            Modify_MoveBooksApiCall(ref _callMoveBooks);
+            Modify_ApiCall(ref _callArchiveBooks);
+            Modify_ArchiveBooksApiCall(ref _callArchiveBooks);
+            Modify_ApiCall(ref _callLongRunningArchiveBooks);
+            Modify_LongRunningArchiveBooksApiCall(ref _callLongRunningArchiveBooks);
+            Modify_ApiCall(ref _callStreamingArchiveBooks);
+            Modify_StreamingArchiveBooksApiCall(ref _callStreamingArchiveBooks);
             Modify_ApiCall(ref _callPrivateListShelves);
             Modify_PrivateListShelvesApiCall(ref _callPrivateListShelves);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);
@@ -20683,6 +21263,10 @@ namespace Google.Example.Library.V1
         partial void Modify_GetBigBookApiCall(ref gaxgrpc::ApiCall<GetBookRequest, lro::Operation> call);
         partial void Modify_GetBigNothingApiCall(ref gaxgrpc::ApiCall<GetBookRequest, lro::Operation> call);
         partial void Modify_TestOptionalRequiredFlatteningParamsApiCall(ref gaxgrpc::ApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> call);
+        partial void Modify_MoveBooksApiCall(ref gaxgrpc::ApiCall<MoveBooksRequest, MoveBooksResponse> call);
+        partial void Modify_ArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
+        partial void Modify_LongRunningArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> call);
+        partial void Modify_StreamingArchiveBooksApiCall(ref gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
         partial void Modify_PrivateListShelvesApiCall(ref gaxgrpc::ApiCall<ListShelvesRequest, Book> call);
         partial void OnConstruction(LibraryService.LibraryServiceClient grpcClient, LibraryServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
@@ -20719,6 +21303,8 @@ namespace Google.Example.Library.V1
         partial void Modify_FindRelatedBooksRequest(ref FindRelatedBooksRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_AddLabelRequest(ref gtv::AddLabelRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_TestOptionalRequiredFlatteningParamsRequest(ref TestOptionalRequiredFlatteningParamsRequest request, ref gaxgrpc::CallSettings settings);
+        partial void Modify_MoveBooksRequest(ref MoveBooksRequest request, ref gaxgrpc::CallSettings settings);
+        partial void Modify_ArchiveBooksRequest(ref ArchiveBooksRequest request, ref gaxgrpc::CallSettings settings);
 
         /// <summary>
         /// Creates a shelf, and returns the new Shelf.
@@ -21814,6 +22400,213 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<MoveBooksResponse> MoveBooksAsync(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MoveBooksRequest(ref request, ref callSettings);
+            return _callMoveBooks.Async(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override MoveBooksResponse MoveBooks(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MoveBooksRequest(ref request, ref callSettings);
+            return _callMoveBooks.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return _callArchiveBooks.Async(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override ArchiveBooksResponse ArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return _callArchiveBooks.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<lro::Operation> LongRunningArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return _callLongRunningArchiveBooks.Async(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override lro::Operation LongRunningArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return _callLongRunningArchiveBooks.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <param name="streamingSettings">
+        /// If not null, applies streaming overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The client-server stream.
+        /// </returns>
+        public override StreamingArchiveBooksStream StreamingArchiveBooks(
+            gaxgrpc::CallSettings callSettings = null,
+            gaxgrpc::BidirectionalStreamingSettings streamingSettings = null)
+        {
+            Modify_ArchiveBooksRequestCallSettings(ref callSettings);
+            gaxgrpc::BidirectionalStreamingSettings effectiveStreamingSettings =
+                streamingSettings ?? _callStreamingArchiveBooks.StreamingSettings;
+            grpccore::AsyncDuplexStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call =
+                _callStreamingArchiveBooks.Call(callSettings);
+            gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest> writeBuffer =
+                new gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest>(
+                    call.RequestStream, effectiveStreamingSettings.BufferedClientWriterCapacity);
+            return new StreamingArchiveBooksStreamImpl(this, call, writeBuffer);
+        }
+
+        internal sealed partial class StreamingArchiveBooksStreamImpl : StreamingArchiveBooksStream
+        {
+            /// <summary>
+            /// Construct the bidirectional streaming method for <c>StreamingArchiveBooks</c>.
+            /// </summary>
+            /// <param name="service">The service containing this streaming method.</param>
+            /// <param name="call">The underlying gRPC duplex streaming call.</param>
+            /// <param name="writeBuffer">The <see cref="gaxgrpc::BufferedClientStreamWriter{ArchiveBooksRequest}"/>
+            /// instance associated with this streaming call.</param>
+            public StreamingArchiveBooksStreamImpl(
+                LibraryServiceClientImpl service,
+                grpccore::AsyncDuplexStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call,
+                gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest> writeBuffer)
+            {
+                _service = service;
+                GrpcCall = call;
+                _writeBuffer = writeBuffer;
+            }
+
+            private LibraryServiceClientImpl _service;
+            private gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest> _writeBuffer;
+
+            private ArchiveBooksRequest ModifyRequest(ArchiveBooksRequest request)
+            {
+                _service.Modify_ArchiveBooksRequestRequest(ref request);
+                return request;
+            }
+
+            /// <inheritdoc/>
+            public override grpccore::AsyncDuplexStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> GrpcCall { get; }
+
+            /// <inheritdoc/>
+            public override stt::Task TryWriteAsync(ArchiveBooksRequest message) =>
+                _writeBuffer.TryWriteAsync(ModifyRequest(message));
+
+            /// <inheritdoc/>
+            public override stt::Task WriteAsync(ArchiveBooksRequest message) =>
+                _writeBuffer.WriteAsync(ModifyRequest(message));
+
+            /// <inheritdoc/>
+            public override stt::Task TryWriteAsync(ArchiveBooksRequest message, grpccore::WriteOptions options) =>
+                _writeBuffer.TryWriteAsync(ModifyRequest(message), options);
+
+            /// <inheritdoc/>
+            public override stt::Task WriteAsync(ArchiveBooksRequest message, grpccore::WriteOptions options) =>
+                _writeBuffer.WriteAsync(ModifyRequest(message), options);
+
+            /// <inheritdoc/>
+            public override stt::Task TryWriteCompleteAsync() =>
+                _writeBuffer.TryWriteCompleteAsync();
+
+            /// <inheritdoc/>
+            public override stt::Task WriteCompleteAsync() =>
+                _writeBuffer.WriteCompleteAsync();
+
+            /// <inheritdoc/>
+            public override scg::IAsyncEnumerator<ArchiveBooksResponse> ResponseStream =>
+                GrpcCall.ResponseStream;
+        }
+
+        /// <summary>
         /// This method is not exposed in the GAPIC config. It should be generated.
         /// </summary>
         /// <param name="request">
@@ -22468,7 +23261,7 @@ namespace Google.Example.Library.V1
     /// </summary>
     public sealed partial class ArchivedBookName : gax::IResourceName, sys::IEquatable<ArchivedBookName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("archives/{archive_path}/books/{book_id=**}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("archives/{archive_path}/books/{book=**}");
 
         /// <summary>
         /// Parses the given archived_book resource name in string form into a new
@@ -22567,7 +23360,7 @@ namespace Google.Example.Library.V1
     /// </summary>
     public sealed partial class BookName : gax::IResourceName, sys::IEquatable<BookName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("shelves/{shelf_id}/books/{book_id}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("shelves/{shelf}/books/{book}");
 
         /// <summary>
         /// Parses the given book resource name in string form into a new
@@ -23606,7 +24399,7 @@ namespace Google.Example.Library.V1
     /// </summary>
     public sealed partial class ShelfName : gax::IResourceName, sys::IEquatable<ShelfName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("shelves/{shelf_id}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("shelves/{shelf}");
 
         /// <summary>
         /// Parses the given shelf resource name in string form into a new

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_samplegen_config_migration_library.baseline
@@ -40,7 +40,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             libraryServiceClient.DeleteShelf(request);
             // Shelf deleted
@@ -100,7 +100,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             libraryServiceClient.DeleteShelf(request);
         }
@@ -159,7 +159,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(request).PollUntilCompleted();
@@ -220,7 +220,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(request).PollUntilCompleted();
@@ -284,11 +284,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNames =
                 {
-                    new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    new BookName("[SHELF]", "[BOOK]"),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedEnumerable<FindRelatedBooksResponse, BookName> response = libraryServiceClient.FindRelatedBooks(request);
@@ -356,7 +356,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Book response = libraryServiceClient.GetBook(request);
             string intKeyVal = response.MapStringValue[123];
@@ -1065,8 +1065,8 @@ namespace Google.Example.Library.V1.Samples
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -1151,7 +1151,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new ArchivedBookName("The archive to search for the book", "The ID of the book")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "The ID of the book")),
             };
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
             Console.WriteLine("Archived book found.");
@@ -1507,7 +1507,7 @@ namespace Google.Example.Library.V1.Samples
                 // Initialize a request
                 DiscussBookRequest request = new DiscussBookRequest
                 {
-                    BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    BookName = new BookName("[SHELF]", "[BOOK]"),
                     Comment = new Comment
                     {
                         Comment = ByteString.CopyFrom(File.ReadAllBytes("comment_file")),
@@ -1755,7 +1755,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = await libraryServiceClient.GetShelfAsync(name);
             // End snippet
@@ -1768,7 +1768,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = libraryServiceClient.GetShelf(name);
             // End snippet
@@ -1782,7 +1782,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             // Make the request
             Shelf response = await libraryServiceClient.GetShelfAsync(name, message);
@@ -1796,7 +1796,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             // Make the request
             Shelf response = libraryServiceClient.GetShelf(name, message);
@@ -1811,7 +1811,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             // Make the request
@@ -1826,7 +1826,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             // Make the request
@@ -1844,7 +1844,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "",
             };
             // Make the request
@@ -1861,7 +1861,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "",
             };
             // Make the request
@@ -2049,7 +2049,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             await libraryServiceClient.DeleteShelfAsync(name);
             // End snippet
@@ -2062,7 +2062,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             libraryServiceClient.DeleteShelf(name);
             // End snippet
@@ -2078,7 +2078,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             await libraryServiceClient.DeleteShelfAsync(request);
@@ -2094,7 +2094,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             libraryServiceClient.DeleteShelf(request);
@@ -2109,8 +2109,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = await libraryServiceClient.MergeShelvesAsync(name, otherShelfName);
             // End snippet
@@ -2123,8 +2123,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = libraryServiceClient.MergeShelves(name, otherShelfName);
             // End snippet
@@ -2140,8 +2140,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Shelf response = await libraryServiceClient.MergeShelvesAsync(request);
@@ -2157,8 +2157,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Shelf response = libraryServiceClient.MergeShelves(request);
@@ -2173,7 +2173,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             // Make the request
             Book response = await libraryServiceClient.CreateBookAsync(name, book);
@@ -2187,7 +2187,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             // Make the request
             Book response = libraryServiceClient.CreateBook(name, book);
@@ -2204,7 +2204,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             // Make the request
@@ -2221,7 +2221,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             // Make the request
@@ -2319,7 +2319,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Book response = await libraryServiceClient.GetBookAsync(name);
             // End snippet
@@ -2332,7 +2332,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Book response = libraryServiceClient.GetBook(name);
             // End snippet
@@ -2348,7 +2348,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Book response = await libraryServiceClient.GetBookAsync(request);
@@ -2364,7 +2364,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Book response = libraryServiceClient.GetBook(request);
@@ -2378,7 +2378,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             string filter = "book-filter-string";
             // Make the request
             PagedAsyncEnumerable<ListBooksResponse, Book> response =
@@ -2423,7 +2423,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             string filter = "book-filter-string";
             // Make the request
             PagedEnumerable<ListBooksResponse, Book> response =
@@ -2470,7 +2470,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             ListBooksRequest request = new ListBooksRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Filter = "book-filter-string",
             };
             // Make the request
@@ -2518,7 +2518,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             ListBooksRequest request = new ListBooksRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Filter = "book-filter-string",
             };
             // Make the request
@@ -2565,7 +2565,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             await libraryServiceClient.DeleteBookAsync(name);
             // End snippet
@@ -2578,7 +2578,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             libraryServiceClient.DeleteBook(name);
             // End snippet
@@ -2594,7 +2594,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             await libraryServiceClient.DeleteBookAsync(request);
@@ -2610,7 +2610,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             libraryServiceClient.DeleteBook(request);
@@ -2625,7 +2625,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book book = new Book();
             // Make the request
             Book response = await libraryServiceClient.UpdateBookAsync(name, book);
@@ -2639,7 +2639,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book book = new Book();
             // Make the request
             Book response = libraryServiceClient.UpdateBook(name, book);
@@ -2654,7 +2654,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string optionalFoo = "";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -2671,7 +2671,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string optionalFoo = "";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -2691,7 +2691,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             // Make the request
@@ -2708,7 +2708,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             // Make the request
@@ -2724,8 +2724,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Book response = await libraryServiceClient.MoveBookAsync(name, otherShelfName);
             // End snippet
@@ -2738,8 +2738,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Book response = libraryServiceClient.MoveBook(name, otherShelfName);
             // End snippet
@@ -2755,8 +2755,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MoveBookRequest request = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Book response = await libraryServiceClient.MoveBookAsync(request);
@@ -2772,8 +2772,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MoveBookRequest request = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Book response = libraryServiceClient.MoveBook(request);
@@ -2871,7 +2871,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            IResourceName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            IResourceName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             // Make the request
             PagedAsyncEnumerable<ListStringsResponse, IResourceName> response =
                 libraryServiceClient.ListStringsAsync(name);
@@ -2915,7 +2915,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            IResourceName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            IResourceName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             // Make the request
             PagedEnumerable<ListStringsResponse, IResourceName> response =
                 libraryServiceClient.ListStrings(name);
@@ -3048,7 +3048,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -3070,7 +3070,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -3095,7 +3095,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -3120,7 +3120,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -3144,7 +3144,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             // Make the request
             BookFromArchive response = await libraryServiceClient.GetBookFromArchiveAsync(name);
             // End snippet
@@ -3157,7 +3157,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             // Make the request
             BookFromArchive response = libraryServiceClient.GetBookFromArchive(name);
             // End snippet
@@ -3173,7 +3173,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromArchiveRequest request = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
             };
             // Make the request
             BookFromArchive response = await libraryServiceClient.GetBookFromArchiveAsync(request);
@@ -3189,7 +3189,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromArchiveRequest request = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
             };
             // Make the request
             BookFromArchive response = libraryServiceClient.GetBookFromArchive(request);
@@ -3204,8 +3204,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
-            BookName altBookName = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookName altBookName = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             BookFromAnywhere response = await libraryServiceClient.GetBookFromAnywhereAsync(name, altBookName);
             // End snippet
@@ -3218,8 +3218,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
-            BookName altBookName = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookName altBookName = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             BookFromAnywhere response = libraryServiceClient.GetBookFromAnywhere(name, altBookName);
             // End snippet
@@ -3235,8 +3235,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             BookFromAnywhere response = await libraryServiceClient.GetBookFromAnywhereAsync(request);
@@ -3252,8 +3252,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             BookFromAnywhere response = libraryServiceClient.GetBookFromAnywhere(request);
@@ -3268,7 +3268,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             BookFromAnywhere response = await libraryServiceClient.GetBookFromAbsolutelyAnywhereAsync(name);
             // End snippet
@@ -3281,7 +3281,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(name);
             // End snippet
@@ -3297,7 +3297,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             BookFromAnywhere response = await libraryServiceClient.GetBookFromAbsolutelyAnywhereAsync(request);
@@ -3313,7 +3313,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
@@ -3328,7 +3328,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -3346,7 +3346,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -3367,7 +3367,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -3388,7 +3388,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -3409,7 +3409,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument
             StreamShelvesRequest request = new StreamShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request, returning a streaming response
             LibraryServiceClient.StreamShelvesStream streamingResponse = libraryServiceClient.StreamShelves(request);
@@ -3481,7 +3481,7 @@ namespace Google.Example.Library.V1.Snippets
                 // Initialize a request
                 DiscussBookRequest request = new DiscussBookRequest
                 {
-                    BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    BookName = new BookName("[SHELF]", "[BOOK]"),
                 };
                 // Stream a request to the server
                 await duplexStream.WriteAsync(request);
@@ -3505,7 +3505,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             IEnumerable<BookName> names = new[]
             {
-                new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                new BookName("[SHELF]", "[BOOK]"),
             };
             IEnumerable<ShelfName> shelves = new List<ShelfName>();
             // Make the request
@@ -3553,7 +3553,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             IEnumerable<BookName> names = new[]
             {
-                new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                new BookName("[SHELF]", "[BOOK]"),
             };
             IEnumerable<ShelfName> shelves = new List<ShelfName>();
             // Make the request
@@ -3603,7 +3603,7 @@ namespace Google.Example.Library.V1.Snippets
             {
                 BookNames =
                 {
-                    new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    new BookName("[SHELF]", "[BOOK]"),
                 },
                 ShelvesAsShelfNames = { },
             };
@@ -3654,7 +3654,7 @@ namespace Google.Example.Library.V1.Snippets
             {
                 BookNames =
                 {
-                    new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                    new BookName("[SHELF]", "[BOOK]"),
                 },
                 ShelvesAsShelfNames = { },
             };
@@ -3702,7 +3702,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            string formattedResource = new BookName("[SHELF_ID]", "[BOOK_ID]").ToString();
+            string formattedResource = new BookName("[SHELF]", "[BOOK]").ToString();
             string label = "";
             // Make the request
             AddLabelResponse response = await libraryServiceClient.AddLabelAsync(formattedResource, label);
@@ -3716,7 +3716,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            string formattedResource = new BookName("[SHELF_ID]", "[BOOK_ID]").ToString();
+            string formattedResource = new BookName("[SHELF]", "[BOOK]").ToString();
             string label = "";
             // Make the request
             AddLabelResponse response = libraryServiceClient.AddLabel(formattedResource, label);
@@ -3733,7 +3733,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                Resource = new BookName("[SHELF_ID]", "[BOOK_ID]").ToString(),
+                Resource = new BookName("[SHELF]", "[BOOK]").ToString(),
                 Label = "",
             };
             // Make the request
@@ -3750,7 +3750,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                Resource = new BookName("[SHELF_ID]", "[BOOK_ID]").ToString(),
+                Resource = new BookName("[SHELF]", "[BOOK]").ToString(),
                 Label = "",
             };
             // Make the request
@@ -3766,7 +3766,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
                 await libraryServiceClient.GetBigBookAsync(name);
@@ -3798,7 +3798,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
                 libraryServiceClient.GetBigBook(name);
@@ -3832,7 +3832,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
@@ -3867,7 +3867,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
@@ -3901,7 +3901,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
                 await libraryServiceClient.GetBigNothingAsync(name);
@@ -3931,7 +3931,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
                 libraryServiceClient.GetBigNothing(name);
@@ -3963,7 +3963,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
@@ -3996,7 +3996,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
@@ -4060,8 +4060,8 @@ namespace Google.Example.Library.V1.Snippets
             string requiredSingularString = "";
             ByteString requiredSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName requiredSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 0;
             long requiredSingularFixed64 = 0L;
@@ -4089,8 +4089,8 @@ namespace Google.Example.Library.V1.Snippets
             string optionalSingularString = "";
             ByteString optionalSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName optionalSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 0;
             long optionalSingularFixed64 = 0L;
@@ -4162,8 +4162,8 @@ namespace Google.Example.Library.V1.Snippets
             string requiredSingularString = "";
             ByteString requiredSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName requiredSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 0;
             long requiredSingularFixed64 = 0L;
@@ -4191,8 +4191,8 @@ namespace Google.Example.Library.V1.Snippets
             string optionalSingularString = "";
             ByteString optionalSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName optionalSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 0;
             long optionalSingularFixed64 = 0L;
@@ -4267,8 +4267,8 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -4311,8 +4311,8 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -4334,6 +4334,130 @@ namespace Google.Example.Library.V1.Snippets
             };
             // Make the request
             TestOptionalRequiredFlatteningParamsResponse response = libraryServiceClient.TestOptionalRequiredFlatteningParams(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MoveBooksAsync</summary>
+        public async Task MoveBooksAsync_RequestObject()
+        {
+            // Snippet: MoveBooksAsync(MoveBooksRequest,CallSettings)
+            // Additional: MoveBooksAsync(MoveBooksRequest,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            MoveBooksRequest request = new MoveBooksRequest();
+            // Make the request
+            MoveBooksResponse response = await libraryServiceClient.MoveBooksAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MoveBooks</summary>
+        public void MoveBooks_RequestObject()
+        {
+            // Snippet: MoveBooks(MoveBooksRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            MoveBooksRequest request = new MoveBooksRequest();
+            // Make the request
+            MoveBooksResponse response = libraryServiceClient.MoveBooks(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for ArchiveBooksAsync</summary>
+        public async Task ArchiveBooksAsync_RequestObject()
+        {
+            // Snippet: ArchiveBooksAsync(ArchiveBooksRequest,CallSettings)
+            // Additional: ArchiveBooksAsync(ArchiveBooksRequest,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            ArchiveBooksResponse response = await libraryServiceClient.ArchiveBooksAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for ArchiveBooks</summary>
+        public void ArchiveBooks_RequestObject()
+        {
+            // Snippet: ArchiveBooks(ArchiveBooksRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            ArchiveBooksResponse response = libraryServiceClient.ArchiveBooks(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for LongRunningArchiveBooksAsync</summary>
+        public async Task LongRunningArchiveBooksAsync_RequestObject()
+        {
+            // Snippet: LongRunningArchiveBooksAsync(ArchiveBooksRequest,CallSettings)
+            // Additional: LongRunningArchiveBooksAsync(ArchiveBooksRequest,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            Operation response = await libraryServiceClient.LongRunningArchiveBooksAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for LongRunningArchiveBooks</summary>
+        public void LongRunningArchiveBooks_RequestObject()
+        {
+            // Snippet: LongRunningArchiveBooks(ArchiveBooksRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            Operation response = libraryServiceClient.LongRunningArchiveBooks(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for StreamingArchiveBooks</summary>
+        public async Task StreamingArchiveBooks()
+        {
+            // Snippet: StreamingArchiveBooks(CallSettings,BidirectionalStreamingSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize streaming call, retrieving the stream object
+            LibraryServiceClient.StreamingArchiveBooksStream duplexStream = libraryServiceClient.StreamingArchiveBooks();
+
+            // Sending requests and retrieving responses can be arbitrarily interleaved.
+            // Exact sequence will depend on client/server behavior.
+
+            // Create task to do something with responses from server
+            Task responseHandlerTask = Task.Run(async () =>
+            {
+                IAsyncEnumerator<ArchiveBooksResponse> responseStream = duplexStream.ResponseStream;
+                while (await responseStream.MoveNext())
+                {
+                    ArchiveBooksResponse response = responseStream.Current;
+                    // Do something with streamed response
+                }
+                // The response stream has completed
+            });
+
+            // Send requests to the server
+            bool done = false;
+            while (!done)
+            {
+                // Initialize a request
+                ArchiveBooksRequest request = new ArchiveBooksRequest();
+                // Stream a request to the server
+                await duplexStream.WriteAsync(request);
+
+                // Set "done" to true when sending requests is complete
+            }
+            // Complete writing requests to the stream
+            await duplexStream.WriteCompleteAsync();
+            // Await the response handler.
+            // This will complete once all server responses have been processed.
+            await responseHandlerTask;
             // End snippet
         }
 
@@ -4508,7 +4632,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -4535,7 +4659,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -4562,7 +4686,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -4588,7 +4712,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -4610,18 +4734,18 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Shelf response = client.GetShelf(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -4637,18 +4761,18 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Shelf response = await client.GetShelfAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -4664,19 +4788,19 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             Shelf response = client.GetShelf(name, message);
             Assert.Same(expectedResponse, response);
@@ -4693,19 +4817,19 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             Shelf response = await client.GetShelfAsync(name, message);
             Assert.Same(expectedResponse, response);
@@ -4722,20 +4846,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
                 StringBuilder = new StringBuilder(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             Shelf response = client.GetShelf(name, message, stringBuilder);
@@ -4753,20 +4877,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
                 StringBuilder = new StringBuilder(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             Shelf response = await client.GetShelfAsync(name, message, stringBuilder);
@@ -4784,12 +4908,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "options-1249474914",
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -4811,12 +4935,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "options-1249474914",
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -4838,13 +4962,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest expectedRequest = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             client.DeleteShelf(name);
             mockGrpcClient.VerifyAll();
         }
@@ -4859,13 +4983,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest expectedRequest = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             await client.DeleteShelfAsync(name);
             mockGrpcClient.VerifyAll();
         }
@@ -4880,7 +5004,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelf(request, It.IsAny<CallOptions>()))
@@ -4900,7 +5024,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelfAsync(request, It.IsAny<CallOptions>()))
@@ -4920,20 +5044,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest expectedRequest = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.MergeShelves(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Shelf response = client.MergeShelves(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -4949,20 +5073,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest expectedRequest = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.MergeShelvesAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Shelf response = await client.MergeShelvesAsync(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -4978,12 +5102,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -5005,12 +5129,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -5032,12 +5156,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest expectedRequest = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5045,7 +5169,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.CreateBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             Book response = client.CreateBook(name, book);
             Assert.Same(expectedResponse, response);
@@ -5062,12 +5186,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest expectedRequest = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5075,7 +5199,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.CreateBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             Book response = await client.CreateBookAsync(name, book);
             Assert.Same(expectedResponse, response);
@@ -5092,12 +5216,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5120,12 +5244,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5292,11 +5416,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest expectedRequest = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5304,7 +5428,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book response = client.GetBook(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -5320,11 +5444,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest expectedRequest = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5332,7 +5456,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book response = await client.GetBookAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -5348,11 +5472,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5375,11 +5499,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest request = new GetBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5402,13 +5526,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest expectedRequest = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             client.DeleteBook(name);
             mockGrpcClient.VerifyAll();
         }
@@ -5423,13 +5547,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest expectedRequest = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             await client.DeleteBookAsync(name);
             mockGrpcClient.VerifyAll();
         }
@@ -5444,7 +5568,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBook(request, It.IsAny<CallOptions>()))
@@ -5464,7 +5588,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBookAsync(request, It.IsAny<CallOptions>()))
@@ -5484,12 +5608,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5497,7 +5621,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book book = new Book();
             Book response = client.UpdateBook(name, book);
             Assert.Same(expectedResponse, response);
@@ -5514,12 +5638,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5527,7 +5651,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             Book book = new Book();
             Book response = await client.UpdateBookAsync(name, book);
             Assert.Same(expectedResponse, response);
@@ -5544,7 +5668,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 OptionalFoo = "optionalFoo1822578535",
                 Book = new Book(),
                 UpdateMask = new FieldMask(),
@@ -5552,7 +5676,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5560,7 +5684,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string optionalFoo = "optionalFoo1822578535";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -5580,7 +5704,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 OptionalFoo = "optionalFoo1822578535",
                 Book = new Book(),
                 UpdateMask = new FieldMask(),
@@ -5588,7 +5712,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5596,7 +5720,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string optionalFoo = "optionalFoo1822578535";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -5616,12 +5740,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5644,12 +5768,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5672,12 +5796,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest expectedRequest = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5685,8 +5809,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.MoveBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Book response = client.MoveBook(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -5702,12 +5826,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest expectedRequest = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5715,8 +5839,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.MoveBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Book response = await client.MoveBookAsync(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -5732,12 +5856,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest request = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5760,12 +5884,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest request = new MoveBookRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5788,7 +5912,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest expectedRequest = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -5803,7 +5927,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.AddComments(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -5827,7 +5951,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest expectedRequest = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -5842,7 +5966,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.AddCommentsAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -5866,7 +5990,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -5895,7 +6019,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 Comments =
                 {
                     new Comment
@@ -5924,11 +6048,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromArchiveRequest expectedRequest = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
             };
             BookFromArchive expectedResponse = new BookFromArchive
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5936,7 +6060,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromArchive(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             BookFromArchive response = client.GetBookFromArchive(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -5952,11 +6076,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromArchiveRequest expectedRequest = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
             };
             BookFromArchive expectedResponse = new BookFromArchive
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -5964,7 +6088,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromArchiveAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<BookFromArchive>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]");
+            ArchivedBookName name = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
             BookFromArchive response = await client.GetBookFromArchiveAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -5980,11 +6104,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromArchiveRequest request = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
             };
             BookFromArchive expectedResponse = new BookFromArchive
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -6007,11 +6131,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromArchiveRequest request = new GetBookFromArchiveRequest
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
             };
             BookFromArchive expectedResponse = new BookFromArchive
             {
-                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK_ID]"),
+                ArchivedBookName = new ArchivedBookName("[ARCHIVE_PATH]", "[BOOK]"),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -6034,12 +6158,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest expectedRequest = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -6047,8 +6171,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAnywhere(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
-            BookName altBookName = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookName altBookName = new BookName("[SHELF]", "[BOOK]");
             BookFromAnywhere response = client.GetBookFromAnywhere(name, altBookName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -6064,12 +6188,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest expectedRequest = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -6077,8 +6201,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAnywhereAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<BookFromAnywhere>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
-            BookName altBookName = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookName altBookName = new BookName("[SHELF]", "[BOOK]");
             BookFromAnywhere response = await client.GetBookFromAnywhereAsync(name, altBookName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -6094,12 +6218,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -6122,12 +6246,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -6150,11 +6274,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest expectedRequest = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -6162,7 +6286,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAbsolutelyAnywhere(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             BookFromAnywhere response = client.GetBookFromAbsolutelyAnywhere(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -6178,11 +6302,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest expectedRequest = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -6190,7 +6314,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAbsolutelyAnywhereAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<BookFromAnywhere>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             BookFromAnywhere response = await client.GetBookFromAbsolutelyAnywhereAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -6206,11 +6330,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -6233,11 +6357,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                AsResourceName = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                AsResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -6260,7 +6384,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest expectedRequest = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -6271,7 +6395,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookIndex(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -6291,7 +6415,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest expectedRequest = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -6302,7 +6426,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookIndexAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            BookName name = new BookName("[SHELF]", "[BOOK]");
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -6322,7 +6446,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -6347,7 +6471,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+                BookName = new BookName("[SHELF]", "[BOOK]"),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -6419,8 +6543,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -6448,8 +6572,8 @@ namespace Google.Example.Library.V1.Tests
                 OptionalSingularString = "optionalSingularString1852995162",
                 OptionalSingularBytes = ByteString.CopyFromUtf8("2"),
                 OptionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                OptionalSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                OptionalSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OptionalSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 OptionalSingularFixed32 = 1648847958,
                 OptionalSingularFixed64 = 1648847863,
@@ -6514,8 +6638,8 @@ namespace Google.Example.Library.V1.Tests
             string requiredSingularString = "requiredSingularString-1949894503";
             ByteString requiredSingularBytes = ByteString.CopyFromUtf8("-29");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName requiredSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 720656715;
             long requiredSingularFixed64 = 720656810;
@@ -6543,8 +6667,8 @@ namespace Google.Example.Library.V1.Tests
             string optionalSingularString = "optionalSingularString1852995162";
             ByteString optionalSingularBytes = ByteString.CopyFromUtf8("2");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName optionalSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 1648847958;
             long optionalSingularFixed64 = 1648847863;
@@ -6619,8 +6743,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -6648,8 +6772,8 @@ namespace Google.Example.Library.V1.Tests
                 OptionalSingularString = "optionalSingularString1852995162",
                 OptionalSingularBytes = ByteString.CopyFromUtf8("2"),
                 OptionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                OptionalSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                OptionalSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OptionalSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 OptionalSingularFixed32 = 1648847958,
                 OptionalSingularFixed64 = 1648847863,
@@ -6714,8 +6838,8 @@ namespace Google.Example.Library.V1.Tests
             string requiredSingularString = "requiredSingularString-1949894503";
             ByteString requiredSingularBytes = ByteString.CopyFromUtf8("-29");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName requiredSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 720656715;
             long requiredSingularFixed64 = 720656810;
@@ -6743,8 +6867,8 @@ namespace Google.Example.Library.V1.Tests
             string optionalSingularString = "optionalSingularString1852995162";
             ByteString optionalSingularBytes = ByteString.CopyFromUtf8("2");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            BookName optionalSingularResourceName = new BookName("[SHELF]", "[BOOK]");
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 1648847958;
             long optionalSingularFixed64 = 1648847863;
@@ -6819,8 +6943,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -6868,8 +6992,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameAsBookName = new BookName("[SHELF]", "[BOOK]"),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -6899,6 +7023,134 @@ namespace Google.Example.Library.V1.Tests
         }
 
         [Fact]
+        public void MoveBooks()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            MoveBooksRequest request = new MoveBooksRequest();
+            MoveBooksResponse expectedResponse = new MoveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.MoveBooks(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            MoveBooksResponse response = client.MoveBooks(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task MoveBooksAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            MoveBooksRequest request = new MoveBooksRequest();
+            MoveBooksResponse expectedResponse = new MoveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.MoveBooksAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<MoveBooksResponse>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            MoveBooksResponse response = await client.MoveBooksAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void ArchiveBooks()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            ArchiveBooksResponse expectedResponse = new ArchiveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.ArchiveBooks(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            ArchiveBooksResponse response = client.ArchiveBooks(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ArchiveBooksAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            ArchiveBooksResponse expectedResponse = new ArchiveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.ArchiveBooksAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<ArchiveBooksResponse>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            ArchiveBooksResponse response = await client.ArchiveBooksAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void LongRunningArchiveBooks()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            Operation expectedResponse = new Operation
+            {
+                Name = "name3373707",
+                Done = true,
+            };
+            mockGrpcClient.Setup(x => x.LongRunningArchiveBooks(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            Operation response = client.LongRunningArchiveBooks(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task LongRunningArchiveBooksAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            Operation expectedResponse = new Operation
+            {
+                Name = "name3373707",
+                Done = true,
+            };
+            mockGrpcClient.Setup(x => x.LongRunningArchiveBooksAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<Operation>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            Operation response = await client.LongRunningArchiveBooksAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
         public void PrivateListShelves()
         {
             Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
@@ -6909,7 +7161,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest request = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -6933,7 +7185,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest request = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -7158,6 +7410,11 @@ namespace Google.Example.Library.V1
             GetBigNothingSettings = existing.GetBigNothingSettings;
             GetBigNothingOperationsSettings = existing.GetBigNothingOperationsSettings?.Clone();
             TestOptionalRequiredFlatteningParamsSettings = existing.TestOptionalRequiredFlatteningParamsSettings;
+            MoveBooksSettings = existing.MoveBooksSettings;
+            ArchiveBooksSettings = existing.ArchiveBooksSettings;
+            LongRunningArchiveBooksSettings = existing.LongRunningArchiveBooksSettings;
+            StreamingArchiveBooksSettings = existing.StreamingArchiveBooksSettings;
+            StreamingArchiveBooksStreamingSettings = existing.StreamingArchiveBooksStreamingSettings;
             PrivateListShelvesSettings = existing.PrivateListShelvesSettings;
             OnCopy(existing);
         }
@@ -7986,6 +8243,112 @@ namespace Google.Example.Library.V1
                 totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.MoveBooks</c> and <c>LibraryServiceClient.MoveBooksAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.MoveBooks</c> and
+        /// <c>LibraryServiceClient.MoveBooksAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings MoveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.ArchiveBooks</c> and <c>LibraryServiceClient.ArchiveBooksAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.ArchiveBooks</c> and
+        /// <c>LibraryServiceClient.ArchiveBooksAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings ArchiveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.LongRunningArchiveBooks</c> and <c>LibraryServiceClient.LongRunningArchiveBooksAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.LongRunningArchiveBooks</c> and
+        /// <c>LibraryServiceClient.LongRunningArchiveBooksAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings LongRunningArchiveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for calls to <c>LibraryServiceClient.StreamingArchiveBooks</c>.
+        /// </summary>
+        /// <remarks>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings StreamingArchiveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::BidirectionalStreamingSettings"/> for calls to
+        /// <c>LibraryServiceClient.StreamingArchiveBooks</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default local send queue size is 100.
+        /// </remarks>
+        public gaxgrpc::BidirectionalStreamingSettings StreamingArchiveBooksStreamingSettings { get; set; } =
+            new gaxgrpc::BidirectionalStreamingSettings(100);
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -15843,6 +16206,200 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            MoveBooksRequest request,
+            st::CancellationToken cancellationToken) => MoveBooksAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MoveBooksResponse MoveBooks(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            st::CancellationToken cancellationToken) => ArchiveBooksAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual ArchiveBooksResponse ArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation> LongRunningArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation> LongRunningArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            st::CancellationToken cancellationToken) => LongRunningArchiveBooksAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual lro::Operation LongRunningArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <param name="streamingSettings">
+        /// If not null, applies streaming overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The client-server stream.
+        /// </returns>
+        public virtual StreamingArchiveBooksStream StreamingArchiveBooks(
+            gaxgrpc::CallSettings callSettings = null,
+            gaxgrpc::BidirectionalStreamingSettings streamingSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Bidirectional streaming methods for <c>StreamingArchiveBooks</c>.
+        /// </summary>
+        public abstract partial class StreamingArchiveBooksStream : gaxgrpc::BidirectionalStreamingBase<ArchiveBooksRequest, ArchiveBooksResponse>
+        {
+        }
+
+        /// <summary>
         /// This method is not exposed in the GAPIC config. It should be generated.
         /// </summary>
         /// <param name="request">
@@ -15931,6 +16488,10 @@ namespace Google.Example.Library.V1
         private readonly gaxgrpc::ApiCall<GetBookRequest, lro::Operation> _callGetBigBook;
         private readonly gaxgrpc::ApiCall<GetBookRequest, lro::Operation> _callGetBigNothing;
         private readonly gaxgrpc::ApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> _callTestOptionalRequiredFlatteningParams;
+        private readonly gaxgrpc::ApiCall<MoveBooksRequest, MoveBooksResponse> _callMoveBooks;
+        private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> _callArchiveBooks;
+        private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> _callLongRunningArchiveBooks;
+        private readonly gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> _callStreamingArchiveBooks;
         private readonly gaxgrpc::ApiCall<ListShelvesRequest, Book> _callPrivateListShelves;
 
         /// <summary>
@@ -16019,6 +16580,17 @@ namespace Google.Example.Library.V1
                 .WithGoogleRequestParam("name", request => request.Name);
             _callTestOptionalRequiredFlatteningParams = clientHelper.BuildApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>(
                 GrpcClient.TestOptionalRequiredFlatteningParamsAsync, GrpcClient.TestOptionalRequiredFlatteningParams, effectiveSettings.TestOptionalRequiredFlatteningParamsSettings);
+            _callMoveBooks = clientHelper.BuildApiCall<MoveBooksRequest, MoveBooksResponse>(
+                GrpcClient.MoveBooksAsync, GrpcClient.MoveBooks, effectiveSettings.MoveBooksSettings)
+                .WithGoogleRequestParam("source", request => request.Source);
+            _callArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, ArchiveBooksResponse>(
+                GrpcClient.ArchiveBooksAsync, GrpcClient.ArchiveBooks, effectiveSettings.ArchiveBooksSettings)
+                .WithGoogleRequestParam("source", request => request.Source);
+            _callLongRunningArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, lro::Operation>(
+                GrpcClient.LongRunningArchiveBooksAsync, GrpcClient.LongRunningArchiveBooks, effectiveSettings.LongRunningArchiveBooksSettings)
+                .WithGoogleRequestParam("source", request => request.Source);
+            _callStreamingArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, ArchiveBooksResponse>(
+                GrpcClient.StreamingArchiveBooks, effectiveSettings.StreamingArchiveBooksSettings, effectiveSettings.StreamingArchiveBooksStreamingSettings);
             _callPrivateListShelves = clientHelper.BuildApiCall<ListShelvesRequest, Book>(
                 GrpcClient.PrivateListShelvesAsync, GrpcClient.PrivateListShelves, effectiveSettings.PrivateListShelvesSettings);
             Modify_ApiCall(ref _callCreateShelf);
@@ -16073,6 +16645,14 @@ namespace Google.Example.Library.V1
             Modify_GetBigNothingApiCall(ref _callGetBigNothing);
             Modify_ApiCall(ref _callTestOptionalRequiredFlatteningParams);
             Modify_TestOptionalRequiredFlatteningParamsApiCall(ref _callTestOptionalRequiredFlatteningParams);
+            Modify_ApiCall(ref _callMoveBooks);
+            Modify_MoveBooksApiCall(ref _callMoveBooks);
+            Modify_ApiCall(ref _callArchiveBooks);
+            Modify_ArchiveBooksApiCall(ref _callArchiveBooks);
+            Modify_ApiCall(ref _callLongRunningArchiveBooks);
+            Modify_LongRunningArchiveBooksApiCall(ref _callLongRunningArchiveBooks);
+            Modify_ApiCall(ref _callStreamingArchiveBooks);
+            Modify_StreamingArchiveBooksApiCall(ref _callStreamingArchiveBooks);
             Modify_ApiCall(ref _callPrivateListShelves);
             Modify_PrivateListShelvesApiCall(ref _callPrivateListShelves);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);
@@ -16120,6 +16700,10 @@ namespace Google.Example.Library.V1
         partial void Modify_GetBigBookApiCall(ref gaxgrpc::ApiCall<GetBookRequest, lro::Operation> call);
         partial void Modify_GetBigNothingApiCall(ref gaxgrpc::ApiCall<GetBookRequest, lro::Operation> call);
         partial void Modify_TestOptionalRequiredFlatteningParamsApiCall(ref gaxgrpc::ApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> call);
+        partial void Modify_MoveBooksApiCall(ref gaxgrpc::ApiCall<MoveBooksRequest, MoveBooksResponse> call);
+        partial void Modify_ArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
+        partial void Modify_LongRunningArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> call);
+        partial void Modify_StreamingArchiveBooksApiCall(ref gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
         partial void Modify_PrivateListShelvesApiCall(ref gaxgrpc::ApiCall<ListShelvesRequest, Book> call);
         partial void OnConstruction(LibraryService.LibraryServiceClient grpcClient, LibraryServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
@@ -16156,6 +16740,8 @@ namespace Google.Example.Library.V1
         partial void Modify_FindRelatedBooksRequest(ref FindRelatedBooksRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_AddLabelRequest(ref gtv::AddLabelRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_TestOptionalRequiredFlatteningParamsRequest(ref TestOptionalRequiredFlatteningParamsRequest request, ref gaxgrpc::CallSettings settings);
+        partial void Modify_MoveBooksRequest(ref MoveBooksRequest request, ref gaxgrpc::CallSettings settings);
+        partial void Modify_ArchiveBooksRequest(ref ArchiveBooksRequest request, ref gaxgrpc::CallSettings settings);
 
         /// <summary>
         /// Creates a shelf, and returns the new Shelf.
@@ -17251,6 +17837,213 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<MoveBooksResponse> MoveBooksAsync(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MoveBooksRequest(ref request, ref callSettings);
+            return _callMoveBooks.Async(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override MoveBooksResponse MoveBooks(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MoveBooksRequest(ref request, ref callSettings);
+            return _callMoveBooks.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return _callArchiveBooks.Async(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override ArchiveBooksResponse ArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return _callArchiveBooks.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<lro::Operation> LongRunningArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return _callLongRunningArchiveBooks.Async(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override lro::Operation LongRunningArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return _callLongRunningArchiveBooks.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <param name="streamingSettings">
+        /// If not null, applies streaming overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The client-server stream.
+        /// </returns>
+        public override StreamingArchiveBooksStream StreamingArchiveBooks(
+            gaxgrpc::CallSettings callSettings = null,
+            gaxgrpc::BidirectionalStreamingSettings streamingSettings = null)
+        {
+            Modify_ArchiveBooksRequestCallSettings(ref callSettings);
+            gaxgrpc::BidirectionalStreamingSettings effectiveStreamingSettings =
+                streamingSettings ?? _callStreamingArchiveBooks.StreamingSettings;
+            grpccore::AsyncDuplexStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call =
+                _callStreamingArchiveBooks.Call(callSettings);
+            gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest> writeBuffer =
+                new gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest>(
+                    call.RequestStream, effectiveStreamingSettings.BufferedClientWriterCapacity);
+            return new StreamingArchiveBooksStreamImpl(this, call, writeBuffer);
+        }
+
+        internal sealed partial class StreamingArchiveBooksStreamImpl : StreamingArchiveBooksStream
+        {
+            /// <summary>
+            /// Construct the bidirectional streaming method for <c>StreamingArchiveBooks</c>.
+            /// </summary>
+            /// <param name="service">The service containing this streaming method.</param>
+            /// <param name="call">The underlying gRPC duplex streaming call.</param>
+            /// <param name="writeBuffer">The <see cref="gaxgrpc::BufferedClientStreamWriter{ArchiveBooksRequest}"/>
+            /// instance associated with this streaming call.</param>
+            public StreamingArchiveBooksStreamImpl(
+                LibraryServiceClientImpl service,
+                grpccore::AsyncDuplexStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call,
+                gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest> writeBuffer)
+            {
+                _service = service;
+                GrpcCall = call;
+                _writeBuffer = writeBuffer;
+            }
+
+            private LibraryServiceClientImpl _service;
+            private gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest> _writeBuffer;
+
+            private ArchiveBooksRequest ModifyRequest(ArchiveBooksRequest request)
+            {
+                _service.Modify_ArchiveBooksRequestRequest(ref request);
+                return request;
+            }
+
+            /// <inheritdoc/>
+            public override grpccore::AsyncDuplexStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> GrpcCall { get; }
+
+            /// <inheritdoc/>
+            public override stt::Task TryWriteAsync(ArchiveBooksRequest message) =>
+                _writeBuffer.TryWriteAsync(ModifyRequest(message));
+
+            /// <inheritdoc/>
+            public override stt::Task WriteAsync(ArchiveBooksRequest message) =>
+                _writeBuffer.WriteAsync(ModifyRequest(message));
+
+            /// <inheritdoc/>
+            public override stt::Task TryWriteAsync(ArchiveBooksRequest message, grpccore::WriteOptions options) =>
+                _writeBuffer.TryWriteAsync(ModifyRequest(message), options);
+
+            /// <inheritdoc/>
+            public override stt::Task WriteAsync(ArchiveBooksRequest message, grpccore::WriteOptions options) =>
+                _writeBuffer.WriteAsync(ModifyRequest(message), options);
+
+            /// <inheritdoc/>
+            public override stt::Task TryWriteCompleteAsync() =>
+                _writeBuffer.TryWriteCompleteAsync();
+
+            /// <inheritdoc/>
+            public override stt::Task WriteCompleteAsync() =>
+                _writeBuffer.WriteCompleteAsync();
+
+            /// <inheritdoc/>
+            public override scg::IAsyncEnumerator<ArchiveBooksResponse> ResponseStream =>
+                GrpcCall.ResponseStream;
+        }
+
+        /// <summary>
         /// This method is not exposed in the GAPIC config. It should be generated.
         /// </summary>
         /// <param name="request">
@@ -17905,7 +18698,7 @@ namespace Google.Example.Library.V1
     /// </summary>
     public sealed partial class ArchivedBookName : gax::IResourceName, sys::IEquatable<ArchivedBookName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("archives/{archive_path}/books/{book_id=**}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("archives/{archive_path}/books/{book=**}");
 
         /// <summary>
         /// Parses the given archived_book resource name in string form into a new
@@ -18004,7 +18797,7 @@ namespace Google.Example.Library.V1
     /// </summary>
     public sealed partial class BookName : gax::IResourceName, sys::IEquatable<BookName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("shelves/{shelf_id}/books/{book_id}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("shelves/{shelf}/books/{book}");
 
         /// <summary>
         /// Parses the given book resource name in string form into a new
@@ -18518,7 +19311,7 @@ namespace Google.Example.Library.V1
     /// </summary>
     public sealed partial class ShelfName : gax::IResourceName, sys::IEquatable<ShelfName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("shelves/{shelf_id}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("shelves/{shelf}");
 
         /// <summary>
         /// Parses the given shelf resource name in string form into a new

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -244,6 +244,10 @@ type CallOptions struct {
     GetBigBook []gax.CallOption
     GetBigNothing []gax.CallOption
     TestOptionalRequiredFlatteningParams []gax.CallOption
+    MoveBooks []gax.CallOption
+    ArchiveBooks []gax.CallOption
+    LongRunningArchiveBooks []gax.CallOption
+    StreamingArchiveBooks []gax.CallOption
     PrivateListShelves []gax.CallOption
 }
 
@@ -299,6 +303,10 @@ func defaultCallOptions() *CallOptions {
         GetBigBook: retry[[2]string{"default", "non_idempotent"}],
         GetBigNothing: retry[[2]string{"default", "non_idempotent"}],
         TestOptionalRequiredFlatteningParams: retry[[2]string{"default", "non_idempotent"}],
+        MoveBooks: retry[[2]string{"default", "non_idempotent"}],
+        ArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
+        LongRunningArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
+        StreamingArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
         PrivateListShelves: retry[[2]string{"default", "idempotent"}],
     }
 }
@@ -914,6 +922,73 @@ func (c *LibClient) TestOptionalRequiredFlatteningParams(ctx context.Context, re
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.TestOptionalRequiredFlatteningParams(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
+}
+
+// MoveBooks
+func (c *LibClient) MoveBooks(ctx context.Context, req *librarypb.MoveBooksRequest, opts ...gax.CallOption) (*librarypb.MoveBooksResponse, error) {
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "source", url.QueryEscape(req.GetSource())))
+    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
+    opts = append(c.CallOptions.MoveBooks[0:len(c.CallOptions.MoveBooks):len(c.CallOptions.MoveBooks)], opts...)
+    var resp *librarypb.MoveBooksResponse
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        resp, err = c.client.MoveBooks(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
+}
+
+// ArchiveBooks
+func (c *LibClient) ArchiveBooks(ctx context.Context, req *librarypb.ArchiveBooksRequest, opts ...gax.CallOption) (*librarypb.ArchiveBooksResponse, error) {
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "source", url.QueryEscape(req.GetSource())))
+    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
+    opts = append(c.CallOptions.ArchiveBooks[0:len(c.CallOptions.ArchiveBooks):len(c.CallOptions.ArchiveBooks)], opts...)
+    var resp *librarypb.ArchiveBooksResponse
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        resp, err = c.client.ArchiveBooks(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
+}
+
+// LongRunningArchiveBooks
+func (c *LibClient) LongRunningArchiveBooks(ctx context.Context, req *librarypb.ArchiveBooksRequest, opts ...gax.CallOption) (*longrunningpb.Operation, error) {
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "source", url.QueryEscape(req.GetSource())))
+    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
+    opts = append(c.CallOptions.LongRunningArchiveBooks[0:len(c.CallOptions.LongRunningArchiveBooks):len(c.CallOptions.LongRunningArchiveBooks)], opts...)
+    var resp *longrunningpb.Operation
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        resp, err = c.client.LongRunningArchiveBooks(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
+}
+
+// StreamingArchiveBooks
+func (c *LibClient) StreamingArchiveBooks(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_StreamingArchiveBooksClient, error) {
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
+    opts = append(c.CallOptions.StreamingArchiveBooks[0:len(c.CallOptions.StreamingArchiveBooks):len(c.CallOptions.StreamingArchiveBooks)], opts...)
+    var resp librarypb.LibraryService_StreamingArchiveBooksClient
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        resp, err = c.client.StreamingArchiveBooks(ctx, settings.GRPC...)
         return err
     }, opts...)
     if err != nil {
@@ -1769,6 +1844,94 @@ func ExampleClient_TestOptionalRequiredFlatteningParams() {
     _ = resp
 }
 
+func ExampleClient_MoveBooks() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &librarypb.MoveBooksRequest{
+        // TODO: Fill request struct fields.
+    }
+    resp, err := c.MoveBooks(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    // TODO: Use resp.
+    _ = resp
+}
+
+func ExampleClient_ArchiveBooks() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &librarypb.ArchiveBooksRequest{
+        // TODO: Fill request struct fields.
+    }
+    resp, err := c.ArchiveBooks(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    // TODO: Use resp.
+    _ = resp
+}
+
+func ExampleClient_LongRunningArchiveBooks() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &librarypb.ArchiveBooksRequest{
+        // TODO: Fill request struct fields.
+    }
+    resp, err := c.LongRunningArchiveBooks(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    // TODO: Use resp.
+    _ = resp
+}
+
+func ExampleClient_StreamingArchiveBooks() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    stream, err := c.StreamingArchiveBooks(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    go func() {
+        reqs := []*librarypb.ArchiveBooksRequest{
+            // TODO: Create requests.
+        }
+        for _, req := range reqs {
+            if err := stream.Send(req); err != nil {
+                // TODO: Handle error.
+            }
+        }
+        stream.CloseSend()
+    }()
+    for {
+        resp, err := stream.Recv()
+        if err == io.EOF {
+            break
+        }
+        if err != nil {
+            // TODO: handle error.
+        }
+        // TODO: Use resp.
+        _ = resp
+    }
+}
+
 func ExampleClient_PrivateListShelves() {
     ctx := context.Background()
     c, err := library.NewClient(ctx)
@@ -2201,6 +2364,67 @@ func (s *mockLibraryServer) GetBigNothing(ctx context.Context, req *librarypb.Ge
     return s.resps[0].(*longrunningpb.Operation), nil
 }
 
+func (s *mockLibraryServer) MoveBooks(ctx context.Context, req *librarypb.MoveBooksRequest) (*librarypb.MoveBooksResponse, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*librarypb.MoveBooksResponse), nil
+}
+
+func (s *mockLibraryServer) ArchiveBooks(ctx context.Context, req *librarypb.ArchiveBooksRequest) (*librarypb.ArchiveBooksResponse, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*librarypb.ArchiveBooksResponse), nil
+}
+
+func (s *mockLibraryServer) LongRunningArchiveBooks(ctx context.Context, req *librarypb.ArchiveBooksRequest) (*longrunningpb.Operation, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*longrunningpb.Operation), nil
+}
+
+func (s *mockLibraryServer) StreamingArchiveBooks(stream librarypb.LibraryService_StreamingArchiveBooksServer) error {
+    md, _ := metadata.FromIncomingContext(stream.Context())
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    for {
+        if req, err := stream.Recv(); err == io.EOF {
+            break
+        } else if err != nil {
+            return err
+        } else {
+            s.reqs = append(s.reqs, req)
+        }
+    }
+    if s.err != nil {
+        return s.err
+    }
+    for _, v := range s.resps {
+        if err := stream.Send(v.(*librarypb.ArchiveBooksResponse)); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+
 func (s *mockLibraryServer) TestOptionalRequiredFlatteningParams(ctx context.Context, req *librarypb.TestOptionalRequiredFlatteningParamsRequest) (*librarypb.TestOptionalRequiredFlatteningParamsResponse, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
@@ -2391,7 +2615,7 @@ func TestLibraryServiceGetShelf(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var options string = "options-1249474914"
     var request = &librarypb.GetShelfRequest{
         Name: formattedName,
@@ -2422,7 +2646,7 @@ func TestLibraryServiceGetShelfError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var options string = "options-1249474914"
     var request = &librarypb.GetShelfRequest{
         Name: formattedName,
@@ -2517,7 +2741,7 @@ func TestLibraryServiceDeleteShelf(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.DeleteShelfRequest{
         Name: formattedName,
     }
@@ -2543,7 +2767,7 @@ func TestLibraryServiceDeleteShelfError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.DeleteShelfRequest{
         Name: formattedName,
     }
@@ -2576,8 +2800,8 @@ func TestLibraryServiceMergeShelves(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
-    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
+    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.MergeShelvesRequest{
         Name: formattedName,
         OtherShelfName: formattedOtherShelfName,
@@ -2607,8 +2831,8 @@ func TestLibraryServiceMergeShelvesError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
-    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
+    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.MergeShelvesRequest{
         Name: formattedName,
         OtherShelfName: formattedOtherShelfName,
@@ -2645,7 +2869,7 @@ func TestLibraryServiceCreateBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var book *librarypb.Book = &librarypb.Book{}
     var request = &librarypb.CreateBookRequest{
         Name: formattedName,
@@ -2676,7 +2900,7 @@ func TestLibraryServiceCreateBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var book *librarypb.Book = &librarypb.Book{}
     var request = &librarypb.CreateBookRequest{
         Name: formattedName,
@@ -2792,7 +3016,7 @@ func TestLibraryServiceGetBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -2821,7 +3045,7 @@ func TestLibraryServiceGetBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -2854,7 +3078,7 @@ func TestLibraryServiceListBooks(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var filter string = "book-filter-string"
     var request = &librarypb.ListBooksRequest{
         Name: formattedName,
@@ -2895,7 +3119,7 @@ func TestLibraryServiceListBooksError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var filter string = "book-filter-string"
     var request = &librarypb.ListBooksRequest{
         Name: formattedName,
@@ -2924,7 +3148,7 @@ func TestLibraryServiceDeleteBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DeleteBookRequest{
         Name: formattedName,
     }
@@ -2950,7 +3174,7 @@ func TestLibraryServiceDeleteBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DeleteBookRequest{
         Name: formattedName,
     }
@@ -2985,7 +3209,7 @@ func TestLibraryServiceUpdateBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var book *librarypb.Book = &librarypb.Book{}
     var request = &librarypb.UpdateBookRequest{
         Name: formattedName,
@@ -3016,7 +3240,7 @@ func TestLibraryServiceUpdateBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var book *librarypb.Book = &librarypb.Book{}
     var request = &librarypb.UpdateBookRequest{
         Name: formattedName,
@@ -3054,8 +3278,8 @@ func TestLibraryServiceMoveBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
-    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.MoveBookRequest{
         Name: formattedName,
         OtherShelfName: formattedOtherShelfName,
@@ -3085,8 +3309,8 @@ func TestLibraryServiceMoveBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
-    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.MoveBookRequest{
         Name: formattedName,
         OtherShelfName: formattedOtherShelfName,
@@ -3180,7 +3404,7 @@ func TestLibraryServiceAddComments(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var comment []byte = []byte("95")
     var stage librarypb.Comment_Stage = librarypb.Comment_UNSET
     var alignment librarypb.SomeMessage2_SomeMessage3_Alignment = librarypb.SomeMessage2_SomeMessage3_CHAR
@@ -3216,7 +3440,7 @@ func TestLibraryServiceAddCommentsError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var comment []byte = []byte("95")
     var stage librarypb.Comment_Stage = librarypb.Comment_UNSET
     var alignment librarypb.SomeMessage2_SomeMessage3_Alignment = librarypb.SomeMessage2_SomeMessage3_CHAR
@@ -3261,8 +3485,8 @@ func TestLibraryServiceGetBookFromAnywhere(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
-    var formattedAltBookName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var formattedAltBookName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var formattedPlace string = fmt.Sprintf("projects/%s/locations/%s", "[PROJECT]", "[LOCATION]")
     var formattedFolder string = fmt.Sprintf("folders/%s", "[FOLDER]")
     var request = &librarypb.GetBookFromAnywhereRequest{
@@ -3296,8 +3520,8 @@ func TestLibraryServiceGetBookFromAnywhereError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
-    var formattedAltBookName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var formattedAltBookName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var formattedPlace string = fmt.Sprintf("projects/%s/locations/%s", "[PROJECT]", "[LOCATION]")
     var formattedFolder string = fmt.Sprintf("folders/%s", "[FOLDER]")
     var request = &librarypb.GetBookFromAnywhereRequest{
@@ -3338,7 +3562,7 @@ func TestLibraryServiceGetBookFromAbsolutelyAnywhere(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookFromAbsolutelyAnywhereRequest{
         Name: formattedName,
     }
@@ -3367,7 +3591,7 @@ func TestLibraryServiceGetBookFromAbsolutelyAnywhereError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookFromAbsolutelyAnywhereRequest{
         Name: formattedName,
     }
@@ -3394,7 +3618,7 @@ func TestLibraryServiceUpdateBookIndex(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var indexName string = "default index"
     var indexMapItem string = "indexMapItem1918721251"
     var indexMap = map[string]string{
@@ -3427,7 +3651,7 @@ func TestLibraryServiceUpdateBookIndexError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var indexName string = "default index"
     var indexMapItem string = "indexMapItem1918721251"
     var indexMap = map[string]string{
@@ -3464,7 +3688,7 @@ func TestLibraryServiceStreamShelves(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.StreamShelvesRequest{
         Name: formattedName,
     }
@@ -3497,7 +3721,7 @@ func TestLibraryServiceStreamShelvesError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.StreamShelvesRequest{
         Name: formattedName,
     }
@@ -3606,7 +3830,7 @@ func TestLibraryServiceDiscussBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3645,7 +3869,7 @@ func TestLibraryServiceDiscussBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3687,7 +3911,7 @@ func TestLibraryServiceMonologAboutBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3723,7 +3947,7 @@ func TestLibraryServiceMonologAboutBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3895,7 +4119,7 @@ func TestLabelerAddLabel(t *testing.T) {
 
     mockLabeler.resps = append(mockLabeler.resps[:0], expectedResponse)
 
-    var formattedResource string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedResource string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var label string = "label102727412"
     var request = &taggerpb.AddLabelRequest{
         Resource: formattedResource,
@@ -3926,7 +4150,7 @@ func TestLabelerAddLabelError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLabeler.err = gstatus.Error(errCode, "test error")
 
-    var formattedResource string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedResource string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var label string = "label102727412"
     var request = &taggerpb.AddLabelRequest{
         Resource: formattedResource,
@@ -3972,7 +4196,7 @@ func TestLibraryServiceGetBigBook(t *testing.T) {
         Result: &longrunningpb.Operation_Response{ Response: any },
     })
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4015,7 +4239,7 @@ func TestLibraryServiceGetBigBookError(t *testing.T) {
         },
     })
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4054,7 +4278,7 @@ func TestLibraryServiceGetBigNothing(t *testing.T) {
         Result: &longrunningpb.Operation_Response{ Response: any },
     })
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4094,7 +4318,7 @@ func TestLibraryServiceGetBigNothingError(t *testing.T) {
         },
     })
 
-    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4133,8 +4357,8 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParams(t *testing.T) {
     var requiredSingularString string = "requiredSingularString-1949894503"
     var requiredSingularBytes []byte = []byte("-29")
     var requiredSingularMessage *librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage = &librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage{}
-    var formattedRequiredSingularResourceName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
-    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedRequiredSingularResourceName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var formattedRequiredSingularResourceNameCommon string = fmt.Sprintf("projects/%s", "[PROJECT]")
     var requiredSingularFixed32 int32 = 720656715
     var requiredSingularFixed64 int64 = 720656810
@@ -4282,8 +4506,8 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
     var requiredSingularString string = "requiredSingularString-1949894503"
     var requiredSingularBytes []byte = []byte("-29")
     var requiredSingularMessage *librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage = &librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage{}
-    var formattedRequiredSingularResourceName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
-    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF_ID]", "[BOOK_ID]")
+    var formattedRequiredSingularResourceName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var formattedRequiredSingularResourceNameCommon string = fmt.Sprintf("projects/%s", "[PROJECT]")
     var requiredSingularFixed32 int32 = 720656715
     var requiredSingularFixed64 int64 = 720656810
@@ -4404,6 +4628,240 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
     }
 
     resp, err := c.TestOptionalRequiredFlatteningParams(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
+    _ = resp
+}
+func TestLibraryServiceMoveBooks(t *testing.T) {
+    var success bool = false
+    var expectedResponse = &librarypb.MoveBooksResponse{
+        Success: success,
+    }
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
+
+    var request *librarypb.MoveBooksRequest = &librarypb.MoveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.MoveBooks(context.Background(), request)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+    if want, got := expectedResponse, resp; !proto.Equal(want, got) {
+        t.Errorf("wrong response %q, want %q)", got, want)
+    }
+}
+
+func TestLibraryServiceMoveBooksError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockLibrary.err = gstatus.Error(errCode, "test error")
+
+    var request *librarypb.MoveBooksRequest = &librarypb.MoveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.MoveBooks(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
+    _ = resp
+}
+func TestLibraryServiceArchiveBooks(t *testing.T) {
+    var success bool = false
+    var expectedResponse = &librarypb.ArchiveBooksResponse{
+        Success: success,
+    }
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.ArchiveBooks(context.Background(), request)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+    if want, got := expectedResponse, resp; !proto.Equal(want, got) {
+        t.Errorf("wrong response %q, want %q)", got, want)
+    }
+}
+
+func TestLibraryServiceArchiveBooksError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockLibrary.err = gstatus.Error(errCode, "test error")
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.ArchiveBooks(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
+    _ = resp
+}
+func TestLibraryServiceLongRunningArchiveBooks(t *testing.T) {
+    var name string = "name3373707"
+    var done bool = true
+    var expectedResponse = &longrunningpb.Operation{
+        Name: name,
+        Done: done,
+    }
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.LongRunningArchiveBooks(context.Background(), request)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+    if want, got := expectedResponse, resp; !proto.Equal(want, got) {
+        t.Errorf("wrong response %q, want %q)", got, want)
+    }
+}
+
+func TestLibraryServiceLongRunningArchiveBooksError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockLibrary.err = gstatus.Error(errCode, "test error")
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.LongRunningArchiveBooks(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
+    _ = resp
+}
+func TestLibraryServiceStreamingArchiveBooks(t *testing.T) {
+    var success bool = false
+    var expectedResponse = &librarypb.ArchiveBooksResponse{
+        Success: success,
+    }
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    stream, err := c.StreamingArchiveBooks(context.Background())
+    if err != nil {
+        t.Fatal(err)
+    }
+    if err := stream.Send(request); err != nil {
+        t.Fatal(err)
+    }
+    if err := stream.CloseSend(); err != nil {
+        t.Fatal(err)
+    }
+    resp, err := stream.Recv()
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+    if want, got := expectedResponse, resp; !proto.Equal(want, got) {
+        t.Errorf("wrong response %q, want %q)", got, want)
+    }
+}
+
+func TestLibraryServiceStreamingArchiveBooksError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockLibrary.err = gstatus.Error(errCode, "test error")
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    stream, err := c.StreamingArchiveBooks(context.Background())
+    if err != nil {
+        t.Fatal(err)
+    }
+    if err := stream.Send(request); err != nil {
+        t.Fatal(err)
+    }
+    if err := stream.CloseSend(); err != nil {
+        t.Fatal(err)
+    }
+    resp, err := stream.Recv()
 
     if st, ok := gstatus.FromError(err); !ok {
         t.Errorf("got error %v, expected grpc error", err)

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -371,7 +371,7 @@ public class DeleteShelfCallableCallableEmptyResponseTypeWithResponseHandling {
   /** Test response handling for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -435,7 +435,7 @@ public class DeleteShelfCallableCallableEmptyResponseTypeWithoutResponseHandling
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -493,7 +493,7 @@ public class DeleteShelfFlattenedEmptyResponseTypeWithResponseHandling {
   /** Test response handling for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       libraryClient.deleteShelf(name.toString());
       // Shelf deleted
       System.out.println("Shelf deleted.");
@@ -546,7 +546,7 @@ public class DeleteShelfFlattenedEmptyResponseTypeWithoutResponseHandling {
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       libraryClient.deleteShelf(name.toString());
     } catch (Exception exception) {
       System.err.println("Failed to create the client due to: " + exception);
@@ -599,7 +599,7 @@ public class DeleteShelfRequestEmptyResponseTypeWithResponseHandling {
   /** Test response handling for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -657,7 +657,7 @@ public class DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling {
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -721,9 +721,9 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
       List<ShelfBookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
       FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
         .addAllNames(ShelfBookName.toStringList(names))
@@ -872,9 +872,9 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
       List<ShelfBookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
       FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
         .addAllNames(ShelfBookName.toStringList(names))
@@ -945,9 +945,9 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
       List<ShelfBookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
       FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
         .addAllNames(ShelfBookName.toStringList(names))
@@ -1842,7 +1842,7 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1904,7 +1904,7 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1966,7 +1966,7 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2033,7 +2033,7 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2096,7 +2096,7 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2162,7 +2162,7 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2228,7 +2228,7 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2296,7 +2296,7 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2361,7 +2361,7 @@ public class GetBookCallableCallableTestOnSuccessMap {
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2426,7 +2426,7 @@ public class GetBookFlattenedTestOnSuccessMap {
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       Book response = libraryClient.getBook(name.toString());
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
@@ -2486,7 +2486,7 @@ public class GetBookRequestTestOnSuccessMap {
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2571,7 +2571,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3492,7 +3492,7 @@ public class StreamShelvesCallableCallableStreamingServerEmpty {
   /** Testing calling forms */
   public static void sampleStreamShelves() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3673,8 +3673,8 @@ public class TestFloatAndInt64 {
       String requiredSingularString = "";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
       int requiredSingularFixed32 = 0;
       long requiredSingularFixed64 = 0L;
@@ -4191,7 +4191,7 @@ public class TuringProgCallableStreamingBidi {
       BidiStream<DiscussBookRequest, Comment> bidiStream =
           libraryClient.discussBookCallable().call();
 
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       Path path = Paths.get("comment_file");
       byte[] data = Files.readAllBytes(path);
       ByteString comment = ByteString.copyFrom(data);
@@ -4406,10 +4406,10 @@ public class LibraryClient implements BackgroundResource {
   private final OperationsClient operationsClient;
 
   private static final PathTemplate ARCHIVED_BOOK_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("archives/{archive_path}/books/{book_id=**}");
+      PathTemplate.createWithoutUrlEncoding("archives/{archive_path}/books/{book=**}");
 
   private static final PathTemplate SHELF_BOOK_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}/books/{book_id}");
+      PathTemplate.createWithoutUrlEncoding("shelves/{shelf}/books/{book}");
 
   private static final PathTemplate FOLDER_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("folders/{folder}");
@@ -4424,7 +4424,7 @@ public class LibraryClient implements BackgroundResource {
       PathTemplate.createWithoutUrlEncoding("projects/{project}/books/{book}");
 
   private static final PathTemplate SHELF_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}");
+      PathTemplate.createWithoutUrlEncoding("shelves/{shelf}");
 
   /**
    * Formats a string containing the fully-qualified path to represent
@@ -4433,10 +4433,10 @@ public class LibraryClient implements BackgroundResource {
    * @deprecated Use the {@link ArchivedBookName} class instead.
    */
   @Deprecated
-  public static final String formatArchivedBookName(String archivePath, String bookId) {
+  public static final String formatArchivedBookName(String archivePath, String book) {
     return ARCHIVED_BOOK_PATH_TEMPLATE.instantiate(
         "archive_path", archivePath,
-        "book_id", bookId);
+        "book", book);
   }
 
   /**
@@ -4446,10 +4446,10 @@ public class LibraryClient implements BackgroundResource {
    * @deprecated Use the {@link ShelfBookName} class instead.
    */
   @Deprecated
-  public static final String formatShelfBookName(String shelfId, String bookId) {
+  public static final String formatShelfBookName(String shelf, String book) {
     return SHELF_BOOK_PATH_TEMPLATE.instantiate(
-        "shelf_id", shelfId,
-        "book_id", bookId);
+        "shelf", shelf,
+        "book", book);
   }
 
   /**
@@ -4509,9 +4509,9 @@ public class LibraryClient implements BackgroundResource {
    * @deprecated Use the {@link ShelfName} class instead.
    */
   @Deprecated
-  public static final String formatShelfName(String shelfId) {
+  public static final String formatShelfName(String shelf) {
     return SHELF_PATH_TEMPLATE.instantiate(
-        "shelf_id", shelfId);
+        "shelf", shelf);
   }
 
   /**
@@ -4526,36 +4526,36 @@ public class LibraryClient implements BackgroundResource {
   }
 
   /**
-   * Parses the book_id from the given fully-qualified path which
+   * Parses the book from the given fully-qualified path which
    * represents a archived_book resource.
    *
    * @deprecated Use the {@link ArchivedBookName} class instead.
    */
   @Deprecated
-  public static final String parseBookIdFromArchivedBookName(String archivedBookName) {
-    return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("book_id");
+  public static final String parseBookFromArchivedBookName(String archivedBookName) {
+    return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("book");
   }
 
   /**
-   * Parses the shelf_id from the given fully-qualified path which
+   * Parses the shelf from the given fully-qualified path which
    * represents a shelf_book resource.
    *
    * @deprecated Use the {@link ShelfBookName} class instead.
    */
   @Deprecated
-  public static final String parseShelfIdFromShelfBookName(String shelfBookName) {
-    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("shelf_id");
+  public static final String parseShelfFromShelfBookName(String shelfBookName) {
+    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("shelf");
   }
 
   /**
-   * Parses the book_id from the given fully-qualified path which
+   * Parses the book from the given fully-qualified path which
    * represents a shelf_book resource.
    *
    * @deprecated Use the {@link ShelfBookName} class instead.
    */
   @Deprecated
-  public static final String parseBookIdFromShelfBookName(String shelfBookName) {
-    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("book_id");
+  public static final String parseBookFromShelfBookName(String shelfBookName) {
+    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("book");
   }
 
   /**
@@ -4625,14 +4625,14 @@ public class LibraryClient implements BackgroundResource {
   }
 
   /**
-   * Parses the shelf_id from the given fully-qualified path which
+   * Parses the shelf from the given fully-qualified path which
    * represents a shelf resource.
    *
    * @deprecated Use the {@link ShelfName} class instead.
    */
   @Deprecated
-  public static final String parseShelfIdFromShelfName(String shelfName) {
-    return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf_id");
+  public static final String parseShelfFromShelfName(String shelfName) {
+    return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf");
   }
 
   /**
@@ -4772,7 +4772,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.getShelf(name);
    * }
    * </code></pre>
@@ -4795,7 +4795,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.getShelf(name.toString());
    * }
    * </code></pre>
@@ -4818,7 +4818,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name, message);
    * }
@@ -4844,7 +4844,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name.toString(), message);
    * }
@@ -4870,7 +4870,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name, message, stringBuilder);
@@ -4899,7 +4899,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name.toString(), message, stringBuilder);
@@ -4928,7 +4928,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String options = "";
    *   GetShelfRequest request = GetShelfRequest.newBuilder()
    *     .setName(name.toString())
@@ -4952,7 +4952,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String options = "";
    *   GetShelfRequest request = GetShelfRequest.newBuilder()
    *     .setName(name.toString())
@@ -5065,7 +5065,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   libraryClient.deleteShelf(name);
    * }
    * </code></pre>
@@ -5088,7 +5088,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   libraryClient.deleteShelf(name.toString());
    * }
    * </code></pre>
@@ -5111,7 +5111,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5133,7 +5133,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5156,8 +5156,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.mergeShelves(name, otherShelfName);
    * }
    * </code></pre>
@@ -5184,8 +5184,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.mergeShelves(name.toString(), otherShelfName.toString());
    * }
    * </code></pre>
@@ -5212,8 +5212,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -5238,8 +5238,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -5261,7 +5261,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.createBook(name, book);
    * }
@@ -5287,7 +5287,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.createBook(name.toString(), book);
    * }
@@ -5313,7 +5313,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   CreateBookRequest request = CreateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -5337,7 +5337,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   CreateBookRequest request = CreateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -5452,7 +5452,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name);
    * }
    * </code></pre>
@@ -5475,7 +5475,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -5498,7 +5498,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5520,7 +5520,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5541,7 +5541,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   for (Book element : libraryClient.listBooks(name, filter).iterateAll()) {
    *     // doThingsWith(element);
@@ -5569,7 +5569,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   for (Book element : libraryClient.listBooks(name.toString(), filter).iterateAll()) {
    *     // doThingsWith(element);
@@ -5597,7 +5597,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -5624,7 +5624,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -5649,7 +5649,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -5681,7 +5681,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name);
    * }
    * </code></pre>
@@ -5704,7 +5704,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -5727,7 +5727,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5749,7 +5749,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5770,7 +5770,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name, book);
    * }
@@ -5796,7 +5796,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name.toString(), book);
    * }
@@ -5822,7 +5822,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -5857,7 +5857,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -5892,7 +5892,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -5916,7 +5916,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -5939,8 +5939,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name, otherShelfName);
    * }
    * </code></pre>
@@ -5965,8 +5965,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name.toString(), otherShelfName.toString());
    * }
    * </code></pre>
@@ -5991,8 +5991,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -6015,8 +6015,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -6059,7 +6059,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   for (ResourceName element : libraryClient.listStrings(name).iterateAllAsResourceName()) {
    *     // doThingsWith(element);
    *   }
@@ -6084,7 +6084,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   for (ResourceName element : libraryClient.listStrings(name.toString()).iterateAllAsResourceName()) {
    *     // doThingsWith(element);
    *   }
@@ -6178,7 +6178,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6212,7 +6212,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6246,7 +6246,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6278,7 +6278,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6309,7 +6309,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   LocationParentName parent = ProjectName.of("[PROJECT]");
    *   BookFromArchive response = libraryClient.getBookFromArchive(name, parent);
    * }
@@ -6335,7 +6335,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   LocationParentName parent = ProjectName.of("[PROJECT]");
    *   BookFromArchive response = libraryClient.getBookFromArchive(name.toString(), parent.toString());
    * }
@@ -6361,7 +6361,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   LocationParentName parent = ProjectName.of("[PROJECT]");
    *   GetBookFromArchiveRequest request = GetBookFromArchiveRequest.newBuilder()
    *     .setName(name.toString())
@@ -6385,7 +6385,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   LocationParentName parent = ProjectName.of("[PROJECT]");
    *   GetBookFromArchiveRequest request = GetBookFromArchiveRequest.newBuilder()
    *     .setName(name.toString())
@@ -6408,8 +6408,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfBookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name, altBookName, place, folder);
@@ -6441,8 +6441,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfBookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name.toString(), altBookName.toString(), place.toString(), folder.toString());
@@ -6474,8 +6474,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6502,8 +6502,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6529,7 +6529,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -6552,7 +6552,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -6575,7 +6575,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ResourceName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ResourceName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6597,7 +6597,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ResourceName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ResourceName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6618,7 +6618,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6649,7 +6649,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6680,7 +6680,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6708,7 +6708,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6736,7 +6736,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6786,7 +6786,7 @@ public class LibraryClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryClient.discussBookCallable().call();
    *
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6828,7 +6828,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6913,7 +6913,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -6941,7 +6941,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -6967,7 +6967,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7000,7 +7000,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelResponse response = libraryClient.addLabel(formattedResource, label);
    * }
@@ -7028,7 +7028,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(formattedResource)
@@ -7053,7 +7053,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(formattedResource)
@@ -7077,7 +7077,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -7101,7 +7101,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7125,7 +7125,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7148,7 +7148,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7170,7 +7170,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7191,7 +7191,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -7215,7 +7215,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7239,7 +7239,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7262,7 +7262,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7284,7 +7284,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7333,8 +7333,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7394,8 +7394,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -7719,8 +7719,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedRequiredSingularResourceName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
-   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedRequiredSingularResourceName = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
+   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String formattedRequiredSingularResourceNameCommon = LibraryClient.formatProjectName("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7780,8 +7780,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedOptionalSingularResourceName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
-   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedOptionalSingularResourceName = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
+   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String formattedOptionalSingularResourceNameCommon = LibraryClient.formatProjectName("[PROJECT]");
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -8105,8 +8105,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8247,8 +8247,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8370,6 +8370,139 @@ public class LibraryClient implements BackgroundResource {
    */
   public final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     return stub.testOptionalRequiredFlatteningParamsCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
+   *   MoveBooksResponse response = libraryClient.moveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(MoveBooksRequest request) {
+    return moveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;MoveBooksResponse&gt; future = libraryClient.moveBooksCallable().futureCall(request);
+   *   // Do something
+   *   MoveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    return stub.moveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ArchiveBooksResponse response = libraryClient.archiveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ArchiveBooksResponse archiveBooks(ArchiveBooksRequest request) {
+    return archiveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;ArchiveBooksResponse&gt; future = libraryClient.archiveBooksCallable().futureCall(request);
+   *   // Do something
+   *   ArchiveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    return stub.archiveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   Operation response = libraryClient.longRunningArchiveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Operation longRunningArchiveBooks(ArchiveBooksRequest request) {
+    return longRunningArchiveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;Operation&gt; future = libraryClient.longRunningArchiveBooksCallable().futureCall(request);
+   *   // Do something
+   *   Operation response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    return stub.longRunningArchiveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BidiStream&lt;ArchiveBooksRequest, ArchiveBooksResponse&gt; bidiStream =
+   *       libraryClient.streamingArchiveBooksCallable().call();
+   *
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   bidiStream.send(request);
+   *   for (ArchiveBooksResponse response : bidiStream) {
+   *     // Do something when receive a response
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    return stub.streamingArchiveBooksCallable();
   }
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
@@ -9184,6 +9317,34 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
   }
 
   /**
+   * Returns the object with the settings used for calls to moveBooks.
+   */
+  public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).moveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to archiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).archiveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).longRunningArchiveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamingArchiveBooks.
+   */
+  public StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).streamingArchiveBooksSettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -9514,6 +9675,34 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return getStubSettingsBuilder().testOptionalRequiredFlatteningParamsSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBooks.
+     */
+    public UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+      return getStubSettingsBuilder().moveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to archiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+      return getStubSettingsBuilder().archiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+      return getStubSettingsBuilder().longRunningArchiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamingArchiveBooks.
+     */
+    public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+      return getStubSettingsBuilder().streamingArchiveBooksSettings();
     }
 
     /**
@@ -10151,6 +10340,8 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -10186,6 +10377,8 @@ import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.LocationParentName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
@@ -10333,6 +10526,8 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -10368,6 +10563,8 @@ import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.LocationParentName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
@@ -10620,6 +10817,34 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<MoveBooksRequest, MoveBooksResponse> moveBooksMethodDescriptor =
+      MethodDescriptor.<MoveBooksRequest, MoveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/MoveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(MoveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(MoveBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/ArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, Operation> longRunningArchiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, Operation>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/LongRunningArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+          .setFullMethodName("google.example.library.v1.LibraryService/StreamingArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<ListShelvesRequest, Book> privateListShelvesMethodDescriptor =
       MethodDescriptor.<ListShelvesRequest, Book>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -10666,6 +10891,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable;
   private final OperationCallable<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationCallable;
   private final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable;
+  private final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable;
+  private final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable;
+  private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
+  private final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable;
   private final UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable;
 
   private final GrpcStubCallableFactory callableFactory;
@@ -10975,6 +11204,49 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
         GrpcCallSettings.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
             .setMethodDescriptor(testOptionalRequiredFlatteningParamsMethodDescriptor)
             .build();
+    GrpcCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksTransportSettings =
+        GrpcCallSettings.<MoveBooksRequest, MoveBooksResponse>newBuilder()
+            .setMethodDescriptor(moveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<MoveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(MoveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+            .setMethodDescriptor(archiveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ArchiveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(ArchiveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, Operation>newBuilder()
+            .setMethodDescriptor(longRunningArchiveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ArchiveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(ArchiveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+            .setMethodDescriptor(streamingArchiveBooksMethodDescriptor)
+            .build();
     GrpcCallSettings<ListShelvesRequest, Book> privateListShelvesTransportSettings =
         GrpcCallSettings.<ListShelvesRequest, Book>newBuilder()
             .setMethodDescriptor(privateListShelvesMethodDescriptor)
@@ -11016,6 +11288,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.getBigNothingOperationCallable = callableFactory.createOperationCallable(
         getBigNothingTransportSettings,settings.getBigNothingOperationSettings(), clientContext, this.operationsStub);
     this.testOptionalRequiredFlatteningParamsCallable = callableFactory.createUnaryCallable(testOptionalRequiredFlatteningParamsTransportSettings,settings.testOptionalRequiredFlatteningParamsSettings(), clientContext);
+    this.moveBooksCallable = callableFactory.createUnaryCallable(moveBooksTransportSettings,settings.moveBooksSettings(), clientContext);
+    this.archiveBooksCallable = callableFactory.createUnaryCallable(archiveBooksTransportSettings,settings.archiveBooksSettings(), clientContext);
+    this.longRunningArchiveBooksCallable = callableFactory.createUnaryCallable(longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksSettings(), clientContext);
+    this.streamingArchiveBooksCallable = callableFactory.createBidiStreamingCallable(streamingArchiveBooksTransportSettings,settings.streamingArchiveBooksSettings(), clientContext);
     this.privateListShelvesCallable = callableFactory.createUnaryCallable(privateListShelvesTransportSettings,settings.privateListShelvesSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -11162,6 +11438,22 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     return testOptionalRequiredFlatteningParamsCallable;
+  }
+
+  public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    return moveBooksCallable;
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    return archiveBooksCallable;
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    return longRunningArchiveBooksCallable;
+  }
+
+  public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    return streamingArchiveBooksCallable;
   }
 
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
@@ -11483,6 +11775,8 @@ import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -11517,6 +11811,8 @@ import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.LocationParentName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
@@ -11712,6 +12008,22 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: testOptionalRequiredFlatteningParamsCallable()");
   }
 
+  public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: moveBooksCallable()");
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: archiveBooksCallable()");
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: longRunningArchiveBooksCallable()");
+  }
+
+  public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: streamingArchiveBooksCallable()");
+  }
+
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
     throw new UnsupportedOperationException("Not implemented: privateListShelvesCallable()");
   }
@@ -11786,6 +12098,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookFromArchive;
@@ -11816,6 +12130,8 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.Shelf;
@@ -11908,6 +12224,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<GetBookRequest, Operation> getBigNothingSettings;
   private final OperationCallSettings<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
   private final UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+  private final UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
+  private final UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
+  private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
+  private final StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
   private final UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings;
 
   /**
@@ -12123,6 +12443,34 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to moveBooks.
+   */
+  public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+    return moveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to archiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+    return archiveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+    return longRunningArchiveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamingArchiveBooks.
+   */
+  public StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+    return streamingArchiveBooksSettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -12245,6 +12593,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     getBigNothingSettings = settingsBuilder.getBigNothingSettings().build();
     getBigNothingOperationSettings = settingsBuilder.getBigNothingOperationSettings().build();
     testOptionalRequiredFlatteningParamsSettings = settingsBuilder.testOptionalRequiredFlatteningParamsSettings().build();
+    moveBooksSettings = settingsBuilder.moveBooksSettings().build();
+    archiveBooksSettings = settingsBuilder.archiveBooksSettings().build();
+    longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
+    streamingArchiveBooksSettings = settingsBuilder.streamingArchiveBooksSettings().build();
     privateListShelvesSettings = settingsBuilder.privateListShelvesSettings().build();
   }
 
@@ -12599,6 +12951,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings;
     private final OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
     private final UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+    private final UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
+    private final UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
+    private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
+    private final StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
     private final UnaryCallSettings.Builder<ListShelvesRequest, Book> privateListShelvesSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
@@ -12707,6 +13063,14 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       testOptionalRequiredFlatteningParamsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      moveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      archiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      longRunningArchiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      streamingArchiveBooksSettings = StreamingCallSettings.newBuilder();
+
       privateListShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -12733,6 +13097,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          moveBooksSettings,
+          archiveBooksSettings,
+          longRunningArchiveBooksSettings,
           privateListShelvesSettings
       );
 
@@ -12870,6 +13237,18 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.moveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.archiveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.longRunningArchiveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       builder.privateListShelvesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
@@ -12950,6 +13329,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
       getBigNothingOperationSettings = settings.getBigNothingOperationSettings.toBuilder();
       testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
+      moveBooksSettings = settings.moveBooksSettings.toBuilder();
+      archiveBooksSettings = settings.archiveBooksSettings.toBuilder();
+      longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
+      streamingArchiveBooksSettings = settings.streamingArchiveBooksSettings.toBuilder();
       privateListShelvesSettings = settings.privateListShelvesSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -12976,6 +13359,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          moveBooksSettings,
+          archiveBooksSettings,
+          longRunningArchiveBooksSettings,
           privateListShelvesSettings
       );
     }
@@ -13205,6 +13591,34 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return testOptionalRequiredFlatteningParamsSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBooks.
+     */
+    public UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+      return moveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to archiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+      return archiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+      return longRunningArchiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamingArchiveBooks.
+     */
+    public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+      return streamingArchiveBooksSettings;
     }
 
     /**
@@ -13690,7 +14104,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createShelfTest() {
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13736,7 +14150,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13746,7 +14160,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
 
     Shelf actualResponse =
         client.getShelf(name);
@@ -13770,7 +14184,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
 
       client.getShelf(name);
       Assert.fail("No exception raised");
@@ -13782,7 +14196,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest2() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13792,7 +14206,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     SomeMessage message = SomeMessage.newBuilder().build();
 
     Shelf actualResponse =
@@ -13818,7 +14232,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       SomeMessage message = SomeMessage.newBuilder().build();
 
       client.getShelf(name, message);
@@ -13831,7 +14245,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest3() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13841,7 +14255,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     SomeMessage message = SomeMessage.newBuilder().build();
     com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
 
@@ -13869,7 +14283,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       SomeMessage message = SomeMessage.newBuilder().build();
       com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
 
@@ -13928,7 +14342,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
 
     client.deleteShelf(name);
 
@@ -13950,7 +14364,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
 
       client.deleteShelf(name);
       Assert.fail("No exception raised");
@@ -13962,7 +14376,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void mergeShelvesTest() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13972,8 +14386,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
-    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Shelf actualResponse =
         client.mergeShelves(name, otherShelfName);
@@ -13998,8 +14412,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
-      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.mergeShelves(name, otherShelfName);
       Assert.fail("No exception raised");
@@ -14011,7 +14425,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14023,7 +14437,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -14049,7 +14463,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       Book book = Book.newBuilder().build();
 
       client.createBook(name, book);
@@ -14120,7 +14534,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14132,7 +14546,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBook(name);
@@ -14156,7 +14570,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -14177,7 +14591,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     String filter = "book-filter-string";
 
     ListBooksPagedResponse pagedListResponse = client.listBooks(name, filter);
@@ -14205,7 +14619,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       String filter = "book-filter-string";
 
       client.listBooks(name, filter);
@@ -14221,7 +14635,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     client.deleteBook(name);
 
@@ -14243,7 +14657,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -14255,7 +14669,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14267,7 +14681,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -14293,7 +14707,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -14306,7 +14720,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14318,7 +14732,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -14350,7 +14764,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -14366,7 +14780,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14378,8 +14792,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
         client.moveBook(name, otherShelfName);
@@ -14404,8 +14818,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
       Assert.fail("No exception raised");
@@ -14418,7 +14832,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void listStringsTest() {
     String nextPageToken = "";
-    ResourceName stringsElement = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    ResourceName stringsElement = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
     List<ResourceName> strings = Arrays.asList(stringsElement);
     ListStringsResponse expectedResponse = ListStringsResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -14464,7 +14878,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void listStringsTest2() {
     String nextPageToken = "";
-    ResourceName stringsElement = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    ResourceName stringsElement = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
     List<ResourceName> strings = Arrays.asList(stringsElement);
     ListStringsResponse expectedResponse = ListStringsResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -14472,7 +14886,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
 
     ListStringsPagedResponse pagedListResponse = client.listStrings(name);
 
@@ -14502,7 +14916,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+      ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
 
       client.listStrings(name);
       Assert.fail("No exception raised");
@@ -14517,7 +14931,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     ByteString comment = ByteString.copyFromUtf8("95");
     Comment.Stage stage = Comment.Stage.UNSET;
     SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -14549,7 +14963,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       ByteString comment = ByteString.copyFromUtf8("95");
       Comment.Stage stage = Comment.Stage.UNSET;
       SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -14570,7 +14984,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromArchiveTest() {
-    ArchivedBookName name2 = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    ArchivedBookName name2 = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14582,7 +14996,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
     LocationParentName parent = ProjectName.of("[PROJECT]");
 
     BookFromArchive actualResponse =
@@ -14608,7 +15022,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+      ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
       LocationParentName parent = ProjectName.of("[PROJECT]");
 
       client.getBookFromArchive(name, parent);
@@ -14621,7 +15035,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14633,8 +15047,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    ShelfBookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
     LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
     FolderName folder = FolderName.of("[FOLDER]");
 
@@ -14663,8 +15077,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      ShelfBookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
       LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
       FolderName folder = FolderName.of("[FOLDER]");
 
@@ -14678,7 +15092,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14690,7 +15104,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -14714,7 +15128,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -14729,7 +15143,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String indexName = "default index";
     String indexMapItem = "indexMapItem1918721251";
     Map<String, String> indexMap = new HashMap<>();
@@ -14757,7 +15171,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       String indexName = "default index";
       String indexMapItem = "indexMapItem1918721251";
       Map<String, String> indexMap = new HashMap<>();
@@ -14779,7 +15193,7 @@ public class LibraryClientTest {
       .addAllShelves(shelves)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -14800,7 +15214,7 @@ public class LibraryClientTest {
   public void streamShelvesExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -14824,7 +15238,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14887,7 +15301,7 @@ public class LibraryClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -14912,7 +15326,7 @@ public class LibraryClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -14940,7 +15354,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    ShelfBookName namesElement2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName namesElement2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     List<ShelfBookName> names2 = Arrays.asList(namesElement2);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -14998,7 +15412,7 @@ public class LibraryClientTest {
     AddLabelResponse expectedResponse = AddLabelResponse.newBuilder().build();
     mockLabeler.addResponse(expectedResponse);
 
-    String formattedResource = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+    String formattedResource = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
     String label = "label102727412";
 
     AddLabelResponse actualResponse =
@@ -15024,7 +15438,7 @@ public class LibraryClientTest {
     mockLabeler.addException(exception);
 
     try {
-      String formattedResource = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+      String formattedResource = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
       String label = "label102727412";
 
       client.addLabel(formattedResource, label);
@@ -15037,7 +15451,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15055,7 +15469,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -15079,7 +15493,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -15103,7 +15517,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -15127,7 +15541,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -15188,8 +15602,8 @@ public class LibraryClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
     ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -15249,8 +15663,8 @@ public class LibraryClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
     ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -15454,8 +15868,8 @@ public class LibraryClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -15515,8 +15929,8 @@ public class LibraryClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -15572,6 +15986,57 @@ public class LibraryClientTest {
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamingArchiveBooksTest() throws Exception {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+
+    MockStreamObserver<ArchiveBooksResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> callable =
+        client.streamingArchiveBooksCallable();
+    ApiStreamObserver<ArchiveBooksRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+    requestObserver.onCompleted();
+
+    List<ArchiveBooksResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamingArchiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+
+    MockStreamObserver<ArchiveBooksResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> callable =
+        client.streamingArchiveBooksCallable();
+    ApiStreamObserver<ArchiveBooksRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+
+    try {
+      List<ArchiveBooksResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
     }
   }
 
@@ -16335,6 +16800,81 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
     } else {
       responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
     }
+  }
+
+  @Override
+  public void moveBooks(MoveBooksRequest request,
+    StreamObserver<MoveBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof MoveBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((MoveBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void archiveBooks(ArchiveBooksRequest request,
+    StreamObserver<ArchiveBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof ArchiveBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((ArchiveBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void longRunningArchiveBooks(ArchiveBooksRequest request,
+    StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public StreamObserver<ArchiveBooksRequest> streamingArchiveBooks(
+      final StreamObserver<ArchiveBooksResponse> responseObserver) {
+    final Object response = responses.remove();
+    StreamObserver<ArchiveBooksRequest> requestObserver =
+        new StreamObserver<ArchiveBooksRequest>() {
+      @Override
+      public void onNext(ArchiveBooksRequest value) {
+        if (response instanceof ArchiveBooksResponse) {
+          responseObserver.onNext((ArchiveBooksResponse) response);
+        } else if (response instanceof Exception) {
+          responseObserver.onError((Exception) response);
+        } else {
+          responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+        }
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        responseObserver.onError(t);
+      }
+
+      @Override
+      public void onCompleted() {
+        responseObserver.onCompleted();
+      }
+    };
+    return requestObserver;
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -370,7 +370,7 @@ public class DeleteShelfRequestEmptyResponseTypeWithResponseHandling {
   /** Test response handling for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -428,7 +428,7 @@ public class DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling {
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -490,7 +490,7 @@ public class EmptyResponseTypeWithResponseHandling {
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -557,7 +557,7 @@ public class EmptyResponseTypeWithoutResponseHandling {
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -622,9 +622,9 @@ public class FindRelatedBooksOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
       List<ShelfBookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
       FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
         .addAllNames(ShelfBookName.toStringList(names))
@@ -687,7 +687,7 @@ public class GetBookRequestTestOnSuccessMap {
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1338,7 +1338,7 @@ public class SampleMonologAboutBook {
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1483,8 +1483,8 @@ public class TestFloatAndInt64 {
       String requiredSingularString = "";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
       int requiredSingularFixed32 = 0;
       long requiredSingularFixed64 = 0L;
@@ -1594,11 +1594,11 @@ public class TestFloatAndInt64 {
 package com.google.example.examples.library.v1;
 
 import com.google.api.resourcenames.ResourceName;
-import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof {
   // [START test_resource_name_oneof]
@@ -1606,16 +1606,16 @@ public class TestResourceNameOneof {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.resourcenames.ResourceName;
-   * import com.google.example.library.v1.ArchivedBookName;
    * import com.google.example.library.v1.BookFromAnywhere;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ResourceName name = ArchivedBookName.of("The archive to search for the book", "The ID of the book");
+      ResourceName name = ShelfBookName.of("[SHELF]", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2008,7 +2008,7 @@ public class Turing {
       BidiStream<DiscussBookRequest, Comment> bidiStream =
           libraryClient.discussBookCallable().call();
 
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       Path path = Paths.get("comment_file");
       byte[] data = Files.readAllBytes(path);
       ByteString comment = ByteString.copyFrom(data);
@@ -2355,16 +2355,16 @@ public class LibraryClient implements BackgroundResource {
   private final OperationsClient operationsClient;
 
   private static final PathTemplate ARCHIVED_BOOK_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("archives/{archive_path}/books/{book_id=**}");
+      PathTemplate.createWithoutUrlEncoding("archives/{archive_path}/books/{book=**}");
 
   private static final PathTemplate SHELF_BOOK_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}/books/{book_id}");
+      PathTemplate.createWithoutUrlEncoding("shelves/{shelf}/books/{book}");
 
   private static final PathTemplate PROJECT_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("projects/{project}");
 
   private static final PathTemplate SHELF_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}");
+      PathTemplate.createWithoutUrlEncoding("shelves/{shelf}");
 
   /**
    * Formats a string containing the fully-qualified path to represent
@@ -2373,10 +2373,10 @@ public class LibraryClient implements BackgroundResource {
    * @deprecated Use the {@link ArchivedBookName} class instead.
    */
   @Deprecated
-  public static final String formatArchivedBookName(String archivePath, String bookId) {
+  public static final String formatArchivedBookName(String archivePath, String book) {
     return ARCHIVED_BOOK_PATH_TEMPLATE.instantiate(
         "archive_path", archivePath,
-        "book_id", bookId);
+        "book", book);
   }
 
   /**
@@ -2386,10 +2386,10 @@ public class LibraryClient implements BackgroundResource {
    * @deprecated Use the {@link ShelfBookName} class instead.
    */
   @Deprecated
-  public static final String formatShelfBookName(String shelfId, String bookId) {
+  public static final String formatShelfBookName(String shelf, String book) {
     return SHELF_BOOK_PATH_TEMPLATE.instantiate(
-        "shelf_id", shelfId,
-        "book_id", bookId);
+        "shelf", shelf,
+        "book", book);
   }
 
   /**
@@ -2411,9 +2411,9 @@ public class LibraryClient implements BackgroundResource {
    * @deprecated Use the {@link ShelfName} class instead.
    */
   @Deprecated
-  public static final String formatShelfName(String shelfId) {
+  public static final String formatShelfName(String shelf) {
     return SHELF_PATH_TEMPLATE.instantiate(
-        "shelf_id", shelfId);
+        "shelf", shelf);
   }
 
   /**
@@ -2428,36 +2428,36 @@ public class LibraryClient implements BackgroundResource {
   }
 
   /**
-   * Parses the book_id from the given fully-qualified path which
+   * Parses the book from the given fully-qualified path which
    * represents a archived_book resource.
    *
    * @deprecated Use the {@link ArchivedBookName} class instead.
    */
   @Deprecated
-  public static final String parseBookIdFromArchivedBookName(String archivedBookName) {
-    return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("book_id");
+  public static final String parseBookFromArchivedBookName(String archivedBookName) {
+    return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("book");
   }
 
   /**
-   * Parses the shelf_id from the given fully-qualified path which
+   * Parses the shelf from the given fully-qualified path which
    * represents a shelf_book resource.
    *
    * @deprecated Use the {@link ShelfBookName} class instead.
    */
   @Deprecated
-  public static final String parseShelfIdFromShelfBookName(String shelfBookName) {
-    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("shelf_id");
+  public static final String parseShelfFromShelfBookName(String shelfBookName) {
+    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("shelf");
   }
 
   /**
-   * Parses the book_id from the given fully-qualified path which
+   * Parses the book from the given fully-qualified path which
    * represents a shelf_book resource.
    *
    * @deprecated Use the {@link ShelfBookName} class instead.
    */
   @Deprecated
-  public static final String parseBookIdFromShelfBookName(String shelfBookName) {
-    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("book_id");
+  public static final String parseBookFromShelfBookName(String shelfBookName) {
+    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("book");
   }
 
   /**
@@ -2472,14 +2472,14 @@ public class LibraryClient implements BackgroundResource {
   }
 
   /**
-   * Parses the shelf_id from the given fully-qualified path which
+   * Parses the shelf from the given fully-qualified path which
    * represents a shelf resource.
    *
    * @deprecated Use the {@link ShelfName} class instead.
    */
   @Deprecated
-  public static final String parseShelfIdFromShelfName(String shelfName) {
-    return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf_id");
+  public static final String parseShelfFromShelfName(String shelfName) {
+    return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf");
   }
 
   /**
@@ -2619,7 +2619,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.getShelf(name);
    * }
    * </code></pre>
@@ -2642,7 +2642,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.getShelf(name.toString());
    * }
    * </code></pre>
@@ -2665,7 +2665,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name, message);
    * }
@@ -2691,7 +2691,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name.toString(), message);
    * }
@@ -2717,7 +2717,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name, message, stringBuilder);
@@ -2746,7 +2746,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name.toString(), message, stringBuilder);
@@ -2775,7 +2775,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String options = "";
    *   GetShelfRequest request = GetShelfRequest.newBuilder()
    *     .setName(name.toString())
@@ -2799,7 +2799,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String options = "";
    *   GetShelfRequest request = GetShelfRequest.newBuilder()
    *     .setName(name.toString())
@@ -2912,7 +2912,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   libraryClient.deleteShelf(name);
    * }
    * </code></pre>
@@ -2935,7 +2935,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   libraryClient.deleteShelf(name.toString());
    * }
    * </code></pre>
@@ -2958,7 +2958,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2980,7 +2980,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -3003,8 +3003,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.mergeShelves(name, otherShelfName);
    * }
    * </code></pre>
@@ -3031,8 +3031,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.mergeShelves(name.toString(), otherShelfName.toString());
    * }
    * </code></pre>
@@ -3059,8 +3059,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -3085,8 +3085,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -3108,7 +3108,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.createBook(name, book);
    * }
@@ -3134,7 +3134,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.createBook(name.toString(), book);
    * }
@@ -3160,7 +3160,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   CreateBookRequest request = CreateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -3184,7 +3184,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   CreateBookRequest request = CreateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -3299,7 +3299,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name);
    * }
    * </code></pre>
@@ -3322,7 +3322,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -3345,7 +3345,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -3367,7 +3367,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -3388,7 +3388,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   for (Book element : libraryClient.listBooks(name, filter).iterateAll()) {
    *     // doThingsWith(element);
@@ -3416,7 +3416,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   for (Book element : libraryClient.listBooks(name.toString(), filter).iterateAll()) {
    *     // doThingsWith(element);
@@ -3444,7 +3444,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -3471,7 +3471,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -3496,7 +3496,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -3528,7 +3528,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name);
    * }
    * </code></pre>
@@ -3551,7 +3551,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -3574,7 +3574,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -3596,7 +3596,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -3617,7 +3617,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name, book);
    * }
@@ -3643,7 +3643,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name.toString(), book);
    * }
@@ -3669,7 +3669,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -3704,7 +3704,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -3739,7 +3739,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -3763,7 +3763,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -3786,8 +3786,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name, otherShelfName);
    * }
    * </code></pre>
@@ -3812,8 +3812,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name.toString(), otherShelfName.toString());
    * }
    * </code></pre>
@@ -3838,8 +3838,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -3862,8 +3862,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -3906,7 +3906,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   for (ResourceName element : libraryClient.listStrings(name).iterateAllAsResourceName()) {
    *     // doThingsWith(element);
    *   }
@@ -3931,7 +3931,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   for (ResourceName element : libraryClient.listStrings(name.toString()).iterateAllAsResourceName()) {
    *     // doThingsWith(element);
    *   }
@@ -4025,7 +4025,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -4059,7 +4059,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -4093,7 +4093,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -4125,7 +4125,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -4156,7 +4156,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   BookFromArchive response = libraryClient.getBookFromArchive(name);
    * }
    * </code></pre>
@@ -4179,7 +4179,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   BookFromArchive response = libraryClient.getBookFromArchive(name.toString());
    * }
    * </code></pre>
@@ -4202,7 +4202,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   GetBookFromArchiveRequest request = GetBookFromArchiveRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -4224,7 +4224,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+   *   ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
    *   GetBookFromArchiveRequest request = GetBookFromArchiveRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -4245,8 +4245,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfBookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name, altBookName);
    * }
    * </code></pre>
@@ -4272,8 +4272,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   ShelfBookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name.toString(), altBookName.toString());
    * }
    * </code></pre>
@@ -4299,8 +4299,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .setAltBookName(altBookName.toString())
@@ -4323,8 +4323,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .setAltBookName(altBookName.toString())
@@ -4346,7 +4346,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -4369,7 +4369,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -4392,7 +4392,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ResourceName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ResourceName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -4414,7 +4414,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ResourceName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ResourceName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -4435,7 +4435,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -4466,7 +4466,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -4497,7 +4497,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -4525,7 +4525,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -4553,7 +4553,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -4603,7 +4603,7 @@ public class LibraryClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryClient.discussBookCallable().call();
    *
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -4645,7 +4645,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -4730,7 +4730,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -4758,7 +4758,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -4784,7 +4784,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;ShelfBookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -4817,7 +4817,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelResponse response = libraryClient.addLabel(formattedResource, label);
    * }
@@ -4845,7 +4845,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(formattedResource)
@@ -4870,7 +4870,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedResource = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(formattedResource)
@@ -4894,7 +4894,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -4918,7 +4918,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -4942,7 +4942,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -4965,7 +4965,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -4987,7 +4987,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5008,7 +5008,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -5032,7 +5032,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -5056,7 +5056,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5079,7 +5079,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5101,7 +5101,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5150,8 +5150,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -5179,8 +5179,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -5440,8 +5440,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedRequiredSingularResourceName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
-   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedRequiredSingularResourceName = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
+   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String formattedRequiredSingularResourceNameCommon = LibraryClient.formatProjectName("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -5469,8 +5469,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedOptionalSingularResourceName = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
-   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+   *   String formattedOptionalSingularResourceName = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
+   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String formattedOptionalSingularResourceNameCommon = LibraryClient.formatProjectName("[PROJECT]");
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -5730,8 +5730,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -5808,8 +5808,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -5867,6 +5867,139 @@ public class LibraryClient implements BackgroundResource {
    */
   public final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     return stub.testOptionalRequiredFlatteningParamsCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
+   *   MoveBooksResponse response = libraryClient.moveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(MoveBooksRequest request) {
+    return moveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;MoveBooksResponse&gt; future = libraryClient.moveBooksCallable().futureCall(request);
+   *   // Do something
+   *   MoveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    return stub.moveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ArchiveBooksResponse response = libraryClient.archiveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ArchiveBooksResponse archiveBooks(ArchiveBooksRequest request) {
+    return archiveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;ArchiveBooksResponse&gt; future = libraryClient.archiveBooksCallable().futureCall(request);
+   *   // Do something
+   *   ArchiveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    return stub.archiveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   Operation response = libraryClient.longRunningArchiveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Operation longRunningArchiveBooks(ArchiveBooksRequest request) {
+    return longRunningArchiveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;Operation&gt; future = libraryClient.longRunningArchiveBooksCallable().futureCall(request);
+   *   // Do something
+   *   Operation response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    return stub.longRunningArchiveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BidiStream&lt;ArchiveBooksRequest, ArchiveBooksResponse&gt; bidiStream =
+   *       libraryClient.streamingArchiveBooksCallable().call();
+   *
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   bidiStream.send(request);
+   *   for (ArchiveBooksResponse response : bidiStream) {
+   *     // Do something when receive a response
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    return stub.streamingArchiveBooksCallable();
   }
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
@@ -6681,6 +6814,34 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
   }
 
   /**
+   * Returns the object with the settings used for calls to moveBooks.
+   */
+  public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).moveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to archiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).archiveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).longRunningArchiveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamingArchiveBooks.
+   */
+  public StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).streamingArchiveBooksSettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -7011,6 +7172,34 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return getStubSettingsBuilder().testOptionalRequiredFlatteningParamsSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBooks.
+     */
+    public UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+      return getStubSettingsBuilder().moveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to archiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+      return getStubSettingsBuilder().archiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+      return getStubSettingsBuilder().longRunningArchiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamingArchiveBooks.
+     */
+    public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+      return getStubSettingsBuilder().streamingArchiveBooksSettings();
     }
 
     /**
@@ -7648,6 +7837,8 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -7680,6 +7871,8 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
@@ -7827,6 +8020,8 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -7859,6 +8054,8 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
@@ -8111,6 +8308,34 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<MoveBooksRequest, MoveBooksResponse> moveBooksMethodDescriptor =
+      MethodDescriptor.<MoveBooksRequest, MoveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/MoveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(MoveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(MoveBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/ArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, Operation> longRunningArchiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, Operation>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/LongRunningArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+          .setFullMethodName("google.example.library.v1.LibraryService/StreamingArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<ListShelvesRequest, Book> privateListShelvesMethodDescriptor =
       MethodDescriptor.<ListShelvesRequest, Book>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -8157,6 +8382,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable;
   private final OperationCallable<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationCallable;
   private final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable;
+  private final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable;
+  private final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable;
+  private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
+  private final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable;
   private final UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable;
 
   private final GrpcStubCallableFactory callableFactory;
@@ -8466,6 +8695,49 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
         GrpcCallSettings.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
             .setMethodDescriptor(testOptionalRequiredFlatteningParamsMethodDescriptor)
             .build();
+    GrpcCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksTransportSettings =
+        GrpcCallSettings.<MoveBooksRequest, MoveBooksResponse>newBuilder()
+            .setMethodDescriptor(moveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<MoveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(MoveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+            .setMethodDescriptor(archiveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ArchiveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(ArchiveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, Operation>newBuilder()
+            .setMethodDescriptor(longRunningArchiveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ArchiveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(ArchiveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+            .setMethodDescriptor(streamingArchiveBooksMethodDescriptor)
+            .build();
     GrpcCallSettings<ListShelvesRequest, Book> privateListShelvesTransportSettings =
         GrpcCallSettings.<ListShelvesRequest, Book>newBuilder()
             .setMethodDescriptor(privateListShelvesMethodDescriptor)
@@ -8507,6 +8779,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.getBigNothingOperationCallable = callableFactory.createOperationCallable(
         getBigNothingTransportSettings,settings.getBigNothingOperationSettings(), clientContext, this.operationsStub);
     this.testOptionalRequiredFlatteningParamsCallable = callableFactory.createUnaryCallable(testOptionalRequiredFlatteningParamsTransportSettings,settings.testOptionalRequiredFlatteningParamsSettings(), clientContext);
+    this.moveBooksCallable = callableFactory.createUnaryCallable(moveBooksTransportSettings,settings.moveBooksSettings(), clientContext);
+    this.archiveBooksCallable = callableFactory.createUnaryCallable(archiveBooksTransportSettings,settings.archiveBooksSettings(), clientContext);
+    this.longRunningArchiveBooksCallable = callableFactory.createUnaryCallable(longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksSettings(), clientContext);
+    this.streamingArchiveBooksCallable = callableFactory.createBidiStreamingCallable(streamingArchiveBooksTransportSettings,settings.streamingArchiveBooksSettings(), clientContext);
     this.privateListShelvesCallable = callableFactory.createUnaryCallable(privateListShelvesTransportSettings,settings.privateListShelvesSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -8653,6 +8929,22 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     return testOptionalRequiredFlatteningParamsCallable;
+  }
+
+  public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    return moveBooksCallable;
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    return archiveBooksCallable;
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    return longRunningArchiveBooksCallable;
+  }
+
+  public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    return streamingArchiveBooksCallable;
   }
 
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
@@ -8974,6 +9266,8 @@ import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -9005,6 +9299,8 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
@@ -9200,6 +9496,22 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: testOptionalRequiredFlatteningParamsCallable()");
   }
 
+  public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: moveBooksCallable()");
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: archiveBooksCallable()");
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: longRunningArchiveBooksCallable()");
+  }
+
+  public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: streamingArchiveBooksCallable()");
+  }
+
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
     throw new UnsupportedOperationException("Not implemented: privateListShelvesCallable()");
   }
@@ -9274,6 +9586,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookFromArchive;
@@ -9304,6 +9618,8 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.Shelf;
@@ -9396,6 +9712,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<GetBookRequest, Operation> getBigNothingSettings;
   private final OperationCallSettings<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
   private final UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+  private final UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
+  private final UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
+  private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
+  private final StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
   private final UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings;
 
   /**
@@ -9611,6 +9931,34 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to moveBooks.
+   */
+  public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+    return moveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to archiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+    return archiveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+    return longRunningArchiveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamingArchiveBooks.
+   */
+  public StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+    return streamingArchiveBooksSettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -9733,6 +10081,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     getBigNothingSettings = settingsBuilder.getBigNothingSettings().build();
     getBigNothingOperationSettings = settingsBuilder.getBigNothingOperationSettings().build();
     testOptionalRequiredFlatteningParamsSettings = settingsBuilder.testOptionalRequiredFlatteningParamsSettings().build();
+    moveBooksSettings = settingsBuilder.moveBooksSettings().build();
+    archiveBooksSettings = settingsBuilder.archiveBooksSettings().build();
+    longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
+    streamingArchiveBooksSettings = settingsBuilder.streamingArchiveBooksSettings().build();
     privateListShelvesSettings = settingsBuilder.privateListShelvesSettings().build();
   }
 
@@ -10087,6 +10439,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings;
     private final OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
     private final UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+    private final UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
+    private final UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
+    private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
+    private final StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
     private final UnaryCallSettings.Builder<ListShelvesRequest, Book> privateListShelvesSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
@@ -10195,6 +10551,14 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       testOptionalRequiredFlatteningParamsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      moveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      archiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      longRunningArchiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      streamingArchiveBooksSettings = StreamingCallSettings.newBuilder();
+
       privateListShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -10221,6 +10585,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          moveBooksSettings,
+          archiveBooksSettings,
+          longRunningArchiveBooksSettings,
           privateListShelvesSettings
       );
 
@@ -10358,6 +10725,18 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.moveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.archiveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.longRunningArchiveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       builder.privateListShelvesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
@@ -10438,6 +10817,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
       getBigNothingOperationSettings = settings.getBigNothingOperationSettings.toBuilder();
       testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
+      moveBooksSettings = settings.moveBooksSettings.toBuilder();
+      archiveBooksSettings = settings.archiveBooksSettings.toBuilder();
+      longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
+      streamingArchiveBooksSettings = settings.streamingArchiveBooksSettings.toBuilder();
       privateListShelvesSettings = settings.privateListShelvesSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -10464,6 +10847,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          moveBooksSettings,
+          archiveBooksSettings,
+          longRunningArchiveBooksSettings,
           privateListShelvesSettings
       );
     }
@@ -10693,6 +11079,34 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return testOptionalRequiredFlatteningParamsSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBooks.
+     */
+    public UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+      return moveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to archiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+      return archiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+      return longRunningArchiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamingArchiveBooks.
+     */
+    public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+      return streamingArchiveBooksSettings;
     }
 
     /**
@@ -11178,7 +11592,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createShelfTest() {
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -11224,7 +11638,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -11234,7 +11648,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
 
     Shelf actualResponse =
         client.getShelf(name);
@@ -11258,7 +11672,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
 
       client.getShelf(name);
       Assert.fail("No exception raised");
@@ -11270,7 +11684,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest2() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -11280,7 +11694,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     SomeMessage message = SomeMessage.newBuilder().build();
 
     Shelf actualResponse =
@@ -11306,7 +11720,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       SomeMessage message = SomeMessage.newBuilder().build();
 
       client.getShelf(name, message);
@@ -11319,7 +11733,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest3() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -11329,7 +11743,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     SomeMessage message = SomeMessage.newBuilder().build();
     com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
 
@@ -11357,7 +11771,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       SomeMessage message = SomeMessage.newBuilder().build();
       com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
 
@@ -11416,7 +11830,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
 
     client.deleteShelf(name);
 
@@ -11438,7 +11852,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
 
       client.deleteShelf(name);
       Assert.fail("No exception raised");
@@ -11450,7 +11864,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void mergeShelvesTest() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -11460,8 +11874,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
-    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Shelf actualResponse =
         client.mergeShelves(name, otherShelfName);
@@ -11486,8 +11900,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
-      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.mergeShelves(name, otherShelfName);
       Assert.fail("No exception raised");
@@ -11499,7 +11913,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -11511,7 +11925,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -11537,7 +11951,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       Book book = Book.newBuilder().build();
 
       client.createBook(name, book);
@@ -11608,7 +12022,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -11620,7 +12034,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBook(name);
@@ -11644,7 +12058,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -11665,7 +12079,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     String filter = "book-filter-string";
 
     ListBooksPagedResponse pagedListResponse = client.listBooks(name, filter);
@@ -11693,7 +12107,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       String filter = "book-filter-string";
 
       client.listBooks(name, filter);
@@ -11709,7 +12123,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     client.deleteBook(name);
 
@@ -11731,7 +12145,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -11743,7 +12157,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -11755,7 +12169,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -11781,7 +12195,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -11794,7 +12208,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -11806,7 +12220,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -11838,7 +12252,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -11854,7 +12268,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -11866,8 +12280,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
         client.moveBook(name, otherShelfName);
@@ -11892,8 +12306,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
       Assert.fail("No exception raised");
@@ -11906,7 +12320,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void listStringsTest() {
     String nextPageToken = "";
-    ResourceName stringsElement = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    ResourceName stringsElement = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
     List<ResourceName> strings = Arrays.asList(stringsElement);
     ListStringsResponse expectedResponse = ListStringsResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -11952,7 +12366,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void listStringsTest2() {
     String nextPageToken = "";
-    ResourceName stringsElement = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    ResourceName stringsElement = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
     List<ResourceName> strings = Arrays.asList(stringsElement);
     ListStringsResponse expectedResponse = ListStringsResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -11960,7 +12374,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
 
     ListStringsPagedResponse pagedListResponse = client.listStrings(name);
 
@@ -11990,7 +12404,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+      ResourceName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
 
       client.listStrings(name);
       Assert.fail("No exception raised");
@@ -12005,7 +12419,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     ByteString comment = ByteString.copyFromUtf8("95");
     Comment.Stage stage = Comment.Stage.UNSET;
     SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -12037,7 +12451,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       ByteString comment = ByteString.copyFromUtf8("95");
       Comment.Stage stage = Comment.Stage.UNSET;
       SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -12058,7 +12472,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromArchiveTest() {
-    ArchivedBookName name2 = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    ArchivedBookName name2 = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -12070,7 +12484,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+    ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
 
     BookFromArchive actualResponse =
         client.getBookFromArchive(name);
@@ -12094,7 +12508,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK_ID]");
+      ArchivedBookName name = ArchivedBookName.of("[ARCHIVE_PATH]", "[BOOK]");
 
       client.getBookFromArchive(name);
       Assert.fail("No exception raised");
@@ -12106,7 +12520,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -12118,8 +12532,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    ShelfBookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     BookFromAnywhere actualResponse =
         client.getBookFromAnywhere(name, altBookName);
@@ -12144,8 +12558,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      ShelfBookName altBookName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      ShelfBookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBookFromAnywhere(name, altBookName);
       Assert.fail("No exception raised");
@@ -12157,7 +12571,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -12169,7 +12583,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -12193,7 +12607,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -12208,7 +12622,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String indexName = "default index";
     String indexMapItem = "indexMapItem1918721251";
     Map<String, String> indexMap = new HashMap<>();
@@ -12236,7 +12650,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       String indexName = "default index";
       String indexMapItem = "indexMapItem1918721251";
       Map<String, String> indexMap = new HashMap<>();
@@ -12258,7 +12672,7 @@ public class LibraryClientTest {
       .addAllShelves(shelves)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -12279,7 +12693,7 @@ public class LibraryClientTest {
   public void streamShelvesExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -12303,7 +12717,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -12366,7 +12780,7 @@ public class LibraryClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -12391,7 +12805,7 @@ public class LibraryClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -12419,7 +12833,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    ShelfBookName namesElement2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName namesElement2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     List<ShelfBookName> names2 = Arrays.asList(namesElement2);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -12477,7 +12891,7 @@ public class LibraryClientTest {
     AddLabelResponse expectedResponse = AddLabelResponse.newBuilder().build();
     mockLabeler.addResponse(expectedResponse);
 
-    String formattedResource = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+    String formattedResource = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
     String label = "label102727412";
 
     AddLabelResponse actualResponse =
@@ -12503,7 +12917,7 @@ public class LibraryClientTest {
     mockLabeler.addException(exception);
 
     try {
-      String formattedResource = LibraryClient.formatShelfBookName("[SHELF_ID]", "[BOOK_ID]");
+      String formattedResource = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
       String label = "label102727412";
 
       client.addLabel(formattedResource, label);
@@ -12516,7 +12930,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -12534,7 +12948,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -12558,7 +12972,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -12582,7 +12996,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -12606,7 +13020,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfBookName name = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -12667,8 +13081,8 @@ public class LibraryClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
     ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -12696,8 +13110,8 @@ public class LibraryClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-    BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
     ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -12869,8 +13283,8 @@ public class LibraryClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -12898,8 +13312,8 @@ public class LibraryClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
-      BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -12955,6 +13369,57 @@ public class LibraryClientTest {
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamingArchiveBooksTest() throws Exception {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+
+    MockStreamObserver<ArchiveBooksResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> callable =
+        client.streamingArchiveBooksCallable();
+    ApiStreamObserver<ArchiveBooksRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+    requestObserver.onCompleted();
+
+    List<ArchiveBooksResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamingArchiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+
+    MockStreamObserver<ArchiveBooksResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> callable =
+        client.streamingArchiveBooksCallable();
+    ApiStreamObserver<ArchiveBooksRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+
+    try {
+      List<ArchiveBooksResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
     }
   }
 
@@ -13718,6 +14183,81 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
     } else {
       responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
     }
+  }
+
+  @Override
+  public void moveBooks(MoveBooksRequest request,
+    StreamObserver<MoveBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof MoveBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((MoveBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void archiveBooks(ArchiveBooksRequest request,
+    StreamObserver<ArchiveBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof ArchiveBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((ArchiveBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void longRunningArchiveBooks(ArchiveBooksRequest request,
+    StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public StreamObserver<ArchiveBooksRequest> streamingArchiveBooks(
+      final StreamObserver<ArchiveBooksResponse> responseObserver) {
+    final Object response = responses.remove();
+    StreamObserver<ArchiveBooksRequest> requestObserver =
+        new StreamObserver<ArchiveBooksRequest>() {
+      @Override
+      public void onNext(ArchiveBooksRequest value) {
+        if (response instanceof ArchiveBooksResponse) {
+          responseObserver.onNext((ArchiveBooksResponse) response);
+        } else if (response instanceof Exception) {
+          responseObserver.onError((Exception) response);
+        } else {
+          responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+        }
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        responseObserver.onError(t);
+      }
+
+      @Override
+      public void onCompleted() {
+        responseObserver.onCompleted();
+      }
+    };
+    return requestObserver;
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -193,7 +193,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 function sampleDeleteShelf() {
   const client = new LibraryServiceClient();
-  const formattedName = client.shelfPath('[SHELF_ID]');
+  const formattedName = client.shelfPath('[SHELF]');
   client.deleteShelf({name: formattedName}).catch(err => {
     console.error(err);
   });
@@ -236,7 +236,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 function sampleDeleteShelf() {
   const client = new LibraryServiceClient();
-  const formattedName = client.shelfPath('[SHELF_ID]');
+  const formattedName = client.shelfPath('[SHELF]');
   client.deleteShelf({name: formattedName}).catch(err => {
     console.error(err);
   });
@@ -868,7 +868,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Handle the operation using the event emitter pattern.
   client.getBigNothing({name: formattedName})
@@ -933,7 +933,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Handle the operation using the event emitter pattern.
   client.getBigNothing({name: formattedName})
@@ -996,7 +996,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 async function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigNothing({name: formattedName});
@@ -1043,7 +1043,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 async function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigNothing({name: formattedName});
@@ -1088,7 +1088,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Handle the operation using the promise pattern.
   client.getBigNothing({name: formattedName})
@@ -1146,7 +1146,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Handle the operation using the promise pattern.
   client.getBigNothing({name: formattedName})
@@ -1202,7 +1202,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 
 function sampleGetBook() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
   client.getBook({name: formattedName})
     .then(responses => {
       const response = responses[0];
@@ -1300,7 +1300,7 @@ function sampleMonologAboutBook() {
     }
     console.log(`The stage of the comment is: ${response.stage}`);
   });
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
   const request = {
     name: formattedName,
   };
@@ -1683,7 +1683,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Testing calling forms */
 function sampleStreamShelves() {
   const client = new LibraryServiceClient();
-  const formattedName = client.shelfPath('[SHELF_ID]');
+  const formattedName = client.shelfPath('[SHELF]');
     client.streamShelves({name: formattedName}).on('data', response => {
       console.log(response);
     });
@@ -1779,8 +1779,8 @@ function sampleTestOptionalRequiredFlatteningParams(paramFloat, paramLong) {
   const requiredSingularString = '';
   const requiredSingularBytes = Buffer.from('');
   const requiredSingularMessage = {};
-  const formattedRequiredSingularResourceName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-  const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+  const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
   const formattedRequiredSingularResourceNameCommon = client.projectPath('[PROJECT]');
   const requiredSingularFixed32 = 0;
   const requiredSingularFixed64 = 0;
@@ -2171,7 +2171,7 @@ function sampleDiscussBook(imageFileName, stage) {
   });
   // const imageFileName = 'image_file.jpg';
   // const stage = 'DRAFT';
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
   const comment = fs.readFileSync('comment_file').toString('base64');
   const comment2 = {
     comment: comment,
@@ -2766,7 +2766,7 @@ const SomeMessage2 = {
  *
  * @property {string} name
  *   The resource name of the shelf.
- *   Shelf names have the form `bookShelves/{shelf_id}`.
+ *   Shelf names have the form `shelves/{shelf}`.
  *
  * @property {string} theme
  *   The theme of the shelf
@@ -3743,6 +3743,58 @@ const TestOptionalRequiredFlatteningParamsRequest = {
  * @see [google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 const TestOptionalRequiredFlatteningParamsResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {string} source
+ *
+ * @property {string} destination
+ *
+ * @property {string[]} publishers
+ *
+ * @property {string} project
+ *
+ * @typedef MoveBooksRequest
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.MoveBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const MoveBooksRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {boolean} success
+ *
+ * @typedef MoveBooksResponse
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.MoveBooksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const MoveBooksResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {string} source
+ *
+ * @property {string} archive
+ *
+ * @typedef ArchiveBooksRequest
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.ArchiveBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const ArchiveBooksRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {boolean} success
+ *
+ * @typedef ArchiveBooksResponse
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.ArchiveBooksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const ArchiveBooksResponse = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 ============== file: src/v1/doc/google/longrunning/doc_operations.js ==============
@@ -5037,10 +5089,10 @@ class LibraryServiceClient {
     // Create useful helper objects for these.
     this._pathTemplates = {
       archivedBookPathTemplate: new gaxModule.PathTemplate(
-        'archives/{archive_path}/books/{book_id=**}'
+        'archives/{archive_path}/books/{book=**}'
       ),
       bookPathTemplate: new gaxModule.PathTemplate(
-        'shelves/{shelf_id}/books/{book_id}'
+        'shelves/{shelf}/books/{book}'
       ),
       folderPathTemplate: new gaxModule.PathTemplate(
         'folders/{folder}'
@@ -5055,7 +5107,7 @@ class LibraryServiceClient {
         'projects/{project}/books/{book}'
       ),
       shelfPathTemplate: new gaxModule.PathTemplate(
-        'shelves/{shelf_id}'
+        'shelves/{shelf}'
       ),
     };
 
@@ -5093,6 +5145,7 @@ class LibraryServiceClient {
       discussBook: new gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
       monologAboutBook: new gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
       babbleAboutBook: new gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
+      streamingArchiveBooks: new gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
     };
 
     const protoFilesRoot = opts.fallback ?
@@ -5207,6 +5260,10 @@ class LibraryServiceClient {
       'getBigBook',
       'getBigNothing',
       'testOptionalRequiredFlatteningParams',
+      'moveBooks',
+      'archiveBooks',
+      'longRunningArchiveBooks',
+      'streamingArchiveBooks',
       'privateListShelves',
     ];
     for (const methodName of libraryServiceStubMethods) {
@@ -5386,7 +5443,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const options = '';
    * const request = {
    *   name: formattedName,
@@ -5575,7 +5632,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * client.deleteShelf({name: formattedName}).catch(err => {
    *   console.error(err);
    * });
@@ -5627,8 +5684,8 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
-   * const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
+   * const formattedOtherShelfName = client.shelfPath('[SHELF]');
    * const request = {
    *   name: formattedName,
    *   otherShelfName: formattedOtherShelfName,
@@ -5689,7 +5746,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const book = {};
    * const request = {
    *   name: formattedName,
@@ -5826,7 +5883,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * client.getBook({name: formattedName})
    *   .then(responses => {
    *     const response = responses[0];
@@ -5900,7 +5957,7 @@ class LibraryServiceClient {
    * });
    *
    * // Iterate over all elements.
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const filter = 'book-filter-string';
    * const request = {
    *   name: formattedName,
@@ -5919,7 +5976,7 @@ class LibraryServiceClient {
    *   });
    *
    * // Or obtain the paged response.
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const filter = 'book-filter-string';
    * const request = {
    *   name: formattedName,
@@ -6005,7 +6062,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const filter = 'book-filter-string';
    * const request = {
    *   name: formattedName,
@@ -6051,7 +6108,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * client.deleteBook({name: formattedName}).catch(err => {
    *   console.error(err);
    * });
@@ -6113,7 +6170,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const book = {};
    * const request = {
    *   name: formattedName,
@@ -6173,8 +6230,8 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-   * const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+   * const formattedOtherShelfName = client.shelfPath('[SHELF]');
    * const request = {
    *   name: formattedName,
    *   otherShelfName: formattedOtherShelfName,
@@ -6373,7 +6430,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const comment = Buffer.from('');
    * const stage = 'UNSET';
    * const alignment = 'CHAR';
@@ -6435,7 +6492,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK_ID]');
+   * const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK]');
    * const formattedParent = client.projectPath('[PROJECT]');
    * const request = {
    *   name: formattedName,
@@ -6498,8 +6555,8 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-   * const formattedAltBookName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+   * const formattedAltBookName = client.bookPath('[SHELF]', '[BOOK]');
    * const formattedPlace = client.locationPath('[PROJECT]', '[LOCATION]');
    * const formattedFolder = client.folderPath('[FOLDER]');
    * const request = {
@@ -6563,7 +6620,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * client.getBookFromAbsolutelyAnywhere({name: formattedName})
    *   .then(responses => {
    *     const response = responses[0];
@@ -6617,7 +6674,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const indexName = 'default index';
    * const indexMapItem = '';
    * const indexMap = {'default_key' : indexMapItem};
@@ -6669,7 +6726,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * client.streamShelves({name: formattedName}).on('data', response => {
    *   // doThingsWith(response)
    * });
@@ -6737,7 +6794,7 @@ class LibraryServiceClient {
    * const stream = client.discussBook().on('data', response => {
    *   // doThingsWith(response)
    * });
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const request = {
    *   name: formattedName,
    * };
@@ -6778,7 +6835,7 @@ class LibraryServiceClient {
    *   }
    *   // doThingsWith(response)
    * });
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const request = {
    *   name: formattedName,
    * };
@@ -7031,7 +7088,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
    * const label = '';
    * const request = {
    *   resource: formattedResource,
@@ -7089,7 +7146,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the promise pattern.
    * client.getBigBook({name: formattedName})
@@ -7108,7 +7165,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the event emitter pattern.
    * client.getBigBook({name: formattedName})
@@ -7136,7 +7193,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the await pattern.
    * const [operation] = await client.getBigBook({name: formattedName});
@@ -7186,7 +7243,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the promise pattern.
    * client.getBigNothing({name: formattedName})
@@ -7205,7 +7262,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the event emitter pattern.
    * client.getBigNothing({name: formattedName})
@@ -7233,7 +7290,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the await pattern.
    * const [operation] = await client.getBigNothing({name: formattedName});
@@ -7484,8 +7541,8 @@ class LibraryServiceClient {
    * const requiredSingularString = '';
    * const requiredSingularBytes = Buffer.from('');
    * const requiredSingularMessage = {};
-   * const formattedRequiredSingularResourceName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-   * const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+   * const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
    * const formattedRequiredSingularResourceNameCommon = client.projectPath('[PROJECT]');
    * const requiredSingularFixed32 = 0;
    * const requiredSingularFixed64 = 0;
@@ -7620,6 +7677,191 @@ class LibraryServiceClient {
   }
 
   /**
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.source]
+   * @param {string} [request.destination]
+   * @param {string[]} [request.publishers]
+   * @param {string} [request.project]
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [MoveBooksResponse]{@link google.example.library.v1.MoveBooksResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [MoveBooksResponse]{@link google.example.library.v1.MoveBooksResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.moveBooks({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  moveBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'source': request.source
+      });
+
+    return this._innerApiCalls.moveBooks(request, options, callback);
+  }
+
+  /**
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.source]
+   * @param {string} [request.archive]
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [ArchiveBooksResponse]{@link google.example.library.v1.ArchiveBooksResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [ArchiveBooksResponse]{@link google.example.library.v1.ArchiveBooksResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.archiveBooks({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  archiveBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'source': request.source
+      });
+
+    return this._innerApiCalls.archiveBooks(request, options, callback);
+  }
+
+  /**
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.source]
+   * @param {string} [request.archive]
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Operation]{@link google.longrunning.Operation}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Operation]{@link google.longrunning.Operation}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.longRunningArchiveBooks({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  longRunningArchiveBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'source': request.source
+      });
+
+    return this._innerApiCalls.longRunningArchiveBooks(request, options, callback);
+  }
+
+  /**
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @returns {Stream}
+   *   An object stream which is both readable and writable. It accepts objects
+   *   representing [ArchiveBooksRequest]{@link google.example.library.v1.ArchiveBooksRequest} for write() method, and
+   *   will emit objects representing [ArchiveBooksResponse]{@link google.example.library.v1.ArchiveBooksResponse} on 'data' event asynchronously.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * const stream = client.streamingArchiveBooks().on('data', response => {
+   *   // doThingsWith(response)
+   * });
+   * const request = {};
+   * // Write request objects.
+   * stream.write(request);
+   */
+  streamingArchiveBooks(options) {
+    options = options || {};
+
+    return this._innerApiCalls.streamingArchiveBooks(options);
+  }
+
+  /**
    * This method is not exposed in the GAPIC config. It should be generated.
    *
    * @param {Object} request
@@ -7677,27 +7919,27 @@ class LibraryServiceClient {
    * Return a fully-qualified archived_book resource name string.
    *
    * @param {String} archivePath
-   * @param {String} bookId
+   * @param {String} book
    * @returns {String}
    */
-  archivedBookPath(archivePath, bookId) {
+  archivedBookPath(archivePath, book) {
     return this._pathTemplates.archivedBookPathTemplate.render({
       archive_path: archivePath,
-      book_id: bookId,
+      book: book,
     });
   }
 
   /**
    * Return a fully-qualified book resource name string.
    *
-   * @param {String} shelfId
-   * @param {String} bookId
+   * @param {String} shelf
+   * @param {String} book
    * @returns {String}
    */
-  bookPath(shelfId, bookId) {
+  bookPath(shelf, book) {
     return this._pathTemplates.bookPathTemplate.render({
-      shelf_id: shelfId,
-      book_id: bookId,
+      shelf: shelf,
+      book: book,
     });
   }
 
@@ -7756,12 +7998,12 @@ class LibraryServiceClient {
   /**
    * Return a fully-qualified shelf resource name string.
    *
-   * @param {String} shelfId
+   * @param {String} shelf
    * @returns {String}
    */
-  shelfPath(shelfId) {
+  shelfPath(shelf) {
     return this._pathTemplates.shelfPathTemplate.render({
-      shelf_id: shelfId,
+      shelf: shelf,
     });
   }
 
@@ -7783,12 +8025,12 @@ class LibraryServiceClient {
    *
    * @param {String} archivedBookName
    *   A fully-qualified path representing a archived_book resources.
-   * @returns {String} - A string representing the book_id.
+   * @returns {String} - A string representing the book.
    */
-  matchBookIdFromArchivedBookName(archivedBookName) {
+  matchBookFromArchivedBookName(archivedBookName) {
     return this._pathTemplates.archivedBookPathTemplate
       .match(archivedBookName)
-      .book_id;
+      .book;
   }
 
   /**
@@ -7796,12 +8038,12 @@ class LibraryServiceClient {
    *
    * @param {String} bookName
    *   A fully-qualified path representing a book resources.
-   * @returns {String} - A string representing the shelf_id.
+   * @returns {String} - A string representing the shelf.
    */
-  matchShelfIdFromBookName(bookName) {
+  matchShelfFromBookName(bookName) {
     return this._pathTemplates.bookPathTemplate
       .match(bookName)
-      .shelf_id;
+      .shelf;
   }
 
   /**
@@ -7809,12 +8051,12 @@ class LibraryServiceClient {
    *
    * @param {String} bookName
    *   A fully-qualified path representing a book resources.
-   * @returns {String} - A string representing the book_id.
+   * @returns {String} - A string representing the book.
    */
-  matchBookIdFromBookName(bookName) {
+  matchBookFromBookName(bookName) {
     return this._pathTemplates.bookPathTemplate
       .match(bookName)
-      .book_id;
+      .book;
   }
 
   /**
@@ -7900,12 +8142,12 @@ class LibraryServiceClient {
    *
    * @param {String} shelfName
    *   A fully-qualified path representing a shelf resources.
-   * @returns {String} - A string representing the shelf_id.
+   * @returns {String} - A string representing the shelf.
    */
-  matchShelfIdFromShelfName(shelfName) {
+  matchShelfFromShelfName(shelfName) {
     return this._pathTemplates.shelfPathTemplate
       .match(shelfName)
-      .shelf_id;
+      .shelf;
   }
 }
 
@@ -8083,6 +8325,26 @@ module.exports = LibraryServiceClient;
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -8598,7 +8860,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const options = 'options-1249474914';
       const request = {
         name: formattedName,
@@ -8635,7 +8897,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const options = 'options-1249474914';
       const request = {
         name: formattedName,
@@ -8723,7 +8985,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -8744,7 +9006,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -8772,8 +9034,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -8809,8 +9071,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -8840,7 +9102,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const book = {};
       const request = {
         name: formattedName,
@@ -8879,7 +9141,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const book = {};
       const request = {
         name: formattedName,
@@ -8985,7 +9247,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9022,7 +9284,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9051,7 +9313,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const filter = 'book-filter-string';
       const request = {
         name: formattedName,
@@ -9087,7 +9349,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const filter = 'book-filter-string';
       const request = {
         name: formattedName,
@@ -9118,7 +9380,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9139,7 +9401,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9167,7 +9429,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const book = {};
       const request = {
         name: formattedName,
@@ -9206,7 +9468,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const book = {};
       const request = {
         name: formattedName,
@@ -9237,8 +9499,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -9276,8 +9538,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -9364,7 +9626,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const comment = '95';
       const stage = 'UNSET';
       const alignment = 'CHAR';
@@ -9395,7 +9657,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const comment = '95';
       const stage = 'UNSET';
       const alignment = 'CHAR';
@@ -9433,7 +9695,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK_ID]');
+      const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK]');
       const formattedParent = client.projectPath('[PROJECT]');
       const request = {
         name: formattedName,
@@ -9472,7 +9734,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK_ID]');
+      const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK]');
       const formattedParent = client.projectPath('[PROJECT]');
       const request = {
         name: formattedName,
@@ -9503,8 +9765,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedAltBookName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedAltBookName = client.bookPath('[SHELF]', '[BOOK]');
       const formattedPlace = client.locationPath('[PROJECT]', '[LOCATION]');
       const formattedFolder = client.folderPath('[FOLDER]');
       const request = {
@@ -9546,8 +9808,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedAltBookName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedAltBookName = client.bookPath('[SHELF]', '[BOOK]');
       const formattedPlace = client.locationPath('[PROJECT]', '[LOCATION]');
       const formattedFolder = client.folderPath('[FOLDER]');
       const request = {
@@ -9581,7 +9843,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9618,7 +9880,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9647,7 +9909,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const indexName = 'default index';
       const indexMapItem = 'indexMapItem1918721251';
       const indexMap = {'default_key' : indexMapItem};
@@ -9673,7 +9935,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const indexName = 'default index';
       const indexMapItem = 'indexMapItem1918721251';
       const indexMap = {'default_key' : indexMapItem};
@@ -9706,7 +9968,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -9740,7 +10002,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -9839,7 +10101,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9872,7 +10134,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9969,7 +10231,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
       const label = 'label102727412';
       const request = {
         resource: formattedResource,
@@ -9999,7 +10261,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
       const label = 'label102727412';
       const request = {
         resource: formattedResource,
@@ -10030,7 +10292,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10068,7 +10330,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10106,7 +10368,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10135,7 +10397,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10182,8 +10444,8 @@ describe('LibraryServiceClient', () => {
       const requiredSingularString = 'requiredSingularString-1949894503';
       const requiredSingularBytes = '-29';
       const requiredSingularMessage = {};
-      const formattedRequiredSingularResourceName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
       const formattedRequiredSingularResourceNameCommon = client.projectPath('[PROJECT]');
       const requiredSingularFixed32 = 720656715;
       const requiredSingularFixed64 = 720656810;
@@ -10330,8 +10592,8 @@ describe('LibraryServiceClient', () => {
       const requiredSingularString = 'requiredSingularString-1949894503';
       const requiredSingularBytes = '-29';
       const requiredSingularMessage = {};
-      const formattedRequiredSingularResourceName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
       const formattedRequiredSingularResourceNameCommon = client.projectPath('[PROJECT]');
       const requiredSingularFixed32 = 720656715;
       const requiredSingularFixed64 = 720656810;
@@ -10459,6 +10721,223 @@ describe('LibraryServiceClient', () => {
         assert(typeof response === 'undefined');
         done();
       });
+    });
+  });
+
+  describe('moveBooks', () => {
+    it('invokes moveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const success = false;
+      const expectedResponse = {
+        success: success,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.moveBooks = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.moveBooks(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes moveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.moveBooks = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.moveBooks(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('archiveBooks', () => {
+    it('invokes archiveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const success = false;
+      const expectedResponse = {
+        success: success,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.archiveBooks = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.archiveBooks(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes archiveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.archiveBooks = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.archiveBooks(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('longRunningArchiveBooks', () => {
+    it('invokes longRunningArchiveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const name = 'name3373707';
+      const done_ = true;
+      const expectedResponse = {
+        name: name,
+        done: done_,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.longRunningArchiveBooks = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.longRunningArchiveBooks(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes longRunningArchiveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.longRunningArchiveBooks = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.longRunningArchiveBooks(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('streamingArchiveBooks', () => {
+    it('invokes streamingArchiveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const success = false;
+      const expectedResponse = {
+        success: success,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.streamingArchiveBooks = mockBidiStreamingGrpcMethod(request, expectedResponse);
+
+      const stream = client.streamingArchiveBooks().on('data', response => {
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      }).on('error', err => {
+        done(err);
+      });
+
+      stream.write(request);
+    });
+
+    it('invokes streamingArchiveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.streamingArchiveBooks = mockBidiStreamingGrpcMethod(request, null, error);
+
+      const stream = client.streamingArchiveBooks().on('data', () => {
+        assert.fail();
+      }).on('error', err => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+
+      stream.write(request);
     });
   });
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
@@ -193,7 +193,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 function sampleDeleteShelf() {
   const client = new LibraryServiceClient();
-  const formattedName = client.shelfPath('[SHELF_ID]');
+  const formattedName = client.shelfPath('[SHELF]');
   client.deleteShelf({name: formattedName}).catch(err => {
     console.error(err);
   });
@@ -236,7 +236,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 function sampleDeleteShelf() {
   const client = new LibraryServiceClient();
-  const formattedName = client.shelfPath('[SHELF_ID]');
+  const formattedName = client.shelfPath('[SHELF]');
   client.deleteShelf({name: formattedName}).catch(err => {
     console.error(err);
   });
@@ -277,7 +277,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 async function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigNothing({name: formattedName});
@@ -324,7 +324,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 async function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigNothing({name: formattedName});
@@ -427,7 +427,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 
 function sampleGetBook() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
   client.getBook({name: formattedName})
     .then(responses => {
       const response = responses[0];
@@ -935,7 +935,7 @@ function sampleMonologAboutBook() {
     }
     console.log(`The stage of the comment is: ${response.stage}`);
   });
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
   const request = {
     name: formattedName,
   };
@@ -1033,8 +1033,8 @@ function sampleTestOptionalRequiredFlatteningParams(paramFloat, paramLong) {
   const requiredSingularString = '';
   const requiredSingularBytes = Buffer.from('');
   const requiredSingularMessage = {};
-  const formattedRequiredSingularResourceName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-  const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+  const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
   const formattedRequiredSingularResourceNameCommon = client.projectPath('[PROJECT]');
   const requiredSingularFixed32 = 0;
   const requiredSingularFixed64 = 0;
@@ -1138,7 +1138,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 
 function sampleGetBookFromAbsolutelyAnywhere() {
   const client = new LibraryServiceClient();
-  const formattedName = client.archivedBookPath('The archive to search for the book', 'The ID of the book');
+  const formattedName = client.bookPath('[SHELF]', 'The ID of the book');
   client.getBookFromAbsolutelyAnywhere({name: formattedName})
     .then(responses => {
       const response = responses[0];
@@ -1417,7 +1417,7 @@ function sampleDiscussBook(imageFileName, stage) {
   });
   // const imageFileName = 'image_file.jpg';
   // const stage = 'DRAFT';
-  const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
   const comment = fs.readFileSync('comment_file').toString('base64');
   const comment2 = {
     comment: comment,
@@ -2012,7 +2012,7 @@ const SomeMessage2 = {
  *
  * @property {string} name
  *   The resource name of the shelf.
- *   Shelf names have the form `bookShelves/{shelf_id}`.
+ *   Shelf names have the form `shelves/{shelf}`.
  *
  * @property {string} theme
  *   The theme of the shelf
@@ -2989,6 +2989,58 @@ const TestOptionalRequiredFlatteningParamsRequest = {
  * @see [google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 const TestOptionalRequiredFlatteningParamsResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {string} source
+ *
+ * @property {string} destination
+ *
+ * @property {string[]} publishers
+ *
+ * @property {string} project
+ *
+ * @typedef MoveBooksRequest
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.MoveBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const MoveBooksRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {boolean} success
+ *
+ * @typedef MoveBooksResponse
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.MoveBooksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const MoveBooksResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {string} source
+ *
+ * @property {string} archive
+ *
+ * @typedef ArchiveBooksRequest
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.ArchiveBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const ArchiveBooksRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {boolean} success
+ *
+ * @typedef ArchiveBooksResponse
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.ArchiveBooksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const ArchiveBooksResponse = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 ============== file: src/v1/doc/google/longrunning/doc_operations.js ==============
@@ -4283,16 +4335,16 @@ class LibraryServiceClient {
     // Create useful helper objects for these.
     this._pathTemplates = {
       archivedBookPathTemplate: new gaxModule.PathTemplate(
-        'archives/{archive_path}/books/{book_id=**}'
+        'archives/{archive_path}/books/{book=**}'
       ),
       bookPathTemplate: new gaxModule.PathTemplate(
-        'shelves/{shelf_id}/books/{book_id}'
+        'shelves/{shelf}/books/{book}'
       ),
       projectPathTemplate: new gaxModule.PathTemplate(
         'projects/{project}'
       ),
       shelfPathTemplate: new gaxModule.PathTemplate(
-        'shelves/{shelf_id}'
+        'shelves/{shelf}'
       ),
     };
 
@@ -4330,6 +4382,7 @@ class LibraryServiceClient {
       discussBook: new gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
       monologAboutBook: new gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
       babbleAboutBook: new gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
+      streamingArchiveBooks: new gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
     };
 
     const protoFilesRoot = opts.fallback ?
@@ -4444,6 +4497,10 @@ class LibraryServiceClient {
       'getBigBook',
       'getBigNothing',
       'testOptionalRequiredFlatteningParams',
+      'moveBooks',
+      'archiveBooks',
+      'longRunningArchiveBooks',
+      'streamingArchiveBooks',
       'privateListShelves',
     ];
     for (const methodName of libraryServiceStubMethods) {
@@ -4623,7 +4680,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const options = '';
    * const request = {
    *   name: formattedName,
@@ -4812,7 +4869,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * client.deleteShelf({name: formattedName}).catch(err => {
    *   console.error(err);
    * });
@@ -4864,8 +4921,8 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
-   * const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
+   * const formattedOtherShelfName = client.shelfPath('[SHELF]');
    * const request = {
    *   name: formattedName,
    *   otherShelfName: formattedOtherShelfName,
@@ -4926,7 +4983,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const book = {};
    * const request = {
    *   name: formattedName,
@@ -5063,7 +5120,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * client.getBook({name: formattedName})
    *   .then(responses => {
    *     const response = responses[0];
@@ -5137,7 +5194,7 @@ class LibraryServiceClient {
    * });
    *
    * // Iterate over all elements.
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const filter = 'book-filter-string';
    * const request = {
    *   name: formattedName,
@@ -5156,7 +5213,7 @@ class LibraryServiceClient {
    *   });
    *
    * // Or obtain the paged response.
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const filter = 'book-filter-string';
    * const request = {
    *   name: formattedName,
@@ -5242,7 +5299,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const filter = 'book-filter-string';
    * const request = {
    *   name: formattedName,
@@ -5288,7 +5345,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * client.deleteBook({name: formattedName}).catch(err => {
    *   console.error(err);
    * });
@@ -5350,7 +5407,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const book = {};
    * const request = {
    *   name: formattedName,
@@ -5410,8 +5467,8 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-   * const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+   * const formattedOtherShelfName = client.shelfPath('[SHELF]');
    * const request = {
    *   name: formattedName,
    *   otherShelfName: formattedOtherShelfName,
@@ -5610,7 +5667,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const comment = Buffer.from('');
    * const stage = 'UNSET';
    * const alignment = 'CHAR';
@@ -5672,7 +5729,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK_ID]');
+   * const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK]');
    * client.getBookFromArchive({name: formattedName})
    *   .then(responses => {
    *     const response = responses[0];
@@ -5730,8 +5787,8 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-   * const formattedAltBookName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+   * const formattedAltBookName = client.bookPath('[SHELF]', '[BOOK]');
    * const request = {
    *   name: formattedName,
    *   altBookName: formattedAltBookName,
@@ -5791,7 +5848,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * client.getBookFromAbsolutelyAnywhere({name: formattedName})
    *   .then(responses => {
    *     const response = responses[0];
@@ -5845,7 +5902,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const indexName = 'default index';
    * const indexMapItem = '';
    * const indexMap = {'default_key' : indexMapItem};
@@ -5897,7 +5954,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * client.streamShelves({name: formattedName}).on('data', response => {
    *   // doThingsWith(response)
    * });
@@ -5965,7 +6022,7 @@ class LibraryServiceClient {
    * const stream = client.discussBook().on('data', response => {
    *   // doThingsWith(response)
    * });
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const request = {
    *   name: formattedName,
    * };
@@ -6006,7 +6063,7 @@ class LibraryServiceClient {
    *   }
    *   // doThingsWith(response)
    * });
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const request = {
    *   name: formattedName,
    * };
@@ -6259,7 +6316,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
    * const label = '';
    * const request = {
    *   resource: formattedResource,
@@ -6317,7 +6374,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the promise pattern.
    * client.getBigBook({name: formattedName})
@@ -6336,7 +6393,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the event emitter pattern.
    * client.getBigBook({name: formattedName})
@@ -6364,7 +6421,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the await pattern.
    * const [operation] = await client.getBigBook({name: formattedName});
@@ -6414,7 +6471,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the promise pattern.
    * client.getBigNothing({name: formattedName})
@@ -6433,7 +6490,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the event emitter pattern.
    * client.getBigNothing({name: formattedName})
@@ -6461,7 +6518,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the await pattern.
    * const [operation] = await client.getBigNothing({name: formattedName});
@@ -6712,8 +6769,8 @@ class LibraryServiceClient {
    * const requiredSingularString = '';
    * const requiredSingularBytes = Buffer.from('');
    * const requiredSingularMessage = {};
-   * const formattedRequiredSingularResourceName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-   * const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+   * const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+   * const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
    * const formattedRequiredSingularResourceNameCommon = client.projectPath('[PROJECT]');
    * const requiredSingularFixed32 = 0;
    * const requiredSingularFixed64 = 0;
@@ -6784,6 +6841,191 @@ class LibraryServiceClient {
   }
 
   /**
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.source]
+   * @param {string} [request.destination]
+   * @param {string[]} [request.publishers]
+   * @param {string} [request.project]
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [MoveBooksResponse]{@link google.example.library.v1.MoveBooksResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [MoveBooksResponse]{@link google.example.library.v1.MoveBooksResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.moveBooks({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  moveBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'source': request.source
+      });
+
+    return this._innerApiCalls.moveBooks(request, options, callback);
+  }
+
+  /**
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.source]
+   * @param {string} [request.archive]
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [ArchiveBooksResponse]{@link google.example.library.v1.ArchiveBooksResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [ArchiveBooksResponse]{@link google.example.library.v1.ArchiveBooksResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.archiveBooks({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  archiveBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'source': request.source
+      });
+
+    return this._innerApiCalls.archiveBooks(request, options, callback);
+  }
+
+  /**
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.source]
+   * @param {string} [request.archive]
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Operation]{@link google.longrunning.Operation}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Operation]{@link google.longrunning.Operation}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.longRunningArchiveBooks({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  longRunningArchiveBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'source': request.source
+      });
+
+    return this._innerApiCalls.longRunningArchiveBooks(request, options, callback);
+  }
+
+  /**
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @returns {Stream}
+   *   An object stream which is both readable and writable. It accepts objects
+   *   representing [ArchiveBooksRequest]{@link google.example.library.v1.ArchiveBooksRequest} for write() method, and
+   *   will emit objects representing [ArchiveBooksResponse]{@link google.example.library.v1.ArchiveBooksResponse} on 'data' event asynchronously.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * const stream = client.streamingArchiveBooks().on('data', response => {
+   *   // doThingsWith(response)
+   * });
+   * const request = {};
+   * // Write request objects.
+   * stream.write(request);
+   */
+  streamingArchiveBooks(options) {
+    options = options || {};
+
+    return this._innerApiCalls.streamingArchiveBooks(options);
+  }
+
+  /**
    * This method is not exposed in the GAPIC config. It should be generated.
    *
    * @param {Object} request
@@ -6841,27 +7083,27 @@ class LibraryServiceClient {
    * Return a fully-qualified archived_book resource name string.
    *
    * @param {String} archivePath
-   * @param {String} bookId
+   * @param {String} book
    * @returns {String}
    */
-  archivedBookPath(archivePath, bookId) {
+  archivedBookPath(archivePath, book) {
     return this._pathTemplates.archivedBookPathTemplate.render({
       archive_path: archivePath,
-      book_id: bookId,
+      book: book,
     });
   }
 
   /**
    * Return a fully-qualified book resource name string.
    *
-   * @param {String} shelfId
-   * @param {String} bookId
+   * @param {String} shelf
+   * @param {String} book
    * @returns {String}
    */
-  bookPath(shelfId, bookId) {
+  bookPath(shelf, book) {
     return this._pathTemplates.bookPathTemplate.render({
-      shelf_id: shelfId,
-      book_id: bookId,
+      shelf: shelf,
+      book: book,
     });
   }
 
@@ -6880,12 +7122,12 @@ class LibraryServiceClient {
   /**
    * Return a fully-qualified shelf resource name string.
    *
-   * @param {String} shelfId
+   * @param {String} shelf
    * @returns {String}
    */
-  shelfPath(shelfId) {
+  shelfPath(shelf) {
     return this._pathTemplates.shelfPathTemplate.render({
-      shelf_id: shelfId,
+      shelf: shelf,
     });
   }
 
@@ -6907,12 +7149,12 @@ class LibraryServiceClient {
    *
    * @param {String} archivedBookName
    *   A fully-qualified path representing a archived_book resources.
-   * @returns {String} - A string representing the book_id.
+   * @returns {String} - A string representing the book.
    */
-  matchBookIdFromArchivedBookName(archivedBookName) {
+  matchBookFromArchivedBookName(archivedBookName) {
     return this._pathTemplates.archivedBookPathTemplate
       .match(archivedBookName)
-      .book_id;
+      .book;
   }
 
   /**
@@ -6920,12 +7162,12 @@ class LibraryServiceClient {
    *
    * @param {String} bookName
    *   A fully-qualified path representing a book resources.
-   * @returns {String} - A string representing the shelf_id.
+   * @returns {String} - A string representing the shelf.
    */
-  matchShelfIdFromBookName(bookName) {
+  matchShelfFromBookName(bookName) {
     return this._pathTemplates.bookPathTemplate
       .match(bookName)
-      .shelf_id;
+      .shelf;
   }
 
   /**
@@ -6933,12 +7175,12 @@ class LibraryServiceClient {
    *
    * @param {String} bookName
    *   A fully-qualified path representing a book resources.
-   * @returns {String} - A string representing the book_id.
+   * @returns {String} - A string representing the book.
    */
-  matchBookIdFromBookName(bookName) {
+  matchBookFromBookName(bookName) {
     return this._pathTemplates.bookPathTemplate
       .match(bookName)
-      .book_id;
+      .book;
   }
 
   /**
@@ -6959,12 +7201,12 @@ class LibraryServiceClient {
    *
    * @param {String} shelfName
    *   A fully-qualified path representing a shelf resources.
-   * @returns {String} - A string representing the shelf_id.
+   * @returns {String} - A string representing the shelf.
    */
-  matchShelfIdFromShelfName(shelfName) {
+  matchShelfFromShelfName(shelfName) {
     return this._pathTemplates.shelfPathTemplate
       .match(shelfName)
-      .shelf_id;
+      .shelf;
   }
 }
 
@@ -7142,6 +7384,26 @@ module.exports = LibraryServiceClient;
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -7657,7 +7919,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const options = 'options-1249474914';
       const request = {
         name: formattedName,
@@ -7694,7 +7956,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const options = 'options-1249474914';
       const request = {
         name: formattedName,
@@ -7782,7 +8044,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -7803,7 +8065,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -7831,8 +8093,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -7868,8 +8130,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -7899,7 +8161,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const book = {};
       const request = {
         name: formattedName,
@@ -7938,7 +8200,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const book = {};
       const request = {
         name: formattedName,
@@ -8044,7 +8306,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -8081,7 +8343,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -8110,7 +8372,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const filter = 'book-filter-string';
       const request = {
         name: formattedName,
@@ -8146,7 +8408,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const filter = 'book-filter-string';
       const request = {
         name: formattedName,
@@ -8177,7 +8439,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -8198,7 +8460,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -8226,7 +8488,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const book = {};
       const request = {
         name: formattedName,
@@ -8265,7 +8527,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const book = {};
       const request = {
         name: formattedName,
@@ -8296,8 +8558,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -8335,8 +8597,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -8423,7 +8685,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const comment = '95';
       const stage = 'UNSET';
       const alignment = 'CHAR';
@@ -8454,7 +8716,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const comment = '95';
       const stage = 'UNSET';
       const alignment = 'CHAR';
@@ -8492,7 +8754,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK_ID]');
+      const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -8529,7 +8791,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK_ID]');
+      const formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -8558,8 +8820,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedAltBookName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedAltBookName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
         altBookName: formattedAltBookName,
@@ -8597,8 +8859,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedAltBookName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedAltBookName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
         altBookName: formattedAltBookName,
@@ -8628,7 +8890,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -8665,7 +8927,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -8694,7 +8956,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const indexName = 'default index';
       const indexMapItem = 'indexMapItem1918721251';
       const indexMap = {'default_key' : indexMapItem};
@@ -8720,7 +8982,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const indexName = 'default index';
       const indexMapItem = 'indexMapItem1918721251';
       const indexMap = {'default_key' : indexMapItem};
@@ -8753,7 +9015,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -8787,7 +9049,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -8886,7 +9148,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -8919,7 +9181,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9016,7 +9278,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
       const label = 'label102727412';
       const request = {
         resource: formattedResource,
@@ -9046,7 +9308,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
       const label = 'label102727412';
       const request = {
         resource: formattedResource,
@@ -9077,7 +9339,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9115,7 +9377,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9153,7 +9415,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9182,7 +9444,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9229,8 +9491,8 @@ describe('LibraryServiceClient', () => {
       const requiredSingularString = 'requiredSingularString-1949894503';
       const requiredSingularBytes = '-29';
       const requiredSingularMessage = {};
-      const formattedRequiredSingularResourceName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
       const formattedRequiredSingularResourceNameCommon = client.projectPath('[PROJECT]');
       const requiredSingularFixed32 = 720656715;
       const requiredSingularFixed64 = 720656810;
@@ -9313,8 +9575,8 @@ describe('LibraryServiceClient', () => {
       const requiredSingularString = 'requiredSingularString-1949894503';
       const requiredSingularBytes = '-29';
       const requiredSingularMessage = {};
-      const formattedRequiredSingularResourceName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
-      const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
+      const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
       const formattedRequiredSingularResourceNameCommon = client.projectPath('[PROJECT]');
       const requiredSingularFixed32 = 720656715;
       const requiredSingularFixed64 = 720656810;
@@ -9378,6 +9640,223 @@ describe('LibraryServiceClient', () => {
         assert(typeof response === 'undefined');
         done();
       });
+    });
+  });
+
+  describe('moveBooks', () => {
+    it('invokes moveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const success = false;
+      const expectedResponse = {
+        success: success,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.moveBooks = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.moveBooks(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes moveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.moveBooks = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.moveBooks(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('archiveBooks', () => {
+    it('invokes archiveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const success = false;
+      const expectedResponse = {
+        success: success,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.archiveBooks = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.archiveBooks(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes archiveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.archiveBooks = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.archiveBooks(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('longRunningArchiveBooks', () => {
+    it('invokes longRunningArchiveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const name = 'name3373707';
+      const done_ = true;
+      const expectedResponse = {
+        name: name,
+        done: done_,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.longRunningArchiveBooks = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.longRunningArchiveBooks(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes longRunningArchiveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.longRunningArchiveBooks = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.longRunningArchiveBooks(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('streamingArchiveBooks', () => {
+    it('invokes streamingArchiveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const success = false;
+      const expectedResponse = {
+        success: success,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.streamingArchiveBooks = mockBidiStreamingGrpcMethod(request, expectedResponse);
+
+      const stream = client.streamingArchiveBooks().on('data', response => {
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      }).on('error', err => {
+        done(err);
+      });
+
+      stream.write(request);
+    });
+
+    it('invokes streamingArchiveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.streamingArchiveBooks = mockBidiStreamingGrpcMethod(request, null, error);
+
+      const stream = client.streamingArchiveBooks().on('data', () => {
+        assert.fail();
+      }).on('error', err => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+
+      stream.write(request);
     });
   });
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -274,7 +274,7 @@ function sampleDeleteShelf()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $formattedName = $libraryServiceClient->shelfName('[SHELF]');
 
     try {
         $libraryServiceClient->deleteShelf($formattedName);
@@ -324,7 +324,7 @@ function sampleDeleteShelf()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $formattedName = $libraryServiceClient->shelfName('[SHELF]');
 
     try {
         $libraryServiceClient->deleteShelf($formattedName);
@@ -833,7 +833,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -895,7 +895,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -957,7 +957,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -1012,7 +1012,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -1068,7 +1068,7 @@ function sampleGetBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $response = $libraryServiceClient->getBook($formattedName);
@@ -1175,7 +1175,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1234,7 +1234,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1625,7 +1625,7 @@ function sampleStreamShelves()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $formattedName = $libraryServiceClient->shelfName('[SHELF]');
 
     try {
         // Read all responses until the stream is complete
@@ -1752,8 +1752,8 @@ function sampleTestOptionalRequiredFlatteningParams($paramFloat, $paramLong)
     $requiredSingularString = '';
     $requiredSingularBytes = '';
     $requiredSingularMessage = new InnerMessage();
-    $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $formattedRequiredSingularResourceNameCommon = $libraryServiceClient->projectName('[PROJECT]');
     $requiredSingularFixed32 = 0;
     $requiredSingularFixed64 = 0;
@@ -2109,7 +2109,7 @@ function sampleDiscussBook($imageFileName, $stage)
 
     // $imageFileName = 'image_file.jpg';
     // $stage = Stage::DRAFT;
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $comment = file_get_contents('comment_file');
     $comment2 = new Comment();
     $comment2->setComment($comment);
@@ -2194,7 +2194,7 @@ function sampleDiscussBook($imageFileName, $stage)
 
     // $imageFileName = 'image_file.jpg';
     // $stage = Stage::DRAFT;
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $comment = file_get_contents('comment_file');
     $comment2 = new Comment();
     $comment2->setComment($comment);
@@ -2289,6 +2289,8 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Example\Library\V1\AddCommentsRequest;
+use Google\Example\Library\V1\ArchiveBooksRequest;
+use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
@@ -2315,6 +2317,8 @@ use Google\Example\Library\V1\ListStringsRequest;
 use Google\Example\Library\V1\ListStringsResponse;
 use Google\Example\Library\V1\MergeShelvesRequest;
 use Google\Example\Library\V1\MoveBookRequest;
+use Google\Example\Library\V1\MoveBooksRequest;
+use Google\Example\Library\V1\MoveBooksResponse;
 use Google\Example\Library\V1\PublishSeriesRequest;
 use Google\Example\Library\V1\PublishSeriesResponse;
 use Google\Example\Library\V1\SeriesUuid;
@@ -2453,7 +2457,7 @@ class LibraryServiceGapicClient
     private static function getArchivedBookNameTemplate()
     {
         if (self::$archivedBookNameTemplate == null) {
-            self::$archivedBookNameTemplate = new PathTemplate('archives/{archive_path}/books/{book_id=**}');
+            self::$archivedBookNameTemplate = new PathTemplate('archives/{archive_path}/books/{book=**}');
         }
 
         return self::$archivedBookNameTemplate;
@@ -2462,7 +2466,7 @@ class LibraryServiceGapicClient
     private static function getBookNameTemplate()
     {
         if (self::$bookNameTemplate == null) {
-            self::$bookNameTemplate = new PathTemplate('shelves/{shelf_id}/books/{book_id}');
+            self::$bookNameTemplate = new PathTemplate('shelves/{shelf}/books/{book}');
         }
 
         return self::$bookNameTemplate;
@@ -2507,7 +2511,7 @@ class LibraryServiceGapicClient
     private static function getShelfNameTemplate()
     {
         if (self::$shelfNameTemplate == null) {
-            self::$shelfNameTemplate = new PathTemplate('shelves/{shelf_id}');
+            self::$shelfNameTemplate = new PathTemplate('shelves/{shelf}');
         }
 
         return self::$shelfNameTemplate;
@@ -2534,15 +2538,15 @@ class LibraryServiceGapicClient
      * a archived_book resource.
      *
      * @param string $archivePath
-     * @param string $bookId
+     * @param string $book
      * @return string The formatted archived_book resource.
      * @experimental
      */
-    public static function archivedBookName($archivePath, $bookId)
+    public static function archivedBookName($archivePath, $book)
     {
         return self::getArchivedBookNameTemplate()->render([
             'archive_path' => $archivePath,
-            'book_id' => $bookId,
+            'book' => $book,
         ]);
     }
 
@@ -2550,16 +2554,16 @@ class LibraryServiceGapicClient
      * Formats a string containing the fully-qualified path to represent
      * a book resource.
      *
-     * @param string $shelfId
-     * @param string $bookId
+     * @param string $shelf
+     * @param string $book
      * @return string The formatted book resource.
      * @experimental
      */
-    public static function bookName($shelfId, $bookId)
+    public static function bookName($shelf, $book)
     {
         return self::getBookNameTemplate()->render([
-            'shelf_id' => $shelfId,
-            'book_id' => $bookId,
+            'shelf' => $shelf,
+            'book' => $book,
         ]);
     }
 
@@ -2631,14 +2635,14 @@ class LibraryServiceGapicClient
      * Formats a string containing the fully-qualified path to represent
      * a shelf resource.
      *
-     * @param string $shelfId
+     * @param string $shelf
      * @return string The formatted shelf resource.
      * @experimental
      */
-    public static function shelfName($shelfId)
+    public static function shelfName($shelf)
     {
         return self::getShelfNameTemplate()->render([
-            'shelf_id' => $shelfId,
+            'shelf' => $shelf,
         ]);
     }
 
@@ -2646,13 +2650,13 @@ class LibraryServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
-     * - archivedBook: archives/{archive_path}/books/{book_id=**}
-     * - book: shelves/{shelf_id}/books/{book_id}
+     * - archivedBook: archives/{archive_path}/books/{book=**}
+     * - book: shelves/{shelf}/books/{book}
      * - folder: folders/{folder}
      * - location: projects/{project}/locations/{location}
      * - project: projects/{project}
      * - projectBook: projects/{project}/books/{book}
-     * - shelf: shelves/{shelf_id}
+     * - shelf: shelves/{shelf}
      *
      * The optional $template argument can be supplied to specify a particular pattern, and must
      * match one of the templates listed above. If no $template argument is provided, or if the
@@ -2827,7 +2831,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $options = '';
      *     $response = $libraryServiceClient->getShelf($formattedName, $options);
      * } finally {
@@ -2950,7 +2954,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $libraryServiceClient->deleteShelf($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -2999,8 +3003,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
-     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
+     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF]');
      *     $response = $libraryServiceClient->mergeShelves($formattedName, $formattedOtherShelfName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3051,7 +3055,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $book = new Book();
      *     $response = $libraryServiceClient->createBook($formattedName, $book);
      * } finally {
@@ -3175,7 +3179,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $response = $libraryServiceClient->getBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3224,7 +3228,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $filter = 'book-filter-string';
      *     // Iterate over pages of elements
      *     $pagedResponse = $libraryServiceClient->listBooks($formattedName, ['filter' => $filter]);
@@ -3309,7 +3313,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $libraryServiceClient->deleteBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3356,7 +3360,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $book = new Book();
      *     $response = $libraryServiceClient->updateBook($formattedName, $book);
      * } finally {
@@ -3423,8 +3427,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF]');
      *     $response = $libraryServiceClient->moveBook($formattedName, $formattedOtherShelfName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3548,7 +3552,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $comment = '';
      *     $stage = Stage::UNSET;
      *     $alignment = Alignment::CHAR;
@@ -3605,7 +3609,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->archivedBookName('[ARCHIVE_PATH]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->archivedBookName('[ARCHIVE_PATH]', '[BOOK]');
      *     $formattedParent = $libraryServiceClient->projectName('[PROJECT]');
      *     $response = $libraryServiceClient->getBookFromArchive($formattedName, $formattedParent);
      * } finally {
@@ -3657,8 +3661,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-     *     $formattedAltBookName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $formattedAltBookName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $formattedPlace = $libraryServiceClient->locationName('[PROJECT]', '[LOCATION]');
      *     $formattedFolder = $libraryServiceClient->folderName('[FOLDER]');
      *     $response = $libraryServiceClient->getBookFromAnywhere($formattedName, $formattedAltBookName, $formattedPlace, $formattedFolder);
@@ -3716,7 +3720,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3772,7 +3776,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $indexName = 'default index';
      *     $indexMapItem = '';
      *     $indexMap = ['default_key' => $indexMapItem];
@@ -3827,7 +3831,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     // Read all responses until the stream is complete
      *     $stream = $libraryServiceClient->streamShelves($formattedName);
      *     foreach ($stream->readAll() as $element) {
@@ -3916,7 +3920,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write all requests to the server, then read all responses until the
@@ -3982,7 +3986,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write data to server and wait for a response
@@ -4163,7 +4167,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedResource = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedResource = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $label = '';
      *     $response = $libraryServiceClient->addLabel($formattedResource, $label);
      * } finally {
@@ -4218,7 +4222,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigBook($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -4295,7 +4299,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -4379,8 +4383,8 @@ class LibraryServiceGapicClient
      *     $requiredSingularString = '';
      *     $requiredSingularBytes = '';
      *     $requiredSingularMessage = new InnerMessage();
-     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $formattedRequiredSingularResourceNameCommon = $libraryServiceClient->projectName('[PROJECT]');
      *     $requiredSingularFixed32 = 0;
      *     $requiredSingularFixed64 = 0;
@@ -4829,6 +4833,240 @@ class LibraryServiceGapicClient
             $optionalArgs,
             $request
         )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $response = $libraryServiceClient->moveBooks();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $destination
+     *     @type string[] $publishers
+     *     @type string $project
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\MoveBooksResponse
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function moveBooks(array $optionalArgs = [])
+    {
+        $request = new MoveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['destination'])) {
+            $request->setDestination($optionalArgs['destination']);
+        }
+        if (isset($optionalArgs['publishers'])) {
+            $request->setPublishers($optionalArgs['publishers']);
+        }
+        if (isset($optionalArgs['project'])) {
+            $request->setProject($optionalArgs['project']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'MoveBooks',
+            MoveBooksResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $response = $libraryServiceClient->archiveBooks();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $archive
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\ArchiveBooksResponse
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function archiveBooks(array $optionalArgs = [])
+    {
+        $request = new ArchiveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['archive'])) {
+            $request->setArchive($optionalArgs['archive']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'ArchiveBooks',
+            ArchiveBooksResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $response = $libraryServiceClient->longRunningArchiveBooks();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $archive
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\LongRunning\Operation
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function longRunningArchiveBooks(array $optionalArgs = [])
+    {
+        $request = new ArchiveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['archive'])) {
+            $request->setArchive($optionalArgs['archive']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'LongRunningArchiveBooks',
+            Operation::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $request = new ArchiveBooksRequest();
+     *     // Write all requests to the server, then read all responses until the
+     *     // stream is complete
+     *     $requests = [$request];
+     *     $stream = $libraryServiceClient->streamingArchiveBooks();
+     *     $stream->writeAll($requests);
+     *     foreach ($stream->closeWriteAndReadAll() as $element) {
+     *         // doSomethingWith($element);
+     *     }
+     *
+     *
+     *     // Alternatively:
+     *
+     *     // Write requests individually, making read() calls if
+     *     // required. Call closeWrite() once writes are complete, and read the
+     *     // remaining responses from the server.
+     *     $requests = [$request];
+     *     $stream = $libraryServiceClient->streamingArchiveBooks();
+     *     foreach ($requests as $request) {
+     *         $stream->write($request);
+     *         // if required, read a single response from the stream
+     *         $element = $stream->read();
+     *         // doSomethingWith($element)
+     *     }
+     *     $stream->closeWrite();
+     *     $element = $stream->read();
+     *     while (!is_null($element)) {
+     *         // doSomethingWith($element)
+     *         $element = $stream->read();
+     *     }
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type int $timeoutMillis
+     *          Timeout to use for this call.
+     * }
+     *
+     * @return \Google\ApiCore\BidiStream
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function streamingArchiveBooks(array $optionalArgs = [])
+    {
+        return $this->startCall(
+            'StreamingArchiveBooks',
+            ArchiveBooksResponse::class,
+            $optionalArgs,
+            null,
+            Call::BIDI_STREAMING_CALL
+        );
     }
 
     /**
@@ -5427,6 +5665,24 @@ class MyProtoClient extends MyProtoGapicClient
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
+          "timeout_millis": 60000
+        },
         "PrivateListShelves": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -5525,6 +5781,11 @@ return [
             'BabbleAboutBook' => [
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'ClientStreaming',
+                ]
+            ],
+            'StreamingArchiveBooks' => [
+                'grpcStreaming' => [
+                    'grpcStreamingType' => 'BidiStreaming',
                 ]
             ],
         ]
@@ -5779,6 +6040,42 @@ return [
                 'uriTemplate' => '/v1/testofp',
                 'body' => '*',
             ],
+            'MoveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:move',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
+            'ArchiveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:archive',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
+            'LongRunningArchiveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:longrunningmove',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
             'PrivateListShelves' => [
                 'method' => 'get',
                 'uriTemplate' => '/v1/bookShelves',
@@ -5949,6 +6246,8 @@ use Google\ApiCore\ServerStream;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Example\Library\V1\AddCommentsRequest;
+use Google\Example\Library\V1\ArchiveBooksRequest;
+use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
@@ -5975,6 +6274,8 @@ use Google\Example\Library\V1\ListStringsRequest;
 use Google\Example\Library\V1\ListStringsResponse;
 use Google\Example\Library\V1\MergeShelvesRequest;
 use Google\Example\Library\V1\MoveBookRequest;
+use Google\Example\Library\V1\MoveBooksRequest;
+use Google\Example\Library\V1\MoveBooksResponse;
 use Google\Example\Library\V1\PublishSeriesRequest;
 use Google\Example\Library\V1\PublishSeriesResponse;
 use Google\Example\Library\V1\SeriesUuid;
@@ -6147,7 +6448,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $options = 'options-1249474914';
 
         $response = $client->getShelf($formattedName, $options);
@@ -6191,7 +6492,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $options = 'options-1249474914';
 
         try {
@@ -6293,7 +6594,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $client->deleteShelf($formattedName);
         $actualRequests = $transport->popReceivedCalls();
@@ -6332,7 +6633,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         try {
             $client->deleteShelf($formattedName);
@@ -6369,8 +6670,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         $response = $client->mergeShelves($formattedName, $formattedOtherShelfName);
         $this->assertEquals($expectedResponse, $response);
@@ -6413,8 +6714,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         try {
             $client->mergeShelves($formattedName, $formattedOtherShelfName);
@@ -6453,7 +6754,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $book = new Book();
 
         $response = $client->createBook($formattedName, $book);
@@ -6497,7 +6798,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $book = new Book();
 
         try {
@@ -6625,7 +6926,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBook($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -6665,7 +6966,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->getBook($formattedName);
@@ -6701,7 +7002,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $filter = 'book-filter-string';
 
         $response = $client->listBooks($formattedName, ['filter' => $filter]);
@@ -6748,7 +7049,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $filter = 'book-filter-string';
 
         try {
@@ -6780,7 +7081,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $client->deleteBook($formattedName);
         $actualRequests = $transport->popReceivedCalls();
@@ -6819,7 +7120,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->deleteBook($formattedName);
@@ -6858,7 +7159,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $book = new Book();
 
         $response = $client->updateBook($formattedName, $book);
@@ -6902,7 +7203,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $book = new Book();
 
         try {
@@ -6942,8 +7243,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         $response = $client->moveBook($formattedName, $formattedOtherShelfName);
         $this->assertEquals($expectedResponse, $response);
@@ -6986,8 +7287,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         try {
             $client->moveBook($formattedName, $formattedOtherShelfName);
@@ -7088,7 +7389,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -7138,7 +7439,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -7185,7 +7486,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->archivedBookName('[ARCHIVE_PATH]', '[BOOK_ID]');
+        $formattedName = $client->archivedBookName('[ARCHIVE_PATH]', '[BOOK]');
         $formattedParent = $client->projectName('[PROJECT]');
 
         $response = $client->getBookFromArchive($formattedName, $formattedParent);
@@ -7229,7 +7530,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->archivedBookName('[ARCHIVE_PATH]', '[BOOK_ID]');
+        $formattedName = $client->archivedBookName('[ARCHIVE_PATH]', '[BOOK]');
         $formattedParent = $client->projectName('[PROJECT]');
 
         try {
@@ -7269,8 +7570,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedAltBookName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedAltBookName = $client->bookName('[SHELF]', '[BOOK]');
         $formattedPlace = $client->locationName('[PROJECT]', '[LOCATION]');
         $formattedFolder = $client->folderName('[FOLDER]');
 
@@ -7321,8 +7622,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedAltBookName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedAltBookName = $client->bookName('[SHELF]', '[BOOK]');
         $formattedPlace = $client->locationName('[PROJECT]', '[LOCATION]');
         $formattedFolder = $client->folderName('[FOLDER]');
 
@@ -7363,7 +7664,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBookFromAbsolutelyAnywhere($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -7403,7 +7704,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->getBookFromAbsolutelyAnywhere($formattedName);
@@ -7434,7 +7735,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -7482,7 +7783,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -7529,7 +7830,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $serverStream = $client->streamShelves($formattedName);
         $this->assertInstanceOf(ServerStream::class, $serverStream);
@@ -7579,7 +7880,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $serverStream = $client->streamShelves($formattedName);
         $results = $serverStream->readAll();
@@ -7741,13 +8042,13 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $request = new DiscussBookRequest();
         $request->setName($formattedName);
-        $formattedName2 = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName2 = $client->bookName('[SHELF]', '[BOOK]');
         $request2 = new DiscussBookRequest();
         $request2->setName($formattedName2);
-        $formattedName3 = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName3 = $client->bookName('[SHELF]', '[BOOK]');
         $request3 = new DiscussBookRequest();
         $request3->setName($formattedName3);
 
@@ -7931,7 +8232,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedResource = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
         $label = 'label102727412';
 
         $response = $client->addLabel($formattedResource, $label);
@@ -7975,7 +8276,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedResource = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
         $label = 'label102727412';
 
         try {
@@ -8035,7 +8336,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -8113,7 +8414,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -8175,7 +8476,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -8253,7 +8554,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -8304,8 +8605,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedRequiredSingularResourceName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF]', '[BOOK]');
         $formattedRequiredSingularResourceNameCommon = $client->projectName('[PROJECT]');
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
@@ -8584,8 +8885,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedRequiredSingularResourceName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF]', '[BOOK]');
         $formattedRequiredSingularResourceNameCommon = $client->projectName('[PROJECT]');
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
@@ -8642,6 +8943,308 @@ class LibraryServiceClientTest extends GeneratedTest
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function moveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new MoveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->moveBooks();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/MoveBooks', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function moveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->moveBooks();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function archiveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new ArchiveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->archiveBooks();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/ArchiveBooks', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function archiveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->archiveBooks();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function longRunningArchiveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $name = 'name3373707';
+        $done = true;
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setDone($done);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->longRunningArchiveBooks();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/LongRunningArchiveBooks', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function longRunningArchiveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->longRunningArchiveBooks();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function streamingArchiveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new ArchiveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+        $success2 = true;
+        $expectedResponse2 = new ArchiveBooksResponse();
+        $expectedResponse2->setSuccess($success2);
+        $transport->addResponse($expectedResponse2);
+        $success3 = false;
+        $expectedResponse3 = new ArchiveBooksResponse();
+        $expectedResponse3->setSuccess($success3);
+        $transport->addResponse($expectedResponse3);
+
+        // Mock request
+        $request = new ArchiveBooksRequest();
+        $request2 = new ArchiveBooksRequest();
+        $request3 = new ArchiveBooksRequest();
+
+        $bidi = $client->streamingArchiveBooks();
+        $this->assertInstanceOf(BidiStream::class, $bidi);
+
+        $bidi->write($request);
+        $responses = [];
+        $responses[] = $bidi->read();
+
+        $bidi->writeAll([$request2, $request3]);
+        foreach ($bidi->closeWriteAndReadAll() as $response) {
+            $responses[] = $response;
+        }
+
+        $expectedResponses = [];
+        $expectedResponses[] = $expectedResponse;
+        $expectedResponses[] = $expectedResponse2;
+        $expectedResponses[] = $expectedResponse3;
+        $this->assertEquals($expectedResponses, $responses);
+
+        $createStreamRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($createStreamRequests));
+        $streamFuncCall = $createStreamRequests[0]->getFuncCall();
+        $streamRequestObject = $createStreamRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/StreamingArchiveBooks', $streamFuncCall);
+        $this->assertNull($streamRequestObject);
+
+        $callObjects = $transport->popCallObjects();
+        $this->assertSame(1, count($callObjects));
+        $bidiCall = $callObjects[0];
+
+        $writeRequests = $bidiCall->popReceivedCalls();
+        $expectedRequests = [];
+        $expectedRequests[] = $request;
+        $expectedRequests[] = $request2;
+        $expectedRequests[] = $request3;
+        $this->assertEquals($expectedRequests, $writeRequests);
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function streamingArchiveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+
+        $transport->setStreamingStatus($status);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $bidi = $client->streamingArchiveBooks();
+        $results = $bidi->closeWriteAndReadAll();
+
+        try {
+            iterator_to_array($results);
+            // If the close stream method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        }  catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_samplegen_config_migration_library.baseline
@@ -274,7 +274,7 @@ function sampleDeleteShelf()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $formattedName = $libraryServiceClient->shelfName('[SHELF]');
 
     try {
         $libraryServiceClient->deleteShelf($formattedName);
@@ -324,7 +324,7 @@ function sampleDeleteShelf()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $formattedName = $libraryServiceClient->shelfName('[SHELF]');
 
     try {
         $libraryServiceClient->deleteShelf($formattedName);
@@ -373,7 +373,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -428,7 +428,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -540,7 +540,7 @@ function sampleGetBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $response = $libraryServiceClient->getBook($formattedName);
@@ -1070,7 +1070,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1126,7 +1126,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1242,8 +1242,8 @@ function sampleTestOptionalRequiredFlatteningParams($paramFloat, $paramLong)
     $requiredSingularString = '';
     $requiredSingularBytes = '';
     $requiredSingularMessage = new InnerMessage();
-    $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $formattedRequiredSingularResourceNameCommon = $libraryServiceClient->projectName('[PROJECT]');
     $requiredSingularFixed32 = 0;
     $requiredSingularFixed64 = 0;
@@ -1324,7 +1324,7 @@ function sampleGetBookFromAbsolutelyAnywhere()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->archivedBookName('The archive to search for the book', 'The ID of the book');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', 'The ID of the book');
 
     try {
         $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
@@ -1621,7 +1621,7 @@ function sampleDiscussBook($imageFileName, $stage)
 
     // $imageFileName = 'image_file.jpg';
     // $stage = Stage::DRAFT;
-    $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $comment = file_get_contents('comment_file');
     $comment2 = new Comment();
     $comment2->setComment($comment);
@@ -1707,6 +1707,8 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Example\Library\V1\AddCommentsRequest;
+use Google\Example\Library\V1\ArchiveBooksRequest;
+use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
@@ -1733,6 +1735,8 @@ use Google\Example\Library\V1\ListStringsRequest;
 use Google\Example\Library\V1\ListStringsResponse;
 use Google\Example\Library\V1\MergeShelvesRequest;
 use Google\Example\Library\V1\MoveBookRequest;
+use Google\Example\Library\V1\MoveBooksRequest;
+use Google\Example\Library\V1\MoveBooksResponse;
 use Google\Example\Library\V1\PublishSeriesRequest;
 use Google\Example\Library\V1\PublishSeriesResponse;
 use Google\Example\Library\V1\SeriesUuid;
@@ -1868,7 +1872,7 @@ class LibraryServiceGapicClient
     private static function getArchivedBookNameTemplate()
     {
         if (self::$archivedBookNameTemplate == null) {
-            self::$archivedBookNameTemplate = new PathTemplate('archives/{archive_path}/books/{book_id=**}');
+            self::$archivedBookNameTemplate = new PathTemplate('archives/{archive_path}/books/{book=**}');
         }
 
         return self::$archivedBookNameTemplate;
@@ -1877,7 +1881,7 @@ class LibraryServiceGapicClient
     private static function getBookNameTemplate()
     {
         if (self::$bookNameTemplate == null) {
-            self::$bookNameTemplate = new PathTemplate('shelves/{shelf_id}/books/{book_id}');
+            self::$bookNameTemplate = new PathTemplate('shelves/{shelf}/books/{book}');
         }
 
         return self::$bookNameTemplate;
@@ -1895,7 +1899,7 @@ class LibraryServiceGapicClient
     private static function getShelfNameTemplate()
     {
         if (self::$shelfNameTemplate == null) {
-            self::$shelfNameTemplate = new PathTemplate('shelves/{shelf_id}');
+            self::$shelfNameTemplate = new PathTemplate('shelves/{shelf}');
         }
 
         return self::$shelfNameTemplate;
@@ -1919,15 +1923,15 @@ class LibraryServiceGapicClient
      * a archived_book resource.
      *
      * @param string $archivePath
-     * @param string $bookId
+     * @param string $book
      * @return string The formatted archived_book resource.
      * @experimental
      */
-    public static function archivedBookName($archivePath, $bookId)
+    public static function archivedBookName($archivePath, $book)
     {
         return self::getArchivedBookNameTemplate()->render([
             'archive_path' => $archivePath,
-            'book_id' => $bookId,
+            'book' => $book,
         ]);
     }
 
@@ -1935,16 +1939,16 @@ class LibraryServiceGapicClient
      * Formats a string containing the fully-qualified path to represent
      * a book resource.
      *
-     * @param string $shelfId
-     * @param string $bookId
+     * @param string $shelf
+     * @param string $book
      * @return string The formatted book resource.
      * @experimental
      */
-    public static function bookName($shelfId, $bookId)
+    public static function bookName($shelf, $book)
     {
         return self::getBookNameTemplate()->render([
-            'shelf_id' => $shelfId,
-            'book_id' => $bookId,
+            'shelf' => $shelf,
+            'book' => $book,
         ]);
     }
 
@@ -1967,14 +1971,14 @@ class LibraryServiceGapicClient
      * Formats a string containing the fully-qualified path to represent
      * a shelf resource.
      *
-     * @param string $shelfId
+     * @param string $shelf
      * @return string The formatted shelf resource.
      * @experimental
      */
-    public static function shelfName($shelfId)
+    public static function shelfName($shelf)
     {
         return self::getShelfNameTemplate()->render([
-            'shelf_id' => $shelfId,
+            'shelf' => $shelf,
         ]);
     }
 
@@ -1982,10 +1986,10 @@ class LibraryServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
-     * - archivedBook: archives/{archive_path}/books/{book_id=**}
-     * - book: shelves/{shelf_id}/books/{book_id}
+     * - archivedBook: archives/{archive_path}/books/{book=**}
+     * - book: shelves/{shelf}/books/{book}
      * - project: projects/{project}
-     * - shelf: shelves/{shelf_id}
+     * - shelf: shelves/{shelf}
      *
      * The optional $template argument can be supplied to specify a particular pattern, and must
      * match one of the templates listed above. If no $template argument is provided, or if the
@@ -2160,7 +2164,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $options = '';
      *     $response = $libraryServiceClient->getShelf($formattedName, $options);
      * } finally {
@@ -2283,7 +2287,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $libraryServiceClient->deleteShelf($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -2332,8 +2336,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
-     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
+     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF]');
      *     $response = $libraryServiceClient->mergeShelves($formattedName, $formattedOtherShelfName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -2384,7 +2388,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $book = new Book();
      *     $response = $libraryServiceClient->createBook($formattedName, $book);
      * } finally {
@@ -2508,7 +2512,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $response = $libraryServiceClient->getBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -2557,7 +2561,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $filter = 'book-filter-string';
      *     // Iterate over pages of elements
      *     $pagedResponse = $libraryServiceClient->listBooks($formattedName, ['filter' => $filter]);
@@ -2642,7 +2646,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $libraryServiceClient->deleteBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -2689,7 +2693,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $book = new Book();
      *     $response = $libraryServiceClient->updateBook($formattedName, $book);
      * } finally {
@@ -2756,8 +2760,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF]');
      *     $response = $libraryServiceClient->moveBook($formattedName, $formattedOtherShelfName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -2881,7 +2885,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $comment = '';
      *     $stage = Stage::UNSET;
      *     $alignment = Alignment::CHAR;
@@ -2938,7 +2942,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->archivedBookName('[ARCHIVE_PATH]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->archivedBookName('[ARCHIVE_PATH]', '[BOOK]');
      *     $response = $libraryServiceClient->getBookFromArchive($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -2991,8 +2995,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-     *     $formattedAltBookName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $formattedAltBookName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $response = $libraryServiceClient->getBookFromAnywhere($formattedName, $formattedAltBookName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3052,7 +3056,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3108,7 +3112,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $indexName = 'default index';
      *     $indexMapItem = '';
      *     $indexMap = ['default_key' => $indexMapItem];
@@ -3163,7 +3167,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     // Read all responses until the stream is complete
      *     $stream = $libraryServiceClient->streamShelves($formattedName);
      *     foreach ($stream->readAll() as $element) {
@@ -3252,7 +3256,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write all requests to the server, then read all responses until the
@@ -3318,7 +3322,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write data to server and wait for a response
@@ -3499,7 +3503,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedResource = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedResource = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $label = '';
      *     $response = $libraryServiceClient->addLabel($formattedResource, $label);
      * } finally {
@@ -3554,7 +3558,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigBook($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -3631,7 +3635,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -3715,8 +3719,8 @@ class LibraryServiceGapicClient
      *     $requiredSingularString = '';
      *     $requiredSingularBytes = '';
      *     $requiredSingularMessage = new InnerMessage();
-     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
-     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF_ID]', '[BOOK_ID]');
+     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $formattedRequiredSingularResourceNameCommon = $libraryServiceClient->projectName('[PROJECT]');
      *     $requiredSingularFixed32 = 0;
      *     $requiredSingularFixed64 = 0;
@@ -4197,6 +4201,240 @@ class LibraryServiceGapicClient
             $optionalArgs,
             $request
         )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $response = $libraryServiceClient->moveBooks();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $destination
+     *     @type string[] $publishers
+     *     @type string $project
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\MoveBooksResponse
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function moveBooks(array $optionalArgs = [])
+    {
+        $request = new MoveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['destination'])) {
+            $request->setDestination($optionalArgs['destination']);
+        }
+        if (isset($optionalArgs['publishers'])) {
+            $request->setPublishers($optionalArgs['publishers']);
+        }
+        if (isset($optionalArgs['project'])) {
+            $request->setProject($optionalArgs['project']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'MoveBooks',
+            MoveBooksResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $response = $libraryServiceClient->archiveBooks();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $archive
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\ArchiveBooksResponse
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function archiveBooks(array $optionalArgs = [])
+    {
+        $request = new ArchiveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['archive'])) {
+            $request->setArchive($optionalArgs['archive']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'ArchiveBooks',
+            ArchiveBooksResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $response = $libraryServiceClient->longRunningArchiveBooks();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $archive
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\LongRunning\Operation
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function longRunningArchiveBooks(array $optionalArgs = [])
+    {
+        $request = new ArchiveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['archive'])) {
+            $request->setArchive($optionalArgs['archive']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'LongRunningArchiveBooks',
+            Operation::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $request = new ArchiveBooksRequest();
+     *     // Write all requests to the server, then read all responses until the
+     *     // stream is complete
+     *     $requests = [$request];
+     *     $stream = $libraryServiceClient->streamingArchiveBooks();
+     *     $stream->writeAll($requests);
+     *     foreach ($stream->closeWriteAndReadAll() as $element) {
+     *         // doSomethingWith($element);
+     *     }
+     *
+     *
+     *     // Alternatively:
+     *
+     *     // Write requests individually, making read() calls if
+     *     // required. Call closeWrite() once writes are complete, and read the
+     *     // remaining responses from the server.
+     *     $requests = [$request];
+     *     $stream = $libraryServiceClient->streamingArchiveBooks();
+     *     foreach ($requests as $request) {
+     *         $stream->write($request);
+     *         // if required, read a single response from the stream
+     *         $element = $stream->read();
+     *         // doSomethingWith($element)
+     *     }
+     *     $stream->closeWrite();
+     *     $element = $stream->read();
+     *     while (!is_null($element)) {
+     *         // doSomethingWith($element)
+     *         $element = $stream->read();
+     *     }
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type int $timeoutMillis
+     *          Timeout to use for this call.
+     * }
+     *
+     * @return \Google\ApiCore\BidiStream
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function streamingArchiveBooks(array $optionalArgs = [])
+    {
+        return $this->startCall(
+            'StreamingArchiveBooks',
+            ArchiveBooksResponse::class,
+            $optionalArgs,
+            null,
+            Call::BIDI_STREAMING_CALL
+        );
     }
 
     /**
@@ -4795,6 +5033,24 @@ class MyProtoClient extends MyProtoGapicClient
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
+          "timeout_millis": 60000
+        },
         "PrivateListShelves": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -4893,6 +5149,11 @@ return [
             'BabbleAboutBook' => [
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'ClientStreaming',
+                ]
+            ],
+            'StreamingArchiveBooks' => [
+                'grpcStreaming' => [
+                    'grpcStreamingType' => 'BidiStreaming',
                 ]
             ],
         ]
@@ -5147,6 +5408,42 @@ return [
                 'uriTemplate' => '/v1/testofp',
                 'body' => '*',
             ],
+            'MoveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:move',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
+            'ArchiveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:archive',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
+            'LongRunningArchiveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:longrunningmove',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
             'PrivateListShelves' => [
                 'method' => 'get',
                 'uriTemplate' => '/v1/bookShelves',
@@ -5317,6 +5614,8 @@ use Google\ApiCore\ServerStream;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Example\Library\V1\AddCommentsRequest;
+use Google\Example\Library\V1\ArchiveBooksRequest;
+use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
@@ -5343,6 +5642,8 @@ use Google\Example\Library\V1\ListStringsRequest;
 use Google\Example\Library\V1\ListStringsResponse;
 use Google\Example\Library\V1\MergeShelvesRequest;
 use Google\Example\Library\V1\MoveBookRequest;
+use Google\Example\Library\V1\MoveBooksRequest;
+use Google\Example\Library\V1\MoveBooksResponse;
 use Google\Example\Library\V1\PublishSeriesRequest;
 use Google\Example\Library\V1\PublishSeriesResponse;
 use Google\Example\Library\V1\SeriesUuid;
@@ -5500,7 +5801,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $options = 'options-1249474914';
 
         $response = $client->getShelf($formattedName, $options);
@@ -5544,7 +5845,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $options = 'options-1249474914';
 
         try {
@@ -5646,7 +5947,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $client->deleteShelf($formattedName);
         $actualRequests = $transport->popReceivedCalls();
@@ -5685,7 +5986,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         try {
             $client->deleteShelf($formattedName);
@@ -5722,8 +6023,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         $response = $client->mergeShelves($formattedName, $formattedOtherShelfName);
         $this->assertEquals($expectedResponse, $response);
@@ -5766,8 +6067,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         try {
             $client->mergeShelves($formattedName, $formattedOtherShelfName);
@@ -5806,7 +6107,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $book = new Book();
 
         $response = $client->createBook($formattedName, $book);
@@ -5850,7 +6151,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $book = new Book();
 
         try {
@@ -5978,7 +6279,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBook($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -6018,7 +6319,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->getBook($formattedName);
@@ -6054,7 +6355,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $filter = 'book-filter-string';
 
         $response = $client->listBooks($formattedName, ['filter' => $filter]);
@@ -6101,7 +6402,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $filter = 'book-filter-string';
 
         try {
@@ -6133,7 +6434,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $client->deleteBook($formattedName);
         $actualRequests = $transport->popReceivedCalls();
@@ -6172,7 +6473,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->deleteBook($formattedName);
@@ -6211,7 +6512,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $book = new Book();
 
         $response = $client->updateBook($formattedName, $book);
@@ -6255,7 +6556,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $book = new Book();
 
         try {
@@ -6295,8 +6596,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         $response = $client->moveBook($formattedName, $formattedOtherShelfName);
         $this->assertEquals($expectedResponse, $response);
@@ -6339,8 +6640,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         try {
             $client->moveBook($formattedName, $formattedOtherShelfName);
@@ -6441,7 +6742,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -6491,7 +6792,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -6538,7 +6839,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->archivedBookName('[ARCHIVE_PATH]', '[BOOK_ID]');
+        $formattedName = $client->archivedBookName('[ARCHIVE_PATH]', '[BOOK]');
 
         $response = $client->getBookFromArchive($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -6578,7 +6879,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->archivedBookName('[ARCHIVE_PATH]', '[BOOK_ID]');
+        $formattedName = $client->archivedBookName('[ARCHIVE_PATH]', '[BOOK]');
 
         try {
             $client->getBookFromArchive($formattedName);
@@ -6617,8 +6918,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedAltBookName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedAltBookName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBookFromAnywhere($formattedName, $formattedAltBookName);
         $this->assertEquals($expectedResponse, $response);
@@ -6661,8 +6962,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedAltBookName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedAltBookName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->getBookFromAnywhere($formattedName, $formattedAltBookName);
@@ -6701,7 +7002,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBookFromAbsolutelyAnywhere($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -6741,7 +7042,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->getBookFromAbsolutelyAnywhere($formattedName);
@@ -6772,7 +7073,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -6820,7 +7121,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -6867,7 +7168,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $serverStream = $client->streamShelves($formattedName);
         $this->assertInstanceOf(ServerStream::class, $serverStream);
@@ -6917,7 +7218,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $serverStream = $client->streamShelves($formattedName);
         $results = $serverStream->readAll();
@@ -7079,13 +7380,13 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $request = new DiscussBookRequest();
         $request->setName($formattedName);
-        $formattedName2 = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName2 = $client->bookName('[SHELF]', '[BOOK]');
         $request2 = new DiscussBookRequest();
         $request2->setName($formattedName2);
-        $formattedName3 = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName3 = $client->bookName('[SHELF]', '[BOOK]');
         $request3 = new DiscussBookRequest();
         $request3->setName($formattedName3);
 
@@ -7269,7 +7570,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedResource = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
         $label = 'label102727412';
 
         $response = $client->addLabel($formattedResource, $label);
@@ -7313,7 +7614,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedResource = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
         $label = 'label102727412';
 
         try {
@@ -7373,7 +7674,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -7451,7 +7752,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -7513,7 +7814,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -7591,7 +7892,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -7642,8 +7943,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedRequiredSingularResourceName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF]', '[BOOK]');
         $formattedRequiredSingularResourceNameCommon = $client->projectName('[PROJECT]');
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
@@ -7794,8 +8095,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF_ID]', '[BOOK_ID]');
+        $formattedRequiredSingularResourceName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF]', '[BOOK]');
         $formattedRequiredSingularResourceNameCommon = $client->projectName('[PROJECT]');
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
@@ -7820,6 +8121,308 @@ class LibraryServiceClientTest extends GeneratedTest
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function moveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new MoveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->moveBooks();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/MoveBooks', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function moveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->moveBooks();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function archiveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new ArchiveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->archiveBooks();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/ArchiveBooks', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function archiveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->archiveBooks();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function longRunningArchiveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $name = 'name3373707';
+        $done = true;
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setDone($done);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->longRunningArchiveBooks();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/LongRunningArchiveBooks', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function longRunningArchiveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->longRunningArchiveBooks();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function streamingArchiveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new ArchiveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+        $success2 = true;
+        $expectedResponse2 = new ArchiveBooksResponse();
+        $expectedResponse2->setSuccess($success2);
+        $transport->addResponse($expectedResponse2);
+        $success3 = false;
+        $expectedResponse3 = new ArchiveBooksResponse();
+        $expectedResponse3->setSuccess($success3);
+        $transport->addResponse($expectedResponse3);
+
+        // Mock request
+        $request = new ArchiveBooksRequest();
+        $request2 = new ArchiveBooksRequest();
+        $request3 = new ArchiveBooksRequest();
+
+        $bidi = $client->streamingArchiveBooks();
+        $this->assertInstanceOf(BidiStream::class, $bidi);
+
+        $bidi->write($request);
+        $responses = [];
+        $responses[] = $bidi->read();
+
+        $bidi->writeAll([$request2, $request3]);
+        foreach ($bidi->closeWriteAndReadAll() as $response) {
+            $responses[] = $response;
+        }
+
+        $expectedResponses = [];
+        $expectedResponses[] = $expectedResponse;
+        $expectedResponses[] = $expectedResponse2;
+        $expectedResponses[] = $expectedResponse3;
+        $this->assertEquals($expectedResponses, $responses);
+
+        $createStreamRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($createStreamRequests));
+        $streamFuncCall = $createStreamRequests[0]->getFuncCall();
+        $streamRequestObject = $createStreamRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/StreamingArchiveBooks', $streamFuncCall);
+        $this->assertNull($streamRequestObject);
+
+        $callObjects = $transport->popCallObjects();
+        $this->assertSame(1, count($callObjects));
+        $bidiCall = $callObjects[0];
+
+        $writeRequests = $bidiCall->popReceivedCalls();
+        $expectedRequests = [];
+        $expectedRequests[] = $request;
+        $expectedRequests[] = $request2;
+        $expectedRequests[] = $request3;
+        $this->assertEquals($expectedRequests, $writeRequests);
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function streamingArchiveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+
+        $transport->setStreamingStatus($status);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $bidi = $client->streamingArchiveBooks();
+        $results = $bidi->closeWriteAndReadAll();
+
+        try {
+            iterator_to_array($results);
+            // If the close stream method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        }  catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -284,7 +284,7 @@ LibraryServiceClient
 
     client = library_v1.LibraryServiceClient()
 
-    name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+    name = client.book_path('[SHELF]', '[BOOK]')
 
     # TODO: Initialize `book`:
     book = {}
@@ -744,7 +744,7 @@ LibraryServiceClient
 
     client = library_v1.LibraryServiceClient()
 
-    name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+    name = client.book_path('[SHELF]', '[BOOK]')
 
     # TODO: Initialize `book`:
     book = {}
@@ -1156,21 +1156,21 @@ class LibraryServiceClient(object):
 
 
     @classmethod
-    def archived_book_path(cls, archive_path, book_id):
+    def archived_book_path(cls, archive_path, book):
         """Return a fully-qualified archived_book string."""
         return google.api_core.path_template.expand(
-            'archives/{archive_path}/books/{book_id=**}',
+            'archives/{archive_path}/books/{book=**}',
             archive_path=archive_path,
-            book_id=book_id,
+            book=book,
         )
 
     @classmethod
-    def book_path(cls, shelf_id, book_id):
+    def book_path(cls, shelf, book):
         """Return a fully-qualified book string."""
         return google.api_core.path_template.expand(
-            'shelves/{shelf_id}/books/{book_id}',
-            shelf_id=shelf_id,
-            book_id=book_id,
+            'shelves/{shelf}/books/{book}',
+            shelf=shelf,
+            book=book,
         )
 
     @classmethod
@@ -1208,11 +1208,11 @@ class LibraryServiceClient(object):
         )
 
     @classmethod
-    def shelf_path(cls, shelf_id):
+    def shelf_path(cls, shelf):
         """Return a fully-qualified shelf string."""
         return google.api_core.path_template.expand(
-            'shelves/{shelf_id}',
-            shelf_id=shelf_id,
+            'shelves/{shelf}',
+            shelf=shelf,
         )
 
     def __init__(self, transport=None, channel=None, credentials=None,
@@ -1391,7 +1391,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> # TODO: Initialize `options_`:
             >>> options_ = ''
@@ -1538,7 +1538,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> client.delete_shelf(name)
 
@@ -1602,8 +1602,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
-            >>> other_shelf_name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
+            >>> other_shelf_name = client.shelf_path('[SHELF]')
             >>>
             >>> response = client.merge_shelves(name, other_shelf_name)
 
@@ -1670,7 +1670,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> # TODO: Initialize `book`:
             >>> book = {}
@@ -1843,7 +1843,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_book(name)
 
@@ -1909,7 +1909,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>> filter_ = 'book-filter-string'
             >>>
             >>> # Iterate over all results
@@ -2005,7 +2005,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> client.delete_book(name)
 
@@ -2070,7 +2070,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> # TODO: Initialize `book`:
             >>> book = {}
@@ -2155,8 +2155,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-            >>> other_shelf_name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
+            >>> other_shelf_name = client.shelf_path('[SHELF]')
             >>>
             >>> response = client.move_book(name, other_shelf_name)
 
@@ -2305,7 +2305,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> comment = b''
             >>> stage = enums.Comment.Stage.UNSET
             >>> alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -2376,7 +2376,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK_ID]')
+            >>> name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK]')
             >>> parent = client.project_path('[PROJECT]')
             >>>
             >>> response = client.get_book_from_archive(name, parent)
@@ -2446,8 +2446,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-            >>> alt_book_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
+            >>> alt_book_name = client.book_path('[SHELF]', '[BOOK]')
             >>> place = client.location_path('[PROJECT]', '[LOCATION]')
             >>> folder = client.folder_path('[FOLDER]')
             >>>
@@ -2521,7 +2521,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_book_from_absolutely_anywhere(name)
 
@@ -2590,7 +2590,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> index_name = 'default index'
             >>>
             >>> # TODO: Initialize `index_map_item`:
@@ -2661,7 +2661,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> for element in client.stream_shelves(name):
             ...     # process element
@@ -2775,7 +2775,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -2832,7 +2832,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -3028,7 +3028,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> resource = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> # TODO: Initialize `label`:
             >>> label = ''
@@ -3098,7 +3098,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_big_book(name)
             >>>
@@ -3177,7 +3177,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_big_nothing(name)
             >>>
@@ -3404,8 +3404,8 @@ class LibraryServiceClient(object):
             >>>
             >>> # TODO: Initialize `required_singular_message`:
             >>> required_singular_message = {}
-            >>> required_singular_resource_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-            >>> required_singular_resource_name_oneof = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+            >>> required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
             >>> required_singular_resource_name_common = client.project_path('[PROJECT]')
             >>>
             >>> # TODO: Initialize `required_singular_fixed32`:
@@ -3970,6 +3970,259 @@ class LibraryServiceClient(object):
         )
         return self._inner_api_calls['test_optional_required_flattening_params'](request, retry=retry, timeout=timeout, metadata=metadata)
 
+    def move_books(
+            self,
+            source=None,
+            destination=None,
+            publishers=None,
+            project=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> response = client.move_books()
+
+        Args:
+            source (str)
+            destination (str)
+            publishers (list[str])
+            project (str)
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.MoveBooksResponse` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'move_books' not in self._inner_api_calls:
+            self._inner_api_calls['move_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.move_books,
+                default_retry=self._method_configs['MoveBooks'].retry,
+                default_timeout=self._method_configs['MoveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.MoveBooksRequest(
+            source=source,
+            destination=destination,
+            publishers=publishers,
+            project=project,
+        )
+        if metadata is None:
+            metadata = []
+        metadata = list(metadata)
+        try:
+            routing_header = [('source', source)]
+        except AttributeError:
+            pass
+        else:
+            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
+            metadata.append(routing_metadata)
+
+        return self._inner_api_calls['move_books'](request, retry=retry, timeout=timeout, metadata=metadata)
+
+    def archive_books(
+            self,
+            source=None,
+            archive=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> response = client.archive_books()
+
+        Args:
+            source (str)
+            archive (str)
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.ArchiveBooksResponse` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'archive_books' not in self._inner_api_calls:
+            self._inner_api_calls['archive_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.archive_books,
+                default_retry=self._method_configs['ArchiveBooks'].retry,
+                default_timeout=self._method_configs['ArchiveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.ArchiveBooksRequest(
+            source=source,
+            archive=archive,
+        )
+        if metadata is None:
+            metadata = []
+        metadata = list(metadata)
+        try:
+            routing_header = [('source', source)]
+        except AttributeError:
+            pass
+        else:
+            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
+            metadata.append(routing_metadata)
+
+        return self._inner_api_calls['archive_books'](request, retry=retry, timeout=timeout, metadata=metadata)
+
+    def long_running_archive_books(
+            self,
+            source=None,
+            archive=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> response = client.long_running_archive_books()
+
+        Args:
+            source (str)
+            archive (str)
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.Operation` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'long_running_archive_books' not in self._inner_api_calls:
+            self._inner_api_calls['long_running_archive_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.long_running_archive_books,
+                default_retry=self._method_configs['LongRunningArchiveBooks'].retry,
+                default_timeout=self._method_configs['LongRunningArchiveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.ArchiveBooksRequest(
+            source=source,
+            archive=archive,
+        )
+        if metadata is None:
+            metadata = []
+        metadata = list(metadata)
+        try:
+            routing_header = [('source', source)]
+        except AttributeError:
+            pass
+        else:
+            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
+            metadata.append(routing_metadata)
+
+        return self._inner_api_calls['long_running_archive_books'](request, retry=retry, timeout=timeout, metadata=metadata)
+
+    def streaming_archive_books(
+            self,
+            requests,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        EXPERIMENTAL: This method interface might change in the future.
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> request = {}
+            >>>
+            >>> requests = [request]
+            >>> for element in client.streaming_archive_books(requests):
+            ...     # process element
+            ...     pass
+
+        Args:
+            requests (iterator[dict|google.cloud.example.library_v1.proto.library_pb2.ArchiveBooksRequest]): The input objects. If a dict is provided, it must be of the
+                same form as the protobuf message :class:`~google.cloud.example.library_v1.types.ArchiveBooksRequest`
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            Iterable[~google.cloud.example.library_v1.types.ArchiveBooksResponse].
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'streaming_archive_books' not in self._inner_api_calls:
+            self._inner_api_calls['streaming_archive_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.streaming_archive_books,
+                default_retry=self._method_configs['StreamingArchiveBooks'].retry,
+                default_timeout=self._method_configs['StreamingArchiveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        return self._inner_api_calls['streaming_archive_books'](requests, retry=retry, timeout=timeout, metadata=metadata)
+
     def private_list_shelves(
             self,
             page_token=None,
@@ -4195,6 +4448,26 @@ config = {
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -5001,6 +5274,54 @@ class LibraryServiceGrpcTransport(object):
         return self._stubs['library_service_stub'].TestOptionalRequiredFlatteningParams
 
     @property
+    def move_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.move_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].MoveBooks
+
+    @property
+    def archive_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.archive_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].ArchiveBooks
+
+    @property
+    def long_running_archive_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.long_running_archive_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].LongRunningArchiveBooks
+
+    @property
+    def streaming_archive_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.streaming_archive_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].StreamingArchiveBooks
+
+    @property
     def private_list_shelves(self):
         """Return the gRPC stub for :meth:`LibraryServiceClient.private_list_shelves`.
 
@@ -5432,7 +5753,7 @@ def sample_delete_shelf():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.shelf_path('[SHELF_ID]')
+  name = client.shelf_path('[SHELF]')
 
   client.delete_shelf(name)
   # Shelf deleted
@@ -5479,7 +5800,7 @@ def sample_delete_shelf():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.shelf_path('[SHELF_ID]')
+  name = client.shelf_path('[SHELF]')
 
   client.delete_shelf(name)
 # [END sample]
@@ -5763,7 +6084,7 @@ def sample_get_big_nothing():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  name = client.book_path('[SHELF]', '[BOOK]')
 
   operation = client.get_big_nothing(name)
 
@@ -5814,7 +6135,7 @@ def sample_get_big_nothing():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  name = client.book_path('[SHELF]', '[BOOK]')
 
   operation = client.get_big_nothing(name)
 
@@ -5864,7 +6185,7 @@ def sample_get_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  name = client.book_path('[SHELF]', '[BOOK]')
 
   response = client.get_book(name)
   int_key_val = response.map_string_value[123]
@@ -5961,7 +6282,7 @@ def sample_monolog_about_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  name = client.book_path('[SHELF]', '[BOOK]')
   request = {'name': name}
 
   requests = [request]
@@ -6309,7 +6630,7 @@ def sample_stream_shelves():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.shelf_path('[SHELF_ID]')
+  name = client.shelf_path('[SHELF]')
 
   for response_item in client.stream_shelves(name):
     print(response_item)
@@ -6408,8 +6729,8 @@ def sample_test_optional_required_flattening_params(param_float, param_long):
   required_singular_string = ''
   required_singular_bytes = b''
   required_singular_message = {}
-  required_singular_resource_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-  required_singular_resource_name_oneof = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+  required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
   required_singular_resource_name_common = client.project_path('[PROJECT]')
   required_singular_fixed32 = 0
   required_singular_fixed64 = 0
@@ -6725,7 +7046,7 @@ def sample_discuss_book(image_file_name, stage):
 
   # image_file_name = 'image_file.jpg'
   # stage = enums.Comment.Stage.DRAFT
-  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  name = client.book_path('[SHELF]', '[BOOK]')
   with io.open('comment_file', 'rb') as f:
     comment = f.read()
   comment_2 = {'comment': comment, 'stage': stage}
@@ -7018,7 +7339,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         options_ = 'options-1249474914'
 
         response = client.get_shelf(name, options_)
@@ -7038,7 +7359,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         options_ = 'options-1249474914'
 
         with pytest.raises(CustomException):
@@ -7089,7 +7410,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         client.delete_shelf(name)
 
@@ -7107,7 +7428,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.delete_shelf(name)
@@ -7128,8 +7449,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         response = client.merge_shelves(name, other_shelf_name)
         assert expected_response == response
@@ -7148,8 +7469,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.merge_shelves(name, other_shelf_name)
@@ -7171,7 +7492,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         book = {}
 
         response = client.create_book(name, book)
@@ -7191,7 +7512,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         book = {}
 
         with pytest.raises(CustomException):
@@ -7259,7 +7580,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_book(name)
         assert expected_response == response
@@ -7278,7 +7599,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.get_book(name)
@@ -7299,7 +7620,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         filter_ = 'book-filter-string'
 
         paged_list_response = client.list_books(name, filter=filter_)
@@ -7321,7 +7642,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         filter_ = 'book-filter-string'
 
         paged_list_response = client.list_books(name, filter=filter_)
@@ -7336,7 +7657,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         client.delete_book(name)
 
@@ -7354,7 +7675,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.delete_book(name)
@@ -7376,7 +7697,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         book = {}
 
         response = client.update_book(name, book)
@@ -7396,7 +7717,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         book = {}
 
         with pytest.raises(CustomException):
@@ -7419,8 +7740,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         response = client.move_book(name, other_shelf_name)
         assert expected_response == response
@@ -7439,8 +7760,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.move_book(name, other_shelf_name)
@@ -7490,7 +7811,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         comment = b'95'
         stage = enums.Comment.Stage.UNSET
         alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -7513,7 +7834,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         comment = b'95'
         stage = enums.Comment.Stage.UNSET
         alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -7540,7 +7861,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK_ID]')
+        name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK]')
         parent = client.project_path('[PROJECT]')
 
         response = client.get_book_from_archive(name, parent)
@@ -7560,7 +7881,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK_ID]')
+        name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK]')
         parent = client.project_path('[PROJECT]')
 
         with pytest.raises(CustomException):
@@ -7583,8 +7904,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        alt_book_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
+        alt_book_name = client.book_path('[SHELF]', '[BOOK]')
         place = client.location_path('[PROJECT]', '[LOCATION]')
         folder = client.folder_path('[FOLDER]')
 
@@ -7605,8 +7926,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        alt_book_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
+        alt_book_name = client.book_path('[SHELF]', '[BOOK]')
         place = client.location_path('[PROJECT]', '[LOCATION]')
         folder = client.folder_path('[FOLDER]')
 
@@ -7630,7 +7951,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_book_from_absolutely_anywhere(name)
         assert expected_response == response
@@ -7649,7 +7970,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.get_book_from_absolutely_anywhere(name)
@@ -7662,7 +7983,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         index_name = 'default index'
         index_map_item = 'indexMapItem1918721251'
         index_map = {'default_key': index_map_item}
@@ -7683,7 +8004,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         index_name = 'default index'
         index_map_item = 'indexMapItem1918721251'
         index_map = {'default_key': index_map_item}
@@ -7707,7 +8028,7 @@ class TestLibraryServiceClient(object):
 
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         response = client.stream_shelves(name)
         resources = list(response)
@@ -7728,7 +8049,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.stream_shelves(name)
@@ -7792,7 +8113,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -7817,7 +8138,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)
@@ -7841,7 +8162,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -7864,7 +8185,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)
@@ -7971,7 +8292,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        resource = client.book_path('[SHELF]', '[BOOK]')
         label = 'label102727412'
 
         response = client.add_label(resource, label)
@@ -7991,7 +8312,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        resource = client.book_path('[SHELF]', '[BOOK]')
         label = 'label102727412'
 
         with pytest.raises(CustomException):
@@ -8016,7 +8337,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_book(name)
         result = response.result()
@@ -8042,7 +8363,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_book(name)
         exception = response.exception()
@@ -8063,7 +8384,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_nothing(name)
         result = response.result()
@@ -8089,7 +8410,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_nothing(name)
         exception = response.exception()
@@ -8117,8 +8438,8 @@ class TestLibraryServiceClient(object):
         required_singular_string = 'requiredSingularString-1949894503'
         required_singular_bytes = b'-29'
         required_singular_message = {}
-        required_singular_resource_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        required_singular_resource_name_oneof = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+        required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
         required_singular_resource_name_common = client.project_path('[PROJECT]')
         required_singular_fixed32 = 720656715
         required_singular_fixed64 = 720656810
@@ -8196,8 +8517,8 @@ class TestLibraryServiceClient(object):
         required_singular_string = 'requiredSingularString-1949894503'
         required_singular_bytes = b'-29'
         required_singular_message = {}
-        required_singular_resource_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        required_singular_resource_name_oneof = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+        required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
         required_singular_resource_name_common = client.project_path('[PROJECT]')
         required_singular_fixed32 = 720656715
         required_singular_fixed64 = 720656810
@@ -8251,6 +8572,149 @@ class TestLibraryServiceClient(object):
 
         with pytest.raises(CustomException):
             client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map, required_any_value, required_struct_value, required_value_value, required_list_value_value, required_time_value, required_duration_value, required_field_mask_value, required_int32_value, required_uint32_value, required_int64_value, required_uint64_value, required_float_value, required_double_value, required_string_value, required_bool_value, required_bytes_value, required_repeated_any_value, required_repeated_struct_value, required_repeated_value_value, required_repeated_list_value_value, required_repeated_time_value, required_repeated_duration_value, required_repeated_field_mask_value, required_repeated_int32_value, required_repeated_uint32_value, required_repeated_int64_value, required_repeated_uint64_value, required_repeated_float_value, required_repeated_double_value, required_repeated_string_value, required_repeated_bool_value, required_repeated_bytes_value)
+
+    def test_move_books(self):
+        # Setup Expected Response
+        success = False
+        expected_response = {'success': success}
+        expected_response = library_pb2.MoveBooksResponse(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        response = client.move_books()
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.MoveBooksRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_move_books_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        with pytest.raises(CustomException):
+            client.move_books()
+
+    def test_archive_books(self):
+        # Setup Expected Response
+        success = False
+        expected_response = {'success': success}
+        expected_response = library_pb2.ArchiveBooksResponse(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        response = client.archive_books()
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.ArchiveBooksRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_archive_books_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        with pytest.raises(CustomException):
+            client.archive_books()
+
+    def test_long_running_archive_books(self):
+        # Setup Expected Response
+        name = 'name3373707'
+        done = True
+        expected_response = {'name': name, 'done': done}
+        expected_response = operations_pb2.Operation(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        response = client.long_running_archive_books()
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.ArchiveBooksRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_long_running_archive_books_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        with pytest.raises(CustomException):
+            client.long_running_archive_books()
+
+    def test_streaming_archive_books(self):
+        # Setup Expected Response
+        success = False
+        expected_response = {'success': success}
+        expected_response = library_pb2.ArchiveBooksResponse(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [iter([expected_response])])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        # Setup Request
+        request = {}
+        request = library_pb2.ArchiveBooksRequest(**request)
+        requests = [request]
+
+        response = client.streaming_archive_books(requests)
+        resources = list(response)
+        assert len(resources) == 1
+        assert expected_response == resources[0]
+
+        assert len(channel.requests) == 1
+        actual_requests = channel.requests[0][1]
+        assert len(actual_requests) == 1
+        actual_request = list(actual_requests)[0]
+        assert request == actual_request
+
+    def test_streaming_archive_books_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        # Setup request
+        request = {}
+
+        request = library_pb2.ArchiveBooksRequest(**request)
+        requests = [request]
+
+        with pytest.raises(CustomException):
+            client.streaming_archive_books(requests)
 
     def test_private_list_shelves(self):
         # Setup Expected Response

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
@@ -284,7 +284,7 @@ LibraryServiceClient
 
     client = library_v1.LibraryServiceClient()
 
-    name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+    name = client.book_path('[SHELF]', '[BOOK]')
 
     # TODO: Initialize `book`:
     book = {}
@@ -744,7 +744,7 @@ LibraryServiceClient
 
     client = library_v1.LibraryServiceClient()
 
-    name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+    name = client.book_path('[SHELF]', '[BOOK]')
 
     # TODO: Initialize `book`:
     book = {}
@@ -1156,21 +1156,21 @@ class LibraryServiceClient(object):
 
 
     @classmethod
-    def archived_book_path(cls, archive_path, book_id):
+    def archived_book_path(cls, archive_path, book):
         """Return a fully-qualified archived_book string."""
         return google.api_core.path_template.expand(
-            'archives/{archive_path}/books/{book_id=**}',
+            'archives/{archive_path}/books/{book=**}',
             archive_path=archive_path,
-            book_id=book_id,
+            book=book,
         )
 
     @classmethod
-    def book_path(cls, shelf_id, book_id):
+    def book_path(cls, shelf, book):
         """Return a fully-qualified book string."""
         return google.api_core.path_template.expand(
-            'shelves/{shelf_id}/books/{book_id}',
-            shelf_id=shelf_id,
-            book_id=book_id,
+            'shelves/{shelf}/books/{book}',
+            shelf=shelf,
+            book=book,
         )
 
     @classmethod
@@ -1182,11 +1182,11 @@ class LibraryServiceClient(object):
         )
 
     @classmethod
-    def shelf_path(cls, shelf_id):
+    def shelf_path(cls, shelf):
         """Return a fully-qualified shelf string."""
         return google.api_core.path_template.expand(
-            'shelves/{shelf_id}',
-            shelf_id=shelf_id,
+            'shelves/{shelf}',
+            shelf=shelf,
         )
 
     def __init__(self, transport=None, channel=None, credentials=None,
@@ -1365,7 +1365,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> # TODO: Initialize `options_`:
             >>> options_ = ''
@@ -1512,7 +1512,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> client.delete_shelf(name)
 
@@ -1576,8 +1576,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
-            >>> other_shelf_name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
+            >>> other_shelf_name = client.shelf_path('[SHELF]')
             >>>
             >>> response = client.merge_shelves(name, other_shelf_name)
 
@@ -1644,7 +1644,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> # TODO: Initialize `book`:
             >>> book = {}
@@ -1817,7 +1817,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_book(name)
 
@@ -1883,7 +1883,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>> filter_ = 'book-filter-string'
             >>>
             >>> # Iterate over all results
@@ -1979,7 +1979,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> client.delete_book(name)
 
@@ -2044,7 +2044,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> # TODO: Initialize `book`:
             >>> book = {}
@@ -2129,8 +2129,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-            >>> other_shelf_name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
+            >>> other_shelf_name = client.shelf_path('[SHELF]')
             >>>
             >>> response = client.move_book(name, other_shelf_name)
 
@@ -2279,7 +2279,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> comment = b''
             >>> stage = enums.Comment.Stage.UNSET
             >>> alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -2350,7 +2350,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK_ID]')
+            >>> name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK]')
             >>>
             >>> response = client.get_book_from_archive(name)
 
@@ -2419,8 +2419,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-            >>> alt_book_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
+            >>> alt_book_name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_book_from_anywhere(name, alt_book_name)
 
@@ -2492,7 +2492,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_book_from_absolutely_anywhere(name)
 
@@ -2561,7 +2561,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> index_name = 'default index'
             >>>
             >>> # TODO: Initialize `index_map_item`:
@@ -2632,7 +2632,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> for element in client.stream_shelves(name):
             ...     # process element
@@ -2746,7 +2746,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -2803,7 +2803,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -2999,7 +2999,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> resource = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> # TODO: Initialize `label`:
             >>> label = ''
@@ -3069,7 +3069,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_big_book(name)
             >>>
@@ -3148,7 +3148,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_big_nothing(name)
             >>>
@@ -3375,8 +3375,8 @@ class LibraryServiceClient(object):
             >>>
             >>> # TODO: Initialize `required_singular_message`:
             >>> required_singular_message = {}
-            >>> required_singular_resource_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-            >>> required_singular_resource_name_oneof = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+            >>> required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+            >>> required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
             >>> required_singular_resource_name_common = client.project_path('[PROJECT]')
             >>>
             >>> # TODO: Initialize `required_singular_fixed32`:
@@ -3845,6 +3845,259 @@ class LibraryServiceClient(object):
         )
         return self._inner_api_calls['test_optional_required_flattening_params'](request, retry=retry, timeout=timeout, metadata=metadata)
 
+    def move_books(
+            self,
+            source=None,
+            destination=None,
+            publishers=None,
+            project=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> response = client.move_books()
+
+        Args:
+            source (str)
+            destination (str)
+            publishers (list[str])
+            project (str)
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.MoveBooksResponse` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'move_books' not in self._inner_api_calls:
+            self._inner_api_calls['move_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.move_books,
+                default_retry=self._method_configs['MoveBooks'].retry,
+                default_timeout=self._method_configs['MoveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.MoveBooksRequest(
+            source=source,
+            destination=destination,
+            publishers=publishers,
+            project=project,
+        )
+        if metadata is None:
+            metadata = []
+        metadata = list(metadata)
+        try:
+            routing_header = [('source', source)]
+        except AttributeError:
+            pass
+        else:
+            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
+            metadata.append(routing_metadata)
+
+        return self._inner_api_calls['move_books'](request, retry=retry, timeout=timeout, metadata=metadata)
+
+    def archive_books(
+            self,
+            source=None,
+            archive=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> response = client.archive_books()
+
+        Args:
+            source (str)
+            archive (str)
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.ArchiveBooksResponse` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'archive_books' not in self._inner_api_calls:
+            self._inner_api_calls['archive_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.archive_books,
+                default_retry=self._method_configs['ArchiveBooks'].retry,
+                default_timeout=self._method_configs['ArchiveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.ArchiveBooksRequest(
+            source=source,
+            archive=archive,
+        )
+        if metadata is None:
+            metadata = []
+        metadata = list(metadata)
+        try:
+            routing_header = [('source', source)]
+        except AttributeError:
+            pass
+        else:
+            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
+            metadata.append(routing_metadata)
+
+        return self._inner_api_calls['archive_books'](request, retry=retry, timeout=timeout, metadata=metadata)
+
+    def long_running_archive_books(
+            self,
+            source=None,
+            archive=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> response = client.long_running_archive_books()
+
+        Args:
+            source (str)
+            archive (str)
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.Operation` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'long_running_archive_books' not in self._inner_api_calls:
+            self._inner_api_calls['long_running_archive_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.long_running_archive_books,
+                default_retry=self._method_configs['LongRunningArchiveBooks'].retry,
+                default_timeout=self._method_configs['LongRunningArchiveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.ArchiveBooksRequest(
+            source=source,
+            archive=archive,
+        )
+        if metadata is None:
+            metadata = []
+        metadata = list(metadata)
+        try:
+            routing_header = [('source', source)]
+        except AttributeError:
+            pass
+        else:
+            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
+            metadata.append(routing_metadata)
+
+        return self._inner_api_calls['long_running_archive_books'](request, retry=retry, timeout=timeout, metadata=metadata)
+
+    def streaming_archive_books(
+            self,
+            requests,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        EXPERIMENTAL: This method interface might change in the future.
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> request = {}
+            >>>
+            >>> requests = [request]
+            >>> for element in client.streaming_archive_books(requests):
+            ...     # process element
+            ...     pass
+
+        Args:
+            requests (iterator[dict|google.cloud.example.library_v1.proto.library_pb2.ArchiveBooksRequest]): The input objects. If a dict is provided, it must be of the
+                same form as the protobuf message :class:`~google.cloud.example.library_v1.types.ArchiveBooksRequest`
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            Iterable[~google.cloud.example.library_v1.types.ArchiveBooksResponse].
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'streaming_archive_books' not in self._inner_api_calls:
+            self._inner_api_calls['streaming_archive_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.streaming_archive_books,
+                default_retry=self._method_configs['StreamingArchiveBooks'].retry,
+                default_timeout=self._method_configs['StreamingArchiveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        return self._inner_api_calls['streaming_archive_books'](requests, retry=retry, timeout=timeout, metadata=metadata)
+
     def private_list_shelves(
             self,
             page_token=None,
@@ -4070,6 +4323,26 @@ config = {
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -4876,6 +5149,54 @@ class LibraryServiceGrpcTransport(object):
         return self._stubs['library_service_stub'].TestOptionalRequiredFlatteningParams
 
     @property
+    def move_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.move_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].MoveBooks
+
+    @property
+    def archive_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.archive_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].ArchiveBooks
+
+    @property
+    def long_running_archive_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.long_running_archive_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].LongRunningArchiveBooks
+
+    @property
+    def streaming_archive_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.streaming_archive_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].StreamingArchiveBooks
+
+    @property
     def private_list_shelves(self):
         """Return the gRPC stub for :meth:`LibraryServiceClient.private_list_shelves`.
 
@@ -5307,7 +5628,7 @@ def sample_delete_shelf():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.shelf_path('[SHELF_ID]')
+  name = client.shelf_path('[SHELF]')
 
   client.delete_shelf(name)
   # Shelf deleted
@@ -5354,7 +5675,7 @@ def sample_delete_shelf():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.shelf_path('[SHELF_ID]')
+  name = client.shelf_path('[SHELF]')
 
   client.delete_shelf(name)
 # [END sample]
@@ -5399,7 +5720,7 @@ def sample_get_big_nothing():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  name = client.book_path('[SHELF]', '[BOOK]')
 
   operation = client.get_big_nothing(name)
 
@@ -5450,7 +5771,7 @@ def sample_get_big_nothing():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  name = client.book_path('[SHELF]', '[BOOK]')
 
   operation = client.get_big_nothing(name)
 
@@ -5551,7 +5872,7 @@ def sample_get_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  name = client.book_path('[SHELF]', '[BOOK]')
 
   response = client.get_book(name)
   int_key_val = response.map_string_value[123]
@@ -6018,7 +6339,7 @@ def sample_monolog_about_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  name = client.book_path('[SHELF]', '[BOOK]')
   request = {'name': name}
 
   requests = [request]
@@ -6119,8 +6440,8 @@ def sample_test_optional_required_flattening_params(param_float, param_long):
   required_singular_string = ''
   required_singular_bytes = b''
   required_singular_message = {}
-  required_singular_resource_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-  required_singular_resource_name_oneof = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+  required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
   required_singular_resource_name_common = client.project_path('[PROJECT]')
   required_singular_fixed32 = 0
   required_singular_fixed64 = 0
@@ -6189,7 +6510,7 @@ def sample_get_book_from_absolutely_anywhere():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.archived_book_path('The archive to search for the book', 'The ID of the book')
+  name = client.book_path('[SHELF]', 'The ID of the book')
 
   response = client.get_book_from_absolutely_anywhere(name)
   print(u'Archived book found.')
@@ -6452,7 +6773,7 @@ def sample_discuss_book(image_file_name, stage):
 
   # image_file_name = 'image_file.jpg'
   # stage = enums.Comment.Stage.DRAFT
-  name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+  name = client.book_path('[SHELF]', '[BOOK]')
   with io.open('comment_file', 'rb') as f:
     comment = f.read()
   comment_2 = {'comment': comment, 'stage': stage}
@@ -6739,7 +7060,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         options_ = 'options-1249474914'
 
         response = client.get_shelf(name, options_)
@@ -6759,7 +7080,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         options_ = 'options-1249474914'
 
         with pytest.raises(CustomException):
@@ -6810,7 +7131,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         client.delete_shelf(name)
 
@@ -6828,7 +7149,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.delete_shelf(name)
@@ -6849,8 +7170,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         response = client.merge_shelves(name, other_shelf_name)
         assert expected_response == response
@@ -6869,8 +7190,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.merge_shelves(name, other_shelf_name)
@@ -6892,7 +7213,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         book = {}
 
         response = client.create_book(name, book)
@@ -6912,7 +7233,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         book = {}
 
         with pytest.raises(CustomException):
@@ -6980,7 +7301,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_book(name)
         assert expected_response == response
@@ -6999,7 +7320,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.get_book(name)
@@ -7020,7 +7341,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         filter_ = 'book-filter-string'
 
         paged_list_response = client.list_books(name, filter=filter_)
@@ -7042,7 +7363,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         filter_ = 'book-filter-string'
 
         paged_list_response = client.list_books(name, filter=filter_)
@@ -7057,7 +7378,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         client.delete_book(name)
 
@@ -7075,7 +7396,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.delete_book(name)
@@ -7097,7 +7418,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         book = {}
 
         response = client.update_book(name, book)
@@ -7117,7 +7438,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         book = {}
 
         with pytest.raises(CustomException):
@@ -7140,8 +7461,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         response = client.move_book(name, other_shelf_name)
         assert expected_response == response
@@ -7160,8 +7481,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.move_book(name, other_shelf_name)
@@ -7211,7 +7532,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         comment = b'95'
         stage = enums.Comment.Stage.UNSET
         alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -7234,7 +7555,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         comment = b'95'
         stage = enums.Comment.Stage.UNSET
         alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -7261,7 +7582,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK_ID]')
+        name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK]')
 
         response = client.get_book_from_archive(name)
         assert expected_response == response
@@ -7280,7 +7601,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK_ID]')
+        name = client.archived_book_path('[ARCHIVE_PATH]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.get_book_from_archive(name)
@@ -7302,8 +7623,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        alt_book_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
+        alt_book_name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_book_from_anywhere(name, alt_book_name)
         assert expected_response == response
@@ -7322,8 +7643,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        alt_book_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
+        alt_book_name = client.book_path('[SHELF]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.get_book_from_anywhere(name, alt_book_name)
@@ -7345,7 +7666,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_book_from_absolutely_anywhere(name)
         assert expected_response == response
@@ -7364,7 +7685,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.get_book_from_absolutely_anywhere(name)
@@ -7377,7 +7698,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         index_name = 'default index'
         index_map_item = 'indexMapItem1918721251'
         index_map = {'default_key': index_map_item}
@@ -7398,7 +7719,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         index_name = 'default index'
         index_map_item = 'indexMapItem1918721251'
         index_map = {'default_key': index_map_item}
@@ -7422,7 +7743,7 @@ class TestLibraryServiceClient(object):
 
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         response = client.stream_shelves(name)
         resources = list(response)
@@ -7443,7 +7764,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.stream_shelves(name)
@@ -7507,7 +7828,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -7532,7 +7853,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)
@@ -7556,7 +7877,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -7579,7 +7900,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)
@@ -7686,7 +8007,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        resource = client.book_path('[SHELF]', '[BOOK]')
         label = 'label102727412'
 
         response = client.add_label(resource, label)
@@ -7706,7 +8027,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        resource = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        resource = client.book_path('[SHELF]', '[BOOK]')
         label = 'label102727412'
 
         with pytest.raises(CustomException):
@@ -7731,7 +8052,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_book(name)
         result = response.result()
@@ -7757,7 +8078,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_book(name)
         exception = response.exception()
@@ -7778,7 +8099,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_nothing(name)
         result = response.result()
@@ -7804,7 +8125,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_nothing(name)
         exception = response.exception()
@@ -7832,8 +8153,8 @@ class TestLibraryServiceClient(object):
         required_singular_string = 'requiredSingularString-1949894503'
         required_singular_bytes = b'-29'
         required_singular_message = {}
-        required_singular_resource_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        required_singular_resource_name_oneof = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+        required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
         required_singular_resource_name_common = client.project_path('[PROJECT]')
         required_singular_fixed32 = 720656715
         required_singular_fixed64 = 720656810
@@ -7879,8 +8200,8 @@ class TestLibraryServiceClient(object):
         required_singular_string = 'requiredSingularString-1949894503'
         required_singular_bytes = b'-29'
         required_singular_message = {}
-        required_singular_resource_name = client.book_path('[SHELF_ID]', '[BOOK_ID]')
-        required_singular_resource_name_oneof = client.book_path('[SHELF_ID]', '[BOOK_ID]')
+        required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+        required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
         required_singular_resource_name_common = client.project_path('[PROJECT]')
         required_singular_fixed32 = 720656715
         required_singular_fixed64 = 720656810
@@ -7902,6 +8223,149 @@ class TestLibraryServiceClient(object):
 
         with pytest.raises(CustomException):
             client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
+
+    def test_move_books(self):
+        # Setup Expected Response
+        success = False
+        expected_response = {'success': success}
+        expected_response = library_pb2.MoveBooksResponse(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        response = client.move_books()
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.MoveBooksRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_move_books_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        with pytest.raises(CustomException):
+            client.move_books()
+
+    def test_archive_books(self):
+        # Setup Expected Response
+        success = False
+        expected_response = {'success': success}
+        expected_response = library_pb2.ArchiveBooksResponse(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        response = client.archive_books()
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.ArchiveBooksRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_archive_books_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        with pytest.raises(CustomException):
+            client.archive_books()
+
+    def test_long_running_archive_books(self):
+        # Setup Expected Response
+        name = 'name3373707'
+        done = True
+        expected_response = {'name': name, 'done': done}
+        expected_response = operations_pb2.Operation(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        response = client.long_running_archive_books()
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.ArchiveBooksRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_long_running_archive_books_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        with pytest.raises(CustomException):
+            client.long_running_archive_books()
+
+    def test_streaming_archive_books(self):
+        # Setup Expected Response
+        success = False
+        expected_response = {'success': success}
+        expected_response = library_pb2.ArchiveBooksResponse(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [iter([expected_response])])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        # Setup Request
+        request = {}
+        request = library_pb2.ArchiveBooksRequest(**request)
+        requests = [request]
+
+        response = client.streaming_archive_books(requests)
+        resources = list(response)
+        assert len(resources) == 1
+        assert expected_response == resources[0]
+
+        assert len(channel.requests) == 1
+        actual_requests = channel.requests[0][1]
+        assert len(actual_requests) == 1
+        actual_request = list(actual_requests)[0]
+        assert request == actual_request
+
+    def test_streaming_archive_books_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        # Setup request
+        request = {}
+
+        request = library_pb2.ArchiveBooksRequest(**request)
+        requests = [request]
+
+        with pytest.raises(CustomException):
+            client.streaming_archive_books(requests)
 
     def test_private_list_shelves(self):
         # Setup Expected Response

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -2221,7 +2221,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name of the shelf.
-        #     Shelf names have the form `bookShelves/{shelf_id}`.
+        #     Shelf names have the form `shelves/{shelf}`.
         # @!attribute [rw] theme
         #   @return [String]
         #     The theme of the shelf
@@ -2810,6 +2810,30 @@ module Google
         end
 
         class TestOptionalRequiredFlatteningParamsResponse; end
+
+        # @!attribute [rw] source
+        #   @return [String]
+        # @!attribute [rw] destination
+        #   @return [String]
+        # @!attribute [rw] publishers
+        #   @return [Array<String>]
+        # @!attribute [rw] project
+        #   @return [String]
+        class MoveBooksRequest; end
+
+        # @!attribute [rw] success
+        #   @return [true, false]
+        class MoveBooksResponse; end
+
+        # @!attribute [rw] source
+        #   @return [String]
+        # @!attribute [rw] archive
+        #   @return [String]
+        class ArchiveBooksRequest; end
+
+        # @!attribute [rw] success
+        #   @return [true, false]
+        class ArchiveBooksResponse; end
       end
     end
   end
@@ -2994,13 +3018,13 @@ module Library
       end
 
       ARCHIVED_BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "archives/{archive_path}/books/{book_id=**}"
+        "archives/{archive_path}/books/{book=**}"
       )
 
       private_constant :ARCHIVED_BOOK_PATH_TEMPLATE
 
       BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "shelves/{shelf_id}/books/{book_id}"
+        "shelves/{shelf}/books/{book}"
       )
 
       private_constant :BOOK_PATH_TEMPLATE
@@ -3030,30 +3054,30 @@ module Library
       private_constant :PROJECT_BOOK_PATH_TEMPLATE
 
       SHELF_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "shelves/{shelf_id}"
+        "shelves/{shelf}"
       )
 
       private_constant :SHELF_PATH_TEMPLATE
 
       # Returns a fully-qualified archived_book resource name string.
       # @param archive_path [String]
-      # @param book_id [String]
+      # @param book [String]
       # @return [String]
-      def self.archived_book_path archive_path, book_id
+      def self.archived_book_path archive_path, book
         ARCHIVED_BOOK_PATH_TEMPLATE.render(
           :"archive_path" => archive_path,
-          :"book_id" => book_id
+          :"book" => book
         )
       end
 
       # Returns a fully-qualified book resource name string.
-      # @param shelf_id [String]
-      # @param book_id [String]
+      # @param shelf [String]
+      # @param book [String]
       # @return [String]
-      def self.book_path shelf_id, book_id
+      def self.book_path shelf, book
         BOOK_PATH_TEMPLATE.render(
-          :"shelf_id" => shelf_id,
-          :"book_id" => book_id
+          :"shelf" => shelf,
+          :"book" => book
         )
       end
 
@@ -3098,11 +3122,11 @@ module Library
       end
 
       # Returns a fully-qualified shelf resource name string.
-      # @param shelf_id [String]
+      # @param shelf [String]
       # @return [String]
-      def self.shelf_path shelf_id
+      def self.shelf_path shelf
         SHELF_PATH_TEMPLATE.render(
-          :"shelf_id" => shelf_id
+          :"shelf" => shelf
         )
       end
 
@@ -3425,6 +3449,35 @@ module Library
           defaults["test_optional_required_flattening_params"],
           exception_transformer: exception_transformer
         )
+        @move_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:move_books),
+          defaults["move_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:archive_books),
+          defaults["archive_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @long_running_archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:long_running_archive_books),
+          defaults["long_running_archive_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @streaming_archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:streaming_archive_books),
+          defaults["streaming_archive_books"],
+          exception_transformer: exception_transformer
+        )
         @private_list_shelves = Google::Gax.create_api_call(
           @library_service_stub.method(:private_list_shelves),
           defaults["private_list_shelves"],
@@ -3494,7 +3547,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #
       #   # TODO: Initialize `options_`:
       #   options_ = ''
@@ -3569,7 +3622,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   library_client.delete_shelf(formatted_name)
 
       def delete_shelf \
@@ -3604,8 +3657,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   response = library_client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
       def merge_shelves \
@@ -3641,7 +3694,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #
       #   # TODO: Initialize `book`:
       #   book = {}
@@ -3739,7 +3792,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   response = library_client.get_book(formatted_name)
 
       def get_book \
@@ -3781,7 +3834,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   filter = "book-filter-string"
       #
       #   # Iterate over all results.
@@ -3827,7 +3880,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   library_client.delete_book(formatted_name)
 
       def delete_book \
@@ -3872,7 +3925,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # TODO: Initialize `book`:
       #   book = {}
@@ -3915,8 +3968,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   response = library_client.move_book(formatted_name, formatted_other_shelf_name)
 
       def move_book \
@@ -4001,7 +4054,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   comment = ''
       #   stage = :UNSET
       #   alignment = :CHAR
@@ -4044,7 +4097,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK]")
       #   formatted_parent = Library::V1::LibraryServiceClient.project_path("[PROJECT]")
       #   response = library_client.get_book_from_archive(formatted_name, formatted_parent)
 
@@ -4082,8 +4135,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      #   formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   formatted_place = Library::V1::LibraryServiceClient.location_path("[PROJECT]", "[LOCATION]")
       #   formatted_folder = Library::V1::LibraryServiceClient.folder_path("[FOLDER]")
       #   response = library_client.get_book_from_anywhere(formatted_name, formatted_alt_book_name, formatted_place, formatted_folder)
@@ -4124,7 +4177,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   response = library_client.get_book_from_absolutely_anywhere(formatted_name)
 
       def get_book_from_absolutely_anywhere \
@@ -4159,7 +4212,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   index_name = "default index"
       #
       #   # TODO: Initialize `index_map_item`:
@@ -4199,7 +4252,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   library_client.stream_shelves(formatted_name).each do |element|
       #     # Process element.
       #   end
@@ -4268,7 +4321,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   request = { name: formatted_name }
       #   requests = [request]
       #   library_client.discuss_book(requests).each do |element|
@@ -4301,7 +4354,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   request = { name: formatted_name }
       #   requests = [request]
       #   response = library_client.monolog_about_book(requests)
@@ -4423,7 +4476,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # TODO: Initialize `label`:
       #   label = ''
@@ -4455,7 +4508,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # Register a callback during the method call.
       #   operation = library_client.get_big_book(formatted_name) do |op|
@@ -4515,7 +4568,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # Register a callback during the method call.
       #   operation = library_client.get_big_nothing(formatted_name) do |op|
@@ -4861,8 +4914,8 @@ module Library
       #
       #   # TODO: Initialize `required_singular_message`:
       #   required_singular_message = {}
-      #   formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      #   formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   formatted_required_singular_resource_name_common = Library::V1::LibraryServiceClient.project_path("[PROJECT]")
       #
       #   # TODO: Initialize `required_singular_fixed32`:
@@ -5266,6 +5319,131 @@ module Library
         @test_optional_required_flattening_params.call(req, options, &block)
       end
 
+      # @param source [String]
+      # @param destination [String]
+      # @param publishers [Array<String>]
+      # @param project [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::MoveBooksResponse]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::MoveBooksResponse]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   response = library_client.move_books
+
+      def move_books \
+          source: nil,
+          destination: nil,
+          publishers: nil,
+          project: nil,
+          options: nil,
+          &block
+        req = {
+          source: source,
+          destination: destination,
+          publishers: publishers,
+          project: project
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MoveBooksRequest)
+        @move_books.call(req, options, &block)
+      end
+
+      # @param source [String]
+      # @param archive [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::ArchiveBooksResponse]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::ArchiveBooksResponse]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   response = library_client.archive_books
+
+      def archive_books \
+          source: nil,
+          archive: nil,
+          options: nil,
+          &block
+        req = {
+          source: source,
+          archive: archive
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        @archive_books.call(req, options, &block)
+      end
+
+      # @param source [String]
+      # @param archive [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Longrunning::Operation]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Longrunning::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   response = library_client.long_running_archive_books
+
+      def long_running_archive_books \
+          source: nil,
+          archive: nil,
+          options: nil,
+          &block
+        req = {
+          source: source,
+          archive: archive
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        @long_running_archive_books.call(req, options, &block)
+      end
+
+      # @param reqs [Enumerable<Google::Example::Library::V1::ArchiveBooksRequest>]
+      #   The input requests.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @return [Enumerable<Google::Example::Library::V1::ArchiveBooksResponse>]
+      #   An enumerable of Google::Example::Library::V1::ArchiveBooksResponse instances.
+      #
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      #
+      # @note
+      #   EXPERIMENTAL:
+      #     Streaming requests are still undergoing review.
+      #     This method interface might change in the future.
+      #
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   request = {}
+      #   requests = [request]
+      #   library_client.streaming_archive_books(requests).each do |element|
+      #     # Process element.
+      #   end
+
+      def streaming_archive_books reqs, options: nil
+        request_protos = reqs.lazy.map do |req|
+          Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        end
+        @streaming_archive_books.call(request_protos, options)
+      end
+
       # This method is not exposed in the GAPIC config. It should be generated.
       #
       # @param page_token [String]
@@ -5472,6 +5650,26 @@ end
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -5906,7 +6104,7 @@ def sample_delete_shelf
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.shelf_path("[SHELF_ID]")
+  formatted_name = library_client.class.shelf_path("[SHELF]")
 
   library_client.delete_shelf(formatted_name)
 
@@ -5953,7 +6151,7 @@ def sample_delete_shelf
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.shelf_path("[SHELF_ID]")
+  formatted_name = library_client.class.shelf_path("[SHELF]")
 
   library_client.delete_shelf(formatted_name)
 end
@@ -6253,7 +6451,7 @@ def sample_get_big_nothing
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
 
   # Make the long-running operation request
   operation = library_client.get_big_nothing(formatted_name)
@@ -6308,7 +6506,7 @@ def sample_get_big_nothing
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
 
   # Make the long-running operation request
   operation = library_client.get_big_nothing(formatted_name)
@@ -6360,7 +6558,7 @@ def sample_get_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
 
   response = library_client.get_book(formatted_name)
   int_key_val = response.map_string_value[123]
@@ -6455,7 +6653,7 @@ def sample_monolog_about_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
   request = { name: formatted_name }
 
   requests = [request]
@@ -6803,7 +7001,7 @@ def sample_stream_shelves
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.shelf_path("[SHELF_ID]")
+  formatted_name = library_client.class.shelf_path("[SHELF]")
 
   library_client.stream_shelves(formatted_name).each do |element|
     puts element.inspect
@@ -6901,8 +7099,8 @@ def sample_test_optional_required_flattening_params param_float, param_long
   required_singular_string = ''
   required_singular_bytes = ''
   required_singular_message = {}
-  formatted_required_singular_resource_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
-  formatted_required_singular_resource_name_oneof = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_required_singular_resource_name = library_client.class.book_path("[SHELF]", "[BOOK]")
+  formatted_required_singular_resource_name_oneof = library_client.class.book_path("[SHELF]", "[BOOK]")
   formatted_required_singular_resource_name_common = library_client.class.project_path("[PROJECT]")
   required_singular_fixed32 = 0
   required_singular_fixed64 = 0
@@ -7226,7 +7424,7 @@ def sample_discuss_book image_file_name, stage
 
   # image_file_name = "image_file.jpg"
   # stage = :DRAFT
-  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
   comment = File.binread "comment_file"
   comment_2 = { comment: comment, stage: stage }
   image = File.binread image_file_name
@@ -7418,7 +7616,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_shelf without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       options_ = ''
 
       # Create expected grpc response
@@ -7466,7 +7664,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_shelf with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       options_ = ''
 
       # Mock Grpc layer
@@ -7564,7 +7762,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_shelf without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7599,7 +7797,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_shelf with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7633,8 +7831,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes merge_shelves without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -7681,8 +7879,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes merge_shelves with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7717,7 +7915,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       book = {}
 
       # Create expected grpc response
@@ -7767,7 +7965,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       book = {}
 
       # Mock Grpc layer
@@ -7906,7 +8104,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -7954,7 +8152,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7988,7 +8186,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes list_books without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       filter = "book-filter-string"
 
       # Create expected grpc response
@@ -8028,7 +8226,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes list_books with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       filter = "book-filter-string"
 
       # Mock Grpc layer
@@ -8064,7 +8262,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8099,7 +8297,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8133,7 +8331,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       book = {}
 
       # Create expected grpc response
@@ -8183,7 +8381,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       book = {}
 
       # Mock Grpc layer
@@ -8219,8 +8417,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes move_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -8269,8 +8467,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes move_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8367,7 +8565,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_comments without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       comment = ''
       stage = :UNSET
       alignment = :CHAR
@@ -8415,7 +8613,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_comments with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       comment = ''
       stage = :UNSET
       alignment = :CHAR
@@ -8462,7 +8660,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_archive without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK]")
       formatted_parent = Library::V1::LibraryServiceClient.project_path("[PROJECT]")
 
       # Create expected grpc response
@@ -8512,7 +8710,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_archive with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK]")
       formatted_parent = Library::V1::LibraryServiceClient.project_path("[PROJECT]")
 
       # Mock Grpc layer
@@ -8548,8 +8746,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_anywhere without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       formatted_place = Library::V1::LibraryServiceClient.location_path("[PROJECT]", "[LOCATION]")
       formatted_folder = Library::V1::LibraryServiceClient.folder_path("[FOLDER]")
 
@@ -8612,8 +8810,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_anywhere with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       formatted_place = Library::V1::LibraryServiceClient.location_path("[PROJECT]", "[LOCATION]")
       formatted_folder = Library::V1::LibraryServiceClient.folder_path("[FOLDER]")
 
@@ -8657,7 +8855,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_absolutely_anywhere without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -8705,7 +8903,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_absolutely_anywhere with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8739,7 +8937,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book_index without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       index_name = "default index"
       index_map_item = ''
       index_map = { "default_key" => index_map_item }
@@ -8787,7 +8985,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book_index with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       index_name = "default index"
       index_map_item = ''
       index_map = { "default_key" => index_map_item }
@@ -8830,7 +9028,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       shelves_element = {}
@@ -8865,7 +9063,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8975,7 +9173,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes discuss_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Create expected grpc response
@@ -9012,7 +9210,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes discuss_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -9048,7 +9246,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes monolog_about_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Create expected grpc response
@@ -9084,7 +9282,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes monolog_about_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -9257,7 +9455,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label without error' do
       # Create request parameters
-      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       label = ''
 
       # Create expected grpc response
@@ -9298,7 +9496,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label with error' do
       # Create request parameters
-      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       label = ''
 
       # Mock Grpc layer
@@ -9334,7 +9532,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -9382,7 +9580,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book and returns an operation error.' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
@@ -9421,7 +9619,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -9455,7 +9653,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       expected_response = {}
@@ -9494,7 +9692,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing and returns an operation error.' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
@@ -9533,7 +9731,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -9576,8 +9774,8 @@ describe Library::V1::LibraryServiceClient do
       required_singular_string = ''
       required_singular_bytes = ''
       required_singular_message = {}
-      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       formatted_required_singular_resource_name_common = Library::V1::LibraryServiceClient.project_path("[PROJECT]")
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0
@@ -9910,8 +10108,8 @@ describe Library::V1::LibraryServiceClient do
       required_singular_string = ''
       required_singular_bytes = ''
       required_singular_message = {}
-      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       formatted_required_singular_resource_name_common = Library::V1::LibraryServiceClient.project_path("[PROJECT]")
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0
@@ -10154,6 +10352,264 @@ describe Library::V1::LibraryServiceClient do
               required_repeated_bool_value,
               required_repeated_bytes_value
             )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'move_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#move_books."
+
+    it 'invokes move_books without error' do
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::MoveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:move_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("move_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.move_books
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.move_books do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes move_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:move_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("move_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.move_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#archive_books."
+
+    it 'invokes archive_books without error' do
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ArchiveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.archive_books
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.archive_books do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes archive_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.archive_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'long_running_archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#long_running_archive_books."
+
+    it 'invokes long_running_archive_books without error' do
+      # Create expected grpc response
+      name = "name3373707"
+      done = true
+      expected_response = { name: name, done: done }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Longrunning::Operation)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:long_running_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("long_running_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.long_running_archive_books
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.long_running_archive_books do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes long_running_archive_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:long_running_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("long_running_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.long_running_archive_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'streaming_archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#streaming_archive_books."
+
+    it 'invokes streaming_archive_books without error' do
+      # Create request parameters
+      request = {}
+
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ArchiveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do |requests|
+        request = requests.first
+        OpenStruct.new(execute: [expected_response])
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:streaming_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("streaming_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.streaming_archive_books([request])
+
+          # Verify the response
+          assert_equal(1, response.count)
+          assert_equal(expected_response, response.first)
+        end
+      end
+    end
+
+    it 'invokes streaming_archive_books with error' do
+      # Create request parameters
+      request = {}
+
+      # Mock Grpc layer
+      mock_method = proc do |requests|
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:streaming_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("streaming_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.streaming_archive_books([request])
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_samplegen_config_migration_library.baseline
@@ -2221,7 +2221,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name of the shelf.
-        #     Shelf names have the form `bookShelves/{shelf_id}`.
+        #     Shelf names have the form `shelves/{shelf}`.
         # @!attribute [rw] theme
         #   @return [String]
         #     The theme of the shelf
@@ -2810,6 +2810,30 @@ module Google
         end
 
         class TestOptionalRequiredFlatteningParamsResponse; end
+
+        # @!attribute [rw] source
+        #   @return [String]
+        # @!attribute [rw] destination
+        #   @return [String]
+        # @!attribute [rw] publishers
+        #   @return [Array<String>]
+        # @!attribute [rw] project
+        #   @return [String]
+        class MoveBooksRequest; end
+
+        # @!attribute [rw] success
+        #   @return [true, false]
+        class MoveBooksResponse; end
+
+        # @!attribute [rw] source
+        #   @return [String]
+        # @!attribute [rw] archive
+        #   @return [String]
+        class ArchiveBooksRequest; end
+
+        # @!attribute [rw] success
+        #   @return [true, false]
+        class ArchiveBooksResponse; end
       end
     end
   end
@@ -2994,13 +3018,13 @@ module Library
       end
 
       ARCHIVED_BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "archives/{archive_path}/books/{book_id=**}"
+        "archives/{archive_path}/books/{book=**}"
       )
 
       private_constant :ARCHIVED_BOOK_PATH_TEMPLATE
 
       BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "shelves/{shelf_id}/books/{book_id}"
+        "shelves/{shelf}/books/{book}"
       )
 
       private_constant :BOOK_PATH_TEMPLATE
@@ -3012,30 +3036,30 @@ module Library
       private_constant :PROJECT_PATH_TEMPLATE
 
       SHELF_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "shelves/{shelf_id}"
+        "shelves/{shelf}"
       )
 
       private_constant :SHELF_PATH_TEMPLATE
 
       # Returns a fully-qualified archived_book resource name string.
       # @param archive_path [String]
-      # @param book_id [String]
+      # @param book [String]
       # @return [String]
-      def self.archived_book_path archive_path, book_id
+      def self.archived_book_path archive_path, book
         ARCHIVED_BOOK_PATH_TEMPLATE.render(
           :"archive_path" => archive_path,
-          :"book_id" => book_id
+          :"book" => book
         )
       end
 
       # Returns a fully-qualified book resource name string.
-      # @param shelf_id [String]
-      # @param book_id [String]
+      # @param shelf [String]
+      # @param book [String]
       # @return [String]
-      def self.book_path shelf_id, book_id
+      def self.book_path shelf, book
         BOOK_PATH_TEMPLATE.render(
-          :"shelf_id" => shelf_id,
-          :"book_id" => book_id
+          :"shelf" => shelf,
+          :"book" => book
         )
       end
 
@@ -3049,11 +3073,11 @@ module Library
       end
 
       # Returns a fully-qualified shelf resource name string.
-      # @param shelf_id [String]
+      # @param shelf [String]
       # @return [String]
-      def self.shelf_path shelf_id
+      def self.shelf_path shelf
         SHELF_PATH_TEMPLATE.render(
-          :"shelf_id" => shelf_id
+          :"shelf" => shelf
         )
       end
 
@@ -3376,6 +3400,35 @@ module Library
           defaults["test_optional_required_flattening_params"],
           exception_transformer: exception_transformer
         )
+        @move_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:move_books),
+          defaults["move_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:archive_books),
+          defaults["archive_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @long_running_archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:long_running_archive_books),
+          defaults["long_running_archive_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @streaming_archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:streaming_archive_books),
+          defaults["streaming_archive_books"],
+          exception_transformer: exception_transformer
+        )
         @private_list_shelves = Google::Gax.create_api_call(
           @library_service_stub.method(:private_list_shelves),
           defaults["private_list_shelves"],
@@ -3445,7 +3498,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #
       #   # TODO: Initialize `options_`:
       #   options_ = ''
@@ -3520,7 +3573,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   library_client.delete_shelf(formatted_name)
 
       def delete_shelf \
@@ -3555,8 +3608,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   response = library_client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
       def merge_shelves \
@@ -3592,7 +3645,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #
       #   # TODO: Initialize `book`:
       #   book = {}
@@ -3690,7 +3743,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   response = library_client.get_book(formatted_name)
 
       def get_book \
@@ -3732,7 +3785,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   filter = "book-filter-string"
       #
       #   # Iterate over all results.
@@ -3778,7 +3831,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   library_client.delete_book(formatted_name)
 
       def delete_book \
@@ -3823,7 +3876,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # TODO: Initialize `book`:
       #   book = {}
@@ -3866,8 +3919,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   response = library_client.move_book(formatted_name, formatted_other_shelf_name)
 
       def move_book \
@@ -3952,7 +4005,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   comment = ''
       #   stage = :UNSET
       #   alignment = :CHAR
@@ -3995,7 +4048,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK]")
       #   response = library_client.get_book_from_archive(formatted_name)
 
       def get_book_from_archive \
@@ -4032,8 +4085,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      #   formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   response = library_client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
 
       def get_book_from_anywhere \
@@ -4072,7 +4125,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   response = library_client.get_book_from_absolutely_anywhere(formatted_name)
 
       def get_book_from_absolutely_anywhere \
@@ -4107,7 +4160,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   index_name = "default index"
       #
       #   # TODO: Initialize `index_map_item`:
@@ -4147,7 +4200,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   library_client.stream_shelves(formatted_name).each do |element|
       #     # Process element.
       #   end
@@ -4216,7 +4269,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   request = { name: formatted_name }
       #   requests = [request]
       #   library_client.discuss_book(requests).each do |element|
@@ -4249,7 +4302,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   request = { name: formatted_name }
       #   requests = [request]
       #   response = library_client.monolog_about_book(requests)
@@ -4371,7 +4424,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # TODO: Initialize `label`:
       #   label = ''
@@ -4403,7 +4456,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # Register a callback during the method call.
       #   operation = library_client.get_big_book(formatted_name) do |op|
@@ -4463,7 +4516,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # Register a callback during the method call.
       #   operation = library_client.get_big_nothing(formatted_name) do |op|
@@ -4809,8 +4862,8 @@ module Library
       #
       #   # TODO: Initialize `required_singular_message`:
       #   required_singular_message = {}
-      #   formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      #   formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   formatted_required_singular_resource_name_common = Library::V1::LibraryServiceClient.project_path("[PROJECT]")
       #
       #   # TODO: Initialize `required_singular_fixed32`:
@@ -5118,6 +5171,131 @@ module Library
         @test_optional_required_flattening_params.call(req, options, &block)
       end
 
+      # @param source [String]
+      # @param destination [String]
+      # @param publishers [Array<String>]
+      # @param project [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::MoveBooksResponse]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::MoveBooksResponse]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   response = library_client.move_books
+
+      def move_books \
+          source: nil,
+          destination: nil,
+          publishers: nil,
+          project: nil,
+          options: nil,
+          &block
+        req = {
+          source: source,
+          destination: destination,
+          publishers: publishers,
+          project: project
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MoveBooksRequest)
+        @move_books.call(req, options, &block)
+      end
+
+      # @param source [String]
+      # @param archive [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::ArchiveBooksResponse]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::ArchiveBooksResponse]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   response = library_client.archive_books
+
+      def archive_books \
+          source: nil,
+          archive: nil,
+          options: nil,
+          &block
+        req = {
+          source: source,
+          archive: archive
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        @archive_books.call(req, options, &block)
+      end
+
+      # @param source [String]
+      # @param archive [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Longrunning::Operation]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Longrunning::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   response = library_client.long_running_archive_books
+
+      def long_running_archive_books \
+          source: nil,
+          archive: nil,
+          options: nil,
+          &block
+        req = {
+          source: source,
+          archive: archive
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        @long_running_archive_books.call(req, options, &block)
+      end
+
+      # @param reqs [Enumerable<Google::Example::Library::V1::ArchiveBooksRequest>]
+      #   The input requests.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @return [Enumerable<Google::Example::Library::V1::ArchiveBooksResponse>]
+      #   An enumerable of Google::Example::Library::V1::ArchiveBooksResponse instances.
+      #
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      #
+      # @note
+      #   EXPERIMENTAL:
+      #     Streaming requests are still undergoing review.
+      #     This method interface might change in the future.
+      #
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   request = {}
+      #   requests = [request]
+      #   library_client.streaming_archive_books(requests).each do |element|
+      #     # Process element.
+      #   end
+
+      def streaming_archive_books reqs, options: nil
+        request_protos = reqs.lazy.map do |req|
+          Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        end
+        @streaming_archive_books.call(request_protos, options)
+      end
+
       # This method is not exposed in the GAPIC config. It should be generated.
       #
       # @param page_token [String]
@@ -5324,6 +5502,26 @@ end
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -5759,7 +5957,7 @@ def sample_delete_shelf
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.shelf_path("[SHELF_ID]")
+  formatted_name = library_client.class.shelf_path("[SHELF]")
 
   library_client.delete_shelf(formatted_name)
 
@@ -5806,7 +6004,7 @@ def sample_delete_shelf
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.shelf_path("[SHELF_ID]")
+  formatted_name = library_client.class.shelf_path("[SHELF]")
 
   library_client.delete_shelf(formatted_name)
 end
@@ -5850,7 +6048,7 @@ def sample_get_big_nothing
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
 
   # Make the long-running operation request
   operation = library_client.get_big_nothing(formatted_name)
@@ -5905,7 +6103,7 @@ def sample_get_big_nothing
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
 
   # Make the long-running operation request
   operation = library_client.get_big_nothing(formatted_name)
@@ -6008,7 +6206,7 @@ def sample_get_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
 
   response = library_client.get_book(formatted_name)
   int_key_val = response.map_string_value[123]
@@ -6483,7 +6681,7 @@ def sample_monolog_about_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
   request = { name: formatted_name }
 
   requests = [request]
@@ -6583,8 +6781,8 @@ def sample_test_optional_required_flattening_params param_float, param_long
   required_singular_string = ''
   required_singular_bytes = ''
   required_singular_message = {}
-  formatted_required_singular_resource_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
-  formatted_required_singular_resource_name_oneof = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_required_singular_resource_name = library_client.class.book_path("[SHELF]", "[BOOK]")
+  formatted_required_singular_resource_name_oneof = library_client.class.book_path("[SHELF]", "[BOOK]")
   formatted_required_singular_resource_name_common = library_client.class.project_path("[PROJECT]")
   required_singular_fixed32 = 0
   required_singular_fixed64 = 0
@@ -6656,7 +6854,7 @@ def sample_get_book_from_absolutely_anywhere
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.archived_book_path("The archive to search for the book", "The ID of the book")
+  formatted_name = library_client.class.book_path("[SHELF]", "The ID of the book")
 
   response = library_client.get_book_from_absolutely_anywhere(formatted_name)
   puts "Archived book found."
@@ -6918,7 +7116,7 @@ def sample_discuss_book image_file_name, stage
 
   # image_file_name = "image_file.jpg"
   # stage = :DRAFT
-  formatted_name = library_client.class.book_path("[SHELF_ID]", "[BOOK_ID]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
   comment = File.binread "comment_file"
   comment_2 = { comment: comment, stage: stage }
   image = File.binread image_file_name
@@ -7110,7 +7308,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_shelf without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       options_ = ''
 
       # Create expected grpc response
@@ -7158,7 +7356,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_shelf with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       options_ = ''
 
       # Mock Grpc layer
@@ -7256,7 +7454,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_shelf without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7291,7 +7489,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_shelf with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7325,8 +7523,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes merge_shelves without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -7373,8 +7571,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes merge_shelves with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7409,7 +7607,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       book = {}
 
       # Create expected grpc response
@@ -7459,7 +7657,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       book = {}
 
       # Mock Grpc layer
@@ -7598,7 +7796,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -7646,7 +7844,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7680,7 +7878,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes list_books without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       filter = "book-filter-string"
 
       # Create expected grpc response
@@ -7720,7 +7918,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes list_books with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       filter = "book-filter-string"
 
       # Mock Grpc layer
@@ -7756,7 +7954,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7791,7 +7989,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7825,7 +8023,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       book = {}
 
       # Create expected grpc response
@@ -7875,7 +8073,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       book = {}
 
       # Mock Grpc layer
@@ -7911,8 +8109,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes move_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -7961,8 +8159,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes move_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8059,7 +8257,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_comments without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       comment = ''
       stage = :UNSET
       alignment = :CHAR
@@ -8107,7 +8305,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_comments with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       comment = ''
       stage = :UNSET
       alignment = :CHAR
@@ -8154,7 +8352,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_archive without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -8202,7 +8400,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_archive with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8236,8 +8434,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_anywhere without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -8286,8 +8484,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_anywhere with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8322,7 +8520,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_absolutely_anywhere without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -8370,7 +8568,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_absolutely_anywhere with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8404,7 +8602,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book_index without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       index_name = "default index"
       index_map_item = ''
       index_map = { "default_key" => index_map_item }
@@ -8452,7 +8650,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book_index with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       index_name = "default index"
       index_map_item = ''
       index_map = { "default_key" => index_map_item }
@@ -8495,7 +8693,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       shelves_element = {}
@@ -8530,7 +8728,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8640,7 +8838,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes discuss_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Create expected grpc response
@@ -8677,7 +8875,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes discuss_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -8713,7 +8911,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes monolog_about_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Create expected grpc response
@@ -8749,7 +8947,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes monolog_about_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -8922,7 +9120,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label without error' do
       # Create request parameters
-      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       label = ''
 
       # Create expected grpc response
@@ -8963,7 +9161,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label with error' do
       # Create request parameters
-      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       label = ''
 
       # Mock Grpc layer
@@ -8999,7 +9197,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -9047,7 +9245,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book and returns an operation error.' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
@@ -9086,7 +9284,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -9120,7 +9318,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       expected_response = {}
@@ -9159,7 +9357,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing and returns an operation error.' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
@@ -9198,7 +9396,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -9241,8 +9439,8 @@ describe Library::V1::LibraryServiceClient do
       required_singular_string = ''
       required_singular_bytes = ''
       required_singular_message = {}
-      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       formatted_required_singular_resource_name_common = Library::V1::LibraryServiceClient.project_path("[PROJECT]")
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0
@@ -9399,8 +9597,8 @@ describe Library::V1::LibraryServiceClient do
       required_singular_string = ''
       required_singular_bytes = ''
       required_singular_message = {}
-      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       formatted_required_singular_resource_name_common = Library::V1::LibraryServiceClient.project_path("[PROJECT]")
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0
@@ -9499,6 +9697,264 @@ describe Library::V1::LibraryServiceClient do
               required_repeated_fixed64,
               required_map
             )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'move_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#move_books."
+
+    it 'invokes move_books without error' do
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::MoveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:move_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("move_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.move_books
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.move_books do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes move_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:move_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("move_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.move_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#archive_books."
+
+    it 'invokes archive_books without error' do
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ArchiveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.archive_books
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.archive_books do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes archive_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.archive_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'long_running_archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#long_running_archive_books."
+
+    it 'invokes long_running_archive_books without error' do
+      # Create expected grpc response
+      name = "name3373707"
+      done = true
+      expected_response = { name: name, done: done }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Longrunning::Operation)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:long_running_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("long_running_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.long_running_archive_books
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.long_running_archive_books do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes long_running_archive_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:long_running_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("long_running_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.long_running_archive_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'streaming_archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#streaming_archive_books."
+
+    it 'invokes streaming_archive_books without error' do
+      # Create request parameters
+      request = {}
+
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ArchiveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do |requests|
+        request = requests.first
+        OpenStruct.new(execute: [expected_response])
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:streaming_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("streaming_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.streaming_archive_books([request])
+
+          # Verify the response
+          assert_equal(1, response.count)
+          assert_equal(expected_response, response.first)
+        end
+      end
+    end
+
+    it 'invokes streaming_archive_books with error' do
+      # Create request parameters
+      request = {}
+
+      # Mock Grpc layer
+      mock_method = proc do |requests|
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:streaming_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("streaming_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.streaming_archive_books([request])
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -534,7 +534,7 @@ namespace Google.Example.Library.V1.Samples
             while (!done)
             {
                 // Initialize a request
-                BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+                BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
                 Comment comment2 = new Comment
                 {
                     Comment = ByteString.CopyFrom(File.ReadAllBytes("comment_file")),
@@ -620,7 +620,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleDiscussBookAsync(string imageFileName, Comment.Types.Stage stage)
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             Comment comment2 = new Comment
             {
                 Comment = ByteString.CopyFrom(File.ReadAllBytes("comment_file")),
@@ -708,7 +708,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
@@ -780,7 +780,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
@@ -854,7 +854,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
@@ -932,7 +932,7 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                    BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
@@ -1007,7 +1007,7 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                    BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
@@ -1084,7 +1084,7 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                    BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
@@ -1160,7 +1160,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
@@ -1231,7 +1231,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
@@ -1305,7 +1305,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
@@ -1382,7 +1382,7 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                    BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
@@ -1456,7 +1456,7 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                    BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
@@ -1533,7 +1533,7 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                    BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
@@ -1608,7 +1608,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBigBookAsync(string shelf)
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "War and Peace"));
+            BookNameOneof name = BookNameOneof.From(new BookName(shelf, "War and Peace"));
             // Poll until the returned long-running operation is complete
             Operation<Book, GetBigBookMetadata> operation = await libraryServiceClient.GetBigBookAsync(name);
             Book response = (await operation.PollUntilCompletedAsync()).Result;
@@ -1696,7 +1696,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBigBookAsync(string shelf, string bigBookName)
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", bigBookName));
+            BookNameOneof name = BookNameOneof.From(new BookName(shelf, bigBookName));
             // Poll until the returned long-running operation is complete
             Operation<Book, GetBigBookMetadata> operation = await libraryServiceClient.GetBigBookAsync(name);
             Book response = (await operation.PollUntilCompletedAsync()).Result;
@@ -1771,7 +1771,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "War and Peace")),
+                BookNameOneof = BookNameOneof.From(new BookName(shelf, "War and Peace")),
             };
             // Poll until the returned long-running operation is complete
             Operation<Book, GetBigBookMetadata> operation = await libraryServiceClient.GetBigBookAsync(request);
@@ -1862,7 +1862,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", bigBookName)),
+                BookNameOneof = BookNameOneof.From(new BookName(shelf, bigBookName)),
             };
             // Poll until the returned long-running operation is complete
             Operation<Book, GetBigBookMetadata> operation = await libraryServiceClient.GetBigBookAsync(request);
@@ -1935,7 +1935,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBigBook(string shelf)
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "War and Peace"));
+            BookNameOneof name = BookNameOneof.From(new BookName(shelf, "War and Peace"));
             // Poll until the returned long-running operation is complete
             Book response = libraryServiceClient.GetBigBook(name).PollUntilCompleted().Result;
             // Testing iterating over map fields when both key and value are specified.
@@ -2021,7 +2021,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBigBook(string shelf, string bigBookName)
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", bigBookName));
+            BookNameOneof name = BookNameOneof.From(new BookName(shelf, bigBookName));
             // Poll until the returned long-running operation is complete
             Book response = libraryServiceClient.GetBigBook(name).PollUntilCompleted().Result;
             Console.WriteLine(response);
@@ -2094,7 +2094,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "War and Peace")),
+                BookNameOneof = BookNameOneof.From(new BookName(shelf, "War and Peace")),
             };
             // Poll until the returned long-running operation is complete
             Book response = libraryServiceClient.GetBigBook(request).PollUntilCompleted().Result;
@@ -2183,7 +2183,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", bigBookName)),
+                BookNameOneof = BookNameOneof.From(new BookName(shelf, bigBookName)),
             };
             // Poll until the returned long-running operation is complete
             Book response = libraryServiceClient.GetBigBook(request).PollUntilCompleted().Result;
@@ -2254,7 +2254,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBigNothingAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(name);
             await operation.PollUntilCompletedAsync();
@@ -2314,7 +2314,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBigNothingAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(name);
             await operation.PollUntilCompletedAsync();
@@ -2375,7 +2375,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(request);
@@ -2438,7 +2438,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(request);
@@ -2497,7 +2497,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBigNothing()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(name).PollUntilCompleted();
             // Got nothing
@@ -2555,7 +2555,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBigNothing()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(name).PollUntilCompleted();
         }
@@ -2614,7 +2614,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(request).PollUntilCompleted();
@@ -2675,7 +2675,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(request).PollUntilCompleted();
@@ -2736,7 +2736,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBookAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             Book response = await libraryServiceClient.GetBookAsync(name);
             string intKeyVal = response.MapStringValue[123];
             string booleanKeyVal = response.MapBoolKey[true];
@@ -2802,7 +2802,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             Book response = await libraryServiceClient.GetBookAsync(request);
             string intKeyVal = response.MapStringValue[123];
@@ -2866,7 +2866,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBook()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             Book response = libraryServiceClient.GetBook(name);
             string intKeyVal = response.MapStringValue[123];
             string booleanKeyVal = response.MapBoolKey[true];
@@ -2931,7 +2931,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             Book response = libraryServiceClient.GetBook(request);
             string intKeyVal = response.MapStringValue[123];
@@ -4210,8 +4210,8 @@ namespace Google.Example.Library.V1.Samples
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "",
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -4328,7 +4328,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "The ID of the book")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "The ID of the book")),
             };
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
             Console.WriteLine("Archived book found.");
@@ -4384,7 +4384,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "The ID of the book")),
+                BookNameOneof = BookNameOneof.From(new BookName("The Shelf to search for the book", "The ID of the book")),
             };
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
             Console.WriteLine("Book on shelf found.");
@@ -4509,7 +4509,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "War and Peace")),
+                BookNameOneof = BookNameOneof.From(new BookName(shelf, "War and Peace")),
             };
             // Poll until the returned long-running operation is complete
             Book response = libraryServiceClient.GetBigBook(request).PollUntilCompleted().Result;
@@ -4623,7 +4623,7 @@ namespace Google.Example.Library.V1.Samples
                 // Initialize a request
                 DiscussBookRequest request = new DiscussBookRequest
                 {
-                    BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                    BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                     Comment = new Comment
                     {
                         Comment = ByteString.CopyFrom(File.ReadAllBytes("comment_file")),
@@ -4712,7 +4712,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             DiscussBookRequest request = new DiscussBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Comment = new Comment
                 {
                     Comment = ByteString.CopyFrom(File.ReadAllBytes("comment_file")),
@@ -4819,7 +4819,7 @@ namespace Google.Example.Library.V1.SmokeTests
             LibraryServiceClient client = LibraryServiceClient.Create();
 
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", projectId));
+            BookNameOneof name = BookNameOneof.From(new BookName($"testShelf-{Guid.NewGuid()}", projectId));
             Book book = new Book
             {
                 Rating = Book.Types.Rating.Good,
@@ -5525,7 +5525,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             Book response = await libraryServiceClient.GetBookAsync(name);
             // End snippet
@@ -5538,7 +5538,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             Book response = libraryServiceClient.GetBook(name);
             // End snippet
@@ -5554,7 +5554,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             Book response = await libraryServiceClient.GetBookAsync(request);
@@ -5570,7 +5570,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             Book response = libraryServiceClient.GetBook(request);
@@ -5771,7 +5771,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             await libraryServiceClient.DeleteBookAsync(name);
             // End snippet
@@ -5784,7 +5784,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             libraryServiceClient.DeleteBook(name);
             // End snippet
@@ -5800,7 +5800,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             await libraryServiceClient.DeleteBookAsync(request);
@@ -5816,7 +5816,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             libraryServiceClient.DeleteBook(request);
@@ -5831,7 +5831,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             Book book = new Book();
             // Make the request
             Book response = await libraryServiceClient.UpdateBookAsync(name, book);
@@ -5845,7 +5845,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             Book book = new Book();
             // Make the request
             Book response = libraryServiceClient.UpdateBook(name, book);
@@ -5860,7 +5860,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string optionalFoo = "";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -5877,7 +5877,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string optionalFoo = "";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -5897,7 +5897,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Book = new Book(),
             };
             // Make the request
@@ -5914,7 +5914,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Book = new Book(),
             };
             // Make the request
@@ -5930,7 +5930,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Book response = await libraryServiceClient.MoveBookAsync(name, otherShelfName);
@@ -5944,7 +5944,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Book response = libraryServiceClient.MoveBook(name, otherShelfName);
@@ -5961,7 +5961,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MoveBookRequest request = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
@@ -5978,7 +5978,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MoveBookRequest request = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
@@ -6254,7 +6254,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -6276,7 +6276,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -6301,7 +6301,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -6326,7 +6326,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -6414,8 +6414,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof altBookName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof altBookName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             // Make the request
@@ -6430,8 +6430,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof altBookName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof altBookName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             // Make the request
@@ -6449,8 +6449,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
@@ -6468,8 +6468,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
@@ -6486,7 +6486,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             BookFromAnywhere response = await libraryServiceClient.GetBookFromAbsolutelyAnywhereAsync(name);
             // End snippet
@@ -6499,7 +6499,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(name);
             // End snippet
@@ -6515,7 +6515,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             BookFromAnywhere response = await libraryServiceClient.GetBookFromAbsolutelyAnywhereAsync(request);
@@ -6531,7 +6531,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
@@ -6546,7 +6546,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -6564,7 +6564,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -6585,7 +6585,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -6606,7 +6606,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -6699,7 +6699,7 @@ namespace Google.Example.Library.V1.Snippets
                 // Initialize a request
                 DiscussBookRequest request = new DiscussBookRequest
                 {
-                    BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                    BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 };
                 // Stream a request to the server
                 await duplexStream.WriteAsync(request);
@@ -6723,7 +6723,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new List<ShelfName>();
             // Make the request
@@ -6771,7 +6771,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new List<ShelfName>();
             // Make the request
@@ -6821,7 +6821,7 @@ namespace Google.Example.Library.V1.Snippets
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                    BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames = { },
             };
@@ -6872,7 +6872,7 @@ namespace Google.Example.Library.V1.Snippets
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                    BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames = { },
             };
@@ -6922,7 +6922,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                ResourceAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                ResourceAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Label = "",
             };
             // Make the request
@@ -6939,7 +6939,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                ResourceAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                ResourceAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Label = "",
             };
             // Make the request
@@ -6955,7 +6955,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
                 await libraryServiceClient.GetBigBookAsync(name);
@@ -6987,7 +6987,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
                 libraryServiceClient.GetBigBook(name);
@@ -7021,7 +7021,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
@@ -7056,7 +7056,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
@@ -7090,7 +7090,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
                 await libraryServiceClient.GetBigNothingAsync(name);
@@ -7120,7 +7120,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
                 libraryServiceClient.GetBigNothing(name);
@@ -7152,7 +7152,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
@@ -7185,7 +7185,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
@@ -7249,8 +7249,8 @@ namespace Google.Example.Library.V1.Snippets
             string requiredSingularString = "";
             ByteString requiredSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string requiredSingularResourceNameCommon = "";
             int requiredSingularFixed32 = 0;
             long requiredSingularFixed64 = 0L;
@@ -7310,8 +7310,8 @@ namespace Google.Example.Library.V1.Snippets
             string optionalSingularString = "";
             ByteString optionalSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string optionalSingularResourceNameCommon = "";
             int optionalSingularFixed32 = 0;
             long optionalSingularFixed64 = 0L;
@@ -7383,8 +7383,8 @@ namespace Google.Example.Library.V1.Snippets
             string requiredSingularString = "";
             ByteString requiredSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string requiredSingularResourceNameCommon = "";
             int requiredSingularFixed32 = 0;
             long requiredSingularFixed64 = 0L;
@@ -7444,8 +7444,8 @@ namespace Google.Example.Library.V1.Snippets
             string optionalSingularString = "";
             ByteString optionalSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string optionalSingularResourceNameCommon = "";
             int optionalSingularFixed32 = 0;
             long optionalSingularFixed64 = 0L;
@@ -7520,8 +7520,8 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "",
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -7596,8 +7596,8 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "",
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -8666,7 +8666,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8696,7 +8696,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8726,7 +8726,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8754,7 +8754,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8925,11 +8925,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest expectedRequest = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8937,7 +8937,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             Book response = client.GetBook(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -8953,11 +8953,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest expectedRequest = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8965,7 +8965,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             Book response = await client.GetBookAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -8981,11 +8981,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9008,11 +9008,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9035,13 +9035,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest expectedRequest = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             client.DeleteBook(name);
             mockGrpcClient.VerifyAll();
         }
@@ -9056,13 +9056,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest expectedRequest = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             await client.DeleteBookAsync(name);
             mockGrpcClient.VerifyAll();
         }
@@ -9077,7 +9077,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBook(request, It.IsAny<CallOptions>()))
@@ -9097,7 +9097,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBookAsync(request, It.IsAny<CallOptions>()))
@@ -9117,12 +9117,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9130,7 +9130,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             Book book = new Book();
             Book response = client.UpdateBook(name, book);
             Assert.Same(expectedResponse, response);
@@ -9147,12 +9147,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9160,7 +9160,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             Book book = new Book();
             Book response = await client.UpdateBookAsync(name, book);
             Assert.Same(expectedResponse, response);
@@ -9177,7 +9177,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OptionalFoo = "optionalFoo1822578535",
                 Book = new Book(),
                 UpdateMask = new FieldMask(),
@@ -9185,7 +9185,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9193,7 +9193,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string optionalFoo = "optionalFoo1822578535";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -9213,7 +9213,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OptionalFoo = "optionalFoo1822578535",
                 Book = new Book(),
                 UpdateMask = new FieldMask(),
@@ -9221,7 +9221,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9229,7 +9229,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string optionalFoo = "optionalFoo1822578535";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -9249,12 +9249,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9277,12 +9277,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9305,12 +9305,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest expectedRequest = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9318,7 +9318,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.MoveBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ShelfName otherShelfName = new ShelfName("[SHELF]");
             Book response = client.MoveBook(name, otherShelfName);
             Assert.Same(expectedResponse, response);
@@ -9335,12 +9335,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest expectedRequest = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9348,7 +9348,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.MoveBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             ShelfName otherShelfName = new ShelfName("[SHELF]");
             Book response = await client.MoveBookAsync(name, otherShelfName);
             Assert.Same(expectedResponse, response);
@@ -9365,12 +9365,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest request = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9393,12 +9393,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest request = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9421,7 +9421,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest expectedRequest = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -9436,7 +9436,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.AddComments(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -9460,7 +9460,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest expectedRequest = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -9475,7 +9475,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.AddCommentsAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -9499,7 +9499,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -9528,7 +9528,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -9673,14 +9673,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest expectedRequest = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9688,8 +9688,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAnywhere(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof altBookName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof altBookName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             BookFromAnywhere response = client.GetBookFromAnywhere(name, altBookName, place, folder);
@@ -9707,14 +9707,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest expectedRequest = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9722,8 +9722,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAnywhereAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<BookFromAnywhere>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof altBookName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof altBookName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             BookFromAnywhere response = await client.GetBookFromAnywhereAsync(name, altBookName, place, folder);
@@ -9741,14 +9741,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9771,14 +9771,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9801,11 +9801,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest expectedRequest = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9813,7 +9813,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAbsolutelyAnywhere(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             BookFromAnywhere response = client.GetBookFromAbsolutelyAnywhere(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -9829,11 +9829,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest expectedRequest = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9841,7 +9841,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAbsolutelyAnywhereAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<BookFromAnywhere>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             BookFromAnywhere response = await client.GetBookFromAbsolutelyAnywhereAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -9857,11 +9857,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9884,11 +9884,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9911,7 +9911,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest expectedRequest = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -9922,7 +9922,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookIndex(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -9942,7 +9942,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest expectedRequest = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -9953,7 +9953,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookIndexAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -9973,7 +9973,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -9998,7 +9998,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -10070,8 +10070,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002",
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -10131,8 +10131,8 @@ namespace Google.Example.Library.V1.Tests
                 OptionalSingularString = "optionalSingularString1852995162",
                 OptionalSingularBytes = ByteString.CopyFromUtf8("2"),
                 OptionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                OptionalSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                OptionalSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OptionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657",
                 OptionalSingularFixed32 = 1648847958,
                 OptionalSingularFixed64 = 1648847863,
@@ -10197,8 +10197,8 @@ namespace Google.Example.Library.V1.Tests
             string requiredSingularString = "requiredSingularString-1949894503";
             ByteString requiredSingularBytes = ByteString.CopyFromUtf8("-29");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
             int requiredSingularFixed32 = 720656715;
             long requiredSingularFixed64 = 720656810;
@@ -10258,8 +10258,8 @@ namespace Google.Example.Library.V1.Tests
             string optionalSingularString = "optionalSingularString1852995162";
             ByteString optionalSingularBytes = ByteString.CopyFromUtf8("2");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
             int optionalSingularFixed32 = 1648847958;
             long optionalSingularFixed64 = 1648847863;
@@ -10334,8 +10334,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002",
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -10395,8 +10395,8 @@ namespace Google.Example.Library.V1.Tests
                 OptionalSingularString = "optionalSingularString1852995162",
                 OptionalSingularBytes = ByteString.CopyFromUtf8("2"),
                 OptionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                OptionalSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                OptionalSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 OptionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657",
                 OptionalSingularFixed32 = 1648847958,
                 OptionalSingularFixed64 = 1648847863,
@@ -10461,8 +10461,8 @@ namespace Google.Example.Library.V1.Tests
             string requiredSingularString = "requiredSingularString-1949894503";
             ByteString requiredSingularBytes = ByteString.CopyFromUtf8("-29");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
             int requiredSingularFixed32 = 720656715;
             long requiredSingularFixed64 = 720656810;
@@ -10522,8 +10522,8 @@ namespace Google.Example.Library.V1.Tests
             string optionalSingularString = "optionalSingularString1852995162";
             ByteString optionalSingularBytes = ByteString.CopyFromUtf8("2");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
             string optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
             int optionalSingularFixed32 = 1648847958;
             long optionalSingularFixed64 = 1648847863;
@@ -10598,8 +10598,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002",
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -10679,8 +10679,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002",
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -10952,7 +10952,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest expectedRequest = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -10977,7 +10977,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest expectedRequest = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -11002,7 +11002,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest request = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -11026,7 +11026,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest request = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -24075,6 +24075,105 @@ namespace Google.Example.Library.V1
     }
 
     /// <summary>
+    /// Resource name for the 'book' resource.
+    /// </summary>
+    public sealed partial class BookName : gax::IResourceName, sys::IEquatable<BookName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("shelves/{shelf}/books/{book}");
+
+        /// <summary>
+        /// Parses the given book resource name in string form into a new
+        /// <see cref="BookName"/> instance.
+        /// </summary>
+        /// <param name="bookName">The book resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="BookName"/> if successful.</returns>
+        public static BookName Parse(string bookName)
+        {
+            gax::GaxPreconditions.CheckNotNull(bookName, nameof(bookName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(bookName);
+            return new BookName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given book resource name in string form into a new
+        /// <see cref="BookName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="bookName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="bookName">The book resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="BookName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string bookName, out BookName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(bookName, nameof(bookName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(bookName, out resourceName))
+            {
+                result = new BookName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>Formats the IDs into the string representation of the <see cref="BookName"/>.</summary>
+        /// <param name="shelfId">The <c>shelf</c> ID. Must not be <c>null</c>.</param>
+        /// <param name="bookId">The <c>book</c> ID. Must not be <c>null</c>.</param>
+        /// <returns>The string representation of the <see cref="BookName"/>.</returns>
+        public static string Format(string shelfId, string bookId) =>
+            s_template.Expand(gax::GaxPreconditions.CheckNotNull(shelfId, nameof(shelfId)), gax::GaxPreconditions.CheckNotNull(bookId, nameof(bookId)));
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="BookName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="shelfId">The shelf ID. Must not be <c>null</c>.</param>
+        /// <param name="bookId">The book ID. Must not be <c>null</c>.</param>
+        public BookName(string shelfId, string bookId)
+        {
+            ShelfId = gax::GaxPreconditions.CheckNotNull(shelfId, nameof(shelfId));
+            BookId = gax::GaxPreconditions.CheckNotNull(bookId, nameof(bookId));
+        }
+
+        /// <summary>
+        /// The shelf ID. Never <c>null</c>.
+        /// </summary>
+        public string ShelfId { get; }
+
+        /// <summary>
+        /// The book ID. Never <c>null</c>.
+        /// </summary>
+        public string BookId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ShelfId, BookId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as BookName);
+
+        /// <inheritdoc />
+        public bool Equals(BookName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(BookName a, BookName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(BookName a, BookName b) => !(a == b);
+    }
+
+    /// <summary>
     /// Resource name for the 'book_from_archive' resource.
     /// </summary>
     public sealed partial class BookFromArchiveName : gax::IResourceName, sys::IEquatable<BookFromArchiveName>
@@ -24179,6 +24278,7 @@ namespace Google.Example.Library.V1
     /// <remarks>
     /// This resource name will contain one of the following:
     /// <list type="bullet">
+    /// <item><description>BookName: A resource of type 'book'.</description></item>
     /// <item><description>BookFromArchiveName: A resource of type 'book_from_archive'.</description></item>
     /// <item><description>ProjectBookName: A resource of type 'project_book'.</description></item>
     /// </list>
@@ -24196,14 +24296,19 @@ namespace Google.Example.Library.V1
             Unknown = 0,
 
             /// <summary>
+            /// A resource of type 'book'.
+            /// </summary>
+            BookName = 1,
+
+            /// <summary>
             /// A resource of type 'book_from_archive'.
             /// </summary>
-            BookFromArchiveName = 1,
+            BookFromArchiveName = 2,
 
             /// <summary>
             /// A resource of type 'project_book'.
             /// </summary>
-            ProjectBookName = 2,
+            ProjectBookName = 3,
         }
 
         /// <summary>
@@ -24212,6 +24317,7 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// To parse successfully the resource name must be one of the following:
         /// <list type="bullet">
+        /// <item><description>BookName: A resource of type 'book'.</description></item>
         /// <item><description>BookFromArchiveName: A resource of type 'book_from_archive'.</description></item>
         /// <item><description>ProjectBookName: A resource of type 'project_book'.</description></item>
         /// </list>
@@ -24238,6 +24344,7 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// To parse successfully the resource name must be one of the following:
         /// <list type="bullet">
+        /// <item><description>BookName: A resource of type 'book'.</description></item>
         /// <item><description>BookFromArchiveName: A resource of type 'book_from_archive'.</description></item>
         /// <item><description>ProjectBookName: A resource of type 'project_book'.</description></item>
         /// </list>
@@ -24252,6 +24359,12 @@ namespace Google.Example.Library.V1
         public static bool TryParse(string name, bool allowUnknown, out BookNameOneof result)
         {
             gax::GaxPreconditions.CheckNotNull(name, nameof(name));
+            BookName bookName;
+            if (BookName.TryParse(name, out bookName))
+            {
+                result = new BookNameOneof(OneofType.BookName, bookName);
+                return true;
+            }
             BookFromArchiveName bookFromArchiveName;
             if (BookFromArchiveName.TryParse(name, out bookFromArchiveName))
             {
@@ -24278,6 +24391,14 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
+        /// Construct a new instance of <see cref="BookNameOneof"/> from the provided <see cref="BookName"/>
+        /// </summary>
+        /// <param name="bookName">The <see cref="BookName"/> to be contained within
+        /// the returned <see cref="BookNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="BookNameOneof"/>, containing <paramref name="bookName"/>.</returns>
+        public static BookNameOneof From(BookName bookName) => new BookNameOneof(OneofType.BookName, bookName);
+
+        /// <summary>
         /// Construct a new instance of <see cref="BookNameOneof"/> from the provided <see cref="BookFromArchiveName"/>
         /// </summary>
         /// <param name="bookFromArchiveName">The <see cref="BookFromArchiveName"/> to be contained within
@@ -24298,6 +24419,7 @@ namespace Google.Example.Library.V1
             switch (type)
             {
                 case OneofType.Unknown: return true; // Anything goes with Unknown.
+                case OneofType.BookName: return name is BookName;
                 case OneofType.BookFromArchiveName: return name is BookFromArchiveName;
                 case OneofType.ProjectBookName: return name is ProjectBookName;
                 default: return false;
@@ -24336,6 +24458,15 @@ namespace Google.Example.Library.V1
             }
             return (T)Name;
         }
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BookName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="BookName"/>.
+        /// </remarks>
+        public BookName BookName => CheckAndReturn<BookName>(OneofType.BookName);
 
         /// <summary>
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BookFromArchiveName"/>.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -39,7 +39,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleDeleteShelfAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             await libraryServiceClient.DeleteShelfAsync(name);
             // Shelf deleted
             Console.WriteLine("Shelf deleted.");
@@ -97,7 +97,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleDeleteShelfAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             await libraryServiceClient.DeleteShelfAsync(name);
         }
     }
@@ -156,7 +156,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             await libraryServiceClient.DeleteShelfAsync(request);
             // Shelf deleted
@@ -217,7 +217,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             await libraryServiceClient.DeleteShelfAsync(request);
         }
@@ -274,7 +274,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleDeleteShelf()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             libraryServiceClient.DeleteShelf(name);
             // Shelf deleted
             Console.WriteLine("Shelf deleted.");
@@ -331,7 +331,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleDeleteShelf()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             libraryServiceClient.DeleteShelf(name);
         }
     }
@@ -389,7 +389,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             libraryServiceClient.DeleteShelf(request);
             // Shelf deleted
@@ -449,7 +449,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             libraryServiceClient.DeleteShelf(request);
         }
@@ -534,7 +534,7 @@ namespace Google.Example.Library.V1.Samples
             while (!done)
             {
                 // Initialize a request
-                BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+                BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
                 Comment comment2 = new Comment
                 {
                     Comment = ByteString.CopyFrom(File.ReadAllBytes("comment_file")),
@@ -620,7 +620,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleDiscussBookAsync(string imageFileName, Comment.Types.Stage stage)
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             Comment comment2 = new Comment
             {
                 Comment = ByteString.CopyFrom(File.ReadAllBytes("comment_file")),
@@ -708,11 +708,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookNameOneof> response = await libraryServiceClient.FindRelatedBooksAsync(names, shelves);
             // Iterate over pages (of server-defined size), performing one RPC per page
@@ -780,11 +780,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookNameOneof> response = await libraryServiceClient.FindRelatedBooksAsync(names, shelves);
             // Iterate over all response items, lazily performing RPCs as required
@@ -854,11 +854,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookNameOneof> response = await libraryServiceClient.FindRelatedBooksAsync(names, shelves);
             // Retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
@@ -932,11 +932,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookNameOneof> response = await libraryServiceClient.FindRelatedBooksAsync(request);
@@ -1007,11 +1007,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookNameOneof> response = await libraryServiceClient.FindRelatedBooksAsync(request);
@@ -1084,11 +1084,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedAsyncEnumerable<FindRelatedBooksResponse, BookNameOneof> response = await libraryServiceClient.FindRelatedBooksAsync(request);
@@ -1160,11 +1160,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedEnumerable<FindRelatedBooksResponse, BookNameOneof> response = libraryServiceClient.FindRelatedBooks(names, shelves);
             // Iterate over pages (of server-defined size), performing one RPC per page
@@ -1231,11 +1231,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedEnumerable<FindRelatedBooksResponse, BookNameOneof> response = libraryServiceClient.FindRelatedBooks(names, shelves);
             // Iterate over all response items, lazily performing RPCs as required
@@ -1305,11 +1305,11 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new[]
             {
-                new ShelfName("[SHELF_ID]"),
+                new ShelfName("[SHELF]"),
             };
             PagedEnumerable<FindRelatedBooksResponse, BookNameOneof> response = libraryServiceClient.FindRelatedBooks(names, shelves);
             // Retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
@@ -1382,11 +1382,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedEnumerable<FindRelatedBooksResponse, BookNameOneof> response = libraryServiceClient.FindRelatedBooks(request);
@@ -1456,11 +1456,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedEnumerable<FindRelatedBooksResponse, BookNameOneof> response = libraryServiceClient.FindRelatedBooks(request);
@@ -1533,11 +1533,11 @@ namespace Google.Example.Library.V1.Samples
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames =
                 {
-                    new ShelfName("[SHELF_ID]"),
+                    new ShelfName("[SHELF]"),
                 },
             };
             PagedEnumerable<FindRelatedBooksResponse, BookNameOneof> response = libraryServiceClient.FindRelatedBooks(request);
@@ -1608,7 +1608,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBigBookAsync(string shelf)
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "War and Peace"));
             // Poll until the returned long-running operation is complete
             Operation<Book, GetBigBookMetadata> operation = await libraryServiceClient.GetBigBookAsync(name);
             Book response = (await operation.PollUntilCompletedAsync()).Result;
@@ -1696,7 +1696,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBigBookAsync(string shelf, string bigBookName)
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", bigBookName));
             // Poll until the returned long-running operation is complete
             Operation<Book, GetBigBookMetadata> operation = await libraryServiceClient.GetBigBookAsync(name);
             Book response = (await operation.PollUntilCompletedAsync()).Result;
@@ -1771,7 +1771,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "War and Peace")),
             };
             // Poll until the returned long-running operation is complete
             Operation<Book, GetBigBookMetadata> operation = await libraryServiceClient.GetBigBookAsync(request);
@@ -1862,7 +1862,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", bigBookName)),
             };
             // Poll until the returned long-running operation is complete
             Operation<Book, GetBigBookMetadata> operation = await libraryServiceClient.GetBigBookAsync(request);
@@ -1935,7 +1935,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBigBook(string shelf)
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "War and Peace"));
             // Poll until the returned long-running operation is complete
             Book response = libraryServiceClient.GetBigBook(name).PollUntilCompleted().Result;
             // Testing iterating over map fields when both key and value are specified.
@@ -2021,7 +2021,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBigBook(string shelf, string bigBookName)
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", bigBookName));
             // Poll until the returned long-running operation is complete
             Book response = libraryServiceClient.GetBigBook(name).PollUntilCompleted().Result;
             Console.WriteLine(response);
@@ -2094,7 +2094,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "War and Peace")),
             };
             // Poll until the returned long-running operation is complete
             Book response = libraryServiceClient.GetBigBook(request).PollUntilCompleted().Result;
@@ -2183,7 +2183,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", bigBookName)),
             };
             // Poll until the returned long-running operation is complete
             Book response = libraryServiceClient.GetBigBook(request).PollUntilCompleted().Result;
@@ -2254,7 +2254,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBigNothingAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(name);
             await operation.PollUntilCompletedAsync();
@@ -2314,7 +2314,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBigNothingAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(name);
             await operation.PollUntilCompletedAsync();
@@ -2375,7 +2375,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(request);
@@ -2438,7 +2438,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Poll until the returned long-running operation is complete
             Operation<Empty, GetBigBookMetadata> operation = await libraryServiceClient.GetBigNothingAsync(request);
@@ -2497,7 +2497,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBigNothing()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(name).PollUntilCompleted();
             // Got nothing
@@ -2555,7 +2555,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBigNothing()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(name).PollUntilCompleted();
         }
@@ -2614,7 +2614,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(request).PollUntilCompleted();
@@ -2675,7 +2675,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Poll until the returned long-running operation is complete
             libraryServiceClient.GetBigNothing(request).PollUntilCompleted();
@@ -2736,7 +2736,7 @@ namespace Google.Example.Library.V1.Samples
         public static async Task SampleGetBookAsync()
         {
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             Book response = await libraryServiceClient.GetBookAsync(name);
             string intKeyVal = response.MapStringValue[123];
             string booleanKeyVal = response.MapBoolKey[true];
@@ -2802,7 +2802,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             Book response = await libraryServiceClient.GetBookAsync(request);
             string intKeyVal = response.MapStringValue[123];
@@ -2866,7 +2866,7 @@ namespace Google.Example.Library.V1.Samples
         public static void SampleGetBook()
         {
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             Book response = libraryServiceClient.GetBook(name);
             string intKeyVal = response.MapStringValue[123];
             string booleanKeyVal = response.MapBoolKey[true];
@@ -2931,7 +2931,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             Book response = libraryServiceClient.GetBook(request);
             string intKeyVal = response.MapStringValue[123];
@@ -4001,7 +4001,7 @@ namespace Google.Example.Library.V1.Samples
                 // Initialize a request
                 StreamShelvesRequest request = new StreamShelvesRequest
                 {
-                    ShelfName = new ShelfName("[SHELF_ID]"),
+                    ShelfName = new ShelfName("[SHELF]"),
                 };
                 // Stream a request to the server
                 await duplexStream.WriteAsync(request);
@@ -4071,7 +4071,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             StreamShelvesRequest request = new StreamShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
 
             // Make the request, returning a streaming response
@@ -4210,8 +4210,8 @@ namespace Google.Example.Library.V1.Samples
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "",
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -4328,7 +4328,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "The ID of the book")),
             };
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
             Console.WriteLine("Archived book found.");
@@ -4384,7 +4384,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "The ID of the book")),
             };
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
             Console.WriteLine("Book on shelf found.");
@@ -4509,7 +4509,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "War and Peace")),
             };
             // Poll until the returned long-running operation is complete
             Book response = libraryServiceClient.GetBigBook(request).PollUntilCompleted().Result;
@@ -4623,7 +4623,7 @@ namespace Google.Example.Library.V1.Samples
                 // Initialize a request
                 DiscussBookRequest request = new DiscussBookRequest
                 {
-                    BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                    BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                     Comment = new Comment
                     {
                         Comment = ByteString.CopyFrom(File.ReadAllBytes("comment_file")),
@@ -4712,7 +4712,7 @@ namespace Google.Example.Library.V1.Samples
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             DiscussBookRequest request = new DiscussBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Comment = new Comment
                 {
                     Comment = ByteString.CopyFrom(File.ReadAllBytes("comment_file")),
@@ -4806,11 +4806,20 @@ namespace Google.Example.Library.V1.SmokeTests
     {
         public static int Main(string[] args)
         {
+            // Read projectId from args
+            if (args.Length != 1)
+            {
+                Console.WriteLine("Usage: Project ID must be passed as first argument.");
+                Console.WriteLine();
+                return 1;
+            }
+            string projectId = args[0];
+
             // Create client
             LibraryServiceClient client = LibraryServiceClient.Create();
 
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", projectId));
             Book book = new Book
             {
                 Rating = Book.Types.Rating.Good,
@@ -4950,7 +4959,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = await libraryServiceClient.GetShelfAsync(name);
             // End snippet
@@ -4963,7 +4972,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = libraryServiceClient.GetShelf(name);
             // End snippet
@@ -4977,7 +4986,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             // Make the request
             Shelf response = await libraryServiceClient.GetShelfAsync(name, message);
@@ -4991,7 +5000,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             // Make the request
             Shelf response = libraryServiceClient.GetShelf(name, message);
@@ -5006,7 +5015,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             // Make the request
@@ -5021,7 +5030,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             // Make the request
@@ -5039,7 +5048,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "",
             };
             // Make the request
@@ -5056,7 +5065,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "",
             };
             // Make the request
@@ -5244,7 +5253,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             await libraryServiceClient.DeleteShelfAsync(name);
             // End snippet
@@ -5257,7 +5266,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             // Make the request
             libraryServiceClient.DeleteShelf(name);
             // End snippet
@@ -5273,7 +5282,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             await libraryServiceClient.DeleteShelfAsync(request);
@@ -5289,7 +5298,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             libraryServiceClient.DeleteShelf(request);
@@ -5304,8 +5313,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = await libraryServiceClient.MergeShelvesAsync(name, otherShelfName);
             // End snippet
@@ -5318,8 +5327,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Shelf response = libraryServiceClient.MergeShelves(name, otherShelfName);
             // End snippet
@@ -5335,8 +5344,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Shelf response = await libraryServiceClient.MergeShelvesAsync(request);
@@ -5352,8 +5361,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Shelf response = libraryServiceClient.MergeShelves(request);
@@ -5368,7 +5377,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             // Make the request
             Book response = await libraryServiceClient.CreateBookAsync(name, book);
@@ -5382,7 +5391,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             // Make the request
             Book response = libraryServiceClient.CreateBook(name, book);
@@ -5399,7 +5408,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             // Make the request
@@ -5416,7 +5425,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             // Make the request
@@ -5516,7 +5525,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Make the request
             Book response = await libraryServiceClient.GetBookAsync(name);
             // End snippet
@@ -5529,7 +5538,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Make the request
             Book response = libraryServiceClient.GetBook(name);
             // End snippet
@@ -5545,7 +5554,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Make the request
             Book response = await libraryServiceClient.GetBookAsync(request);
@@ -5561,7 +5570,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Make the request
             Book response = libraryServiceClient.GetBook(request);
@@ -5575,7 +5584,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             string filter = "book-filter-string";
             // Make the request
             PagedAsyncEnumerable<ListBooksResponse, Book> response =
@@ -5620,7 +5629,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             string filter = "book-filter-string";
             // Make the request
             PagedEnumerable<ListBooksResponse, Book> response =
@@ -5667,7 +5676,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             ListBooksRequest request = new ListBooksRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Filter = "book-filter-string",
             };
             // Make the request
@@ -5715,7 +5724,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             ListBooksRequest request = new ListBooksRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Filter = "book-filter-string",
             };
             // Make the request
@@ -5762,7 +5771,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Make the request
             await libraryServiceClient.DeleteBookAsync(name);
             // End snippet
@@ -5775,7 +5784,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Make the request
             libraryServiceClient.DeleteBook(name);
             // End snippet
@@ -5791,7 +5800,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Make the request
             await libraryServiceClient.DeleteBookAsync(request);
@@ -5807,7 +5816,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Make the request
             libraryServiceClient.DeleteBook(request);
@@ -5822,7 +5831,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             Book book = new Book();
             // Make the request
             Book response = await libraryServiceClient.UpdateBookAsync(name, book);
@@ -5836,7 +5845,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             Book book = new Book();
             // Make the request
             Book response = libraryServiceClient.UpdateBook(name, book);
@@ -5851,7 +5860,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string optionalFoo = "";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -5868,7 +5877,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string optionalFoo = "";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -5888,7 +5897,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Book = new Book(),
             };
             // Make the request
@@ -5905,7 +5914,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Book = new Book(),
             };
             // Make the request
@@ -5921,8 +5930,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Book response = await libraryServiceClient.MoveBookAsync(name, otherShelfName);
             // End snippet
@@ -5935,8 +5944,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             // Make the request
             Book response = libraryServiceClient.MoveBook(name, otherShelfName);
             // End snippet
@@ -5952,8 +5961,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MoveBookRequest request = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Book response = await libraryServiceClient.MoveBookAsync(request);
@@ -5969,8 +5978,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             MoveBookRequest request = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request
             Book response = libraryServiceClient.MoveBook(request);
@@ -6245,7 +6254,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -6267,7 +6276,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -6292,7 +6301,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -6317,7 +6326,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -6405,8 +6414,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof altBookName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof altBookName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             // Make the request
@@ -6421,8 +6430,8 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof altBookName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof altBookName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             // Make the request
@@ -6440,8 +6449,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
@@ -6459,8 +6468,8 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
@@ -6477,7 +6486,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Make the request
             BookFromAnywhere response = await libraryServiceClient.GetBookFromAbsolutelyAnywhereAsync(name);
             // End snippet
@@ -6490,7 +6499,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Make the request
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(name);
             // End snippet
@@ -6506,7 +6515,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Make the request
             BookFromAnywhere response = await libraryServiceClient.GetBookFromAbsolutelyAnywhereAsync(request);
@@ -6522,7 +6531,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Make the request
             BookFromAnywhere response = libraryServiceClient.GetBookFromAbsolutelyAnywhere(request);
@@ -6537,7 +6546,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -6555,7 +6564,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -6576,7 +6585,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -6597,7 +6606,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -6618,7 +6627,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument
             StreamShelvesRequest request = new StreamShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             // Make the request, returning a streaming response
             LibraryServiceClient.StreamShelvesStream streamingResponse = libraryServiceClient.StreamShelves(request);
@@ -6690,7 +6699,7 @@ namespace Google.Example.Library.V1.Snippets
                 // Initialize a request
                 DiscussBookRequest request = new DiscussBookRequest
                 {
-                    BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                    BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 };
                 // Stream a request to the server
                 await duplexStream.WriteAsync(request);
@@ -6714,7 +6723,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new List<ShelfName>();
             // Make the request
@@ -6762,7 +6771,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             IEnumerable<BookNameOneof> names = new[]
             {
-                BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             IEnumerable<ShelfName> shelves = new List<ShelfName>();
             // Make the request
@@ -6812,7 +6821,7 @@ namespace Google.Example.Library.V1.Snippets
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames = { },
             };
@@ -6863,7 +6872,7 @@ namespace Google.Example.Library.V1.Snippets
             {
                 BookNameOneofs =
                 {
-                    BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                    BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 },
                 ShelvesAsShelfNames = { },
             };
@@ -6913,7 +6922,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                ResourceAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                ResourceAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Label = "",
             };
             // Make the request
@@ -6930,7 +6939,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                ResourceAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                ResourceAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Label = "",
             };
             // Make the request
@@ -6946,7 +6955,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
                 await libraryServiceClient.GetBigBookAsync(name);
@@ -6978,7 +6987,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
                 libraryServiceClient.GetBigBook(name);
@@ -7012,7 +7021,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
@@ -7047,7 +7056,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Make the request
             Operation<Book, GetBigBookMetadata> response =
@@ -7081,7 +7090,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
                 await libraryServiceClient.GetBigNothingAsync(name);
@@ -7111,7 +7120,7 @@ namespace Google.Example.Library.V1.Snippets
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
                 libraryServiceClient.GetBigNothing(name);
@@ -7143,7 +7152,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
@@ -7176,7 +7185,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             // Make the request
             Operation<Empty, GetBigBookMetadata> response =
@@ -7240,8 +7249,8 @@ namespace Google.Example.Library.V1.Snippets
             string requiredSingularString = "";
             ByteString requiredSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string requiredSingularResourceNameCommon = "";
             int requiredSingularFixed32 = 0;
             long requiredSingularFixed64 = 0L;
@@ -7301,8 +7310,8 @@ namespace Google.Example.Library.V1.Snippets
             string optionalSingularString = "";
             ByteString optionalSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string optionalSingularResourceNameCommon = "";
             int optionalSingularFixed32 = 0;
             long optionalSingularFixed64 = 0L;
@@ -7374,8 +7383,8 @@ namespace Google.Example.Library.V1.Snippets
             string requiredSingularString = "";
             ByteString requiredSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string requiredSingularResourceNameCommon = "";
             int requiredSingularFixed32 = 0;
             long requiredSingularFixed64 = 0L;
@@ -7435,8 +7444,8 @@ namespace Google.Example.Library.V1.Snippets
             string optionalSingularString = "";
             ByteString optionalSingularBytes = ByteString.Empty;
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string optionalSingularResourceNameCommon = "";
             int optionalSingularFixed32 = 0;
             long optionalSingularFixed64 = 0L;
@@ -7511,8 +7520,8 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "",
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -7587,8 +7596,8 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredSingularString = "",
                 RequiredSingularBytes = ByteString.Empty,
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "",
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
@@ -7642,6 +7651,296 @@ namespace Google.Example.Library.V1.Snippets
             };
             // Make the request
             TestOptionalRequiredFlatteningParamsResponse response = libraryServiceClient.TestOptionalRequiredFlatteningParams(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MoveBooksAsync</summary>
+        public async Task MoveBooksAsync()
+        {
+            // Snippet: MoveBooksAsync(string,string,IEnumerable<string>,string,CallSettings)
+            // Additional: MoveBooksAsync(string,string,IEnumerable<string>,string,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            string source = "";
+            string destination = "";
+            IEnumerable<string> publishers = new List<string>();
+            string project = "";
+            // Make the request
+            MoveBooksResponse response = await libraryServiceClient.MoveBooksAsync(source, destination, publishers, project);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MoveBooks</summary>
+        public void MoveBooks()
+        {
+            // Snippet: MoveBooks(string,string,IEnumerable<string>,string,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            string source = "";
+            string destination = "";
+            IEnumerable<string> publishers = new List<string>();
+            string project = "";
+            // Make the request
+            MoveBooksResponse response = libraryServiceClient.MoveBooks(source, destination, publishers, project);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MoveBooksAsync</summary>
+        public async Task MoveBooksAsync_RequestObject()
+        {
+            // Snippet: MoveBooksAsync(MoveBooksRequest,CallSettings)
+            // Additional: MoveBooksAsync(MoveBooksRequest,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            MoveBooksRequest request = new MoveBooksRequest();
+            // Make the request
+            MoveBooksResponse response = await libraryServiceClient.MoveBooksAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MoveBooks</summary>
+        public void MoveBooks_RequestObject()
+        {
+            // Snippet: MoveBooks(MoveBooksRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            MoveBooksRequest request = new MoveBooksRequest();
+            // Make the request
+            MoveBooksResponse response = libraryServiceClient.MoveBooks(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for ArchiveBooksAsync</summary>
+        public async Task ArchiveBooksAsync()
+        {
+            // Snippet: ArchiveBooksAsync(string,string,CallSettings)
+            // Additional: ArchiveBooksAsync(string,string,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            string source = "";
+            string archive = "";
+            // Make the request
+            ArchiveBooksResponse response = await libraryServiceClient.ArchiveBooksAsync(source, archive);
+            // End snippet
+        }
+
+        /// <summary>Snippet for ArchiveBooks</summary>
+        public void ArchiveBooks()
+        {
+            // Snippet: ArchiveBooks(string,string,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            string source = "";
+            string archive = "";
+            // Make the request
+            ArchiveBooksResponse response = libraryServiceClient.ArchiveBooks(source, archive);
+            // End snippet
+        }
+
+        /// <summary>Snippet for ArchiveBooksAsync</summary>
+        public async Task ArchiveBooksAsync_RequestObject()
+        {
+            // Snippet: ArchiveBooksAsync(ArchiveBooksRequest,CallSettings)
+            // Additional: ArchiveBooksAsync(ArchiveBooksRequest,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            ArchiveBooksResponse response = await libraryServiceClient.ArchiveBooksAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for ArchiveBooks</summary>
+        public void ArchiveBooks_RequestObject()
+        {
+            // Snippet: ArchiveBooks(ArchiveBooksRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            ArchiveBooksResponse response = libraryServiceClient.ArchiveBooks(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for LongRunningArchiveBooksAsync</summary>
+        public async Task LongRunningArchiveBooksAsync()
+        {
+            // Snippet: LongRunningArchiveBooksAsync(string,string,CallSettings)
+            // Additional: LongRunningArchiveBooksAsync(string,string,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            string source = "";
+            string archive = "";
+            // Make the request
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> response =
+                await libraryServiceClient.LongRunningArchiveBooksAsync(source, archive);
+
+            // Poll until the returned long-running operation is complete
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> completedResponse =
+                await response.PollUntilCompletedAsync();
+            // Retrieve the operation result
+            ArchiveBooksResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> retrievedResponse =
+                await libraryServiceClient.PollOnceLongRunningArchiveBooksAsync(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                ArchiveBooksResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+
+        /// <summary>Snippet for LongRunningArchiveBooks</summary>
+        public void LongRunningArchiveBooks()
+        {
+            // Snippet: LongRunningArchiveBooks(string,string,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            string source = "";
+            string archive = "";
+            // Make the request
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> response =
+                libraryServiceClient.LongRunningArchiveBooks(source, archive);
+
+            // Poll until the returned long-running operation is complete
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> completedResponse =
+                response.PollUntilCompleted();
+            // Retrieve the operation result
+            ArchiveBooksResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> retrievedResponse =
+                libraryServiceClient.PollOnceLongRunningArchiveBooks(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                ArchiveBooksResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+
+        /// <summary>Snippet for LongRunningArchiveBooksAsync</summary>
+        public async Task LongRunningArchiveBooksAsync_RequestObject()
+        {
+            // Snippet: LongRunningArchiveBooksAsync(ArchiveBooksRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> response =
+                await libraryServiceClient.LongRunningArchiveBooksAsync(request);
+
+            // Poll until the returned long-running operation is complete
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> completedResponse =
+                await response.PollUntilCompletedAsync();
+            // Retrieve the operation result
+            ArchiveBooksResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> retrievedResponse =
+                await libraryServiceClient.PollOnceLongRunningArchiveBooksAsync(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                ArchiveBooksResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+
+        /// <summary>Snippet for LongRunningArchiveBooks</summary>
+        public void LongRunningArchiveBooks_RequestObject()
+        {
+            // Snippet: LongRunningArchiveBooks(ArchiveBooksRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            // Make the request
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> response =
+                libraryServiceClient.LongRunningArchiveBooks(request);
+
+            // Poll until the returned long-running operation is complete
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> completedResponse =
+                response.PollUntilCompleted();
+            // Retrieve the operation result
+            ArchiveBooksResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<ArchiveBooksResponse, ArchiveBooksMetadata> retrievedResponse =
+                libraryServiceClient.PollOnceLongRunningArchiveBooks(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                ArchiveBooksResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+
+        /// <summary>Snippet for StreamingArchiveBooks</summary>
+        public async Task StreamingArchiveBooks()
+        {
+            // Snippet: StreamingArchiveBooks(CallSettings,BidirectionalStreamingSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize streaming call, retrieving the stream object
+            LibraryServiceClient.StreamingArchiveBooksStream duplexStream = libraryServiceClient.StreamingArchiveBooks();
+
+            // Sending requests and retrieving responses can be arbitrarily interleaved.
+            // Exact sequence will depend on client/server behavior.
+
+            // Create task to do something with responses from server
+            Task responseHandlerTask = Task.Run(async () =>
+            {
+                IAsyncEnumerator<ArchiveBooksResponse> responseStream = duplexStream.ResponseStream;
+                while (await responseStream.MoveNext())
+                {
+                    ArchiveBooksResponse response = responseStream.Current;
+                    // Do something with streamed response
+                }
+                // The response stream has completed
+            });
+
+            // Send requests to the server
+            bool done = false;
+            while (!done)
+            {
+                // Initialize a request
+                ArchiveBooksRequest request = new ArchiveBooksRequest();
+                // Stream a request to the server
+                await duplexStream.WriteAsync(request);
+
+                // Set "done" to true when sending requests is complete
+            }
+            // Complete writing requests to the stream
+            await duplexStream.WriteCompleteAsync();
+            // Await the response handler.
+            // This will complete once all server responses have been processed.
+            await responseHandlerTask;
             // End snippet
         }
 
@@ -7838,7 +8137,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -7865,7 +8164,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -7892,7 +8191,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -7918,7 +8217,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -7940,18 +8239,18 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Shelf response = client.GetShelf(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -7967,18 +8266,18 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Shelf response = await client.GetShelfAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -7994,19 +8293,19 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             Shelf response = client.GetShelf(name, message);
             Assert.Same(expectedResponse, response);
@@ -8023,19 +8322,19 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             Shelf response = await client.GetShelfAsync(name, message);
             Assert.Same(expectedResponse, response);
@@ -8052,20 +8351,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
                 StringBuilder = new StringBuilder(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             Shelf response = client.GetShelf(name, message, stringBuilder);
@@ -8083,20 +8382,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest expectedRequest = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Message = new SomeMessage(),
                 StringBuilder = new StringBuilder(),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.GetShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             SomeMessage message = new SomeMessage();
             StringBuilder stringBuilder = new StringBuilder();
             Shelf response = await client.GetShelfAsync(name, message, stringBuilder);
@@ -8114,12 +8413,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "options-1249474914",
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -8141,12 +8440,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetShelfRequest request = new GetShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Options = "options-1249474914",
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -8168,13 +8467,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest expectedRequest = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelf(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             client.DeleteShelf(name);
             mockGrpcClient.VerifyAll();
         }
@@ -8189,13 +8488,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest expectedRequest = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelfAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             await client.DeleteShelfAsync(name);
             mockGrpcClient.VerifyAll();
         }
@@ -8210,7 +8509,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelf(request, It.IsAny<CallOptions>()))
@@ -8230,7 +8529,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteShelfRequest request = new DeleteShelfRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteShelfAsync(request, It.IsAny<CallOptions>()))
@@ -8250,20 +8549,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest expectedRequest = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.MergeShelves(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Shelf response = client.MergeShelves(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -8279,20 +8578,20 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest expectedRequest = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
             mockGrpcClient.Setup(x => x.MergeShelvesAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Shelf>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Shelf response = await client.MergeShelvesAsync(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -8308,12 +8607,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -8335,12 +8634,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MergeShelvesRequest request = new MergeShelvesRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Shelf expectedResponse = new Shelf
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Theme = "theme110327241",
                 InternalTheme = "internalTheme792518087",
             };
@@ -8362,12 +8661,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest expectedRequest = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8375,7 +8674,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.CreateBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             Book response = client.CreateBook(name, book);
             Assert.Same(expectedResponse, response);
@@ -8392,12 +8691,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest expectedRequest = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8405,7 +8704,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.CreateBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            ShelfName name = new ShelfName("[SHELF_ID]");
+            ShelfName name = new ShelfName("[SHELF]");
             Book book = new Book();
             Book response = await client.CreateBookAsync(name, book);
             Assert.Same(expectedResponse, response);
@@ -8422,12 +8721,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8450,12 +8749,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             CreateBookRequest request = new CreateBookRequest
             {
-                ShelfName = new ShelfName("[SHELF_ID]"),
+                ShelfName = new ShelfName("[SHELF]"),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8626,11 +8925,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest expectedRequest = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8638,7 +8937,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             Book response = client.GetBook(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -8654,11 +8953,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest expectedRequest = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8666,7 +8965,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             Book response = await client.GetBookAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -8682,11 +8981,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8709,11 +9008,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookRequest request = new GetBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8736,13 +9035,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest expectedRequest = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             client.DeleteBook(name);
             mockGrpcClient.VerifyAll();
         }
@@ -8757,13 +9056,13 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest expectedRequest = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             await client.DeleteBookAsync(name);
             mockGrpcClient.VerifyAll();
         }
@@ -8778,7 +9077,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBook(request, It.IsAny<CallOptions>()))
@@ -8798,7 +9097,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             DeleteBookRequest request = new DeleteBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             Empty expectedResponse = new Empty();
             mockGrpcClient.Setup(x => x.DeleteBookAsync(request, It.IsAny<CallOptions>()))
@@ -8818,12 +9117,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8831,7 +9130,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             Book book = new Book();
             Book response = client.UpdateBook(name, book);
             Assert.Same(expectedResponse, response);
@@ -8848,12 +9147,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8861,7 +9160,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             Book book = new Book();
             Book response = await client.UpdateBookAsync(name, book);
             Assert.Same(expectedResponse, response);
@@ -8878,7 +9177,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 OptionalFoo = "optionalFoo1822578535",
                 Book = new Book(),
                 UpdateMask = new FieldMask(),
@@ -8886,7 +9185,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8894,7 +9193,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string optionalFoo = "optionalFoo1822578535";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -8914,7 +9213,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest expectedRequest = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 OptionalFoo = "optionalFoo1822578535",
                 Book = new Book(),
                 UpdateMask = new FieldMask(),
@@ -8922,7 +9221,7 @@ namespace Google.Example.Library.V1.Tests
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8930,7 +9229,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string optionalFoo = "optionalFoo1822578535";
             Book book = new Book();
             FieldMask updateMask = new FieldMask();
@@ -8950,12 +9249,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -8978,12 +9277,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookRequest request = new UpdateBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Book = new Book(),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9006,12 +9305,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest expectedRequest = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9019,8 +9318,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.MoveBook(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Book response = client.MoveBook(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -9036,12 +9335,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest expectedRequest = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9049,8 +9348,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.MoveBookAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Book>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            ShelfName otherShelfName = new ShelfName("[SHELF_ID]");
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            ShelfName otherShelfName = new ShelfName("[SHELF]");
             Book response = await client.MoveBookAsync(name, otherShelfName);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -9066,12 +9365,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest request = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9094,12 +9393,12 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             MoveBookRequest request = new MoveBookRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                OtherShelfNameAsShelfName = new ShelfName("[SHELF_ID]"),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                OtherShelfNameAsShelfName = new ShelfName("[SHELF]"),
             };
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9122,7 +9421,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest expectedRequest = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -9137,7 +9436,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.AddComments(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -9161,7 +9460,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest expectedRequest = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -9176,7 +9475,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.AddCommentsAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             IEnumerable<Comment> comments = new[]
             {
                 new Comment
@@ -9200,7 +9499,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -9229,7 +9528,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             AddCommentsRequest request = new AddCommentsRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Comments =
                 {
                     new Comment
@@ -9374,14 +9673,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest expectedRequest = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9389,8 +9688,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAnywhere(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof altBookName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof altBookName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             BookFromAnywhere response = client.GetBookFromAnywhere(name, altBookName, place, folder);
@@ -9408,14 +9707,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest expectedRequest = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9423,8 +9722,8 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAnywhereAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<BookFromAnywhere>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof altBookName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof altBookName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             LocationName place = new LocationName("[PROJECT]", "[LOCATION]");
             FolderName folder = new FolderName("[FOLDER]");
             BookFromAnywhere response = await client.GetBookFromAnywhereAsync(name, altBookName, place, folder);
@@ -9442,14 +9741,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9472,14 +9771,14 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAnywhereRequest request = new GetBookFromAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                AltBookNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 PlaceAsLocationName = new LocationName("[PROJECT]", "[LOCATION]"),
                 FolderAsFolderName = new FolderName("[FOLDER]"),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9502,11 +9801,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest expectedRequest = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9514,7 +9813,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAbsolutelyAnywhere(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             BookFromAnywhere response = client.GetBookFromAbsolutelyAnywhere(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -9530,11 +9829,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest expectedRequest = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9542,7 +9841,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.GetBookFromAbsolutelyAnywhereAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<BookFromAnywhere>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             BookFromAnywhere response = await client.GetBookFromAbsolutelyAnywhereAsync(name);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -9558,11 +9857,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9585,11 +9884,11 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             GetBookFromAbsolutelyAnywhereRequest request = new GetBookFromAbsolutelyAnywhereRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
             };
             BookFromAnywhere expectedResponse = new BookFromAnywhere
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -9612,7 +9911,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest expectedRequest = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -9623,7 +9922,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookIndex(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(expectedResponse);
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -9643,7 +9942,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest expectedRequest = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -9654,7 +9953,7 @@ namespace Google.Example.Library.V1.Tests
             mockGrpcClient.Setup(x => x.UpdateBookIndexAsync(expectedRequest, It.IsAny<CallOptions>()))
                 .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
-            BookNameOneof name = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof name = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string indexName = "default index";
             IDictionary<string, string> indexMap = new Dictionary<string, string>
             {
@@ -9674,7 +9973,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -9699,7 +9998,7 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Mock<Operations.OperationsClient>().Object);
             UpdateBookIndexRequest request = new UpdateBookIndexRequest
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 IndexName = "default index",
                 IndexMap =
                 {
@@ -9771,8 +10070,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002",
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -9832,8 +10131,8 @@ namespace Google.Example.Library.V1.Tests
                 OptionalSingularString = "optionalSingularString1852995162",
                 OptionalSingularBytes = ByteString.CopyFromUtf8("2"),
                 OptionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                OptionalSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                OptionalSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 OptionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657",
                 OptionalSingularFixed32 = 1648847958,
                 OptionalSingularFixed64 = 1648847863,
@@ -9898,8 +10197,8 @@ namespace Google.Example.Library.V1.Tests
             string requiredSingularString = "requiredSingularString-1949894503";
             ByteString requiredSingularBytes = ByteString.CopyFromUtf8("-29");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
             int requiredSingularFixed32 = 720656715;
             long requiredSingularFixed64 = 720656810;
@@ -9959,8 +10258,8 @@ namespace Google.Example.Library.V1.Tests
             string optionalSingularString = "optionalSingularString1852995162";
             ByteString optionalSingularBytes = ByteString.CopyFromUtf8("2");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
             int optionalSingularFixed32 = 1648847958;
             long optionalSingularFixed64 = 1648847863;
@@ -10035,8 +10334,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002",
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -10096,8 +10395,8 @@ namespace Google.Example.Library.V1.Tests
                 OptionalSingularString = "optionalSingularString1852995162",
                 OptionalSingularBytes = ByteString.CopyFromUtf8("2"),
                 OptionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                OptionalSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                OptionalSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 OptionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657",
                 OptionalSingularFixed32 = 1648847958,
                 OptionalSingularFixed64 = 1648847863,
@@ -10162,8 +10461,8 @@ namespace Google.Example.Library.V1.Tests
             string requiredSingularString = "requiredSingularString-1949894503";
             ByteString requiredSingularBytes = ByteString.CopyFromUtf8("-29");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
             int requiredSingularFixed32 = 720656715;
             long requiredSingularFixed64 = 720656810;
@@ -10223,8 +10522,8 @@ namespace Google.Example.Library.V1.Tests
             string optionalSingularString = "optionalSingularString1852995162";
             ByteString optionalSingularBytes = ByteString.CopyFromUtf8("2");
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
-            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
-            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceName = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
+            BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]"));
             string optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
             int optionalSingularFixed32 = 1648847958;
             long optionalSingularFixed64 = 1648847863;
@@ -10299,8 +10598,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002",
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -10380,8 +10679,8 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularString = "requiredSingularString-1949894503",
                 RequiredSingularBytes = ByteString.CopyFromUtf8("-29"),
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
-                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
-                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                RequiredSingularResourceNameAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
+                RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 RequiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002",
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
@@ -10443,6 +10742,206 @@ namespace Google.Example.Library.V1.Tests
         }
 
         [Fact]
+        public void MoveBooks()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            MoveBooksRequest expectedRequest = new MoveBooksRequest
+            {
+                Source = "source-896505829",
+                Destination = "destination-1429847026",
+                Publishers = { },
+                Project = "project-309310695",
+            };
+            MoveBooksResponse expectedResponse = new MoveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.MoveBooks(expectedRequest, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            string source = "source-896505829";
+            string destination = "destination-1429847026";
+            IEnumerable<string> publishers = new List<string>();
+            string project = "project-309310695";
+            MoveBooksResponse response = client.MoveBooks(source, destination, publishers, project);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task MoveBooksAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            MoveBooksRequest expectedRequest = new MoveBooksRequest
+            {
+                Source = "source-896505829",
+                Destination = "destination-1429847026",
+                Publishers = { },
+                Project = "project-309310695",
+            };
+            MoveBooksResponse expectedResponse = new MoveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.MoveBooksAsync(expectedRequest, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<MoveBooksResponse>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            string source = "source-896505829";
+            string destination = "destination-1429847026";
+            IEnumerable<string> publishers = new List<string>();
+            string project = "project-309310695";
+            MoveBooksResponse response = await client.MoveBooksAsync(source, destination, publishers, project);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void MoveBooks2()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            MoveBooksRequest request = new MoveBooksRequest();
+            MoveBooksResponse expectedResponse = new MoveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.MoveBooks(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            MoveBooksResponse response = client.MoveBooks(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task MoveBooksAsync2()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            MoveBooksRequest request = new MoveBooksRequest();
+            MoveBooksResponse expectedResponse = new MoveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.MoveBooksAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<MoveBooksResponse>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            MoveBooksResponse response = await client.MoveBooksAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void ArchiveBooks()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest expectedRequest = new ArchiveBooksRequest
+            {
+                Source = "source-896505829",
+                Archive = "archive-748101438",
+            };
+            ArchiveBooksResponse expectedResponse = new ArchiveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.ArchiveBooks(expectedRequest, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            string source = "source-896505829";
+            string archive = "archive-748101438";
+            ArchiveBooksResponse response = client.ArchiveBooks(source, archive);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ArchiveBooksAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest expectedRequest = new ArchiveBooksRequest
+            {
+                Source = "source-896505829",
+                Archive = "archive-748101438",
+            };
+            ArchiveBooksResponse expectedResponse = new ArchiveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.ArchiveBooksAsync(expectedRequest, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<ArchiveBooksResponse>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            string source = "source-896505829";
+            string archive = "archive-748101438";
+            ArchiveBooksResponse response = await client.ArchiveBooksAsync(source, archive);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void ArchiveBooks2()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            ArchiveBooksResponse expectedResponse = new ArchiveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.ArchiveBooks(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            ArchiveBooksResponse response = client.ArchiveBooks(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ArchiveBooksAsync2()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            ArchiveBooksRequest request = new ArchiveBooksRequest();
+            ArchiveBooksResponse expectedResponse = new ArchiveBooksResponse
+            {
+                Success = false,
+            };
+            mockGrpcClient.Setup(x => x.ArchiveBooksAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<ArchiveBooksResponse>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            ArchiveBooksResponse response = await client.ArchiveBooksAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
         public void PrivateListShelves()
         {
             Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
@@ -10453,7 +10952,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest expectedRequest = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -10478,7 +10977,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest expectedRequest = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -10503,7 +11002,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest request = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -10527,7 +11026,7 @@ namespace Google.Example.Library.V1.Tests
             ListShelvesRequest request = new ListShelvesRequest();
             Book expectedResponse = new Book
             {
-                BookNameOneof = BookNameOneof.From(new BookName("[BOOK_SHELF]", "[BOOK]")),
+                BookNameOneof = BookNameOneof.From(new BookFromArchiveName("[ARCHIVE]", "[BOOK]")),
                 Author = "author-1406328437",
                 Title = "title110371416",
                 Read = true,
@@ -10751,6 +11250,12 @@ namespace Google.Example.Library.V1
             GetBigNothingSettings = existing.GetBigNothingSettings;
             GetBigNothingOperationsSettings = existing.GetBigNothingOperationsSettings?.Clone();
             TestOptionalRequiredFlatteningParamsSettings = existing.TestOptionalRequiredFlatteningParamsSettings;
+            MoveBooksSettings = existing.MoveBooksSettings;
+            ArchiveBooksSettings = existing.ArchiveBooksSettings;
+            LongRunningArchiveBooksSettings = existing.LongRunningArchiveBooksSettings;
+            LongRunningArchiveBooksOperationsSettings = existing.LongRunningArchiveBooksOperationsSettings?.Clone();
+            StreamingArchiveBooksSettings = existing.StreamingArchiveBooksSettings;
+            StreamingArchiveBooksStreamingSettings = existing.StreamingArchiveBooksStreamingSettings;
             PrivateListShelvesSettings = existing.PrivateListShelvesSettings;
             OnCopy(existing);
         }
@@ -11579,6 +12084,133 @@ namespace Google.Example.Library.V1
                 totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
                 retryFilter: NonIdempotentRetryFilter
             )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.MoveBooks</c> and <c>LibraryServiceClient.MoveBooksAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.MoveBooks</c> and
+        /// <c>LibraryServiceClient.MoveBooksAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings MoveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.ArchiveBooks</c> and <c>LibraryServiceClient.ArchiveBooksAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.ArchiveBooks</c> and
+        /// <c>LibraryServiceClient.ArchiveBooksAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings ArchiveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.LongRunningArchiveBooks</c> and <c>LibraryServiceClient.LongRunningArchiveBooksAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.LongRunningArchiveBooks</c> and
+        /// <c>LibraryServiceClient.LongRunningArchiveBooksAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings LongRunningArchiveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// Long Running Operation settings for calls to <c>LibraryServiceClient.LongRunningArchiveBooks</c>.
+        /// </summary>
+        /// <remarks>
+        /// Uses default <see cref="gax::PollSettings"/> of:
+        /// <list type="bullet">
+        /// <item><description>Initial delay: 500 milliseconds</description></item>
+        /// <item><description>Delay multiplier: 1.5</description></item>
+        /// <item><description>Maximum delay: 5000 milliseconds</description></item>
+        /// <item><description>Total timeout: 300000 milliseconds</description></item>
+        /// </list>
+        /// </remarks>
+        public lro::OperationsSettings LongRunningArchiveBooksOperationsSettings { get; set; } = new lro::OperationsSettings
+        {
+            DefaultPollSettings = new gax::PollSettings(
+                gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(300000L)),
+                sys::TimeSpan.FromMilliseconds(500L),
+                1.5,
+                sys::TimeSpan.FromMilliseconds(5000L))
+        };
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for calls to <c>LibraryServiceClient.StreamingArchiveBooks</c>.
+        /// </summary>
+        /// <remarks>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings StreamingArchiveBooksSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::BidirectionalStreamingSettings"/> for calls to
+        /// <c>LibraryServiceClient.StreamingArchiveBooks</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default local send queue size is 100.
+        /// </remarks>
+        public gaxgrpc::BidirectionalStreamingSettings StreamingArchiveBooksStreamingSettings { get; set; } =
+            new gaxgrpc::BidirectionalStreamingSettings(100);
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -20521,6 +21153,482 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            string source,
+            string destination,
+            scg::IEnumerable<string> publishers,
+            string project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooksAsync(
+                new MoveBooksRequest
+                {
+                    Source = source ?? "", // Optional
+                    Destination = destination ?? "", // Optional
+                    Publishers = { publishers ?? linq::Enumerable.Empty<string>() }, // Optional
+                    Project = project ?? "", // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            string source,
+            string destination,
+            scg::IEnumerable<string> publishers,
+            string project,
+            st::CancellationToken cancellationToken) => MoveBooksAsync(
+                source,
+                destination,
+                publishers,
+                project,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MoveBooksResponse MoveBooks(
+            string source,
+            string destination,
+            scg::IEnumerable<string> publishers,
+            string project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooks(
+                new MoveBooksRequest
+                {
+                    Source = source ?? "", // Optional
+                    Destination = destination ?? "", // Optional
+                    Publishers = { publishers ?? linq::Enumerable.Empty<string>() }, // Optional
+                    Project = project ?? "", // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            MoveBooksRequest request,
+            st::CancellationToken cancellationToken) => MoveBooksAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MoveBooksResponse MoveBooks(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            string source,
+            string archive,
+            gaxgrpc::CallSettings callSettings = null) => ArchiveBooksAsync(
+                new ArchiveBooksRequest
+                {
+                    Source = source ?? "", // Optional
+                    Archive = archive ?? "", // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            string source,
+            string archive,
+            st::CancellationToken cancellationToken) => ArchiveBooksAsync(
+                source,
+                archive,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual ArchiveBooksResponse ArchiveBooks(
+            string source,
+            string archive,
+            gaxgrpc::CallSettings callSettings = null) => ArchiveBooks(
+                new ArchiveBooksRequest
+                {
+                    Source = source ?? "", // Optional
+                    Archive = archive ?? "", // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            st::CancellationToken cancellationToken) => ArchiveBooksAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual ArchiveBooksResponse ArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata>> LongRunningArchiveBooksAsync(
+            string source,
+            string archive,
+            gaxgrpc::CallSettings callSettings = null) => LongRunningArchiveBooksAsync(
+                new ArchiveBooksRequest
+                {
+                    Source = source ?? "", // Optional
+                    Archive = archive ?? "", // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata>> LongRunningArchiveBooksAsync(
+            string source,
+            string archive,
+            st::CancellationToken cancellationToken) => LongRunningArchiveBooksAsync(
+                source,
+                archive,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata> LongRunningArchiveBooks(
+            string source,
+            string archive,
+            gaxgrpc::CallSettings callSettings = null) => LongRunningArchiveBooks(
+                new ArchiveBooksRequest
+                {
+                    Source = source ?? "", // Optional
+                    Archive = archive ?? "", // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata>> LongRunningArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Asynchronously poll an operation once, using an <c>operationName</c> from a previous invocation of <c>LongRunningArchiveBooksAsync</c>.
+        /// </summary>
+        /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A task representing the result of polling the operation.</returns>
+        public virtual stt::Task<lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata>> PollOnceLongRunningArchiveBooksAsync(
+            string operationName,
+            gaxgrpc::CallSettings callSettings = null) => lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata>.PollOnceFromNameAsync(
+                gax::GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
+                LongRunningArchiveBooksOperationsClient,
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata> LongRunningArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// The long-running operations client for <c>LongRunningArchiveBooks</c>.
+        /// </summary>
+        public virtual lro::OperationsClient LongRunningArchiveBooksOperationsClient
+        {
+            get { throw new sys::NotImplementedException(); }
+        }
+
+        /// <summary>
+        /// Poll an operation once, using an <c>operationName</c> from a previous invocation of <c>LongRunningArchiveBooks</c>.
+        /// </summary>
+        /// <param name="operationName">The name of a previously invoked operation. Must not be <c>null</c> or empty.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The result of polling the operation.</returns>
+        public virtual lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata> PollOnceLongRunningArchiveBooks(
+            string operationName,
+            gaxgrpc::CallSettings callSettings = null) => lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata>.PollOnceFromName(
+                gax::GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
+                LongRunningArchiveBooksOperationsClient,
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The client-server stream.
+        /// </returns>
+        *** ERROR: Cannot handle streaming type 'BidiStreaming' ***
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <param name="streamingSettings">
+        /// If not null, applies streaming overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The client-server stream.
+        /// </returns>
+        public virtual StreamingArchiveBooksStream StreamingArchiveBooks(
+            gaxgrpc::CallSettings callSettings = null,
+            gaxgrpc::BidirectionalStreamingSettings streamingSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Bidirectional streaming methods for <c>StreamingArchiveBooks</c>.
+        /// </summary>
+        public abstract partial class StreamingArchiveBooksStream : gaxgrpc::BidirectionalStreamingBase<ArchiveBooksRequest, ArchiveBooksResponse>
+        {
+        }
+
+        /// <summary>
         /// This method is not exposed in the GAPIC config. It should be generated.
         /// </summary>
         /// <param name="callSettings">
@@ -20654,6 +21762,10 @@ namespace Google.Example.Library.V1
         private readonly gaxgrpc::ApiCall<GetBookRequest, lro::Operation> _callGetBigBook;
         private readonly gaxgrpc::ApiCall<GetBookRequest, lro::Operation> _callGetBigNothing;
         private readonly gaxgrpc::ApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> _callTestOptionalRequiredFlatteningParams;
+        private readonly gaxgrpc::ApiCall<MoveBooksRequest, MoveBooksResponse> _callMoveBooks;
+        private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> _callArchiveBooks;
+        private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> _callLongRunningArchiveBooks;
+        private readonly gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> _callStreamingArchiveBooks;
         private readonly gaxgrpc::ApiCall<ListShelvesRequest, Book> _callPrivateListShelves;
 
         /// <summary>
@@ -20671,6 +21783,8 @@ namespace Google.Example.Library.V1
                 grpcClient.CreateOperationsClient(), effectiveSettings.GetBigBookOperationsSettings);
             GetBigNothingOperationsClient = new lro::OperationsClientImpl(
                 grpcClient.CreateOperationsClient(), effectiveSettings.GetBigNothingOperationsSettings);
+            LongRunningArchiveBooksOperationsClient = new lro::OperationsClientImpl(
+                grpcClient.CreateOperationsClient(), effectiveSettings.LongRunningArchiveBooksOperationsSettings);
             _callCreateShelf = clientHelper.BuildApiCall<CreateShelfRequest, Shelf>(
                 GrpcClient.CreateShelfAsync, GrpcClient.CreateShelf, effectiveSettings.CreateShelfSettings);
             _callGetShelf = clientHelper.BuildApiCall<GetShelfRequest, Shelf>(
@@ -20742,6 +21856,17 @@ namespace Google.Example.Library.V1
                 .WithGoogleRequestParam("name", request => request.Name);
             _callTestOptionalRequiredFlatteningParams = clientHelper.BuildApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>(
                 GrpcClient.TestOptionalRequiredFlatteningParamsAsync, GrpcClient.TestOptionalRequiredFlatteningParams, effectiveSettings.TestOptionalRequiredFlatteningParamsSettings);
+            _callMoveBooks = clientHelper.BuildApiCall<MoveBooksRequest, MoveBooksResponse>(
+                GrpcClient.MoveBooksAsync, GrpcClient.MoveBooks, effectiveSettings.MoveBooksSettings)
+                .WithGoogleRequestParam("source", request => request.Source);
+            _callArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, ArchiveBooksResponse>(
+                GrpcClient.ArchiveBooksAsync, GrpcClient.ArchiveBooks, effectiveSettings.ArchiveBooksSettings)
+                .WithGoogleRequestParam("source", request => request.Source);
+            _callLongRunningArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, lro::Operation>(
+                GrpcClient.LongRunningArchiveBooksAsync, GrpcClient.LongRunningArchiveBooks, effectiveSettings.LongRunningArchiveBooksSettings)
+                .WithGoogleRequestParam("source", request => request.Source);
+            _callStreamingArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, ArchiveBooksResponse>(
+                GrpcClient.StreamingArchiveBooks, effectiveSettings.StreamingArchiveBooksSettings, effectiveSettings.StreamingArchiveBooksStreamingSettings);
             _callPrivateListShelves = clientHelper.BuildApiCall<ListShelvesRequest, Book>(
                 GrpcClient.PrivateListShelvesAsync, GrpcClient.PrivateListShelves, effectiveSettings.PrivateListShelvesSettings);
             Modify_ApiCall(ref _callCreateShelf);
@@ -20796,6 +21921,14 @@ namespace Google.Example.Library.V1
             Modify_GetBigNothingApiCall(ref _callGetBigNothing);
             Modify_ApiCall(ref _callTestOptionalRequiredFlatteningParams);
             Modify_TestOptionalRequiredFlatteningParamsApiCall(ref _callTestOptionalRequiredFlatteningParams);
+            Modify_ApiCall(ref _callMoveBooks);
+            Modify_MoveBooksApiCall(ref _callMoveBooks);
+            Modify_ApiCall(ref _callArchiveBooks);
+            Modify_ArchiveBooksApiCall(ref _callArchiveBooks);
+            Modify_ApiCall(ref _callLongRunningArchiveBooks);
+            Modify_LongRunningArchiveBooksApiCall(ref _callLongRunningArchiveBooks);
+            Modify_ApiCall(ref _callStreamingArchiveBooks);
+            Modify_StreamingArchiveBooksApiCall(ref _callStreamingArchiveBooks);
             Modify_ApiCall(ref _callPrivateListShelves);
             Modify_PrivateListShelvesApiCall(ref _callPrivateListShelves);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);
@@ -20843,6 +21976,10 @@ namespace Google.Example.Library.V1
         partial void Modify_GetBigBookApiCall(ref gaxgrpc::ApiCall<GetBookRequest, lro::Operation> call);
         partial void Modify_GetBigNothingApiCall(ref gaxgrpc::ApiCall<GetBookRequest, lro::Operation> call);
         partial void Modify_TestOptionalRequiredFlatteningParamsApiCall(ref gaxgrpc::ApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> call);
+        partial void Modify_MoveBooksApiCall(ref gaxgrpc::ApiCall<MoveBooksRequest, MoveBooksResponse> call);
+        partial void Modify_ArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
+        partial void Modify_LongRunningArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> call);
+        partial void Modify_StreamingArchiveBooksApiCall(ref gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
         partial void Modify_PrivateListShelvesApiCall(ref gaxgrpc::ApiCall<ListShelvesRequest, Book> call);
         partial void OnConstruction(LibraryService.LibraryServiceClient grpcClient, LibraryServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
@@ -20879,6 +22016,8 @@ namespace Google.Example.Library.V1
         partial void Modify_FindRelatedBooksRequest(ref FindRelatedBooksRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_AddLabelRequest(ref gtv::AddLabelRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_TestOptionalRequiredFlatteningParamsRequest(ref TestOptionalRequiredFlatteningParamsRequest request, ref gaxgrpc::CallSettings settings);
+        partial void Modify_MoveBooksRequest(ref MoveBooksRequest request, ref gaxgrpc::CallSettings settings);
+        partial void Modify_ArchiveBooksRequest(ref ArchiveBooksRequest request, ref gaxgrpc::CallSettings settings);
 
         /// <summary>
         /// Creates a shelf, and returns the new Shelf.
@@ -21974,6 +23113,220 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<MoveBooksResponse> MoveBooksAsync(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MoveBooksRequest(ref request, ref callSettings);
+            return _callMoveBooks.Async(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override MoveBooksResponse MoveBooks(
+            MoveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MoveBooksRequest(ref request, ref callSettings);
+            return _callMoveBooks.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return _callArchiveBooks.Async(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override ArchiveBooksResponse ArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return _callArchiveBooks.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override async stt::Task<lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata>> LongRunningArchiveBooksAsync(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return new lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata>(
+                await _callLongRunningArchiveBooks.Async(request, callSettings).ConfigureAwait(false), LongRunningArchiveBooksOperationsClient);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata> LongRunningArchiveBooks(
+            ArchiveBooksRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ArchiveBooksRequest(ref request, ref callSettings);
+            return new lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata>(
+                _callLongRunningArchiveBooks.Sync(request, callSettings), LongRunningArchiveBooksOperationsClient);
+        }
+
+        /// <summary>
+        /// The long-running operations client for <c>LongRunningArchiveBooks</c>.
+        /// </summary>
+        public override lro::OperationsClient LongRunningArchiveBooksOperationsClient { get; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <param name="streamingSettings">
+        /// If not null, applies streaming overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The client-server stream.
+        /// </returns>
+        public override StreamingArchiveBooksStream StreamingArchiveBooks(
+            gaxgrpc::CallSettings callSettings = null,
+            gaxgrpc::BidirectionalStreamingSettings streamingSettings = null)
+        {
+            Modify_ArchiveBooksRequestCallSettings(ref callSettings);
+            gaxgrpc::BidirectionalStreamingSettings effectiveStreamingSettings =
+                streamingSettings ?? _callStreamingArchiveBooks.StreamingSettings;
+            grpccore::AsyncDuplexStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call =
+                _callStreamingArchiveBooks.Call(callSettings);
+            gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest> writeBuffer =
+                new gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest>(
+                    call.RequestStream, effectiveStreamingSettings.BufferedClientWriterCapacity);
+            return new StreamingArchiveBooksStreamImpl(this, call, writeBuffer);
+        }
+
+        internal sealed partial class StreamingArchiveBooksStreamImpl : StreamingArchiveBooksStream
+        {
+            /// <summary>
+            /// Construct the bidirectional streaming method for <c>StreamingArchiveBooks</c>.
+            /// </summary>
+            /// <param name="service">The service containing this streaming method.</param>
+            /// <param name="call">The underlying gRPC duplex streaming call.</param>
+            /// <param name="writeBuffer">The <see cref="gaxgrpc::BufferedClientStreamWriter{ArchiveBooksRequest}"/>
+            /// instance associated with this streaming call.</param>
+            public StreamingArchiveBooksStreamImpl(
+                LibraryServiceClientImpl service,
+                grpccore::AsyncDuplexStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call,
+                gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest> writeBuffer)
+            {
+                _service = service;
+                GrpcCall = call;
+                _writeBuffer = writeBuffer;
+            }
+
+            private LibraryServiceClientImpl _service;
+            private gaxgrpc::BufferedClientStreamWriter<ArchiveBooksRequest> _writeBuffer;
+
+            private ArchiveBooksRequest ModifyRequest(ArchiveBooksRequest request)
+            {
+                _service.Modify_ArchiveBooksRequestRequest(ref request);
+                return request;
+            }
+
+            /// <inheritdoc/>
+            public override grpccore::AsyncDuplexStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> GrpcCall { get; }
+
+            /// <inheritdoc/>
+            public override stt::Task TryWriteAsync(ArchiveBooksRequest message) =>
+                _writeBuffer.TryWriteAsync(ModifyRequest(message));
+
+            /// <inheritdoc/>
+            public override stt::Task WriteAsync(ArchiveBooksRequest message) =>
+                _writeBuffer.WriteAsync(ModifyRequest(message));
+
+            /// <inheritdoc/>
+            public override stt::Task TryWriteAsync(ArchiveBooksRequest message, grpccore::WriteOptions options) =>
+                _writeBuffer.TryWriteAsync(ModifyRequest(message), options);
+
+            /// <inheritdoc/>
+            public override stt::Task WriteAsync(ArchiveBooksRequest message, grpccore::WriteOptions options) =>
+                _writeBuffer.WriteAsync(ModifyRequest(message), options);
+
+            /// <inheritdoc/>
+            public override stt::Task TryWriteCompleteAsync() =>
+                _writeBuffer.TryWriteCompleteAsync();
+
+            /// <inheritdoc/>
+            public override stt::Task WriteCompleteAsync() =>
+                _writeBuffer.WriteCompleteAsync();
+
+            /// <inheritdoc/>
+            public override scg::IAsyncEnumerator<ArchiveBooksResponse> ResponseStream =>
+                GrpcCall.ResponseStream;
+        }
+
+        /// <summary>
         /// This method is not exposed in the GAPIC config. It should be generated.
         /// </summary>
         /// <param name="request">
@@ -22722,105 +24075,6 @@ namespace Google.Example.Library.V1
     }
 
     /// <summary>
-    /// Resource name for the 'book' resource.
-    /// </summary>
-    public sealed partial class BookName : gax::IResourceName, sys::IEquatable<BookName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("bookShelves/{book_shelf}/books/{book}");
-
-        /// <summary>
-        /// Parses the given book resource name in string form into a new
-        /// <see cref="BookName"/> instance.
-        /// </summary>
-        /// <param name="bookName">The book resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="BookName"/> if successful.</returns>
-        public static BookName Parse(string bookName)
-        {
-            gax::GaxPreconditions.CheckNotNull(bookName, nameof(bookName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(bookName);
-            return new BookName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given book resource name in string form into a new
-        /// <see cref="BookName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="bookName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="bookName">The book resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="BookName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string bookName, out BookName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(bookName, nameof(bookName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(bookName, out resourceName))
-            {
-                result = new BookName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="BookName"/>.</summary>
-        /// <param name="bookShelfId">The <c>bookShelf</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="bookId">The <c>book</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="BookName"/>.</returns>
-        public static string Format(string bookShelfId, string bookId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(bookShelfId, nameof(bookShelfId)), gax::GaxPreconditions.CheckNotNull(bookId, nameof(bookId)));
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="BookName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="bookShelfId">The bookShelf ID. Must not be <c>null</c>.</param>
-        /// <param name="bookId">The book ID. Must not be <c>null</c>.</param>
-        public BookName(string bookShelfId, string bookId)
-        {
-            BookShelfId = gax::GaxPreconditions.CheckNotNull(bookShelfId, nameof(bookShelfId));
-            BookId = gax::GaxPreconditions.CheckNotNull(bookId, nameof(bookId));
-        }
-
-        /// <summary>
-        /// The bookShelf ID. Never <c>null</c>.
-        /// </summary>
-        public string BookShelfId { get; }
-
-        /// <summary>
-        /// The book ID. Never <c>null</c>.
-        /// </summary>
-        public string BookId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(BookShelfId, BookId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as BookName);
-
-        /// <inheritdoc />
-        public bool Equals(BookName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(BookName a, BookName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(BookName a, BookName b) => !(a == b);
-    }
-
-    /// <summary>
     /// Resource name for the 'book_from_archive' resource.
     /// </summary>
     public sealed partial class BookFromArchiveName : gax::IResourceName, sys::IEquatable<BookFromArchiveName>
@@ -22925,7 +24179,6 @@ namespace Google.Example.Library.V1
     /// <remarks>
     /// This resource name will contain one of the following:
     /// <list type="bullet">
-    /// <item><description>BookName: A resource of type 'book'.</description></item>
     /// <item><description>BookFromArchiveName: A resource of type 'book_from_archive'.</description></item>
     /// <item><description>ProjectBookName: A resource of type 'project_book'.</description></item>
     /// </list>
@@ -22943,19 +24196,14 @@ namespace Google.Example.Library.V1
             Unknown = 0,
 
             /// <summary>
-            /// A resource of type 'book'.
-            /// </summary>
-            BookName = 1,
-
-            /// <summary>
             /// A resource of type 'book_from_archive'.
             /// </summary>
-            BookFromArchiveName = 2,
+            BookFromArchiveName = 1,
 
             /// <summary>
             /// A resource of type 'project_book'.
             /// </summary>
-            ProjectBookName = 3,
+            ProjectBookName = 2,
         }
 
         /// <summary>
@@ -22964,7 +24212,6 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// To parse successfully the resource name must be one of the following:
         /// <list type="bullet">
-        /// <item><description>BookName: A resource of type 'book'.</description></item>
         /// <item><description>BookFromArchiveName: A resource of type 'book_from_archive'.</description></item>
         /// <item><description>ProjectBookName: A resource of type 'project_book'.</description></item>
         /// </list>
@@ -22991,7 +24238,6 @@ namespace Google.Example.Library.V1
         /// <remarks>
         /// To parse successfully the resource name must be one of the following:
         /// <list type="bullet">
-        /// <item><description>BookName: A resource of type 'book'.</description></item>
         /// <item><description>BookFromArchiveName: A resource of type 'book_from_archive'.</description></item>
         /// <item><description>ProjectBookName: A resource of type 'project_book'.</description></item>
         /// </list>
@@ -23006,12 +24252,6 @@ namespace Google.Example.Library.V1
         public static bool TryParse(string name, bool allowUnknown, out BookNameOneof result)
         {
             gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            BookName bookName;
-            if (BookName.TryParse(name, out bookName))
-            {
-                result = new BookNameOneof(OneofType.BookName, bookName);
-                return true;
-            }
             BookFromArchiveName bookFromArchiveName;
             if (BookFromArchiveName.TryParse(name, out bookFromArchiveName))
             {
@@ -23038,14 +24278,6 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
-        /// Construct a new instance of <see cref="BookNameOneof"/> from the provided <see cref="BookName"/>
-        /// </summary>
-        /// <param name="bookName">The <see cref="BookName"/> to be contained within
-        /// the returned <see cref="BookNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="BookNameOneof"/>, containing <paramref name="bookName"/>.</returns>
-        public static BookNameOneof From(BookName bookName) => new BookNameOneof(OneofType.BookName, bookName);
-
-        /// <summary>
         /// Construct a new instance of <see cref="BookNameOneof"/> from the provided <see cref="BookFromArchiveName"/>
         /// </summary>
         /// <param name="bookFromArchiveName">The <see cref="BookFromArchiveName"/> to be contained within
@@ -23066,7 +24298,6 @@ namespace Google.Example.Library.V1
             switch (type)
             {
                 case OneofType.Unknown: return true; // Anything goes with Unknown.
-                case OneofType.BookName: return name is BookName;
                 case OneofType.BookFromArchiveName: return name is BookFromArchiveName;
                 case OneofType.ProjectBookName: return name is ProjectBookName;
                 default: return false;
@@ -23105,15 +24336,6 @@ namespace Google.Example.Library.V1
             }
             return (T)Name;
         }
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BookName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="BookName"/>.
-        /// </remarks>
-        public BookName BookName => CheckAndReturn<BookName>(OneofType.BookName);
 
         /// <summary>
         /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BookFromArchiveName"/>.
@@ -23647,7 +24869,7 @@ namespace Google.Example.Library.V1
     /// </summary>
     public sealed partial class ShelfName : gax::IResourceName, sys::IEquatable<ShelfName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("shelves/{shelf_id}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("shelves/{shelf}");
 
         /// <summary>
         /// Parses the given shelf resource name in string form into a new

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -56,7 +56,7 @@ func TestLibClientSmoke(t *testing.T) {
     t.Fatal(err)
   }
 
-  var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+  var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", projectId)
   var rating librarypb.Book_Rating = librarypb.Book_GOOD
   var book = &librarypb.Book{
       Rating: rating,
@@ -244,6 +244,10 @@ type CallOptions struct {
     GetBigBook []gax.CallOption
     GetBigNothing []gax.CallOption
     TestOptionalRequiredFlatteningParams []gax.CallOption
+    MoveBooks []gax.CallOption
+    ArchiveBooks []gax.CallOption
+    LongRunningArchiveBooks []gax.CallOption
+    StreamingArchiveBooks []gax.CallOption
     PrivateListShelves []gax.CallOption
 }
 
@@ -299,6 +303,10 @@ func defaultCallOptions() *CallOptions {
         GetBigBook: retry[[2]string{"default", "non_idempotent"}],
         GetBigNothing: retry[[2]string{"default", "non_idempotent"}],
         TestOptionalRequiredFlatteningParams: retry[[2]string{"default", "non_idempotent"}],
+        MoveBooks: retry[[2]string{"default", "non_idempotent"}],
+        ArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
+        LongRunningArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
+        StreamingArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
         PrivateListShelves: retry[[2]string{"default", "idempotent"}],
     }
 }
@@ -922,6 +930,75 @@ func (c *LibClient) TestOptionalRequiredFlatteningParams(ctx context.Context, re
     return resp, nil
 }
 
+// MoveBooks
+func (c *LibClient) MoveBooks(ctx context.Context, req *librarypb.MoveBooksRequest, opts ...gax.CallOption) (*librarypb.MoveBooksResponse, error) {
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "source", url.QueryEscape(req.GetSource())))
+    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
+    opts = append(c.CallOptions.MoveBooks[0:len(c.CallOptions.MoveBooks):len(c.CallOptions.MoveBooks)], opts...)
+    var resp *librarypb.MoveBooksResponse
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        resp, err = c.client.MoveBooks(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
+}
+
+// ArchiveBooks
+func (c *LibClient) ArchiveBooks(ctx context.Context, req *librarypb.ArchiveBooksRequest, opts ...gax.CallOption) (*librarypb.ArchiveBooksResponse, error) {
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "source", url.QueryEscape(req.GetSource())))
+    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
+    opts = append(c.CallOptions.ArchiveBooks[0:len(c.CallOptions.ArchiveBooks):len(c.CallOptions.ArchiveBooks)], opts...)
+    var resp *librarypb.ArchiveBooksResponse
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        resp, err = c.client.ArchiveBooks(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
+}
+
+// LongRunningArchiveBooks
+func (c *LibClient) LongRunningArchiveBooks(ctx context.Context, req *librarypb.ArchiveBooksRequest, opts ...gax.CallOption) (*LongRunningArchiveBooksOperation, error) {
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "source", url.QueryEscape(req.GetSource())))
+    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
+    opts = append(c.CallOptions.LongRunningArchiveBooks[0:len(c.CallOptions.LongRunningArchiveBooks):len(c.CallOptions.LongRunningArchiveBooks)], opts...)
+    var resp *longrunningpb.Operation
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        resp, err = c.client.LongRunningArchiveBooks(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    if err != nil {
+        return nil, err
+    }
+    return &LongRunningArchiveBooksOperation{
+        lro: longrunning.InternalNewOperation(c.LROClient, resp),
+    }, nil
+}
+
+// StreamingArchiveBooks
+func (c *LibClient) StreamingArchiveBooks(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_StreamingArchiveBooksClient, error) {
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
+    opts = append(c.CallOptions.StreamingArchiveBooks[0:len(c.CallOptions.StreamingArchiveBooks):len(c.CallOptions.StreamingArchiveBooks)], opts...)
+    var resp librarypb.LibraryService_StreamingArchiveBooksClient
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        resp, err = c.client.StreamingArchiveBooks(ctx, settings.GRPC...)
+        return err
+    }, opts...)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
+}
+
 // PrivateListShelves this method is not exposed in the GAPIC config. It should be generated.
 func (c *LibClient) PrivateListShelves(ctx context.Context, req *librarypb.ListShelvesRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
     ctx = insertMetadata(ctx, c.xGoogMetadata)
@@ -1188,6 +1265,75 @@ func (op *GetBigNothingOperation) Done() bool {
 // Name returns the name of the long-running operation.
 // The name is assigned by the server and is unique within the service from which the operation is created.
 func (op *GetBigNothingOperation) Name() string {
+    return op.lro.Name()
+}
+
+// LongRunningArchiveBooksOperation manages a long-running operation from LongRunningArchiveBooks.
+type LongRunningArchiveBooksOperation struct {
+    lro *longrunning.Operation
+}
+
+// LongRunningArchiveBooksOperation returns a new LongRunningArchiveBooksOperation from a given name.
+// The name must be that of a previously created LongRunningArchiveBooksOperation, possibly from a different process.
+func (c *LibClient) LongRunningArchiveBooksOperation(name string) *LongRunningArchiveBooksOperation {
+    return &LongRunningArchiveBooksOperation{
+        lro: longrunning.InternalNewOperation(c.LROClient, &longrunningpb.Operation{Name: name}),
+    }
+}
+
+// Wait blocks until the long-running operation is completed, returning the response and any errors encountered.
+//
+// See documentation of Poll for error-handling information.
+func (op *LongRunningArchiveBooksOperation) Wait(ctx context.Context, opts ...gax.CallOption) (*librarypb.ArchiveBooksResponse, error) {
+    var resp librarypb.ArchiveBooksResponse
+    if err := op.lro.WaitWithInterval(ctx, &resp, 5000*time.Millisecond, opts...); err != nil {
+        return nil, err
+    }
+    return &resp, nil
+}
+
+// Poll fetches the latest state of the long-running operation.
+//
+// Poll also fetches the latest metadata, which can be retrieved by Metadata.
+//
+// If Poll fails, the error is returned and op is unmodified. If Poll succeeds and
+// the operation has completed with failure, the error is returned and op.Done will return true.
+// If Poll succeeds and the operation has completed successfully,
+// op.Done will return true, and the response of the operation is returned.
+// If Poll succeeds and the operation has not completed, the returned response and error are both nil.
+func (op *LongRunningArchiveBooksOperation) Poll(ctx context.Context, opts ...gax.CallOption) (*librarypb.ArchiveBooksResponse, error) {
+    var resp librarypb.ArchiveBooksResponse
+    if err := op.lro.Poll(ctx, &resp, opts...); err != nil {
+        return nil, err
+    }
+    if !op.Done() {
+        return nil, nil
+    }
+    return &resp, nil
+}
+
+// Metadata returns metadata associated with the long-running operation.
+// Metadata itself does not contact the server, but Poll does.
+// To get the latest metadata, call this method after a successful call to Poll.
+// If the metadata is not available, the returned metadata and error are both nil.
+func (op *LongRunningArchiveBooksOperation) Metadata() (*librarypb.ArchiveBooksMetadata, error) {
+    var meta librarypb.ArchiveBooksMetadata
+    if err := op.lro.Metadata(&meta); err == longrunning.ErrNoMetadata {
+        return nil, nil
+    } else if err != nil {
+        return nil, err
+    }
+    return &meta, nil
+}
+
+// Done reports whether the long-running operation has completed.
+func (op *LongRunningArchiveBooksOperation) Done() bool {
+    return op.lro.Done()
+}
+
+// Name returns the name of the long-running operation.
+// The name is assigned by the server and is unique within the service from which the operation is created.
+func (op *LongRunningArchiveBooksOperation) Name() string {
     return op.lro.Name()
 }
 
@@ -1769,6 +1915,99 @@ func ExampleClient_TestOptionalRequiredFlatteningParams() {
     _ = resp
 }
 
+func ExampleClient_MoveBooks() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &librarypb.MoveBooksRequest{
+        // TODO: Fill request struct fields.
+    }
+    resp, err := c.MoveBooks(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    // TODO: Use resp.
+    _ = resp
+}
+
+func ExampleClient_ArchiveBooks() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &librarypb.ArchiveBooksRequest{
+        // TODO: Fill request struct fields.
+    }
+    resp, err := c.ArchiveBooks(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    // TODO: Use resp.
+    _ = resp
+}
+
+func ExampleClient_LongRunningArchiveBooks() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &librarypb.ArchiveBooksRequest{
+        // TODO: Fill request struct fields.
+    }
+    op, err := c.LongRunningArchiveBooks(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    resp, err := op.Wait(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    // TODO: Use resp.
+    _ = resp
+}
+
+func ExampleClient_StreamingArchiveBooks() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    stream, err := c.StreamingArchiveBooks(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    go func() {
+        reqs := []*librarypb.ArchiveBooksRequest{
+            // TODO: Create requests.
+        }
+        for _, req := range reqs {
+            if err := stream.Send(req); err != nil {
+                // TODO: Handle error.
+            }
+        }
+        stream.CloseSend()
+    }()
+    for {
+        resp, err := stream.Recv()
+        if err == io.EOF {
+            break
+        }
+        if err != nil {
+            // TODO: handle error.
+        }
+        // TODO: Use resp.
+        _ = resp
+    }
+}
+
 func ExampleClient_PrivateListShelves() {
     ctx := context.Background()
     c, err := library.NewClient(ctx)
@@ -2201,6 +2440,67 @@ func (s *mockLibraryServer) GetBigNothing(ctx context.Context, req *librarypb.Ge
     return s.resps[0].(*longrunningpb.Operation), nil
 }
 
+func (s *mockLibraryServer) MoveBooks(ctx context.Context, req *librarypb.MoveBooksRequest) (*librarypb.MoveBooksResponse, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*librarypb.MoveBooksResponse), nil
+}
+
+func (s *mockLibraryServer) ArchiveBooks(ctx context.Context, req *librarypb.ArchiveBooksRequest) (*librarypb.ArchiveBooksResponse, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*librarypb.ArchiveBooksResponse), nil
+}
+
+func (s *mockLibraryServer) LongRunningArchiveBooks(ctx context.Context, req *librarypb.ArchiveBooksRequest) (*longrunningpb.Operation, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*longrunningpb.Operation), nil
+}
+
+func (s *mockLibraryServer) StreamingArchiveBooks(stream librarypb.LibraryService_StreamingArchiveBooksServer) error {
+    md, _ := metadata.FromIncomingContext(stream.Context())
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    for {
+        if req, err := stream.Recv(); err == io.EOF {
+            break
+        } else if err != nil {
+            return err
+        } else {
+            s.reqs = append(s.reqs, req)
+        }
+    }
+    if s.err != nil {
+        return s.err
+    }
+    for _, v := range s.resps {
+        if err := stream.Send(v.(*librarypb.ArchiveBooksResponse)); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+
 func (s *mockLibraryServer) TestOptionalRequiredFlatteningParams(ctx context.Context, req *librarypb.TestOptionalRequiredFlatteningParamsRequest) (*librarypb.TestOptionalRequiredFlatteningParamsResponse, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
@@ -2391,7 +2691,7 @@ func TestLibraryServiceGetShelf(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var options string = "options-1249474914"
     var request = &librarypb.GetShelfRequest{
         Name: formattedName,
@@ -2422,7 +2722,7 @@ func TestLibraryServiceGetShelfError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var options string = "options-1249474914"
     var request = &librarypb.GetShelfRequest{
         Name: formattedName,
@@ -2517,7 +2817,7 @@ func TestLibraryServiceDeleteShelf(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.DeleteShelfRequest{
         Name: formattedName,
     }
@@ -2543,7 +2843,7 @@ func TestLibraryServiceDeleteShelfError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.DeleteShelfRequest{
         Name: formattedName,
     }
@@ -2576,8 +2876,8 @@ func TestLibraryServiceMergeShelves(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
-    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
+    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.MergeShelvesRequest{
         Name: formattedName,
         OtherShelfName: formattedOtherShelfName,
@@ -2607,8 +2907,8 @@ func TestLibraryServiceMergeShelvesError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
-    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
+    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.MergeShelvesRequest{
         Name: formattedName,
         OtherShelfName: formattedOtherShelfName,
@@ -2645,7 +2945,7 @@ func TestLibraryServiceCreateBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var book *librarypb.Book = &librarypb.Book{}
     var request = &librarypb.CreateBookRequest{
         Name: formattedName,
@@ -2676,7 +2976,7 @@ func TestLibraryServiceCreateBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var book *librarypb.Book = &librarypb.Book{}
     var request = &librarypb.CreateBookRequest{
         Name: formattedName,
@@ -2792,7 +3092,7 @@ func TestLibraryServiceGetBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -2821,7 +3121,7 @@ func TestLibraryServiceGetBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -2854,7 +3154,7 @@ func TestLibraryServiceListBooks(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var filter string = "book-filter-string"
     var request = &librarypb.ListBooksRequest{
         Name: formattedName,
@@ -2895,7 +3195,7 @@ func TestLibraryServiceListBooksError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var filter string = "book-filter-string"
     var request = &librarypb.ListBooksRequest{
         Name: formattedName,
@@ -2924,7 +3224,7 @@ func TestLibraryServiceDeleteBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.DeleteBookRequest{
         Name: formattedName,
     }
@@ -2950,7 +3250,7 @@ func TestLibraryServiceDeleteBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.DeleteBookRequest{
         Name: formattedName,
     }
@@ -2985,7 +3285,7 @@ func TestLibraryServiceUpdateBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var book *librarypb.Book = &librarypb.Book{}
     var request = &librarypb.UpdateBookRequest{
         Name: formattedName,
@@ -3016,7 +3316,7 @@ func TestLibraryServiceUpdateBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var book *librarypb.Book = &librarypb.Book{}
     var request = &librarypb.UpdateBookRequest{
         Name: formattedName,
@@ -3054,8 +3354,8 @@ func TestLibraryServiceMoveBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
-    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.MoveBookRequest{
         Name: formattedName,
         OtherShelfName: formattedOtherShelfName,
@@ -3085,8 +3385,8 @@ func TestLibraryServiceMoveBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
-    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.MoveBookRequest{
         Name: formattedName,
         OtherShelfName: formattedOtherShelfName,
@@ -3180,7 +3480,7 @@ func TestLibraryServiceAddComments(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var comment []byte = []byte("95")
     var stage librarypb.Comment_Stage = librarypb.Comment_UNSET
     var alignment librarypb.SomeMessage2_SomeMessage3_Alignment = librarypb.SomeMessage2_SomeMessage3_CHAR
@@ -3216,7 +3516,7 @@ func TestLibraryServiceAddCommentsError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var comment []byte = []byte("95")
     var stage librarypb.Comment_Stage = librarypb.Comment_UNSET
     var alignment librarypb.SomeMessage2_SomeMessage3_Alignment = librarypb.SomeMessage2_SomeMessage3_CHAR
@@ -3261,8 +3561,8 @@ func TestLibraryServiceGetBookFromAnywhere(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
-    var formattedAltBookName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedAltBookName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var formattedPlace string = fmt.Sprintf("projects/%s/locations/%s", "[PROJECT]", "[LOCATION]")
     var formattedFolder string = fmt.Sprintf("folders/%s", "[FOLDER]")
     var request = &librarypb.GetBookFromAnywhereRequest{
@@ -3296,8 +3596,8 @@ func TestLibraryServiceGetBookFromAnywhereError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
-    var formattedAltBookName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedAltBookName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var formattedPlace string = fmt.Sprintf("projects/%s/locations/%s", "[PROJECT]", "[LOCATION]")
     var formattedFolder string = fmt.Sprintf("folders/%s", "[FOLDER]")
     var request = &librarypb.GetBookFromAnywhereRequest{
@@ -3338,7 +3638,7 @@ func TestLibraryServiceGetBookFromAbsolutelyAnywhere(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.GetBookFromAbsolutelyAnywhereRequest{
         Name: formattedName,
     }
@@ -3367,7 +3667,7 @@ func TestLibraryServiceGetBookFromAbsolutelyAnywhereError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.GetBookFromAbsolutelyAnywhereRequest{
         Name: formattedName,
     }
@@ -3394,7 +3694,7 @@ func TestLibraryServiceUpdateBookIndex(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var indexName string = "default index"
     var indexMapItem string = "indexMapItem1918721251"
     var indexMap = map[string]string{
@@ -3427,7 +3727,7 @@ func TestLibraryServiceUpdateBookIndexError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var indexName string = "default index"
     var indexMapItem string = "indexMapItem1918721251"
     var indexMap = map[string]string{
@@ -3464,7 +3764,7 @@ func TestLibraryServiceStreamShelves(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.StreamShelvesRequest{
         Name: formattedName,
     }
@@ -3497,7 +3797,7 @@ func TestLibraryServiceStreamShelvesError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF_ID]")
+    var formattedName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.StreamShelvesRequest{
         Name: formattedName,
     }
@@ -3606,7 +3906,7 @@ func TestLibraryServiceDiscussBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3645,7 +3945,7 @@ func TestLibraryServiceDiscussBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3687,7 +3987,7 @@ func TestLibraryServiceMonologAboutBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3723,7 +4023,7 @@ func TestLibraryServiceMonologAboutBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3757,7 +4057,7 @@ func TestLibraryServiceBabbleAboutBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3790,7 +4090,7 @@ func TestLibraryServiceBabbleAboutBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3901,7 +4201,7 @@ func TestLabelerAddLabel(t *testing.T) {
 
     mockLabeler.resps = append(mockLabeler.resps[:0], expectedResponse)
 
-    var formattedResource string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedResource string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var label string = "label102727412"
     var request = &taggerpb.AddLabelRequest{
         Resource: formattedResource,
@@ -3932,7 +4232,7 @@ func TestLabelerAddLabelError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLabeler.err = gstatus.Error(errCode, "test error")
 
-    var formattedResource string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedResource string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var label string = "label102727412"
     var request = &taggerpb.AddLabelRequest{
         Resource: formattedResource,
@@ -3978,7 +4278,7 @@ func TestLibraryServiceGetBigBook(t *testing.T) {
         Result: &longrunningpb.Operation_Response{ Response: any },
     })
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4021,7 +4321,7 @@ func TestLibraryServiceGetBigBookError(t *testing.T) {
         },
     })
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4060,7 +4360,7 @@ func TestLibraryServiceGetBigNothing(t *testing.T) {
         Result: &longrunningpb.Operation_Response{ Response: any },
     })
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4100,7 +4400,7 @@ func TestLibraryServiceGetBigNothingError(t *testing.T) {
         },
     })
 
-    var formattedName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4139,8 +4439,8 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParams(t *testing.T) {
     var requiredSingularString string = "requiredSingularString-1949894503"
     var requiredSingularBytes []byte = []byte("-29")
     var requiredSingularMessage *librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage = &librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage{}
-    var formattedRequiredSingularResourceName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
-    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedRequiredSingularResourceName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var requiredSingularResourceNameCommon string = "requiredSingularResourceNameCommon-1126805002"
     var requiredSingularFixed32 int32 = 720656715
     var requiredSingularFixed64 int64 = 720656810
@@ -4288,8 +4588,8 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
     var requiredSingularString string = "requiredSingularString-1949894503"
     var requiredSingularBytes []byte = []byte("-29")
     var requiredSingularMessage *librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage = &librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage{}
-    var formattedRequiredSingularResourceName string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
-    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("bookShelves/%s/books/%s", "[BOOK_SHELF]", "[BOOK]")
+    var formattedRequiredSingularResourceName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
     var requiredSingularResourceNameCommon string = "requiredSingularResourceNameCommon-1126805002"
     var requiredSingularFixed32 int32 = 720656715
     var requiredSingularFixed64 int64 = 720656810
@@ -4410,6 +4710,264 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
     }
 
     resp, err := c.TestOptionalRequiredFlatteningParams(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
+    _ = resp
+}
+func TestLibraryServiceMoveBooks(t *testing.T) {
+    var success bool = false
+    var expectedResponse = &librarypb.MoveBooksResponse{
+        Success: success,
+    }
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
+
+    var request *librarypb.MoveBooksRequest = &librarypb.MoveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.MoveBooks(context.Background(), request)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+    if want, got := expectedResponse, resp; !proto.Equal(want, got) {
+        t.Errorf("wrong response %q, want %q)", got, want)
+    }
+}
+
+func TestLibraryServiceMoveBooksError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockLibrary.err = gstatus.Error(errCode, "test error")
+
+    var request *librarypb.MoveBooksRequest = &librarypb.MoveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.MoveBooks(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
+    _ = resp
+}
+func TestLibraryServiceArchiveBooks(t *testing.T) {
+    var success bool = false
+    var expectedResponse = &librarypb.ArchiveBooksResponse{
+        Success: success,
+    }
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.ArchiveBooks(context.Background(), request)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+    if want, got := expectedResponse, resp; !proto.Equal(want, got) {
+        t.Errorf("wrong response %q, want %q)", got, want)
+    }
+}
+
+func TestLibraryServiceArchiveBooksError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockLibrary.err = gstatus.Error(errCode, "test error")
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.ArchiveBooks(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
+    _ = resp
+}
+func TestLibraryServiceLongRunningArchiveBooks(t *testing.T) {
+    var success bool = false
+    var expectedResponse = &librarypb.ArchiveBooksResponse{
+        Success: success,
+    }
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    any, err := ptypes.MarshalAny(expectedResponse)
+    if err != nil {
+        t.Fatal(err)
+    }
+    mockLibrary.resps = append(mockLibrary.resps[:0], &longrunningpb.Operation{
+        Name: "longrunning-test",
+        Done: true,
+        Result: &longrunningpb.Operation_Response{ Response: any },
+    })
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    respLRO, err := c.LongRunningArchiveBooks(context.Background(), request)
+    if err != nil {
+        t.Fatal(err)
+    }
+    resp, err := respLRO.Wait(context.Background())
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+    if want, got := expectedResponse, resp; !proto.Equal(want, got) {
+        t.Errorf("wrong response %q, want %q)", got, want)
+    }
+}
+
+func TestLibraryServiceLongRunningArchiveBooksError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockLibrary.err = nil
+    mockLibrary.resps = append(mockLibrary.resps[:0], &longrunningpb.Operation{
+        Name: "longrunning-test",
+        Done: true,
+        Result: &longrunningpb.Operation_Error{
+            Error: &status.Status{
+                Code: int32(errCode),
+                Message: "test error",
+            },
+        },
+    })
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    respLRO, err := c.LongRunningArchiveBooks(context.Background(), request)
+    if err != nil {
+        t.Fatal(err)
+    }
+    resp, err := respLRO.Wait(context.Background())
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
+    _ = resp
+}
+func TestLibraryServiceStreamingArchiveBooks(t *testing.T) {
+    var success bool = false
+    var expectedResponse = &librarypb.ArchiveBooksResponse{
+        Success: success,
+    }
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    stream, err := c.StreamingArchiveBooks(context.Background())
+    if err != nil {
+        t.Fatal(err)
+    }
+    if err := stream.Send(request); err != nil {
+        t.Fatal(err)
+    }
+    if err := stream.CloseSend(); err != nil {
+        t.Fatal(err)
+    }
+    resp, err := stream.Recv()
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+    if want, got := expectedResponse, resp; !proto.Equal(want, got) {
+        t.Errorf("wrong response %q, want %q)", got, want)
+    }
+}
+
+func TestLibraryServiceStreamingArchiveBooksError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockLibrary.err = gstatus.Error(errCode, "test error")
+
+    var request *librarypb.ArchiveBooksRequest = &librarypb.ArchiveBooksRequest{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    stream, err := c.StreamingArchiveBooks(context.Background())
+    if err != nil {
+        t.Fatal(err)
+    }
+    if err := stream.Send(request); err != nil {
+        t.Fatal(err)
+    }
+    if err := stream.CloseSend(); err != nil {
+        t.Fatal(err)
+    }
+    resp, err := stream.Recv()
 
     if st, ok := gstatus.FromError(err); !ok {
         t.Errorf("got error %v, expected grpc error", err)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -56,7 +56,7 @@ func TestLibClientSmoke(t *testing.T) {
     t.Fatal(err)
   }
 
-  var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", projectId)
+  var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "testShelf-" + strconv.FormatInt(time.Now().UnixNano(), 10) + "", projectId)
   var rating librarypb.Book_Rating = librarypb.Book_GOOD
   var book = &librarypb.Book{
       Rating: rating,
@@ -3092,7 +3092,7 @@ func TestLibraryServiceGetBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -3121,7 +3121,7 @@ func TestLibraryServiceGetBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -3224,7 +3224,7 @@ func TestLibraryServiceDeleteBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DeleteBookRequest{
         Name: formattedName,
     }
@@ -3250,7 +3250,7 @@ func TestLibraryServiceDeleteBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DeleteBookRequest{
         Name: formattedName,
     }
@@ -3285,7 +3285,7 @@ func TestLibraryServiceUpdateBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var book *librarypb.Book = &librarypb.Book{}
     var request = &librarypb.UpdateBookRequest{
         Name: formattedName,
@@ -3316,7 +3316,7 @@ func TestLibraryServiceUpdateBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var book *librarypb.Book = &librarypb.Book{}
     var request = &librarypb.UpdateBookRequest{
         Name: formattedName,
@@ -3354,7 +3354,7 @@ func TestLibraryServiceMoveBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.MoveBookRequest{
         Name: formattedName,
@@ -3385,7 +3385,7 @@ func TestLibraryServiceMoveBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var formattedOtherShelfName string = fmt.Sprintf("shelves/%s", "[SHELF]")
     var request = &librarypb.MoveBookRequest{
         Name: formattedName,
@@ -3480,7 +3480,7 @@ func TestLibraryServiceAddComments(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var comment []byte = []byte("95")
     var stage librarypb.Comment_Stage = librarypb.Comment_UNSET
     var alignment librarypb.SomeMessage2_SomeMessage3_Alignment = librarypb.SomeMessage2_SomeMessage3_CHAR
@@ -3516,7 +3516,7 @@ func TestLibraryServiceAddCommentsError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var comment []byte = []byte("95")
     var stage librarypb.Comment_Stage = librarypb.Comment_UNSET
     var alignment librarypb.SomeMessage2_SomeMessage3_Alignment = librarypb.SomeMessage2_SomeMessage3_CHAR
@@ -3561,8 +3561,8 @@ func TestLibraryServiceGetBookFromAnywhere(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
-    var formattedAltBookName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var formattedAltBookName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var formattedPlace string = fmt.Sprintf("projects/%s/locations/%s", "[PROJECT]", "[LOCATION]")
     var formattedFolder string = fmt.Sprintf("folders/%s", "[FOLDER]")
     var request = &librarypb.GetBookFromAnywhereRequest{
@@ -3596,8 +3596,8 @@ func TestLibraryServiceGetBookFromAnywhereError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
-    var formattedAltBookName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var formattedAltBookName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var formattedPlace string = fmt.Sprintf("projects/%s/locations/%s", "[PROJECT]", "[LOCATION]")
     var formattedFolder string = fmt.Sprintf("folders/%s", "[FOLDER]")
     var request = &librarypb.GetBookFromAnywhereRequest{
@@ -3638,7 +3638,7 @@ func TestLibraryServiceGetBookFromAbsolutelyAnywhere(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookFromAbsolutelyAnywhereRequest{
         Name: formattedName,
     }
@@ -3667,7 +3667,7 @@ func TestLibraryServiceGetBookFromAbsolutelyAnywhereError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookFromAbsolutelyAnywhereRequest{
         Name: formattedName,
     }
@@ -3694,7 +3694,7 @@ func TestLibraryServiceUpdateBookIndex(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var indexName string = "default index"
     var indexMapItem string = "indexMapItem1918721251"
     var indexMap = map[string]string{
@@ -3727,7 +3727,7 @@ func TestLibraryServiceUpdateBookIndexError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var indexName string = "default index"
     var indexMapItem string = "indexMapItem1918721251"
     var indexMap = map[string]string{
@@ -3906,7 +3906,7 @@ func TestLibraryServiceDiscussBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3945,7 +3945,7 @@ func TestLibraryServiceDiscussBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -3987,7 +3987,7 @@ func TestLibraryServiceMonologAboutBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -4023,7 +4023,7 @@ func TestLibraryServiceMonologAboutBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -4057,7 +4057,7 @@ func TestLibraryServiceBabbleAboutBook(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -4090,7 +4090,7 @@ func TestLibraryServiceBabbleAboutBookError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.DiscussBookRequest{
         Name: formattedName,
     }
@@ -4201,7 +4201,7 @@ func TestLabelerAddLabel(t *testing.T) {
 
     mockLabeler.resps = append(mockLabeler.resps[:0], expectedResponse)
 
-    var formattedResource string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedResource string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var label string = "label102727412"
     var request = &taggerpb.AddLabelRequest{
         Resource: formattedResource,
@@ -4232,7 +4232,7 @@ func TestLabelerAddLabelError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLabeler.err = gstatus.Error(errCode, "test error")
 
-    var formattedResource string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedResource string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var label string = "label102727412"
     var request = &taggerpb.AddLabelRequest{
         Resource: formattedResource,
@@ -4278,7 +4278,7 @@ func TestLibraryServiceGetBigBook(t *testing.T) {
         Result: &longrunningpb.Operation_Response{ Response: any },
     })
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4321,7 +4321,7 @@ func TestLibraryServiceGetBigBookError(t *testing.T) {
         },
     })
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4360,7 +4360,7 @@ func TestLibraryServiceGetBigNothing(t *testing.T) {
         Result: &longrunningpb.Operation_Response{ Response: any },
     })
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4400,7 +4400,7 @@ func TestLibraryServiceGetBigNothingError(t *testing.T) {
         },
     })
 
-    var formattedName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var request = &librarypb.GetBookRequest{
         Name: formattedName,
     }
@@ -4439,8 +4439,8 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParams(t *testing.T) {
     var requiredSingularString string = "requiredSingularString-1949894503"
     var requiredSingularBytes []byte = []byte("-29")
     var requiredSingularMessage *librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage = &librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage{}
-    var formattedRequiredSingularResourceName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
-    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedRequiredSingularResourceName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var requiredSingularResourceNameCommon string = "requiredSingularResourceNameCommon-1126805002"
     var requiredSingularFixed32 int32 = 720656715
     var requiredSingularFixed64 int64 = 720656810
@@ -4588,8 +4588,8 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
     var requiredSingularString string = "requiredSingularString-1949894503"
     var requiredSingularBytes []byte = []byte("-29")
     var requiredSingularMessage *librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage = &librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage{}
-    var formattedRequiredSingularResourceName string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
-    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("archives/%s/books/%s", "[ARCHIVE]", "[BOOK]")
+    var formattedRequiredSingularResourceName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var formattedRequiredSingularResourceNameOneof string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
     var requiredSingularResourceNameCommon string = "requiredSingularResourceNameCommon-1126805002"
     var requiredSingularFixed32 int32 = 720656715
     var requiredSingularFixed64 int64 = 720656810

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -209,10 +209,10 @@ public class Babbage {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithResponseHandling {
   // [START sample]
@@ -220,10 +220,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test response handling for methods that return empty */
@@ -250,7 +250,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -290,10 +290,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithoutResponseHandling {
   // [START sample]
@@ -301,10 +301,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test default response handling is turned off for methods that return empty */
@@ -328,7 +328,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -711,11 +711,11 @@ public class DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling {
 
 package com.google.example.examples.library.v1;
 
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -725,11 +725,11 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /*
    * Please include the following imports to run this sample.
    *
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -738,7 +738,7 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -863,11 +863,11 @@ public class FindRelatedBooksFlattenedPagedOdyssey {
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -878,11 +878,11 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -891,7 +891,7 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -941,10 +941,10 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
 
 package com.google.example.examples.library.v1;
 
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -954,10 +954,10 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /*
    * Please include the following imports to run this sample.
    *
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -966,7 +966,7 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -1018,10 +1018,10 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1032,10 +1032,10 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1049,7 +1049,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
+      BookName name = ShelfBookName.of(shelf, "War and Peace");
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1124,10 +1124,10 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
   // [START hopper]
@@ -1136,10 +1136,10 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1158,7 +1158,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
+      BookName name = ShelfBookName.of(shelf, bigBookName);
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1222,11 +1222,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1237,11 +1237,11 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1255,7 +1255,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
+      BookName name = ShelfBookName.of(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1333,11 +1333,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
   // [START hopper]
@@ -1346,11 +1346,11 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1369,7 +1369,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
+      BookName name = ShelfBookName.of(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1435,10 +1435,10 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.core.ApiFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 import com.google.protobuf.ListValue;
 import java.util.Map;
@@ -1449,10 +1449,10 @@ public class GetBigBookCallableCallableWap {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
@@ -1467,7 +1467,7 @@ public class GetBigBookCallableCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
+      BookName name = ShelfBookName.of(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1545,10 +1545,10 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.core.ApiFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigBookCallableCallableWap2 {
@@ -1557,10 +1557,10 @@ public class GetBigBookCallableCallableWap2 {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
@@ -1580,7 +1580,7 @@ public class GetBigBookCallableCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
+      BookName name = ShelfBookName.of(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1648,11 +1648,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1663,11 +1663,11 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1681,7 +1681,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
+      BookName name = ShelfBookName.of(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1760,11 +1760,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookOperationCallableLongRunningCallableWap2 {
   // [START hopper]
@@ -1773,11 +1773,11 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1796,7 +1796,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
+      BookName name = ShelfBookName.of(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1859,10 +1859,10 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithResponseHandling {
@@ -1871,17 +1871,17 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1923,10 +1923,10 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -1935,17 +1935,17 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1985,11 +1985,11 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithResponseHandling {
@@ -1998,18 +1998,18 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2054,11 +2054,11 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -2067,18 +2067,18 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2121,10 +2121,10 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling {
@@ -2133,17 +2133,17 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2189,10 +2189,10 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2201,17 +2201,17 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2255,11 +2255,11 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithResponseHandling {
@@ -2268,18 +2268,18 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2325,11 +2325,11 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2338,18 +2338,18 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2396,10 +2396,10 @@ package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookCallableCallableTestOnSuccessMap {
   // [START sample]
@@ -2408,15 +2408,15 @@ public class GetBookCallableCallableTestOnSuccessMap {
    *
    * import com.google.api.core.ApiFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2466,9 +2466,9 @@ public class GetBookCallableCallableTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookFlattenedTestOnSuccessMap {
   // [START sample]
@@ -2476,14 +2476,14 @@ public class GetBookFlattenedTestOnSuccessMap {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       Book response = libraryClient.getBook(name.toString());
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
@@ -2526,10 +2526,10 @@ public class GetBookFlattenedTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookRequestTestOnSuccessMap {
   // [START sample]
@@ -2537,15 +2537,15 @@ public class GetBookRequestTestOnSuccessMap {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2590,11 +2590,11 @@ public class GetBookRequestTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class MonologAboutBookCallableCallableStreamingClientProg {
   // [START sample]
@@ -2602,11 +2602,11 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Testing calling forms */
@@ -2632,7 +2632,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3660,9 +3660,9 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3693,9 +3693,9 @@ public class TestFloatAndInt64 {
   /*
    * Please include the following imports to run this sample.
    *
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3738,8 +3738,8 @@ public class TestFloatAndInt64 {
       String requiredSingularString = "";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       String requiredSingularResourceNameCommon = "";
       int requiredSingularFixed32 = 0;
       long requiredSingularFixed64 = 0L;
@@ -3913,10 +3913,10 @@ public class TestFloatAndInt64 {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.BookFromAnywhere;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof {
   // [START test_resource_name_oneof]
@@ -3924,15 +3924,15 @@ public class TestResourceNameOneof {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.BookFromAnywhere;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "The ID of the book");
+      BookName name = ShelfBookName.of("[SHELF]", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3972,10 +3972,10 @@ public class TestResourceNameOneof {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.BookFromAnywhere;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof2 {
   // [START test_resource_name_oneof_2]
@@ -3983,15 +3983,15 @@ public class TestResourceNameOneof2 {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.BookFromAnywhere;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "The ID of the book");
+      BookName name = ShelfBookName.of("The Shelf to search for the book", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4106,11 +4106,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -4121,11 +4121,11 @@ public class ThisTagShouldBeTheNameOfTheFile {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -4139,7 +4139,7 @@ public class ThisTagShouldBeTheNameOfTheFile {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
+      BookName name = ShelfBookName.of(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4216,11 +4216,11 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.rpc.BidiStream;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ByteString;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -4232,11 +4232,11 @@ public class TuringProgCallableStreamingBidi {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.BidiStream;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ByteString;
    * import java.nio.file.Files;
    * import java.nio.file.Path;
@@ -4256,7 +4256,7 @@ public class TuringProgCallableStreamingBidi {
       BidiStream<DiscussBookRequest, Comment> bidiStream =
           libraryClient.discussBookCallable().call();
 
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       Path path = Paths.get("comment_file");
       byte[] data = Files.readAllBytes(path);
       ByteString comment = ByteString.copyFrom(data);
@@ -4474,7 +4474,7 @@ public class LibraryClient implements BackgroundResource {
       PathTemplate.createWithoutUrlEncoding("archives/{archive}/books/{book}");
 
   private static final PathTemplate SHELF_BOOK_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("bookShelves/{book_shelf}/books/{book}");
+      PathTemplate.createWithoutUrlEncoding("shelves/{shelf}/books/{book}");
 
   private static final PathTemplate BOOK_FROM_ARCHIVE_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("archives/{archive}/books/{book}");
@@ -4517,9 +4517,9 @@ public class LibraryClient implements BackgroundResource {
    * @deprecated Use the {@link ShelfBookName} class instead.
    */
   @Deprecated
-  public static final String formatShelfBookName(String bookShelf, String book) {
+  public static final String formatShelfBookName(String shelf, String book) {
     return SHELF_BOOK_PATH_TEMPLATE.instantiate(
-        "book_shelf", bookShelf,
+        "shelf", shelf,
         "book", book);
   }
 
@@ -4635,14 +4635,14 @@ public class LibraryClient implements BackgroundResource {
   }
 
   /**
-   * Parses the book_shelf from the given fully-qualified path which
+   * Parses the shelf from the given fully-qualified path which
    * represents a shelf_book resource.
    *
    * @deprecated Use the {@link ShelfBookName} class instead.
    */
   @Deprecated
-  public static final String parseBookShelfFromShelfBookName(String shelfBookName) {
-    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("book_shelf");
+  public static final String parseShelfFromShelfBookName(String shelfBookName) {
+    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("shelf");
   }
 
   /**
@@ -5646,7 +5646,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name);
    * }
    * </code></pre>
@@ -5669,7 +5669,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -5692,7 +5692,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5714,7 +5714,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5875,7 +5875,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name);
    * }
    * </code></pre>
@@ -5898,7 +5898,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -5921,7 +5921,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5943,7 +5943,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5964,7 +5964,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name, book);
    * }
@@ -5990,7 +5990,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name.toString(), book);
    * }
@@ -6016,7 +6016,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6051,7 +6051,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6086,7 +6086,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6110,7 +6110,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6133,7 +6133,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name, otherShelfName);
    * }
@@ -6159,7 +6159,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name.toString(), otherShelfName.toString());
    * }
@@ -6185,7 +6185,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6209,7 +6209,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6372,7 +6372,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6406,7 +6406,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6440,7 +6440,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6472,7 +6472,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6602,8 +6602,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name, altBookName, place, folder);
@@ -6635,8 +6635,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name.toString(), altBookName.toString(), place.toString(), folder.toString());
@@ -6668,8 +6668,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6696,8 +6696,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6723,7 +6723,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -6746,7 +6746,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -6769,7 +6769,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6791,7 +6791,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6812,7 +6812,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6843,7 +6843,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6874,7 +6874,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6902,7 +6902,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6980,7 +6980,7 @@ public class LibraryClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryClient.discussBookCallable().call();
    *
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7022,7 +7022,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7062,7 +7062,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7110,7 +7110,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7138,7 +7138,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7164,7 +7164,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7197,7 +7197,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7222,7 +7222,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7246,7 +7246,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -7270,7 +7270,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7294,7 +7294,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7317,7 +7317,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7339,7 +7339,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7360,7 +7360,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -7384,7 +7384,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7408,7 +7408,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7431,7 +7431,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7453,7 +7453,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7502,8 +7502,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7563,8 +7563,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -7888,8 +7888,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedRequiredSingularResourceName = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
-   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
+   *   String formattedRequiredSingularResourceName = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
+   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7949,8 +7949,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedOptionalSingularResourceName = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
-   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
+   *   String formattedOptionalSingularResourceName = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
+   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -8274,8 +8274,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8416,8 +8416,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -14742,7 +14742,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14854,7 +14854,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14866,7 +14866,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBook(name);
@@ -14890,7 +14890,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -14955,7 +14955,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     client.deleteBook(name);
 
@@ -14977,7 +14977,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -14989,7 +14989,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15001,7 +15001,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -15027,7 +15027,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -15040,7 +15040,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15052,7 +15052,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15084,7 +15084,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15100,7 +15100,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15112,7 +15112,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
@@ -15138,7 +15138,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
@@ -15251,7 +15251,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     ByteString comment = ByteString.copyFromUtf8("95");
     Comment.Stage stage = Comment.Stage.UNSET;
     SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15283,7 +15283,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       ByteString comment = ByteString.copyFromUtf8("95");
       Comment.Stage stage = Comment.Stage.UNSET;
       SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15355,7 +15355,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15367,8 +15367,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-    BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
     LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
     FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15397,8 +15397,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-      BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
       LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
       FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15412,7 +15412,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15424,7 +15424,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -15448,7 +15448,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -15463,7 +15463,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String indexName = "default index";
     String indexMapItem = "indexMapItem1918721251";
     Map<String, String> indexMap = new HashMap<>();
@@ -15491,7 +15491,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       String indexName = "default index";
       String indexMapItem = "indexMapItem1918721251";
       Map<String, String> indexMap = new HashMap<>();
@@ -15558,7 +15558,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15621,7 +15621,7 @@ public class LibraryClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -15646,7 +15646,7 @@ public class LibraryClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -15674,7 +15674,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    BookName namesElement2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName namesElement2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     List<BookName> names2 = Arrays.asList(namesElement2);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -15729,7 +15729,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15747,7 +15747,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -15771,7 +15771,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -15795,7 +15795,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -15819,7 +15819,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -15880,8 +15880,8 @@ public class LibraryClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-    BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
     String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -15941,8 +15941,8 @@ public class LibraryClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-    BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
     String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -16146,8 +16146,8 @@ public class LibraryClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -16207,8 +16207,8 @@ public class LibraryClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-      BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -16471,7 +16471,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void privateListShelvesTest() {
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -16563,7 +16563,7 @@ public class LibrarySmokeTest {
 
   public static void executeNoCatch(String projectId) throws Exception {
     try (LibraryClient client = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", projectId);
+      BookName name = ShelfBookName.of("testShelf-" + System.currentTimeMillis(), projectId);
       Book.Rating rating = Book.Rating.GOOD;
       Book book = Book.newBuilder()
         .setRating(rating)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -209,10 +209,10 @@ public class Babbage {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithResponseHandling {
   // [START sample]
@@ -220,10 +220,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test response handling for methods that return empty */
@@ -250,7 +250,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -290,10 +290,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithoutResponseHandling {
   // [START sample]
@@ -301,10 +301,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test default response handling is turned off for methods that return empty */
@@ -328,7 +328,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -386,7 +386,7 @@ public class DeleteShelfCallableCallableEmptyResponseTypeWithResponseHandling {
   /** Test response handling for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -450,7 +450,7 @@ public class DeleteShelfCallableCallableEmptyResponseTypeWithoutResponseHandling
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -508,7 +508,7 @@ public class DeleteShelfFlattenedEmptyResponseTypeWithResponseHandling {
   /** Test response handling for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       libraryClient.deleteShelf(name.toString());
       // Shelf deleted
       System.out.println("Shelf deleted.");
@@ -561,7 +561,7 @@ public class DeleteShelfFlattenedEmptyResponseTypeWithoutResponseHandling {
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       libraryClient.deleteShelf(name.toString());
     } catch (Exception exception) {
       System.err.println("Failed to create the client due to: " + exception);
@@ -614,7 +614,7 @@ public class DeleteShelfRequestEmptyResponseTypeWithResponseHandling {
   /** Test response handling for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -672,7 +672,7 @@ public class DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling {
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -711,11 +711,11 @@ public class DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling {
 
 package com.google.example.examples.library.v1;
 
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -725,11 +725,11 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /*
    * Please include the following imports to run this sample.
    *
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -738,9 +738,9 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
       FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
         .addAllNames(BookName.toStringList(names))
@@ -863,11 +863,11 @@ public class FindRelatedBooksFlattenedPagedOdyssey {
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -878,11 +878,11 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -891,9 +891,9 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
       FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
         .addAllNames(BookName.toStringList(names))
@@ -941,10 +941,10 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
 
 package com.google.example.examples.library.v1;
 
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -954,10 +954,10 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /*
    * Please include the following imports to run this sample.
    *
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -966,9 +966,9 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
       FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
         .addAllNames(BookName.toStringList(names))
@@ -1018,10 +1018,10 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1032,10 +1032,10 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1049,7 +1049,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1124,10 +1124,10 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
   // [START hopper]
@@ -1136,10 +1136,10 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1158,7 +1158,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1222,11 +1222,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1237,11 +1237,11 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1255,7 +1255,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1333,11 +1333,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
   // [START hopper]
@@ -1346,11 +1346,11 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1369,7 +1369,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1435,10 +1435,10 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.core.ApiFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 import com.google.protobuf.ListValue;
 import java.util.Map;
@@ -1449,10 +1449,10 @@ public class GetBigBookCallableCallableWap {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
@@ -1467,7 +1467,7 @@ public class GetBigBookCallableCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1545,10 +1545,10 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.core.ApiFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigBookCallableCallableWap2 {
@@ -1557,10 +1557,10 @@ public class GetBigBookCallableCallableWap2 {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
@@ -1580,7 +1580,7 @@ public class GetBigBookCallableCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1648,11 +1648,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1663,11 +1663,11 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1681,7 +1681,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1760,11 +1760,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookOperationCallableLongRunningCallableWap2 {
   // [START hopper]
@@ -1773,11 +1773,11 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1796,7 +1796,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1859,10 +1859,10 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithResponseHandling {
@@ -1871,17 +1871,17 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1923,10 +1923,10 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -1935,17 +1935,17 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1985,11 +1985,11 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithResponseHandling {
@@ -1998,18 +1998,18 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2054,11 +2054,11 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -2067,18 +2067,18 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2121,10 +2121,10 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling {
@@ -2133,17 +2133,17 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2189,10 +2189,10 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2201,17 +2201,17 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2255,11 +2255,11 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithResponseHandling {
@@ -2268,18 +2268,18 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2325,11 +2325,11 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2338,18 +2338,18 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2396,10 +2396,10 @@ package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookCallableCallableTestOnSuccessMap {
   // [START sample]
@@ -2408,15 +2408,15 @@ public class GetBookCallableCallableTestOnSuccessMap {
    *
    * import com.google.api.core.ApiFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2466,9 +2466,9 @@ public class GetBookCallableCallableTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookFlattenedTestOnSuccessMap {
   // [START sample]
@@ -2476,14 +2476,14 @@ public class GetBookFlattenedTestOnSuccessMap {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       Book response = libraryClient.getBook(name.toString());
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
@@ -2526,10 +2526,10 @@ public class GetBookFlattenedTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookRequestTestOnSuccessMap {
   // [START sample]
@@ -2537,15 +2537,15 @@ public class GetBookRequestTestOnSuccessMap {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2590,11 +2590,11 @@ public class GetBookRequestTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class MonologAboutBookCallableCallableStreamingClientProg {
   // [START sample]
@@ -2602,11 +2602,11 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Testing calling forms */
@@ -2632,7 +2632,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3559,7 +3559,7 @@ public class StreamShelvesCallableCallableStreamingServerEmpty {
   /** Testing calling forms */
   public static void sampleStreamShelves() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3660,9 +3660,9 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3693,9 +3693,9 @@ public class TestFloatAndInt64 {
   /*
    * Please include the following imports to run this sample.
    *
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3738,8 +3738,8 @@ public class TestFloatAndInt64 {
       String requiredSingularString = "";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       String requiredSingularResourceNameCommon = "";
       int requiredSingularFixed32 = 0;
       long requiredSingularFixed64 = 0L;
@@ -3913,10 +3913,10 @@ public class TestFloatAndInt64 {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof {
   // [START test_resource_name_oneof]
@@ -3924,15 +3924,15 @@ public class TestResourceNameOneof {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.BookFromAnywhere;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3972,10 +3972,10 @@ public class TestResourceNameOneof {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof2 {
   // [START test_resource_name_oneof_2]
@@ -3983,15 +3983,15 @@ public class TestResourceNameOneof2 {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.BookFromAnywhere;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4106,11 +4106,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -4121,11 +4121,11 @@ public class ThisTagShouldBeTheNameOfTheFile {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -4139,7 +4139,7 @@ public class ThisTagShouldBeTheNameOfTheFile {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4216,11 +4216,11 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.rpc.BidiStream;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ByteString;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -4232,11 +4232,11 @@ public class TuringProgCallableStreamingBidi {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.BidiStream;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ByteString;
    * import java.nio.file.Files;
    * import java.nio.file.Path;
@@ -4256,7 +4256,7 @@ public class TuringProgCallableStreamingBidi {
       BidiStream<DiscussBookRequest, Comment> bidiStream =
           libraryClient.discussBookCallable().call();
 
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       Path path = Paths.get("comment_file");
       byte[] data = Files.readAllBytes(path);
       ByteString comment = ByteString.copyFrom(data);
@@ -4495,7 +4495,7 @@ public class LibraryClient implements BackgroundResource {
       PathTemplate.createWithoutUrlEncoding("projects/{project}/locations/{location}/publishers/{publisher}");
 
   private static final PathTemplate SHELF_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}");
+      PathTemplate.createWithoutUrlEncoding("shelves/{shelf}");
 
   /**
    * Formats a string containing the fully-qualified path to represent
@@ -4607,9 +4607,9 @@ public class LibraryClient implements BackgroundResource {
    * @deprecated Use the {@link ShelfName} class instead.
    */
   @Deprecated
-  public static final String formatShelfName(String shelfId) {
+  public static final String formatShelfName(String shelf) {
     return SHELF_PATH_TEMPLATE.instantiate(
-        "shelf_id", shelfId);
+        "shelf", shelf);
   }
 
   /**
@@ -4778,14 +4778,14 @@ public class LibraryClient implements BackgroundResource {
   }
 
   /**
-   * Parses the shelf_id from the given fully-qualified path which
+   * Parses the shelf from the given fully-qualified path which
    * represents a shelf resource.
    *
    * @deprecated Use the {@link ShelfName} class instead.
    */
   @Deprecated
-  public static final String parseShelfIdFromShelfName(String shelfName) {
-    return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf_id");
+  public static final String parseShelfFromShelfName(String shelfName) {
+    return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf");
   }
 
   /**
@@ -4925,7 +4925,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.getShelf(name);
    * }
    * </code></pre>
@@ -4948,7 +4948,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.getShelf(name.toString());
    * }
    * </code></pre>
@@ -4971,7 +4971,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name, message);
    * }
@@ -4997,7 +4997,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name.toString(), message);
    * }
@@ -5023,7 +5023,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name, message, stringBuilder);
@@ -5052,7 +5052,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name.toString(), message, stringBuilder);
@@ -5081,7 +5081,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String options = "";
    *   GetShelfRequest request = GetShelfRequest.newBuilder()
    *     .setName(name.toString())
@@ -5105,7 +5105,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String options = "";
    *   GetShelfRequest request = GetShelfRequest.newBuilder()
    *     .setName(name.toString())
@@ -5218,7 +5218,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   libraryClient.deleteShelf(name);
    * }
    * </code></pre>
@@ -5241,7 +5241,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   libraryClient.deleteShelf(name.toString());
    * }
    * </code></pre>
@@ -5264,7 +5264,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5286,7 +5286,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5309,8 +5309,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.mergeShelves(name, otherShelfName);
    * }
    * </code></pre>
@@ -5337,8 +5337,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.mergeShelves(name.toString(), otherShelfName.toString());
    * }
    * </code></pre>
@@ -5365,8 +5365,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -5391,8 +5391,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -5414,7 +5414,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.createBook(name, book);
    * }
@@ -5440,7 +5440,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.createBook(name.toString(), book);
    * }
@@ -5466,7 +5466,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   CreateBookRequest request = CreateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -5490,7 +5490,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   CreateBookRequest request = CreateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -5646,7 +5646,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book response = libraryClient.getBook(name);
    * }
    * </code></pre>
@@ -5669,7 +5669,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book response = libraryClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -5692,7 +5692,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5714,7 +5714,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5735,7 +5735,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   for (Book element : libraryClient.listBooks(name, filter).iterateAll()) {
    *     // doThingsWith(element);
@@ -5763,7 +5763,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   for (Book element : libraryClient.listBooks(name.toString(), filter).iterateAll()) {
    *     // doThingsWith(element);
@@ -5791,7 +5791,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -5818,7 +5818,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -5843,7 +5843,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -5875,7 +5875,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   libraryClient.deleteBook(name);
    * }
    * </code></pre>
@@ -5898,7 +5898,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   libraryClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -5921,7 +5921,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5943,7 +5943,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5964,7 +5964,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name, book);
    * }
@@ -5990,7 +5990,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name.toString(), book);
    * }
@@ -6016,7 +6016,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6051,7 +6051,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6086,7 +6086,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6110,7 +6110,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6133,8 +6133,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name, otherShelfName);
    * }
    * </code></pre>
@@ -6159,8 +6159,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name.toString(), otherShelfName.toString());
    * }
    * </code></pre>
@@ -6185,8 +6185,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -6209,8 +6209,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -6372,7 +6372,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6406,7 +6406,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6440,7 +6440,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6472,7 +6472,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6602,8 +6602,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name, altBookName, place, folder);
@@ -6635,8 +6635,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name.toString(), altBookName.toString(), place.toString(), folder.toString());
@@ -6668,8 +6668,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6696,8 +6696,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6723,7 +6723,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -6746,7 +6746,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -6769,7 +6769,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6791,7 +6791,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6812,7 +6812,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6843,7 +6843,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6874,7 +6874,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6902,7 +6902,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6930,7 +6930,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6980,7 +6980,7 @@ public class LibraryClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryClient.discussBookCallable().call();
    *
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7022,7 +7022,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7062,7 +7062,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7110,7 +7110,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7138,7 +7138,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7164,7 +7164,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7197,7 +7197,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName resource = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7222,7 +7222,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName resource = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7246,7 +7246,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -7270,7 +7270,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7294,7 +7294,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7317,7 +7317,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7339,7 +7339,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7360,7 +7360,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -7384,7 +7384,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7408,7 +7408,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7431,7 +7431,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7453,7 +7453,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7502,8 +7502,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7563,8 +7563,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -7888,8 +7888,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedRequiredSingularResourceName = LibraryClient.formatShelfBookName("[BOOK_SHELF]", "[BOOK]");
-   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatShelfBookName("[BOOK_SHELF]", "[BOOK]");
+   *   String formattedRequiredSingularResourceName = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
+   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7949,8 +7949,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedOptionalSingularResourceName = LibraryClient.formatShelfBookName("[BOOK_SHELF]", "[BOOK]");
-   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatShelfBookName("[BOOK_SHELF]", "[BOOK]");
+   *   String formattedOptionalSingularResourceName = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
+   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -8274,8 +8274,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8416,8 +8416,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8539,6 +8539,244 @@ public class LibraryClient implements BackgroundResource {
    */
   public final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     return stub.testOptionalRequiredFlatteningParamsCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String source = "";
+   *   String destination = "";
+   *   List&lt;String&gt; publishers = new ArrayList&lt;&gt;();
+   *   String project = "";
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, publishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(String source, String destination, List<String> publishers, String project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source)
+            .setDestination(destination)
+            .addAllPublishers(publishers)
+            .setProject(project)
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
+   *   MoveBooksResponse response = libraryClient.moveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(MoveBooksRequest request) {
+    return moveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;MoveBooksResponse&gt; future = libraryClient.moveBooksCallable().futureCall(request);
+   *   // Do something
+   *   MoveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    return stub.moveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String source = "";
+   *   String archive = "";
+   *   ArchiveBooksResponse response = libraryClient.archiveBooks(source, archive);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ArchiveBooksResponse archiveBooks(String source, String archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source)
+            .setArchive(archive)
+            .build();
+    return archiveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ArchiveBooksResponse response = libraryClient.archiveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ArchiveBooksResponse archiveBooks(ArchiveBooksRequest request) {
+    return archiveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;ArchiveBooksResponse&gt; future = libraryClient.archiveBooksCallable().futureCall(request);
+   *   // Do something
+   *   ArchiveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    return stub.archiveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String source = "";
+   *   String archive = "";
+   *   ArchiveBooksResponse response = libraryClient.longRunningArchiveBooksAsync(source, archive).get();
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(String source, String archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source)
+            .setArchive(archive)
+            .build();
+    return longRunningArchiveBooksAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ArchiveBooksResponse response = libraryClient.longRunningArchiveBooksAsync(request).get();
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(ArchiveBooksRequest request) {
+    return longRunningArchiveBooksOperationCallable().futureCall(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   OperationFuture&lt;ArchiveBooksResponse, ArchiveBooksMetadata&gt; future = libraryClient.longRunningArchiveBooksOperationCallable().futureCall(request);
+   *   // Do something
+   *   ArchiveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public final OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable() {
+    return stub.longRunningArchiveBooksOperationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;Operation&gt; future = libraryClient.longRunningArchiveBooksCallable().futureCall(request);
+   *   // Do something
+   *   Operation response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    return stub.longRunningArchiveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BidiStream&lt;ArchiveBooksRequest, ArchiveBooksResponse&gt; bidiStream =
+   *       libraryClient.streamingArchiveBooksCallable().call();
+   *
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   bidiStream.send(request);
+   *   for (ArchiveBooksResponse response : bidiStream) {
+   *     // Do something when receive a response
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    return stub.streamingArchiveBooksCallable();
   }
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
@@ -9372,6 +9610,42 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
   }
 
   /**
+   * Returns the object with the settings used for calls to moveBooks.
+   */
+  public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).moveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to archiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).archiveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).longRunningArchiveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).longRunningArchiveBooksOperationSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamingArchiveBooks.
+   */
+  public StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).streamingArchiveBooksSettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -9702,6 +9976,42 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return getStubSettingsBuilder().testOptionalRequiredFlatteningParamsSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBooks.
+     */
+    public UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+      return getStubSettingsBuilder().moveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to archiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+      return getStubSettingsBuilder().archiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+      return getStubSettingsBuilder().longRunningArchiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+    public OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+      return getStubSettingsBuilder().longRunningArchiveBooksOperationSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamingArchiveBooks.
+     */
+    public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+      return getStubSettingsBuilder().streamingArchiveBooksSettings();
     }
 
     /**
@@ -10291,6 +10601,9 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -10325,6 +10638,8 @@ import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
@@ -10473,6 +10788,9 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -10507,6 +10825,8 @@ import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
@@ -10760,6 +11080,34 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<MoveBooksRequest, MoveBooksResponse> moveBooksMethodDescriptor =
+      MethodDescriptor.<MoveBooksRequest, MoveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/MoveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(MoveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(MoveBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/ArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, Operation> longRunningArchiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, Operation>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/LongRunningArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+          .setFullMethodName("google.example.library.v1.LibraryService/StreamingArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<ListShelvesRequest, Book> privateListShelvesMethodDescriptor =
       MethodDescriptor.<ListShelvesRequest, Book>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -10806,6 +11154,11 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable;
   private final OperationCallable<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationCallable;
   private final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable;
+  private final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable;
+  private final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable;
+  private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
+  private final OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable;
+  private final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable;
   private final UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable;
 
   private final GrpcStubCallableFactory callableFactory;
@@ -11115,6 +11468,49 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
         GrpcCallSettings.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
             .setMethodDescriptor(testOptionalRequiredFlatteningParamsMethodDescriptor)
             .build();
+    GrpcCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksTransportSettings =
+        GrpcCallSettings.<MoveBooksRequest, MoveBooksResponse>newBuilder()
+            .setMethodDescriptor(moveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<MoveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(MoveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+            .setMethodDescriptor(archiveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ArchiveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(ArchiveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, Operation>newBuilder()
+            .setMethodDescriptor(longRunningArchiveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ArchiveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(ArchiveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+            .setMethodDescriptor(streamingArchiveBooksMethodDescriptor)
+            .build();
     GrpcCallSettings<ListShelvesRequest, Book> privateListShelvesTransportSettings =
         GrpcCallSettings.<ListShelvesRequest, Book>newBuilder()
             .setMethodDescriptor(privateListShelvesMethodDescriptor)
@@ -11156,6 +11552,12 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.getBigNothingOperationCallable = callableFactory.createOperationCallable(
         getBigNothingTransportSettings,settings.getBigNothingOperationSettings(), clientContext, this.operationsStub);
     this.testOptionalRequiredFlatteningParamsCallable = callableFactory.createUnaryCallable(testOptionalRequiredFlatteningParamsTransportSettings,settings.testOptionalRequiredFlatteningParamsSettings(), clientContext);
+    this.moveBooksCallable = callableFactory.createUnaryCallable(moveBooksTransportSettings,settings.moveBooksSettings(), clientContext);
+    this.archiveBooksCallable = callableFactory.createUnaryCallable(archiveBooksTransportSettings,settings.archiveBooksSettings(), clientContext);
+    this.longRunningArchiveBooksCallable = callableFactory.createUnaryCallable(longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksSettings(), clientContext);
+    this.longRunningArchiveBooksOperationCallable = callableFactory.createOperationCallable(
+        longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksOperationSettings(), clientContext, this.operationsStub);
+    this.streamingArchiveBooksCallable = callableFactory.createBidiStreamingCallable(streamingArchiveBooksTransportSettings,settings.streamingArchiveBooksSettings(), clientContext);
     this.privateListShelvesCallable = callableFactory.createUnaryCallable(privateListShelvesTransportSettings,settings.privateListShelvesSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -11302,6 +11704,27 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     return testOptionalRequiredFlatteningParamsCallable;
+  }
+
+  public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    return moveBooksCallable;
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    return archiveBooksCallable;
+  }
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable() {
+    return longRunningArchiveBooksOperationCallable;
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    return longRunningArchiveBooksCallable;
+  }
+
+  public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    return streamingArchiveBooksCallable;
   }
 
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
@@ -11623,6 +12046,9 @@ import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -11656,6 +12082,8 @@ import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
@@ -11852,6 +12280,27 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: testOptionalRequiredFlatteningParamsCallable()");
   }
 
+  public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: moveBooksCallable()");
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: archiveBooksCallable()");
+  }
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable() {
+    throw new UnsupportedOperationException("Not implemented: longRunningArchiveBooksOperationCallable()");
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: longRunningArchiveBooksCallable()");
+  }
+
+  public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: streamingArchiveBooksCallable()");
+  }
+
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
     throw new UnsupportedOperationException("Not implemented: privateListShelvesCallable()");
   }
@@ -11926,6 +12375,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookFromArchive;
@@ -11956,6 +12408,8 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.Shelf;
@@ -12048,6 +12502,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<GetBookRequest, Operation> getBigNothingSettings;
   private final OperationCallSettings<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
   private final UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+  private final UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
+  private final UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
+  private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
+  private final OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
+  private final StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
   private final UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings;
 
   /**
@@ -12263,6 +12722,42 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to moveBooks.
+   */
+  public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+    return moveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to archiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+    return archiveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+    return longRunningArchiveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+    return longRunningArchiveBooksOperationSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamingArchiveBooks.
+   */
+  public StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+    return streamingArchiveBooksSettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -12385,6 +12880,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     getBigNothingSettings = settingsBuilder.getBigNothingSettings().build();
     getBigNothingOperationSettings = settingsBuilder.getBigNothingOperationSettings().build();
     testOptionalRequiredFlatteningParamsSettings = settingsBuilder.testOptionalRequiredFlatteningParamsSettings().build();
+    moveBooksSettings = settingsBuilder.moveBooksSettings().build();
+    archiveBooksSettings = settingsBuilder.archiveBooksSettings().build();
+    longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
+    longRunningArchiveBooksOperationSettings = settingsBuilder.longRunningArchiveBooksOperationSettings().build();
+    streamingArchiveBooksSettings = settingsBuilder.streamingArchiveBooksSettings().build();
     privateListShelvesSettings = settingsBuilder.privateListShelvesSettings().build();
   }
 
@@ -12739,6 +13239,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings;
     private final OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
     private final UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+    private final UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
+    private final UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
+    private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
+    private final OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
+    private final StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
     private final UnaryCallSettings.Builder<ListShelvesRequest, Book> privateListShelvesSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
@@ -12847,6 +13352,16 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       testOptionalRequiredFlatteningParamsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      moveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      archiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      longRunningArchiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      longRunningArchiveBooksOperationSettings = OperationCallSettings.newBuilder();
+
+      streamingArchiveBooksSettings = StreamingCallSettings.newBuilder();
+
       privateListShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -12873,6 +13388,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          moveBooksSettings,
+          archiveBooksSettings,
+          longRunningArchiveBooksSettings,
           privateListShelvesSettings
       );
 
@@ -13010,6 +13528,18 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.moveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.archiveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.longRunningArchiveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       builder.privateListShelvesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
@@ -13053,6 +13583,26 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
                      .setMaxRpcTimeout(Duration.ZERO) // ignored
                      .setTotalTimeout(Duration.ofMillis(600000L))
                      .build()));
+      builder
+          .longRunningArchiveBooksOperationSettings()
+          .setInitialCallSettings(
+              UnaryCallSettings.<ArchiveBooksRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
+                  .build())
+          .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create(ArchiveBooksResponse.class))
+          .setMetadataTransformer(ProtoOperationTransformers.MetadataTransformer.create(ArchiveBooksMetadata.class))
+          .setPollingAlgorithm(
+              OperationTimedPollAlgorithm.create(
+                  RetrySettings.newBuilder()
+                     .setInitialRetryDelay(Duration.ofMillis(500L))
+                     .setRetryDelayMultiplier(1.5)
+                     .setMaxRetryDelay(Duration.ofMillis(5000L))
+                     .setInitialRpcTimeout(Duration.ZERO) // ignored
+                     .setRpcTimeoutMultiplier(1.0) // ignored
+                     .setMaxRpcTimeout(Duration.ZERO) // ignored
+                     .setTotalTimeout(Duration.ofMillis(300000L))
+                     .build()));
 
       return builder;
     }
@@ -13090,6 +13640,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
       getBigNothingOperationSettings = settings.getBigNothingOperationSettings.toBuilder();
       testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
+      moveBooksSettings = settings.moveBooksSettings.toBuilder();
+      archiveBooksSettings = settings.archiveBooksSettings.toBuilder();
+      longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
+      longRunningArchiveBooksOperationSettings = settings.longRunningArchiveBooksOperationSettings.toBuilder();
+      streamingArchiveBooksSettings = settings.streamingArchiveBooksSettings.toBuilder();
       privateListShelvesSettings = settings.privateListShelvesSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -13116,6 +13671,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          moveBooksSettings,
+          archiveBooksSettings,
+          longRunningArchiveBooksSettings,
           privateListShelvesSettings
       );
     }
@@ -13345,6 +13903,42 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return testOptionalRequiredFlatteningParamsSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBooks.
+     */
+    public UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+      return moveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to archiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+      return archiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+      return longRunningArchiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+    public OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+      return longRunningArchiveBooksOperationSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamingArchiveBooks.
+     */
+    public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+      return streamingArchiveBooksSettings;
     }
 
     /**
@@ -13827,7 +14421,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createShelfTest() {
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13873,7 +14467,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13883,7 +14477,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
 
     Shelf actualResponse =
         client.getShelf(name);
@@ -13907,7 +14501,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
 
       client.getShelf(name);
       Assert.fail("No exception raised");
@@ -13919,7 +14513,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest2() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13929,7 +14523,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     SomeMessage message = SomeMessage.newBuilder().build();
 
     Shelf actualResponse =
@@ -13955,7 +14549,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       SomeMessage message = SomeMessage.newBuilder().build();
 
       client.getShelf(name, message);
@@ -13968,7 +14562,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest3() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13978,7 +14572,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     SomeMessage message = SomeMessage.newBuilder().build();
     com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
 
@@ -14006,7 +14600,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       SomeMessage message = SomeMessage.newBuilder().build();
       com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
 
@@ -14065,7 +14659,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
 
     client.deleteShelf(name);
 
@@ -14087,7 +14681,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
 
       client.deleteShelf(name);
       Assert.fail("No exception raised");
@@ -14099,7 +14693,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void mergeShelvesTest() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -14109,8 +14703,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
-    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Shelf actualResponse =
         client.mergeShelves(name, otherShelfName);
@@ -14135,8 +14729,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
-      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.mergeShelves(name, otherShelfName);
       Assert.fail("No exception raised");
@@ -14148,7 +14742,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14160,7 +14754,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -14186,7 +14780,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       Book book = Book.newBuilder().build();
 
       client.createBook(name, book);
@@ -14260,7 +14854,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14272,7 +14866,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
     Book actualResponse =
         client.getBook(name);
@@ -14296,7 +14890,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -14317,7 +14911,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     String filter = "book-filter-string";
 
     ListBooksPagedResponse pagedListResponse = client.listBooks(name, filter);
@@ -14345,7 +14939,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       String filter = "book-filter-string";
 
       client.listBooks(name, filter);
@@ -14361,7 +14955,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
     client.deleteBook(name);
 
@@ -14383,7 +14977,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -14395,7 +14989,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14407,7 +15001,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -14433,7 +15027,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -14446,7 +15040,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14458,7 +15052,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -14490,7 +15084,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -14506,7 +15100,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14518,8 +15112,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
         client.moveBook(name, otherShelfName);
@@ -14544,8 +15138,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
       Assert.fail("No exception raised");
@@ -14657,7 +15251,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     ByteString comment = ByteString.copyFromUtf8("95");
     Comment.Stage stage = Comment.Stage.UNSET;
     SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -14689,7 +15283,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       ByteString comment = ByteString.copyFromUtf8("95");
       Comment.Stage stage = Comment.Stage.UNSET;
       SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -14761,7 +15355,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14773,8 +15367,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-    BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
     FolderName folder = FolderName.of("[FOLDER]");
 
@@ -14803,8 +15397,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-      BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
       FolderName folder = FolderName.of("[FOLDER]");
 
@@ -14818,7 +15412,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14830,7 +15424,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -14854,7 +15448,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -14869,7 +15463,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String indexName = "default index";
     String indexMapItem = "indexMapItem1918721251";
     Map<String, String> indexMap = new HashMap<>();
@@ -14897,7 +15491,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       String indexName = "default index";
       String indexMapItem = "indexMapItem1918721251";
       Map<String, String> indexMap = new HashMap<>();
@@ -14919,7 +15513,7 @@ public class LibraryClientTest {
       .addAllShelves(shelves)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -14940,7 +15534,7 @@ public class LibraryClientTest {
   public void streamShelvesExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -14964,7 +15558,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15027,7 +15621,7 @@ public class LibraryClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -15052,7 +15646,7 @@ public class LibraryClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -15080,7 +15674,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    BookName namesElement2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName namesElement2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     List<BookName> names2 = Arrays.asList(namesElement2);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -15135,7 +15729,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15153,7 +15747,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -15177,7 +15771,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -15201,7 +15795,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -15225,7 +15819,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -15286,8 +15880,8 @@ public class LibraryClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-    BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -15347,8 +15941,8 @@ public class LibraryClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName optionalSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-    BookName optionalSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -15552,8 +16146,8 @@ public class LibraryClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -15613,8 +16207,8 @@ public class LibraryClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName optionalSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-      BookName optionalSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -15675,8 +16269,209 @@ public class LibraryClientTest {
 
   @Test
   @SuppressWarnings("all")
+  public void moveBooksTest() {
+    boolean success = false;
+    MoveBooksResponse expectedResponse = MoveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String destination = "destination-1429847026";
+    List<String> publishers = new ArrayList<>();
+    String project = "project-309310695";
+
+    MoveBooksResponse actualResponse =
+        client.moveBooks(source, destination, publishers, project);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MoveBooksRequest actualRequest = (MoveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(destination, actualRequest.getDestination());
+    Assert.assertEquals(publishers, actualRequest.getPublishersList());
+    Assert.assertEquals(project, actualRequest.getProject());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void moveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String destination = "destination-1429847026";
+      List<String> publishers = new ArrayList<>();
+      String project = "project-309310695";
+
+      client.moveBooks(source, destination, publishers, project);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void archiveBooksTest() {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String archive = "archive-748101438";
+
+    ArchiveBooksResponse actualResponse =
+        client.archiveBooks(source, archive);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(archive, actualRequest.getArchive());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void archiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String archive = "archive-748101438";
+
+      client.archiveBooks(source, archive);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void longRunningArchiveBooksTest() throws Exception {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("longRunningArchiveBooksTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockLibraryService.addResponse(resultOperation);
+
+    String source = "source-896505829";
+    String archive = "archive-748101438";
+
+    ArchiveBooksResponse actualResponse =
+        client.longRunningArchiveBooksAsync(source, archive).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(archive, actualRequest.getArchive());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void longRunningArchiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String archive = "archive-748101438";
+
+      client.longRunningArchiveBooksAsync(source, archive).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamingArchiveBooksTest() throws Exception {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+
+    MockStreamObserver<ArchiveBooksResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> callable =
+        client.streamingArchiveBooksCallable();
+    ApiStreamObserver<ArchiveBooksRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+    requestObserver.onCompleted();
+
+    List<ArchiveBooksResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamingArchiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+
+    MockStreamObserver<ArchiveBooksResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> callable =
+        client.streamingArchiveBooksCallable();
+    ApiStreamObserver<ArchiveBooksRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+
+    try {
+      List<ArchiveBooksResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
   public void privateListShelvesTest() {
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15757,7 +16552,7 @@ public class LibrarySmokeTest {
   public static void main(String args[]) {
     Logger.getLogger("").setLevel(Level.WARNING);
     try {
-      executeNoCatch();
+      executeNoCatch(getProjectId());
       System.out.println("OK");
     } catch (Exception e) {
       System.err.println("Failed with exception:");
@@ -15766,9 +16561,9 @@ public class LibrarySmokeTest {
     }
   }
 
-  public static void executeNoCatch() throws Exception {
+  public static void executeNoCatch(String projectId) throws Exception {
     try (LibraryClient client = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", projectId);
       Book.Rating rating = Book.Rating.GOOD;
       Book book = Book.newBuilder()
         .setRating(rating)
@@ -16476,6 +17271,81 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
     } else {
       responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
     }
+  }
+
+  @Override
+  public void moveBooks(MoveBooksRequest request,
+    StreamObserver<MoveBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof MoveBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((MoveBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void archiveBooks(ArchiveBooksRequest request,
+    StreamObserver<ArchiveBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof ArchiveBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((ArchiveBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void longRunningArchiveBooks(ArchiveBooksRequest request,
+    StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public StreamObserver<ArchiveBooksRequest> streamingArchiveBooks(
+      final StreamObserver<ArchiveBooksResponse> responseObserver) {
+    final Object response = responses.remove();
+    StreamObserver<ArchiveBooksRequest> requestObserver =
+        new StreamObserver<ArchiveBooksRequest>() {
+      @Override
+      public void onNext(ArchiveBooksRequest value) {
+        if (response instanceof ArchiveBooksResponse) {
+          responseObserver.onNext((ArchiveBooksResponse) response);
+        } else if (response instanceof Exception) {
+          responseObserver.onError((Exception) response);
+        } else {
+          responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+        }
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        responseObserver.onError(t);
+      }
+
+      @Override
+      public void onCompleted() {
+        responseObserver.onCompleted();
+      }
+    };
+    return requestObserver;
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -377,7 +377,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Shelf response = libraryServiceClient.getShelf(name);
    * }
    * </code></pre>
@@ -400,7 +400,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Shelf response = libraryServiceClient.getShelf(name.toString());
    * }
    * </code></pre>
@@ -423,7 +423,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   Shelf response = libraryServiceClient.getShelf(name, message);
    * }
@@ -449,7 +449,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   Shelf response = libraryServiceClient.getShelf(name.toString(), message);
    * }
@@ -475,7 +475,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
    *   Shelf response = libraryServiceClient.getShelf(name, message, stringBuilder);
@@ -504,7 +504,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
    *   Shelf response = libraryServiceClient.getShelf(name.toString(), message, stringBuilder);
@@ -533,7 +533,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String options = "";
    *   GetShelfRequest request = GetShelfRequest.newBuilder()
    *     .setName(name.toString())
@@ -557,7 +557,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String options = "";
    *   GetShelfRequest request = GetShelfRequest.newBuilder()
    *     .setName(name.toString())
@@ -636,7 +636,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   libraryServiceClient.deleteShelf(name);
    * }
    * </code></pre>
@@ -659,7 +659,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   libraryServiceClient.deleteShelf(name.toString());
    * }
    * </code></pre>
@@ -682,7 +682,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -704,7 +704,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -727,8 +727,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Shelf response = libraryServiceClient.mergeShelves(name, otherShelfName);
    * }
    * </code></pre>
@@ -755,8 +755,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Shelf response = libraryServiceClient.mergeShelves(name.toString(), otherShelfName.toString());
    * }
    * </code></pre>
@@ -783,8 +783,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -809,8 +809,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -832,7 +832,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryServiceClient.createBook(name, book);
    * }
@@ -858,7 +858,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryServiceClient.createBook(name.toString(), book);
    * }
@@ -884,7 +884,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   CreateBookRequest request = CreateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -908,7 +908,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   CreateBookRequest request = CreateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -1141,7 +1141,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "";
    *   for (Book element : libraryServiceClient.listBooks(name, filter).iterateAll()) {
    *     // doThingsWith(element);
@@ -1169,7 +1169,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "";
    *   for (Book element : libraryServiceClient.listBooks(name.toString(), filter).iterateAll()) {
    *     // doThingsWith(element);
@@ -1197,7 +1197,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -1222,7 +1222,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -1245,7 +1245,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -1534,7 +1534,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   String name = "";
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryServiceClient.moveBook(name, otherShelfName);
    * }
    * </code></pre>
@@ -1560,7 +1560,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   String name = "";
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryServiceClient.moveBook(name.toString(), otherShelfName.toString());
    * }
    * </code></pre>
@@ -1586,7 +1586,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   String name = "";
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -1610,7 +1610,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   String name = "";
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -2290,7 +2290,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2873,6 +2873,244 @@ public class LibraryServiceClient implements BackgroundResource {
    */
   public final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable() {
     return stub.getBigNothingCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   String source = "";
+   *   String destination = "";
+   *   List&lt;String&gt; publishers = new ArrayList&lt;&gt;();
+   *   String project = "";
+   *   MoveBooksResponse response = libraryServiceClient.moveBooks(source, destination, publishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(String source, String destination, List<String> publishers, String project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source)
+            .setDestination(destination)
+            .addAllPublishers(publishers)
+            .setProject(project)
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
+   *   MoveBooksResponse response = libraryServiceClient.moveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(MoveBooksRequest request) {
+    return moveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;MoveBooksResponse&gt; future = libraryServiceClient.moveBooksCallable().futureCall(request);
+   *   // Do something
+   *   MoveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    return stub.moveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   String source = "";
+   *   String archive = "";
+   *   ArchiveBooksResponse response = libraryServiceClient.archiveBooks(source, archive);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ArchiveBooksResponse archiveBooks(String source, String archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source)
+            .setArchive(archive)
+            .build();
+    return archiveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ArchiveBooksResponse response = libraryServiceClient.archiveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ArchiveBooksResponse archiveBooks(ArchiveBooksRequest request) {
+    return archiveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;ArchiveBooksResponse&gt; future = libraryServiceClient.archiveBooksCallable().futureCall(request);
+   *   // Do something
+   *   ArchiveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    return stub.archiveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   String source = "";
+   *   String archive = "";
+   *   ArchiveBooksResponse response = libraryServiceClient.longRunningArchiveBooksAsync(source, archive).get();
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(String source, String archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source)
+            .setArchive(archive)
+            .build();
+    return longRunningArchiveBooksAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ArchiveBooksResponse response = libraryServiceClient.longRunningArchiveBooksAsync(request).get();
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(ArchiveBooksRequest request) {
+    return longRunningArchiveBooksOperationCallable().futureCall(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   OperationFuture&lt;ArchiveBooksResponse, ArchiveBooksMetadata&gt; future = libraryServiceClient.longRunningArchiveBooksOperationCallable().futureCall(request);
+   *   // Do something
+   *   ArchiveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public final OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable() {
+    return stub.longRunningArchiveBooksOperationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;Operation&gt; future = libraryServiceClient.longRunningArchiveBooksCallable().futureCall(request);
+   *   // Do something
+   *   Operation response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    return stub.longRunningArchiveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   BidiStream&lt;ArchiveBooksRequest, ArchiveBooksResponse&gt; bidiStream =
+   *       libraryServiceClient.streamingArchiveBooksCallable().call();
+   *
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   bidiStream.send(request);
+   *   for (ArchiveBooksResponse response : bidiStream) {
+   *     // Do something when receive a response
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    return stub.streamingArchiveBooksCallable();
   }
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
@@ -4673,6 +4911,42 @@ public class LibraryServiceSettings extends ClientSettings<LibraryServiceSetting
   }
 
   /**
+   * Returns the object with the settings used for calls to moveBooks.
+   */
+  public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).moveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to archiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).archiveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).longRunningArchiveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).longRunningArchiveBooksOperationSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamingArchiveBooks.
+   */
+  public StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).streamingArchiveBooksSettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to testOptionalRequiredFlatteningParams.
    */
   public UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
@@ -5003,6 +5277,42 @@ public class LibraryServiceSettings extends ClientSettings<LibraryServiceSetting
     @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
     public OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings() {
       return getStubSettingsBuilder().getBigNothingOperationSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBooks.
+     */
+    public UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+      return getStubSettingsBuilder().moveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to archiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+      return getStubSettingsBuilder().archiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+      return getStubSettingsBuilder().longRunningArchiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+    public OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+      return getStubSettingsBuilder().longRunningArchiveBooksOperationSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamingArchiveBooks.
+     */
+    public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+      return getStubSettingsBuilder().streamingArchiveBooksSettings();
     }
 
     /**
@@ -5599,6 +5909,9 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -5632,6 +5945,8 @@ import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
@@ -5780,6 +6095,9 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -5813,6 +6131,8 @@ import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
@@ -6059,6 +6379,34 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(GetBookRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<MoveBooksRequest, MoveBooksResponse> moveBooksMethodDescriptor =
+      MethodDescriptor.<MoveBooksRequest, MoveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/MoveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(MoveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(MoveBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/ArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, Operation> longRunningArchiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, Operation>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/LongRunningArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+          .setFullMethodName("google.example.library.v1.LibraryService/StreamingArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsMethodDescriptor =
       MethodDescriptor.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -6110,6 +6458,11 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final OperationCallable<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationCallable;
   private final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable;
   private final OperationCallable<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationCallable;
+  private final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable;
+  private final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable;
+  private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
+  private final OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable;
+  private final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable;
   private final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable;
   private final UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable;
 
@@ -6416,6 +6769,49 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
                   }
                 })
             .build();
+    GrpcCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksTransportSettings =
+        GrpcCallSettings.<MoveBooksRequest, MoveBooksResponse>newBuilder()
+            .setMethodDescriptor(moveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<MoveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(MoveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+            .setMethodDescriptor(archiveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ArchiveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(ArchiveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, Operation>newBuilder()
+            .setMethodDescriptor(longRunningArchiveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ArchiveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(ArchiveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+            .setMethodDescriptor(streamingArchiveBooksMethodDescriptor)
+            .build();
     GrpcCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsTransportSettings =
         GrpcCallSettings.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
             .setMethodDescriptor(testOptionalRequiredFlatteningParamsMethodDescriptor)
@@ -6459,6 +6855,12 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.getBigNothingCallable = callableFactory.createUnaryCallable(getBigNothingTransportSettings,settings.getBigNothingSettings(), clientContext);
     this.getBigNothingOperationCallable = callableFactory.createOperationCallable(
         getBigNothingTransportSettings,settings.getBigNothingOperationSettings(), clientContext, this.operationsStub);
+    this.moveBooksCallable = callableFactory.createUnaryCallable(moveBooksTransportSettings,settings.moveBooksSettings(), clientContext);
+    this.archiveBooksCallable = callableFactory.createUnaryCallable(archiveBooksTransportSettings,settings.archiveBooksSettings(), clientContext);
+    this.longRunningArchiveBooksCallable = callableFactory.createUnaryCallable(longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksSettings(), clientContext);
+    this.longRunningArchiveBooksOperationCallable = callableFactory.createOperationCallable(
+        longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksOperationSettings(), clientContext, this.operationsStub);
+    this.streamingArchiveBooksCallable = callableFactory.createBidiStreamingCallable(streamingArchiveBooksTransportSettings,settings.streamingArchiveBooksSettings(), clientContext);
     this.testOptionalRequiredFlatteningParamsCallable = callableFactory.createUnaryCallable(testOptionalRequiredFlatteningParamsTransportSettings,settings.testOptionalRequiredFlatteningParamsSettings(), clientContext);
     this.privateListShelvesCallable = callableFactory.createUnaryCallable(privateListShelvesTransportSettings,settings.privateListShelvesSettings(), clientContext);
 
@@ -6597,6 +6999,27 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public UnaryCallable<GetBookRequest, Operation> getBigNothingCallable() {
     return getBigNothingCallable;
+  }
+
+  public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    return moveBooksCallable;
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    return archiveBooksCallable;
+  }
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable() {
+    return longRunningArchiveBooksOperationCallable;
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    return longRunningArchiveBooksCallable;
+  }
+
+  public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    return streamingArchiveBooksCallable;
   }
 
   public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
@@ -6922,6 +7345,9 @@ import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -6954,6 +7380,8 @@ import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
@@ -7141,6 +7569,27 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: getBigNothingCallable()");
   }
 
+  public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: moveBooksCallable()");
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: archiveBooksCallable()");
+  }
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable() {
+    throw new UnsupportedOperationException("Not implemented: longRunningArchiveBooksOperationCallable()");
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: longRunningArchiveBooksCallable()");
+  }
+
+  public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: streamingArchiveBooksCallable()");
+  }
+
   public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     throw new UnsupportedOperationException("Not implemented: testOptionalRequiredFlatteningParamsCallable()");
   }
@@ -7210,6 +7659,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookFromArchive;
@@ -7239,6 +7691,8 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.Shelf;
@@ -7328,6 +7782,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final OperationCallSettings<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationSettings;
   private final UnaryCallSettings<GetBookRequest, Operation> getBigNothingSettings;
   private final OperationCallSettings<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
+  private final UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
+  private final UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
+  private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
+  private final OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
+  private final StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
   private final UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
   private final UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings;
 
@@ -7537,6 +7996,42 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to moveBooks.
+   */
+  public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+    return moveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to archiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+    return archiveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+    return longRunningArchiveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+    return longRunningArchiveBooksOperationSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamingArchiveBooks.
+   */
+  public StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+    return streamingArchiveBooksSettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to testOptionalRequiredFlatteningParams.
    */
   public UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
@@ -7665,6 +8160,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     getBigBookOperationSettings = settingsBuilder.getBigBookOperationSettings().build();
     getBigNothingSettings = settingsBuilder.getBigNothingSettings().build();
     getBigNothingOperationSettings = settingsBuilder.getBigNothingOperationSettings().build();
+    moveBooksSettings = settingsBuilder.moveBooksSettings().build();
+    archiveBooksSettings = settingsBuilder.archiveBooksSettings().build();
+    longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
+    longRunningArchiveBooksOperationSettings = settingsBuilder.longRunningArchiveBooksOperationSettings().build();
+    streamingArchiveBooksSettings = settingsBuilder.streamingArchiveBooksSettings().build();
     testOptionalRequiredFlatteningParamsSettings = settingsBuilder.testOptionalRequiredFlatteningParamsSettings().build();
     privateListShelvesSettings = settingsBuilder.privateListShelvesSettings().build();
   }
@@ -7852,6 +8352,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final OperationCallSettings.Builder<GetBookRequest, Book, GetBigBookMetadata> getBigBookOperationSettings;
     private final UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings;
     private final OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
+    private final UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
+    private final UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
+    private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
+    private final OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
+    private final StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
     private final UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
     private final UnaryCallSettings.Builder<ListShelvesRequest, Book> privateListShelvesSettings;
 
@@ -7954,6 +8459,16 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       getBigNothingOperationSettings = OperationCallSettings.newBuilder();
 
+      moveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      archiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      longRunningArchiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      longRunningArchiveBooksOperationSettings = OperationCallSettings.newBuilder();
+
+      streamingArchiveBooksSettings = StreamingCallSettings.newBuilder();
+
       testOptionalRequiredFlatteningParamsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       privateListShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
@@ -7981,6 +8496,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           addTagSettings,
           getBigBookSettings,
           getBigNothingSettings,
+          moveBooksSettings,
+          archiveBooksSettings,
+          longRunningArchiveBooksSettings,
           testOptionalRequiredFlatteningParamsSettings,
           privateListShelvesSettings
       );
@@ -8095,6 +8613,18 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.moveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.archiveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.longRunningArchiveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       builder.testOptionalRequiredFlatteningParamsSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
@@ -8142,6 +8672,26 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
                      .setMaxRpcTimeout(Duration.ZERO) // ignored
                      .setTotalTimeout(Duration.ofMillis(300000L))
                      .build()));
+      builder
+          .longRunningArchiveBooksOperationSettings()
+          .setInitialCallSettings(
+              UnaryCallSettings.<ArchiveBooksRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"))
+                  .build())
+          .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create(ArchiveBooksResponse.class))
+          .setMetadataTransformer(ProtoOperationTransformers.MetadataTransformer.create(ArchiveBooksMetadata.class))
+          .setPollingAlgorithm(
+              OperationTimedPollAlgorithm.create(
+                  RetrySettings.newBuilder()
+                     .setInitialRetryDelay(Duration.ofMillis(500L))
+                     .setRetryDelayMultiplier(1.5)
+                     .setMaxRetryDelay(Duration.ofMillis(5000L))
+                     .setInitialRpcTimeout(Duration.ZERO) // ignored
+                     .setRpcTimeoutMultiplier(1.0) // ignored
+                     .setMaxRpcTimeout(Duration.ZERO) // ignored
+                     .setTotalTimeout(Duration.ofMillis(300000L))
+                     .build()));
 
       return builder;
     }
@@ -8178,6 +8728,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       getBigBookOperationSettings = settings.getBigBookOperationSettings.toBuilder();
       getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
       getBigNothingOperationSettings = settings.getBigNothingOperationSettings.toBuilder();
+      moveBooksSettings = settings.moveBooksSettings.toBuilder();
+      archiveBooksSettings = settings.archiveBooksSettings.toBuilder();
+      longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
+      longRunningArchiveBooksOperationSettings = settings.longRunningArchiveBooksOperationSettings.toBuilder();
+      streamingArchiveBooksSettings = settings.streamingArchiveBooksSettings.toBuilder();
       testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
       privateListShelvesSettings = settings.privateListShelvesSettings.toBuilder();
 
@@ -8204,6 +8759,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           addTagSettings,
           getBigBookSettings,
           getBigNothingSettings,
+          moveBooksSettings,
+          archiveBooksSettings,
+          longRunningArchiveBooksSettings,
           testOptionalRequiredFlatteningParamsSettings,
           privateListShelvesSettings
       );
@@ -8427,6 +8985,42 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
     public OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings() {
       return getBigNothingOperationSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBooks.
+     */
+    public UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+      return moveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to archiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+      return archiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+      return longRunningArchiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+    public OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+      return longRunningArchiveBooksOperationSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamingArchiveBooks.
+     */
+    public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+      return streamingArchiveBooksSettings;
     }
 
     /**
@@ -8914,7 +9508,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void createShelfTest() {
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -8960,7 +9554,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -8970,7 +9564,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
 
     Shelf actualResponse =
         client.getShelf(name);
@@ -8994,7 +9588,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
 
       client.getShelf(name);
       Assert.fail("No exception raised");
@@ -9006,7 +9600,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest2() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -9016,7 +9610,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     SomeMessage message = SomeMessage.newBuilder().build();
 
     Shelf actualResponse =
@@ -9042,7 +9636,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       SomeMessage message = SomeMessage.newBuilder().build();
 
       client.getShelf(name, message);
@@ -9055,7 +9649,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest3() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -9065,7 +9659,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     SomeMessage message = SomeMessage.newBuilder().build();
     com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
 
@@ -9093,7 +9687,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       SomeMessage message = SomeMessage.newBuilder().build();
       com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
 
@@ -9147,7 +9741,7 @@ public class LibraryServiceClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
 
     client.deleteShelf(name);
 
@@ -9169,7 +9763,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
 
       client.deleteShelf(name);
       Assert.fail("No exception raised");
@@ -9181,7 +9775,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void mergeShelvesTest() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -9191,8 +9785,8 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
-    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Shelf actualResponse =
         client.mergeShelves(name, otherShelfName);
@@ -9217,8 +9811,8 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
-      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.mergeShelves(name, otherShelfName);
       Assert.fail("No exception raised");
@@ -9242,7 +9836,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -9268,7 +9862,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       Book book = Book.newBuilder().build();
 
       client.createBook(name, book);
@@ -9389,7 +9983,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     String filter = "filter-1274492040";
 
     ListBooksPagedResponse pagedListResponse = client.listBooks(name, filter);
@@ -9417,7 +10011,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       String filter = "filter-1274492040";
 
       client.listBooks(name, filter);
@@ -9591,7 +10185,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addResponse(expectedResponse);
 
     String name = "name3373707";
-    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
         client.moveBook(name, otherShelfName);
@@ -9617,7 +10211,7 @@ public class LibraryServiceClientTest {
 
     try {
       String name = "name3373707";
-      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
       Assert.fail("No exception raised");
@@ -9967,7 +10561,7 @@ public class LibraryServiceClientTest {
   public void streamShelvesTest() throws Exception {
     StreamShelvesResponse expectedResponse = StreamShelvesResponse.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -9988,7 +10582,7 @@ public class LibraryServiceClientTest {
   public void streamShelvesExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -10324,6 +10918,207 @@ public class LibraryServiceClientTest {
     }
   }
 
+
+  @Test
+  @SuppressWarnings("all")
+  public void moveBooksTest() {
+    boolean success = false;
+    MoveBooksResponse expectedResponse = MoveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String destination = "destination-1429847026";
+    List<String> publishers = new ArrayList<>();
+    String project = "project-309310695";
+
+    MoveBooksResponse actualResponse =
+        client.moveBooks(source, destination, publishers, project);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MoveBooksRequest actualRequest = (MoveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(destination, actualRequest.getDestination());
+    Assert.assertEquals(publishers, actualRequest.getPublishersList());
+    Assert.assertEquals(project, actualRequest.getProject());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void moveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String destination = "destination-1429847026";
+      List<String> publishers = new ArrayList<>();
+      String project = "project-309310695";
+
+      client.moveBooks(source, destination, publishers, project);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void archiveBooksTest() {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String archive = "archive-748101438";
+
+    ArchiveBooksResponse actualResponse =
+        client.archiveBooks(source, archive);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(archive, actualRequest.getArchive());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void archiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String archive = "archive-748101438";
+
+      client.archiveBooks(source, archive);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void longRunningArchiveBooksTest() throws Exception {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("longRunningArchiveBooksTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockLibraryService.addResponse(resultOperation);
+
+    String source = "source-896505829";
+    String archive = "archive-748101438";
+
+    ArchiveBooksResponse actualResponse =
+        client.longRunningArchiveBooksAsync(source, archive).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(archive, actualRequest.getArchive());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void longRunningArchiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String archive = "archive-748101438";
+
+      client.longRunningArchiveBooksAsync(source, archive).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamingArchiveBooksTest() throws Exception {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+
+    MockStreamObserver<ArchiveBooksResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> callable =
+        client.streamingArchiveBooksCallable();
+    ApiStreamObserver<ArchiveBooksRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+    requestObserver.onCompleted();
+
+    List<ArchiveBooksResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamingArchiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+
+    MockStreamObserver<ArchiveBooksResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> callable =
+        client.streamingArchiveBooksCallable();
+    ApiStreamObserver<ArchiveBooksRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+
+    try {
+      List<ArchiveBooksResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
 
   @Test
   @SuppressWarnings("all")
@@ -11375,6 +12170,81 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
     } else {
       responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
     }
+  }
+
+  @Override
+  public void moveBooks(MoveBooksRequest request,
+    StreamObserver<MoveBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof MoveBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((MoveBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void archiveBooks(ArchiveBooksRequest request,
+    StreamObserver<ArchiveBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof ArchiveBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((ArchiveBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void longRunningArchiveBooks(ArchiveBooksRequest request,
+    StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public StreamObserver<ArchiveBooksRequest> streamingArchiveBooks(
+      final StreamObserver<ArchiveBooksResponse> responseObserver) {
+    final Object response = responses.remove();
+    StreamObserver<ArchiveBooksRequest> requestObserver =
+        new StreamObserver<ArchiveBooksRequest>() {
+      @Override
+      public void onNext(ArchiveBooksRequest value) {
+        if (response instanceof ArchiveBooksResponse) {
+          responseObserver.onNext((ArchiveBooksResponse) response);
+        } else if (response instanceof Exception) {
+          responseObserver.onError((Exception) response);
+        } else {
+          responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+        }
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        responseObserver.onError(t);
+      }
+
+      @Override
+      public void onCompleted() {
+        responseObserver.onCompleted();
+      }
+    };
+    return requestObserver;
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -209,10 +209,10 @@ public class Babbage {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithResponseHandling {
   // [START sample]
@@ -220,10 +220,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test response handling for methods that return empty */
@@ -250,7 +250,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -290,10 +290,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithoutResponseHandling {
   // [START sample]
@@ -301,10 +301,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test default response handling is turned off for methods that return empty */
@@ -328,7 +328,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -711,11 +711,11 @@ public class DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling {
 
 package com.google.example.examples.library.v1;
 
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -725,11 +725,11 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /*
    * Please include the following imports to run this sample.
    *
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -738,7 +738,7 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -863,11 +863,11 @@ public class FindRelatedBooksFlattenedPagedOdyssey {
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -878,11 +878,11 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -891,7 +891,7 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -941,10 +941,10 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
 
 package com.google.example.examples.library.v1;
 
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -954,10 +954,10 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /*
    * Please include the following imports to run this sample.
    *
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -966,7 +966,7 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -1018,10 +1018,10 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1032,10 +1032,10 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1049,7 +1049,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
+      BookName name = ShelfBookName.of(shelf, "War and Peace");
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1124,10 +1124,10 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
   // [START hopper]
@@ -1136,10 +1136,10 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1158,7 +1158,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
+      BookName name = ShelfBookName.of(shelf, bigBookName);
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1222,11 +1222,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1237,11 +1237,11 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1255,7 +1255,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
+      BookName name = ShelfBookName.of(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1333,11 +1333,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
   // [START hopper]
@@ -1346,11 +1346,11 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1369,7 +1369,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
+      BookName name = ShelfBookName.of(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1435,10 +1435,10 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.core.ApiFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 import com.google.protobuf.ListValue;
 import java.util.Map;
@@ -1449,10 +1449,10 @@ public class GetBigBookCallableCallableWap {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
@@ -1467,7 +1467,7 @@ public class GetBigBookCallableCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
+      BookName name = ShelfBookName.of(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1545,10 +1545,10 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.core.ApiFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigBookCallableCallableWap2 {
@@ -1557,10 +1557,10 @@ public class GetBigBookCallableCallableWap2 {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
@@ -1580,7 +1580,7 @@ public class GetBigBookCallableCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
+      BookName name = ShelfBookName.of(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1648,11 +1648,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1663,11 +1663,11 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1681,7 +1681,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
+      BookName name = ShelfBookName.of(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1760,11 +1760,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookOperationCallableLongRunningCallableWap2 {
   // [START hopper]
@@ -1773,11 +1773,11 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1796,7 +1796,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
+      BookName name = ShelfBookName.of(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1859,10 +1859,10 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithResponseHandling {
@@ -1871,17 +1871,17 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1923,10 +1923,10 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -1935,17 +1935,17 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1985,11 +1985,11 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithResponseHandling {
@@ -1998,18 +1998,18 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2054,11 +2054,11 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -2067,18 +2067,18 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2121,10 +2121,10 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling {
@@ -2133,17 +2133,17 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2189,10 +2189,10 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2201,17 +2201,17 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2255,11 +2255,11 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithResponseHandling {
@@ -2268,18 +2268,18 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2325,11 +2325,11 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2338,18 +2338,18 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2396,10 +2396,10 @@ package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookCallableCallableTestOnSuccessMap {
   // [START sample]
@@ -2408,15 +2408,15 @@ public class GetBookCallableCallableTestOnSuccessMap {
    *
    * import com.google.api.core.ApiFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2466,9 +2466,9 @@ public class GetBookCallableCallableTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookFlattenedTestOnSuccessMap {
   // [START sample]
@@ -2476,14 +2476,14 @@ public class GetBookFlattenedTestOnSuccessMap {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       Book response = libraryClient.getBook(name.toString());
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
@@ -2526,10 +2526,10 @@ public class GetBookFlattenedTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookRequestTestOnSuccessMap {
   // [START sample]
@@ -2537,15 +2537,15 @@ public class GetBookRequestTestOnSuccessMap {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2590,11 +2590,11 @@ public class GetBookRequestTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class MonologAboutBookCallableCallableStreamingClientProg {
   // [START sample]
@@ -2602,11 +2602,11 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Testing calling forms */
@@ -2632,7 +2632,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3660,9 +3660,9 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3693,9 +3693,9 @@ public class TestFloatAndInt64 {
   /*
    * Please include the following imports to run this sample.
    *
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3738,8 +3738,8 @@ public class TestFloatAndInt64 {
       String requiredSingularString = "";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       String requiredSingularResourceNameCommon = "";
       int requiredSingularFixed32 = 0;
       long requiredSingularFixed64 = 0L;
@@ -3913,10 +3913,10 @@ public class TestFloatAndInt64 {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.BookFromAnywhere;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof {
   // [START test_resource_name_oneof]
@@ -3924,15 +3924,15 @@ public class TestResourceNameOneof {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.BookFromAnywhere;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "The ID of the book");
+      BookName name = ShelfBookName.of("[SHELF]", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3972,10 +3972,10 @@ public class TestResourceNameOneof {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.BookFromAnywhere;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof2 {
   // [START test_resource_name_oneof_2]
@@ -3983,15 +3983,15 @@ public class TestResourceNameOneof2 {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.BookFromAnywhere;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "The ID of the book");
+      BookName name = ShelfBookName.of("The Shelf to search for the book", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4106,11 +4106,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -4121,11 +4121,11 @@ public class ThisTagShouldBeTheNameOfTheFile {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -4139,7 +4139,7 @@ public class ThisTagShouldBeTheNameOfTheFile {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
+      BookName name = ShelfBookName.of(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4216,11 +4216,11 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.rpc.BidiStream;
-import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
+import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ByteString;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -4232,11 +4232,11 @@ public class TuringProgCallableStreamingBidi {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.BidiStream;
-   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
+   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ByteString;
    * import java.nio.file.Files;
    * import java.nio.file.Path;
@@ -4256,7 +4256,7 @@ public class TuringProgCallableStreamingBidi {
       BidiStream<DiscussBookRequest, Comment> bidiStream =
           libraryClient.discussBookCallable().call();
 
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       Path path = Paths.get("comment_file");
       byte[] data = Files.readAllBytes(path);
       ByteString comment = ByteString.copyFrom(data);
@@ -4474,7 +4474,7 @@ public class LibraryClient implements BackgroundResource {
       PathTemplate.createWithoutUrlEncoding("archives/{archive}/books/{book}");
 
   private static final PathTemplate SHELF_BOOK_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("bookShelves/{book_shelf}/books/{book}");
+      PathTemplate.createWithoutUrlEncoding("shelves/{shelf}/books/{book}");
 
   private static final PathTemplate BOOK_FROM_ARCHIVE_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("archives/{archive}/books/{book}");
@@ -4517,9 +4517,9 @@ public class LibraryClient implements BackgroundResource {
    * @deprecated Use the {@link ShelfBookName} class instead.
    */
   @Deprecated
-  public static final String formatShelfBookName(String bookShelf, String book) {
+  public static final String formatShelfBookName(String shelf, String book) {
     return SHELF_BOOK_PATH_TEMPLATE.instantiate(
-        "book_shelf", bookShelf,
+        "shelf", shelf,
         "book", book);
   }
 
@@ -4635,14 +4635,14 @@ public class LibraryClient implements BackgroundResource {
   }
 
   /**
-   * Parses the book_shelf from the given fully-qualified path which
+   * Parses the shelf from the given fully-qualified path which
    * represents a shelf_book resource.
    *
    * @deprecated Use the {@link ShelfBookName} class instead.
    */
   @Deprecated
-  public static final String parseBookShelfFromShelfBookName(String shelfBookName) {
-    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("book_shelf");
+  public static final String parseShelfFromShelfBookName(String shelfBookName) {
+    return SHELF_BOOK_PATH_TEMPLATE.parse(shelfBookName).get("shelf");
   }
 
   /**
@@ -5646,7 +5646,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name);
    * }
    * </code></pre>
@@ -5669,7 +5669,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -5692,7 +5692,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5714,7 +5714,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5875,7 +5875,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name);
    * }
    * </code></pre>
@@ -5898,7 +5898,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -5921,7 +5921,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5943,7 +5943,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5964,7 +5964,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name, book);
    * }
@@ -5990,7 +5990,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name.toString(), book);
    * }
@@ -6016,7 +6016,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6051,7 +6051,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6086,7 +6086,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6110,7 +6110,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6133,7 +6133,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name, otherShelfName);
    * }
@@ -6159,7 +6159,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name.toString(), otherShelfName.toString());
    * }
@@ -6185,7 +6185,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6209,7 +6209,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6372,7 +6372,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6406,7 +6406,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6440,7 +6440,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6472,7 +6472,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6602,8 +6602,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name, altBookName, place, folder);
@@ -6635,8 +6635,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name.toString(), altBookName.toString(), place.toString(), folder.toString());
@@ -6668,8 +6668,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6696,8 +6696,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6723,7 +6723,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -6746,7 +6746,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -6769,7 +6769,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6791,7 +6791,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6812,7 +6812,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6843,7 +6843,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6874,7 +6874,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6902,7 +6902,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6980,7 +6980,7 @@ public class LibraryClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryClient.discussBookCallable().call();
    *
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7022,7 +7022,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7062,7 +7062,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7110,7 +7110,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7138,7 +7138,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7164,7 +7164,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7197,7 +7197,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7222,7 +7222,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7246,7 +7246,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -7270,7 +7270,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7294,7 +7294,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7317,7 +7317,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7339,7 +7339,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7360,7 +7360,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -7384,7 +7384,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7408,7 +7408,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7431,7 +7431,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7453,7 +7453,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7502,8 +7502,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7563,8 +7563,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -7888,8 +7888,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedRequiredSingularResourceName = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
-   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
+   *   String formattedRequiredSingularResourceName = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
+   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7949,8 +7949,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedOptionalSingularResourceName = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
-   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
+   *   String formattedOptionalSingularResourceName = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
+   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -8274,8 +8274,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8416,8 +8416,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -14746,7 +14746,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14858,7 +14858,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14870,7 +14870,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBook(name);
@@ -14894,7 +14894,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -14959,7 +14959,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     client.deleteBook(name);
 
@@ -14981,7 +14981,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -14993,7 +14993,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15005,7 +15005,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -15031,7 +15031,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -15044,7 +15044,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15056,7 +15056,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15088,7 +15088,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15104,7 +15104,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15116,7 +15116,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
@@ -15142,7 +15142,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
@@ -15255,7 +15255,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     ByteString comment = ByteString.copyFromUtf8("95");
     Comment.Stage stage = Comment.Stage.UNSET;
     SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15287,7 +15287,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       ByteString comment = ByteString.copyFromUtf8("95");
       Comment.Stage stage = Comment.Stage.UNSET;
       SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15359,7 +15359,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15371,8 +15371,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-    BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
     LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
     FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15401,8 +15401,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-      BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
       LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
       FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15416,7 +15416,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15428,7 +15428,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -15452,7 +15452,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -15467,7 +15467,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String indexName = "default index";
     String indexMapItem = "indexMapItem1918721251";
     Map<String, String> indexMap = new HashMap<>();
@@ -15495,7 +15495,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
       String indexName = "default index";
       String indexMapItem = "indexMapItem1918721251";
       Map<String, String> indexMap = new HashMap<>();
@@ -15562,7 +15562,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15625,7 +15625,7 @@ public class LibraryClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -15650,7 +15650,7 @@ public class LibraryClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -15678,7 +15678,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    BookName namesElement2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName namesElement2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     List<BookName> names2 = Arrays.asList(namesElement2);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -15733,7 +15733,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15751,7 +15751,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -15775,7 +15775,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -15799,7 +15799,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -15823,7 +15823,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -15884,8 +15884,8 @@ public class LibraryClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-    BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
     String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -15945,8 +15945,8 @@ public class LibraryClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-    BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
     String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -16150,8 +16150,8 @@ public class LibraryClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -16211,8 +16211,8 @@ public class LibraryClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
-      BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
       String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -16475,7 +16475,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void privateListShelvesTest() {
-    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -16567,7 +16567,7 @@ public class LibrarySmokeTest {
 
   public static void executeNoCatch(String projectId) throws Exception {
     try (LibraryClient client = LibraryClient.create()) {
-      BookName name = BookFromArchiveName.of("[ARCHIVE]", projectId);
+      BookName name = ShelfBookName.of("testShelf-" + System.currentTimeMillis(), projectId);
       Book.Rating rating = Book.Rating.GOOD;
       Book book = Book.newBuilder()
         .setRating(rating)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -209,10 +209,10 @@ public class Babbage {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithResponseHandling {
   // [START sample]
@@ -220,10 +220,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test response handling for methods that return empty */
@@ -250,7 +250,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -290,10 +290,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithoutResponseHandling {
   // [START sample]
@@ -301,10 +301,10 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test default response handling is turned off for methods that return empty */
@@ -328,7 +328,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -386,7 +386,7 @@ public class DeleteShelfCallableCallableEmptyResponseTypeWithResponseHandling {
   /** Test response handling for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -450,7 +450,7 @@ public class DeleteShelfCallableCallableEmptyResponseTypeWithoutResponseHandling
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -508,7 +508,7 @@ public class DeleteShelfFlattenedEmptyResponseTypeWithResponseHandling {
   /** Test response handling for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       libraryClient.deleteShelf(name.toString());
       // Shelf deleted
       System.out.println("Shelf deleted.");
@@ -561,7 +561,7 @@ public class DeleteShelfFlattenedEmptyResponseTypeWithoutResponseHandling {
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       libraryClient.deleteShelf(name.toString());
     } catch (Exception exception) {
       System.err.println("Failed to create the client due to: " + exception);
@@ -614,7 +614,7 @@ public class DeleteShelfRequestEmptyResponseTypeWithResponseHandling {
   /** Test response handling for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -672,7 +672,7 @@ public class DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling {
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleDeleteShelf() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -711,11 +711,11 @@ public class DeleteShelfRequestEmptyResponseTypeWithoutResponseHandling {
 
 package com.google.example.examples.library.v1;
 
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -725,11 +725,11 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /*
    * Please include the following imports to run this sample.
    *
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -738,9 +738,9 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
       FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
         .addAllNames(BookName.toStringList(names))
@@ -863,11 +863,11 @@ public class FindRelatedBooksFlattenedPagedOdyssey {
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -878,11 +878,11 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -891,9 +891,9 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
       FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
         .addAllNames(BookName.toStringList(names))
@@ -941,10 +941,10 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
 
 package com.google.example.examples.library.v1;
 
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -954,10 +954,10 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /*
    * Please include the following imports to run this sample.
    *
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -966,9 +966,9 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
-      ShelfName shelvesElement = ShelfName.of("[SHELF_ID]");
+      ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
       FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
         .addAllNames(BookName.toStringList(names))
@@ -1018,10 +1018,10 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1032,10 +1032,10 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1049,7 +1049,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1124,10 +1124,10 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
   // [START hopper]
@@ -1136,10 +1136,10 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1158,7 +1158,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1222,11 +1222,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1237,11 +1237,11 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1255,7 +1255,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1333,11 +1333,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
   // [START hopper]
@@ -1346,11 +1346,11 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1369,7 +1369,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1435,10 +1435,10 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.core.ApiFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 import com.google.protobuf.ListValue;
 import java.util.Map;
@@ -1449,10 +1449,10 @@ public class GetBigBookCallableCallableWap {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
@@ -1467,7 +1467,7 @@ public class GetBigBookCallableCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1545,10 +1545,10 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.core.ApiFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigBookCallableCallableWap2 {
@@ -1557,10 +1557,10 @@ public class GetBigBookCallableCallableWap2 {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
@@ -1580,7 +1580,7 @@ public class GetBigBookCallableCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1648,11 +1648,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1663,11 +1663,11 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1681,7 +1681,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1760,11 +1760,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookOperationCallableLongRunningCallableWap2 {
   // [START hopper]
@@ -1773,11 +1773,11 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1796,7 +1796,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1859,10 +1859,10 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithResponseHandling {
@@ -1871,17 +1871,17 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1923,10 +1923,10 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -1935,17 +1935,17 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1985,11 +1985,11 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithResponseHandling {
@@ -1998,18 +1998,18 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2054,11 +2054,11 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -2067,18 +2067,18 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2121,10 +2121,10 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling {
@@ -2133,17 +2133,17 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2189,10 +2189,10 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
 package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2201,17 +2201,17 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
    * Please include the following imports to run this sample.
    *
    * import com.google.api.core.ApiFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2255,11 +2255,11 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithResponseHandling {
@@ -2268,18 +2268,18 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2325,11 +2325,11 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2338,18 +2338,18 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.longrunning.OperationFuture;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2396,10 +2396,10 @@ package com.google.example.examples.library.v1;
 
 import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookCallableCallableTestOnSuccessMap {
   // [START sample]
@@ -2408,15 +2408,15 @@ public class GetBookCallableCallableTestOnSuccessMap {
    *
    * import com.google.api.core.ApiFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2466,9 +2466,9 @@ public class GetBookCallableCallableTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookFlattenedTestOnSuccessMap {
   // [START sample]
@@ -2476,14 +2476,14 @@ public class GetBookFlattenedTestOnSuccessMap {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       Book response = libraryClient.getBook(name.toString());
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
@@ -2526,10 +2526,10 @@ public class GetBookFlattenedTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookRequestTestOnSuccessMap {
   // [START sample]
@@ -2537,15 +2537,15 @@ public class GetBookRequestTestOnSuccessMap {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2590,11 +2590,11 @@ public class GetBookRequestTestOnSuccessMap {
 package com.google.example.examples.library.v1;
 
 import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class MonologAboutBookCallableCallableStreamingClientProg {
   // [START sample]
@@ -2602,11 +2602,11 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.ApiStreamObserver;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Testing calling forms */
@@ -2632,7 +2632,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3559,7 +3559,7 @@ public class StreamShelvesCallableCallableStreamingServerEmpty {
   /** Testing calling forms */
   public static void sampleStreamShelves() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3660,9 +3660,9 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3693,9 +3693,9 @@ public class TestFloatAndInt64 {
   /*
    * Please include the following imports to run this sample.
    *
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3738,8 +3738,8 @@ public class TestFloatAndInt64 {
       String requiredSingularString = "";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       String requiredSingularResourceNameCommon = "";
       int requiredSingularFixed32 = 0;
       long requiredSingularFixed64 = 0L;
@@ -3913,10 +3913,10 @@ public class TestFloatAndInt64 {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof {
   // [START test_resource_name_oneof]
@@ -3924,15 +3924,15 @@ public class TestResourceNameOneof {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.BookFromAnywhere;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3972,10 +3972,10 @@ public class TestResourceNameOneof {
 package com.google.example.examples.library.v1;
 
 import com.google.example.library.v1.BookFromAnywhere;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof2 {
   // [START test_resource_name_oneof_2]
@@ -3983,15 +3983,15 @@ public class TestResourceNameOneof2 {
    * Please include the following imports to run this sample.
    *
    * import com.google.example.library.v1.BookFromAnywhere;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4106,11 +4106,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -4121,11 +4121,11 @@ public class ThisTagShouldBeTheNameOfTheFile {
    *
    * import com.google.api.gax.longrunning.OperationFuture;
    * import com.google.example.library.v1.Book;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -4139,7 +4139,7 @@ public class ThisTagShouldBeTheNameOfTheFile {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4216,11 +4216,11 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.api.gax.rpc.BidiStream;
+import com.google.example.library.v1.BookFromArchiveName;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ByteString;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -4232,11 +4232,11 @@ public class TuringProgCallableStreamingBidi {
    * Please include the following imports to run this sample.
    *
    * import com.google.api.gax.rpc.BidiStream;
+   * import com.google.example.library.v1.BookFromArchiveName;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ByteString;
    * import java.nio.file.Files;
    * import java.nio.file.Path;
@@ -4256,7 +4256,7 @@ public class TuringProgCallableStreamingBidi {
       BidiStream<DiscussBookRequest, Comment> bidiStream =
           libraryClient.discussBookCallable().call();
 
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       Path path = Paths.get("comment_file");
       byte[] data = Files.readAllBytes(path);
       ByteString comment = ByteString.copyFrom(data);
@@ -4495,7 +4495,7 @@ public class LibraryClient implements BackgroundResource {
       PathTemplate.createWithoutUrlEncoding("projects/{project}/locations/{location}/publishers/{publisher}");
 
   private static final PathTemplate SHELF_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}");
+      PathTemplate.createWithoutUrlEncoding("shelves/{shelf}");
 
   /**
    * Formats a string containing the fully-qualified path to represent
@@ -4607,9 +4607,9 @@ public class LibraryClient implements BackgroundResource {
    * @deprecated Use the {@link ShelfName} class instead.
    */
   @Deprecated
-  public static final String formatShelfName(String shelfId) {
+  public static final String formatShelfName(String shelf) {
     return SHELF_PATH_TEMPLATE.instantiate(
-        "shelf_id", shelfId);
+        "shelf", shelf);
   }
 
   /**
@@ -4778,14 +4778,14 @@ public class LibraryClient implements BackgroundResource {
   }
 
   /**
-   * Parses the shelf_id from the given fully-qualified path which
+   * Parses the shelf from the given fully-qualified path which
    * represents a shelf resource.
    *
    * @deprecated Use the {@link ShelfName} class instead.
    */
   @Deprecated
-  public static final String parseShelfIdFromShelfName(String shelfName) {
-    return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf_id");
+  public static final String parseShelfFromShelfName(String shelfName) {
+    return SHELF_PATH_TEMPLATE.parse(shelfName).get("shelf");
   }
 
   /**
@@ -4925,7 +4925,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.getShelf(name);
    * }
    * </code></pre>
@@ -4948,7 +4948,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.getShelf(name.toString());
    * }
    * </code></pre>
@@ -4971,7 +4971,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name, message);
    * }
@@ -4997,7 +4997,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name.toString(), message);
    * }
@@ -5023,7 +5023,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name, message, stringBuilder);
@@ -5052,7 +5052,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   SomeMessage message = SomeMessage.newBuilder().build();
    *   com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
    *   Shelf response = libraryClient.getShelf(name.toString(), message, stringBuilder);
@@ -5081,7 +5081,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String options = "";
    *   GetShelfRequest request = GetShelfRequest.newBuilder()
    *     .setName(name.toString())
@@ -5105,7 +5105,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String options = "";
    *   GetShelfRequest request = GetShelfRequest.newBuilder()
    *     .setName(name.toString())
@@ -5218,7 +5218,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   libraryClient.deleteShelf(name);
    * }
    * </code></pre>
@@ -5241,7 +5241,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   libraryClient.deleteShelf(name.toString());
    * }
    * </code></pre>
@@ -5264,7 +5264,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5286,7 +5286,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5309,8 +5309,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.mergeShelves(name, otherShelfName);
    * }
    * </code></pre>
@@ -5337,8 +5337,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Shelf response = libraryClient.mergeShelves(name.toString(), otherShelfName.toString());
    * }
    * </code></pre>
@@ -5365,8 +5365,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -5391,8 +5391,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MergeShelvesRequest request = MergeShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -5414,7 +5414,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.createBook(name, book);
    * }
@@ -5440,7 +5440,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.createBook(name.toString(), book);
    * }
@@ -5466,7 +5466,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   CreateBookRequest request = CreateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -5490,7 +5490,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   Book book = Book.newBuilder().build();
    *   CreateBookRequest request = CreateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -5646,7 +5646,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book response = libraryClient.getBook(name);
    * }
    * </code></pre>
@@ -5669,7 +5669,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book response = libraryClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -5692,7 +5692,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5714,7 +5714,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5735,7 +5735,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   for (Book element : libraryClient.listBooks(name, filter).iterateAll()) {
    *     // doThingsWith(element);
@@ -5763,7 +5763,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   for (Book element : libraryClient.listBooks(name.toString(), filter).iterateAll()) {
    *     // doThingsWith(element);
@@ -5791,7 +5791,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -5818,7 +5818,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -5843,7 +5843,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   String filter = "book-filter-string";
    *   ListBooksRequest request = ListBooksRequest.newBuilder()
    *     .setName(name.toString())
@@ -5875,7 +5875,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   libraryClient.deleteBook(name);
    * }
    * </code></pre>
@@ -5898,7 +5898,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   libraryClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -5921,7 +5921,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5943,7 +5943,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5964,7 +5964,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name, book);
    * }
@@ -5990,7 +5990,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name.toString(), book);
    * }
@@ -6016,7 +6016,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6051,7 +6051,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6086,7 +6086,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6110,7 +6110,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6133,8 +6133,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name, otherShelfName);
    * }
    * </code></pre>
@@ -6159,8 +6159,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name.toString(), otherShelfName.toString());
    * }
    * </code></pre>
@@ -6185,8 +6185,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -6209,8 +6209,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .setOtherShelfName(otherShelfName.toString())
@@ -6372,7 +6372,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6406,7 +6406,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6440,7 +6440,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6472,7 +6472,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6602,8 +6602,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name, altBookName, place, folder);
@@ -6635,8 +6635,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name.toString(), altBookName.toString(), place.toString(), folder.toString());
@@ -6668,8 +6668,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6696,8 +6696,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6723,7 +6723,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -6746,7 +6746,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -6769,7 +6769,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6791,7 +6791,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6812,7 +6812,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6843,7 +6843,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6874,7 +6874,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6902,7 +6902,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6930,7 +6930,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   ShelfName name = ShelfName.of("[SHELF_ID]");
+   *   ShelfName name = ShelfName.of("[SHELF]");
    *   StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6980,7 +6980,7 @@ public class LibraryClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryClient.discussBookCallable().call();
    *
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7022,7 +7022,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7062,7 +7062,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7110,7 +7110,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7138,7 +7138,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7164,7 +7164,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName namesElement = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7197,7 +7197,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName resource = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7222,7 +7222,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName resource = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7246,7 +7246,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -7270,7 +7270,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7294,7 +7294,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7317,7 +7317,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7339,7 +7339,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7360,7 +7360,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -7384,7 +7384,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7408,7 +7408,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7431,7 +7431,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7453,7 +7453,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7502,8 +7502,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7563,8 +7563,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -7888,8 +7888,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedRequiredSingularResourceName = LibraryClient.formatShelfBookName("[BOOK_SHELF]", "[BOOK]");
-   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatShelfBookName("[BOOK_SHELF]", "[BOOK]");
+   *   String formattedRequiredSingularResourceName = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
+   *   String formattedRequiredSingularResourceNameOneof = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7949,8 +7949,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String formattedOptionalSingularResourceName = LibraryClient.formatShelfBookName("[BOOK_SHELF]", "[BOOK]");
-   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatShelfBookName("[BOOK_SHELF]", "[BOOK]");
+   *   String formattedOptionalSingularResourceName = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
+   *   String formattedOptionalSingularResourceNameOneof = LibraryClient.formatBookFromArchiveName("[ARCHIVE]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -8274,8 +8274,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8416,8 +8416,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8539,6 +8539,244 @@ public class LibraryClient implements BackgroundResource {
    */
   public final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     return stub.testOptionalRequiredFlatteningParamsCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String source = "";
+   *   String destination = "";
+   *   List&lt;String&gt; publishers = new ArrayList&lt;&gt;();
+   *   String project = "";
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, publishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(String source, String destination, List<String> publishers, String project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source)
+            .setDestination(destination)
+            .addAllPublishers(publishers)
+            .setProject(project)
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
+   *   MoveBooksResponse response = libraryClient.moveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(MoveBooksRequest request) {
+    return moveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;MoveBooksResponse&gt; future = libraryClient.moveBooksCallable().futureCall(request);
+   *   // Do something
+   *   MoveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    return stub.moveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String source = "";
+   *   String archive = "";
+   *   ArchiveBooksResponse response = libraryClient.archiveBooks(source, archive);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ArchiveBooksResponse archiveBooks(String source, String archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source)
+            .setArchive(archive)
+            .build();
+    return archiveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ArchiveBooksResponse response = libraryClient.archiveBooks(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ArchiveBooksResponse archiveBooks(ArchiveBooksRequest request) {
+    return archiveBooksCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;ArchiveBooksResponse&gt; future = libraryClient.archiveBooksCallable().futureCall(request);
+   *   // Do something
+   *   ArchiveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    return stub.archiveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   String source = "";
+   *   String archive = "";
+   *   ArchiveBooksResponse response = libraryClient.longRunningArchiveBooksAsync(source, archive).get();
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(String source, String archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source)
+            .setArchive(archive)
+            .build();
+    return longRunningArchiveBooksAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ArchiveBooksResponse response = libraryClient.longRunningArchiveBooksAsync(request).get();
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(ArchiveBooksRequest request) {
+    return longRunningArchiveBooksOperationCallable().futureCall(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   OperationFuture&lt;ArchiveBooksResponse, ArchiveBooksMetadata&gt; future = libraryClient.longRunningArchiveBooksOperationCallable().futureCall(request);
+   *   // Do something
+   *   ArchiveBooksResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public final OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable() {
+    return stub.longRunningArchiveBooksOperationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   ApiFuture&lt;Operation&gt; future = libraryClient.longRunningArchiveBooksCallable().futureCall(request);
+   *   // Do something
+   *   Operation response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    return stub.longRunningArchiveBooksCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BidiStream&lt;ArchiveBooksRequest, ArchiveBooksResponse&gt; bidiStream =
+   *       libraryClient.streamingArchiveBooksCallable().call();
+   *
+   *   ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+   *   bidiStream.send(request);
+   *   for (ArchiveBooksResponse response : bidiStream) {
+   *     // Do something when receive a response
+   *   }
+   * }
+   * </code></pre>
+   */
+  public final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    return stub.streamingArchiveBooksCallable();
   }
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
@@ -9372,6 +9610,42 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
   }
 
   /**
+   * Returns the object with the settings used for calls to moveBooks.
+   */
+  public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).moveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to archiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).archiveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).longRunningArchiveBooksSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).longRunningArchiveBooksOperationSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamingArchiveBooks.
+   */
+  public StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).streamingArchiveBooksSettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -9702,6 +9976,42 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return getStubSettingsBuilder().testOptionalRequiredFlatteningParamsSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBooks.
+     */
+    public UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+      return getStubSettingsBuilder().moveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to archiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+      return getStubSettingsBuilder().archiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+      return getStubSettingsBuilder().longRunningArchiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+    public OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+      return getStubSettingsBuilder().longRunningArchiveBooksOperationSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamingArchiveBooks.
+     */
+    public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+      return getStubSettingsBuilder().streamingArchiveBooksSettings();
     }
 
     /**
@@ -10291,6 +10601,9 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -10325,6 +10638,8 @@ import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
@@ -10473,6 +10788,9 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -10507,6 +10825,8 @@ import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
@@ -10760,6 +11080,34 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<MoveBooksRequest, MoveBooksResponse> moveBooksMethodDescriptor =
+      MethodDescriptor.<MoveBooksRequest, MoveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/MoveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(MoveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(MoveBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/ArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, Operation> longRunningArchiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, Operation>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/LongRunningArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksMethodDescriptor =
+      MethodDescriptor.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+          .setFullMethodName("google.example.library.v1.LibraryService/StreamingArchiveBooks")
+          .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<ListShelvesRequest, Book> privateListShelvesMethodDescriptor =
       MethodDescriptor.<ListShelvesRequest, Book>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -10806,6 +11154,11 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable;
   private final OperationCallable<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationCallable;
   private final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable;
+  private final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable;
+  private final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable;
+  private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
+  private final OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable;
+  private final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable;
   private final UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable;
 
   private final GrpcStubCallableFactory callableFactory;
@@ -11115,6 +11468,49 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
         GrpcCallSettings.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
             .setMethodDescriptor(testOptionalRequiredFlatteningParamsMethodDescriptor)
             .build();
+    GrpcCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksTransportSettings =
+        GrpcCallSettings.<MoveBooksRequest, MoveBooksResponse>newBuilder()
+            .setMethodDescriptor(moveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<MoveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(MoveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+            .setMethodDescriptor(archiveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ArchiveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(ArchiveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, Operation>newBuilder()
+            .setMethodDescriptor(longRunningArchiveBooksMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ArchiveBooksRequest>() {
+                  @Override
+                  public Map<String, String> extract(ArchiveBooksRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("source", String.valueOf(request.getSource()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksTransportSettings =
+        GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
+            .setMethodDescriptor(streamingArchiveBooksMethodDescriptor)
+            .build();
     GrpcCallSettings<ListShelvesRequest, Book> privateListShelvesTransportSettings =
         GrpcCallSettings.<ListShelvesRequest, Book>newBuilder()
             .setMethodDescriptor(privateListShelvesMethodDescriptor)
@@ -11156,6 +11552,12 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.getBigNothingOperationCallable = callableFactory.createOperationCallable(
         getBigNothingTransportSettings,settings.getBigNothingOperationSettings(), clientContext, this.operationsStub);
     this.testOptionalRequiredFlatteningParamsCallable = callableFactory.createUnaryCallable(testOptionalRequiredFlatteningParamsTransportSettings,settings.testOptionalRequiredFlatteningParamsSettings(), clientContext);
+    this.moveBooksCallable = callableFactory.createUnaryCallable(moveBooksTransportSettings,settings.moveBooksSettings(), clientContext);
+    this.archiveBooksCallable = callableFactory.createUnaryCallable(archiveBooksTransportSettings,settings.archiveBooksSettings(), clientContext);
+    this.longRunningArchiveBooksCallable = callableFactory.createUnaryCallable(longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksSettings(), clientContext);
+    this.longRunningArchiveBooksOperationCallable = callableFactory.createOperationCallable(
+        longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksOperationSettings(), clientContext, this.operationsStub);
+    this.streamingArchiveBooksCallable = callableFactory.createBidiStreamingCallable(streamingArchiveBooksTransportSettings,settings.streamingArchiveBooksSettings(), clientContext);
     this.privateListShelvesCallable = callableFactory.createUnaryCallable(privateListShelvesTransportSettings,settings.privateListShelvesSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -11302,6 +11704,27 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     return testOptionalRequiredFlatteningParamsCallable;
+  }
+
+  public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    return moveBooksCallable;
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    return archiveBooksCallable;
+  }
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable() {
+    return longRunningArchiveBooksOperationCallable;
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    return longRunningArchiveBooksCallable;
+  }
+
+  public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    return streamingArchiveBooksCallable;
   }
 
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
@@ -11623,6 +12046,9 @@ import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.ArchivedBookName;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
@@ -11656,6 +12082,8 @@ import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.LocationName;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
@@ -11852,6 +12280,27 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: testOptionalRequiredFlatteningParamsCallable()");
   }
 
+  public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: moveBooksCallable()");
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: archiveBooksCallable()");
+  }
+
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable() {
+    throw new UnsupportedOperationException("Not implemented: longRunningArchiveBooksOperationCallable()");
+  }
+
+  public UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: longRunningArchiveBooksCallable()");
+  }
+
+  public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
+    throw new UnsupportedOperationException("Not implemented: streamingArchiveBooksCallable()");
+  }
+
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
     throw new UnsupportedOperationException("Not implemented: privateListShelvesCallable()");
   }
@@ -11926,6 +12375,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.ArchiveBooksMetadata;
+import com.google.example.library.v1.ArchiveBooksRequest;
+import com.google.example.library.v1.ArchiveBooksResponse;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookFromArchive;
@@ -11956,6 +12408,8 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.MoveBooksRequest;
+import com.google.example.library.v1.MoveBooksResponse;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.Shelf;
@@ -12048,6 +12502,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<GetBookRequest, Operation> getBigNothingSettings;
   private final OperationCallSettings<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
   private final UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+  private final UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
+  private final UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
+  private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
+  private final OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
+  private final StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
   private final UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings;
 
   /**
@@ -12263,6 +12722,42 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to moveBooks.
+   */
+  public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+    return moveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to archiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+    return archiveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  public UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+    return longRunningArchiveBooksSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to longRunningArchiveBooks.
+   */
+  @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+  public OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+    return longRunningArchiveBooksOperationSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to streamingArchiveBooks.
+   */
+  public StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+    return streamingArchiveBooksSettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -12385,6 +12880,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     getBigNothingSettings = settingsBuilder.getBigNothingSettings().build();
     getBigNothingOperationSettings = settingsBuilder.getBigNothingOperationSettings().build();
     testOptionalRequiredFlatteningParamsSettings = settingsBuilder.testOptionalRequiredFlatteningParamsSettings().build();
+    moveBooksSettings = settingsBuilder.moveBooksSettings().build();
+    archiveBooksSettings = settingsBuilder.archiveBooksSettings().build();
+    longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
+    longRunningArchiveBooksOperationSettings = settingsBuilder.longRunningArchiveBooksOperationSettings().build();
+    streamingArchiveBooksSettings = settingsBuilder.streamingArchiveBooksSettings().build();
     privateListShelvesSettings = settingsBuilder.privateListShelvesSettings().build();
   }
 
@@ -12739,6 +13239,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings;
     private final OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
     private final UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+    private final UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
+    private final UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
+    private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
+    private final OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
+    private final StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
     private final UnaryCallSettings.Builder<ListShelvesRequest, Book> privateListShelvesSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
@@ -12854,6 +13359,16 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       testOptionalRequiredFlatteningParamsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      moveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      archiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      longRunningArchiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      longRunningArchiveBooksOperationSettings = OperationCallSettings.newBuilder();
+
+      streamingArchiveBooksSettings = StreamingCallSettings.newBuilder();
+
       privateListShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -12880,6 +13395,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          moveBooksSettings,
+          archiveBooksSettings,
+          longRunningArchiveBooksSettings,
           privateListShelvesSettings
       );
 
@@ -13017,6 +13535,18 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"));
 
+      builder.moveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
+      builder.archiveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
+      builder.longRunningArchiveBooksSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
       builder.privateListShelvesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
@@ -13060,6 +13590,26 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
                      .setMaxRpcTimeout(Duration.ZERO) // ignored
                      .setTotalTimeout(Duration.ofMillis(600000L))
                      .build()));
+      builder
+          .longRunningArchiveBooksOperationSettings()
+          .setInitialCallSettings(
+              UnaryCallSettings.<ArchiveBooksRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"))
+                  .build())
+          .setResponseTransformer(ProtoOperationTransformers.ResponseTransformer.create(ArchiveBooksResponse.class))
+          .setMetadataTransformer(ProtoOperationTransformers.MetadataTransformer.create(ArchiveBooksMetadata.class))
+          .setPollingAlgorithm(
+              OperationTimedPollAlgorithm.create(
+                  RetrySettings.newBuilder()
+                     .setInitialRetryDelay(Duration.ofMillis(500L))
+                     .setRetryDelayMultiplier(1.5)
+                     .setMaxRetryDelay(Duration.ofMillis(5000L))
+                     .setInitialRpcTimeout(Duration.ZERO) // ignored
+                     .setRpcTimeoutMultiplier(1.0) // ignored
+                     .setMaxRpcTimeout(Duration.ZERO) // ignored
+                     .setTotalTimeout(Duration.ofMillis(300000L))
+                     .build()));
 
       return builder;
     }
@@ -13097,6 +13647,11 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
       getBigNothingOperationSettings = settings.getBigNothingOperationSettings.toBuilder();
       testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
+      moveBooksSettings = settings.moveBooksSettings.toBuilder();
+      archiveBooksSettings = settings.archiveBooksSettings.toBuilder();
+      longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
+      longRunningArchiveBooksOperationSettings = settings.longRunningArchiveBooksOperationSettings.toBuilder();
+      streamingArchiveBooksSettings = settings.streamingArchiveBooksSettings.toBuilder();
       privateListShelvesSettings = settings.privateListShelvesSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -13123,6 +13678,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          moveBooksSettings,
+          archiveBooksSettings,
+          longRunningArchiveBooksSettings,
           privateListShelvesSettings
       );
     }
@@ -13352,6 +13910,42 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return testOptionalRequiredFlatteningParamsSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to moveBooks.
+     */
+    public UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
+      return moveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to archiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings() {
+      return archiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    public UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings() {
+      return longRunningArchiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to longRunningArchiveBooks.
+     */
+    @BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+    public OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings() {
+      return longRunningArchiveBooksOperationSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to streamingArchiveBooks.
+     */
+    public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
+      return streamingArchiveBooksSettings;
     }
 
     /**
@@ -13831,7 +14425,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createShelfTest() {
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13877,7 +14471,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13887,7 +14481,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
 
     Shelf actualResponse =
         client.getShelf(name);
@@ -13911,7 +14505,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
 
       client.getShelf(name);
       Assert.fail("No exception raised");
@@ -13923,7 +14517,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest2() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13933,7 +14527,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     SomeMessage message = SomeMessage.newBuilder().build();
 
     Shelf actualResponse =
@@ -13959,7 +14553,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       SomeMessage message = SomeMessage.newBuilder().build();
 
       client.getShelf(name, message);
@@ -13972,7 +14566,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getShelfTest3() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -13982,7 +14576,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     SomeMessage message = SomeMessage.newBuilder().build();
     com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
 
@@ -14010,7 +14604,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       SomeMessage message = SomeMessage.newBuilder().build();
       com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
 
@@ -14069,7 +14663,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
 
     client.deleteShelf(name);
 
@@ -14091,7 +14685,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
 
       client.deleteShelf(name);
       Assert.fail("No exception raised");
@@ -14103,7 +14697,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void mergeShelvesTest() {
-    ShelfName name2 = ShelfName.of("[SHELF_ID]");
+    ShelfName name2 = ShelfName.of("[SHELF]");
     String theme = "theme110327241";
     String internalTheme = "internalTheme792518087";
     Shelf expectedResponse = Shelf.newBuilder()
@@ -14113,8 +14707,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
-    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Shelf actualResponse =
         client.mergeShelves(name, otherShelfName);
@@ -14139,8 +14733,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
-      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.mergeShelves(name, otherShelfName);
       Assert.fail("No exception raised");
@@ -14152,7 +14746,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14164,7 +14758,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -14190,7 +14784,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       Book book = Book.newBuilder().build();
 
       client.createBook(name, book);
@@ -14264,7 +14858,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14276,7 +14870,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
     Book actualResponse =
         client.getBook(name);
@@ -14300,7 +14894,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -14321,7 +14915,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     String filter = "book-filter-string";
 
     ListBooksPagedResponse pagedListResponse = client.listBooks(name, filter);
@@ -14349,7 +14943,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      ShelfName name = ShelfName.of("[SHELF_ID]");
+      ShelfName name = ShelfName.of("[SHELF]");
       String filter = "book-filter-string";
 
       client.listBooks(name, filter);
@@ -14365,7 +14959,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
     client.deleteBook(name);
 
@@ -14387,7 +14981,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -14399,7 +14993,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14411,7 +15005,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -14437,7 +15031,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -14450,7 +15044,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14462,7 +15056,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -14494,7 +15088,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -14510,7 +15104,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14522,8 +15116,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-    ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
         client.moveBook(name, otherShelfName);
@@ -14548,8 +15142,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-      ShelfName otherShelfName = ShelfName.of("[SHELF_ID]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
       Assert.fail("No exception raised");
@@ -14661,7 +15255,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     ByteString comment = ByteString.copyFromUtf8("95");
     Comment.Stage stage = Comment.Stage.UNSET;
     SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -14693,7 +15287,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       ByteString comment = ByteString.copyFromUtf8("95");
       Comment.Stage stage = Comment.Stage.UNSET;
       SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -14765,7 +15359,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14777,8 +15371,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-    BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
     FolderName folder = FolderName.of("[FOLDER]");
 
@@ -14807,8 +15401,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-      BookName altBookName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName altBookName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
       FolderName folder = FolderName.of("[FOLDER]");
 
@@ -14822,7 +15416,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -14834,7 +15428,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -14858,7 +15452,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -14873,7 +15467,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String indexName = "default index";
     String indexMapItem = "indexMapItem1918721251";
     Map<String, String> indexMap = new HashMap<>();
@@ -14901,7 +15495,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       String indexName = "default index";
       String indexMapItem = "indexMapItem1918721251";
       Map<String, String> indexMap = new HashMap<>();
@@ -14923,7 +15517,7 @@ public class LibraryClientTest {
       .addAllShelves(shelves)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -14944,7 +15538,7 @@ public class LibraryClientTest {
   public void streamShelvesExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    ShelfName name = ShelfName.of("[SHELF_ID]");
+    ShelfName name = ShelfName.of("[SHELF]");
     StreamShelvesRequest request = StreamShelvesRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -14968,7 +15562,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15031,7 +15625,7 @@ public class LibraryClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -15056,7 +15650,7 @@ public class LibraryClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -15084,7 +15678,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    BookName namesElement2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName namesElement2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     List<BookName> names2 = Arrays.asList(namesElement2);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -15139,7 +15733,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name2 = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15157,7 +15751,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -15181,7 +15775,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -15205,7 +15799,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -15229,7 +15823,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -15290,8 +15884,8 @@ public class LibraryClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-    BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -15351,8 +15945,8 @@ public class LibraryClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName optionalSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-    BookName optionalSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+    BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -15556,8 +16150,8 @@ public class LibraryClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName requiredSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -15617,8 +16211,8 @@ public class LibraryClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName optionalSingularResourceName = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
-      BookName optionalSingularResourceNameOneof = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName optionalSingularResourceName = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
+      BookName optionalSingularResourceNameOneof = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
       String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -15679,8 +16273,209 @@ public class LibraryClientTest {
 
   @Test
   @SuppressWarnings("all")
+  public void moveBooksTest() {
+    boolean success = false;
+    MoveBooksResponse expectedResponse = MoveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String destination = "destination-1429847026";
+    List<String> publishers = new ArrayList<>();
+    String project = "project-309310695";
+
+    MoveBooksResponse actualResponse =
+        client.moveBooks(source, destination, publishers, project);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MoveBooksRequest actualRequest = (MoveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(destination, actualRequest.getDestination());
+    Assert.assertEquals(publishers, actualRequest.getPublishersList());
+    Assert.assertEquals(project, actualRequest.getProject());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void moveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String destination = "destination-1429847026";
+      List<String> publishers = new ArrayList<>();
+      String project = "project-309310695";
+
+      client.moveBooks(source, destination, publishers, project);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void archiveBooksTest() {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String archive = "archive-748101438";
+
+    ArchiveBooksResponse actualResponse =
+        client.archiveBooks(source, archive);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(archive, actualRequest.getArchive());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void archiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String archive = "archive-748101438";
+
+      client.archiveBooks(source, archive);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void longRunningArchiveBooksTest() throws Exception {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("longRunningArchiveBooksTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockLibraryService.addResponse(resultOperation);
+
+    String source = "source-896505829";
+    String archive = "archive-748101438";
+
+    ArchiveBooksResponse actualResponse =
+        client.longRunningArchiveBooksAsync(source, archive).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(archive, actualRequest.getArchive());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void longRunningArchiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String archive = "archive-748101438";
+
+      client.longRunningArchiveBooksAsync(source, archive).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamingArchiveBooksTest() throws Exception {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+
+    MockStreamObserver<ArchiveBooksResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> callable =
+        client.streamingArchiveBooksCallable();
+    ApiStreamObserver<ArchiveBooksRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+    requestObserver.onCompleted();
+
+    List<ArchiveBooksResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void streamingArchiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
+
+    MockStreamObserver<ArchiveBooksResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> callable =
+        client.streamingArchiveBooksCallable();
+    ApiStreamObserver<ArchiveBooksRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+
+    try {
+      List<ArchiveBooksResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
   public void privateListShelvesTest() {
-    BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+    BookName name = BookFromArchiveName.of("[ARCHIVE]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15761,7 +16556,7 @@ public class LibrarySmokeTest {
   public static void main(String args[]) {
     Logger.getLogger("").setLevel(Level.WARNING);
     try {
-      executeNoCatch();
+      executeNoCatch(getProjectId());
       System.out.println("OK");
     } catch (Exception e) {
       System.err.println("Failed with exception:");
@@ -15770,9 +16565,9 @@ public class LibrarySmokeTest {
     }
   }
 
-  public static void executeNoCatch() throws Exception {
+  public static void executeNoCatch(String projectId) throws Exception {
     try (LibraryClient client = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[BOOK_SHELF]", "[BOOK]");
+      BookName name = BookFromArchiveName.of("[ARCHIVE]", projectId);
       Book.Rating rating = Book.Rating.GOOD;
       Book book = Book.newBuilder()
         .setRating(rating)
@@ -16480,6 +17275,81 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
     } else {
       responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
     }
+  }
+
+  @Override
+  public void moveBooks(MoveBooksRequest request,
+    StreamObserver<MoveBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof MoveBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((MoveBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void archiveBooks(ArchiveBooksRequest request,
+    StreamObserver<ArchiveBooksResponse> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof ArchiveBooksResponse) {
+      requests.add(request);
+      responseObserver.onNext((ArchiveBooksResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void longRunningArchiveBooks(ArchiveBooksRequest request,
+    StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public StreamObserver<ArchiveBooksRequest> streamingArchiveBooks(
+      final StreamObserver<ArchiveBooksResponse> responseObserver) {
+    final Object response = responses.remove();
+    StreamObserver<ArchiveBooksRequest> requestObserver =
+        new StreamObserver<ArchiveBooksRequest>() {
+      @Override
+      public void onNext(ArchiveBooksRequest value) {
+        if (response instanceof ArchiveBooksResponse) {
+          responseObserver.onNext((ArchiveBooksResponse) response);
+        } else if (response instanceof Exception) {
+          responseObserver.onError((Exception) response);
+        } else {
+          responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+        }
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        responseObserver.onError(t);
+      }
+
+      @Override
+      public void onCompleted() {
+        responseObserver.onCompleted();
+      }
+    };
+    return requestObserver;
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -107,7 +107,7 @@ function sampleBabbleAboutBook() {
     // No one replied
     console.log(`No one replied.`);
   });
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
   const request = {
     name: formattedName,
   };
@@ -156,7 +156,7 @@ function sampleBabbleAboutBook() {
       return;
     }
   });
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
   const request = {
     name: formattedName,
   };
@@ -199,7 +199,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 function sampleDeleteShelf() {
   const client = new LibraryServiceClient();
-  const formattedName = client.shelfPath('[SHELF_ID]');
+  const formattedName = client.shelfPath('[SHELF]');
   client.deleteShelf({name: formattedName}).catch(err => {
     console.error(err);
   });
@@ -242,7 +242,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 function sampleDeleteShelf() {
   const client = new LibraryServiceClient();
-  const formattedName = client.shelfPath('[SHELF_ID]');
+  const formattedName = client.shelfPath('[SHELF]');
   client.deleteShelf({name: formattedName}).catch(err => {
     console.error(err);
   });
@@ -412,7 +412,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 function sampleGetBigBook(shelf) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel\\"`\b\t\n\r';
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'War and Peace');
 
   // Handle the operation using the event emitter pattern.
   client.getBigBook({name: formattedName})
@@ -507,7 +507,7 @@ function sampleGetBigBook(shelf, bigBookName) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', bigBookName);
 
   // Handle the operation using the event emitter pattern.
   client.getBigBook({name: formattedName})
@@ -583,7 +583,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 async function sampleGetBigBook(shelf) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel\\"`\b\t\n\r';
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'War and Peace');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigBook({name: formattedName});
@@ -660,7 +660,7 @@ async function sampleGetBigBook(shelf, bigBookName) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', bigBookName);
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigBook({name: formattedName});
@@ -718,7 +718,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 function sampleGetBigBook(shelf) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel\\"`\b\t\n\r';
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'War and Peace');
 
   // Handle the operation using the promise pattern.
   client.getBigBook({name: formattedName})
@@ -806,7 +806,7 @@ function sampleGetBigBook(shelf, bigBookName) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', bigBookName);
 
   // Handle the operation using the promise pattern.
   client.getBigBook({name: formattedName})
@@ -874,7 +874,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
 
   // Handle the operation using the event emitter pattern.
   client.getBigNothing({name: formattedName})
@@ -939,7 +939,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
 
   // Handle the operation using the event emitter pattern.
   client.getBigNothing({name: formattedName})
@@ -1002,7 +1002,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 async function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigNothing({name: formattedName});
@@ -1049,7 +1049,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 async function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigNothing({name: formattedName});
@@ -1094,7 +1094,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
 
   // Handle the operation using the promise pattern.
   client.getBigNothing({name: formattedName})
@@ -1152,7 +1152,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
 
   // Handle the operation using the promise pattern.
   client.getBigNothing({name: formattedName})
@@ -1208,7 +1208,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 
 function sampleGetBook() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
   client.getBook({name: formattedName})
     .then(responses => {
       const response = responses[0];
@@ -1306,7 +1306,7 @@ function sampleMonologAboutBook() {
     }
     console.log(`The stage of the comment is: ${response.stage}`);
   });
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
   const request = {
     name: formattedName,
   };
@@ -1689,7 +1689,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Testing calling forms */
 function sampleStreamShelves() {
   const client = new LibraryServiceClient();
-  const formattedName = client.shelfPath('[SHELF_ID]');
+  const formattedName = client.shelfPath('[SHELF]');
     client.streamShelves({name: formattedName}).on('data', response => {
       console.log(response);
     });
@@ -1785,8 +1785,8 @@ function sampleTestOptionalRequiredFlatteningParams(paramFloat, paramLong) {
   const requiredSingularString = '';
   const requiredSingularBytes = Buffer.from('');
   const requiredSingularMessage = {};
-  const formattedRequiredSingularResourceName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
-  const formattedRequiredSingularResourceNameOneof = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedRequiredSingularResourceName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedRequiredSingularResourceNameOneof = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
   const requiredSingularResourceNameCommon = '';
   const requiredSingularFixed32 = 0;
   const requiredSingularFixed64 = 0;
@@ -1954,7 +1954,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 
 function sampleGetBookFromAbsolutelyAnywhere() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'The ID of the book');
   client.getBookFromAbsolutelyAnywhere({name: formattedName})
     .then(responses => {
       const response = responses[0];
@@ -1998,7 +1998,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 
 function sampleGetBookFromAbsolutelyAnywhere() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'The ID of the book');
   client.getBookFromAbsolutelyAnywhere({name: formattedName})
     .then(responses => {
       const response = responses[0];
@@ -2102,7 +2102,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 async function sampleGetBigBook(shelf) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel\\"`\b\t\n\r';
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'War and Peace');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigBook({name: formattedName});
@@ -2177,7 +2177,7 @@ function sampleDiscussBook(imageFileName, stage) {
   });
   // const imageFileName = 'image_file.jpg';
   // const stage = 'DRAFT';
-  const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
   const comment = fs.readFileSync('comment_file').toString('base64');
   const comment2 = {
     comment: comment,
@@ -2228,6 +2228,11 @@ sampleDiscussBook(argv.image_file_name, argv.stage);
 const {describe, it} = require('mocha');
 
 describe('LibraryServiceSmokeTest', () => {
+  if (!process.env.GCLOUD_PROJECT) {
+    throw new Error("Usage: GCLOUD_PROJECT=<project_id> node #{$0}");
+  }
+  const projectId = process.env.GCLOUD_PROJECT;
+
   it('successfully makes a call to the service', done => {
     const library = require('../src');
 
@@ -2235,7 +2240,7 @@ describe('LibraryServiceSmokeTest', () => {
       // optional auth parameters.
     });
 
-    const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+    const formattedName = client.bookFromArchivePath('[ARCHIVE]', projectId);
     const rating = 'GOOD';
     const book = {
       rating: rating,
@@ -2767,7 +2772,7 @@ const SomeMessage2 = {
  *
  * @property {string} name
  *   The resource name of the shelf.
- *   Shelf names have the form `bookShelves/{shelf_id}`.
+ *   Shelf names have the form `shelves/{shelf}`.
  *
  * @property {string} theme
  *   The theme of the shelf
@@ -3744,6 +3749,69 @@ const TestOptionalRequiredFlatteningParamsRequest = {
  * @see [google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 const TestOptionalRequiredFlatteningParamsResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {string} source
+ *
+ * @property {string} destination
+ *
+ * @property {string[]} publishers
+ *
+ * @property {string} project
+ *
+ * @typedef MoveBooksRequest
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.MoveBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const MoveBooksRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {boolean} success
+ *
+ * @typedef MoveBooksResponse
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.MoveBooksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const MoveBooksResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {string} source
+ *
+ * @property {string} archive
+ *
+ * @typedef ArchiveBooksRequest
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.ArchiveBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const ArchiveBooksRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {boolean} success
+ *
+ * @typedef ArchiveBooksResponse
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.ArchiveBooksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const ArchiveBooksResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {number} percentage
+ *
+ * @typedef ArchiveBooksMetadata
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.ArchiveBooksMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const ArchiveBooksMetadata = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 ============== file: src/v1/doc/google/longrunning/doc_operations.js ==============
@@ -5062,7 +5130,7 @@ class LibraryServiceClient {
         'projects/{project}/locations/{location}/publishers/{publisher}'
       ),
       shelfPathTemplate: new gaxModule.PathTemplate(
-        'shelves/{shelf_id}'
+        'shelves/{shelf}'
       ),
     };
 
@@ -5100,6 +5168,7 @@ class LibraryServiceClient {
       discussBook: new gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
       monologAboutBook: new gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
       babbleAboutBook: new gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
+      streamingArchiveBooks: new gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
     };
 
     const protoFilesRoot = opts.fallback ?
@@ -5148,6 +5217,12 @@ class LibraryServiceClient {
     const getBigNothingMetadata = protoFilesRoot.lookup(
       'google.example.library.v1.GetBigBookMetadata'
     );
+    const longRunningArchiveBooksResponse = protoFilesRoot.lookup(
+      'google.example.library.v1.ArchiveBooksResponse'
+    );
+    const longRunningArchiveBooksMetadata = protoFilesRoot.lookup(
+      'google.example.library.v1.ArchiveBooksMetadata'
+    );
 
     this._descriptors.longrunning = {
       getBigBook: new gaxModule.LongrunningDescriptor(
@@ -5159,6 +5234,11 @@ class LibraryServiceClient {
         this.operationsClient,
         getBigNothingResponse.decode.bind(getBigNothingResponse),
         getBigNothingMetadata.decode.bind(getBigNothingMetadata)
+      ),
+      longRunningArchiveBooks: new gaxModule.LongrunningDescriptor(
+        this.operationsClient,
+        longRunningArchiveBooksResponse.decode.bind(longRunningArchiveBooksResponse),
+        longRunningArchiveBooksMetadata.decode.bind(longRunningArchiveBooksMetadata)
       ),
     };
 
@@ -5214,6 +5294,10 @@ class LibraryServiceClient {
       'getBigBook',
       'getBigNothing',
       'testOptionalRequiredFlatteningParams',
+      'moveBooks',
+      'archiveBooks',
+      'longRunningArchiveBooks',
+      'streamingArchiveBooks',
       'privateListShelves',
     ];
     for (const methodName of libraryServiceStubMethods) {
@@ -5393,7 +5477,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const options = '';
    * const request = {
    *   name: formattedName,
@@ -5582,7 +5666,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * client.deleteShelf({name: formattedName}).catch(err => {
    *   console.error(err);
    * });
@@ -5634,8 +5718,8 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
-   * const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
+   * const formattedOtherShelfName = client.shelfPath('[SHELF]');
    * const request = {
    *   name: formattedName,
    *   otherShelfName: formattedOtherShelfName,
@@ -5696,7 +5780,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const book = {};
    * const request = {
    *   name: formattedName,
@@ -5833,7 +5917,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * client.getBook({name: formattedName})
    *   .then(responses => {
    *     const response = responses[0];
@@ -5907,7 +5991,7 @@ class LibraryServiceClient {
    * });
    *
    * // Iterate over all elements.
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const filter = 'book-filter-string';
    * const request = {
    *   name: formattedName,
@@ -5926,7 +6010,7 @@ class LibraryServiceClient {
    *   });
    *
    * // Or obtain the paged response.
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const filter = 'book-filter-string';
    * const request = {
    *   name: formattedName,
@@ -6012,7 +6096,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * const filter = 'book-filter-string';
    * const request = {
    *   name: formattedName,
@@ -6058,7 +6142,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * client.deleteBook({name: formattedName}).catch(err => {
    *   console.error(err);
    * });
@@ -6120,7 +6204,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * const book = {};
    * const request = {
    *   name: formattedName,
@@ -6180,8 +6264,8 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
-   * const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedOtherShelfName = client.shelfPath('[SHELF]');
    * const request = {
    *   name: formattedName,
    *   otherShelfName: formattedOtherShelfName,
@@ -6380,7 +6464,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * const comment = Buffer.from('');
    * const stage = 'UNSET';
    * const alignment = 'CHAR';
@@ -6505,8 +6589,8 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
-   * const formattedAltBookName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedAltBookName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * const formattedPlace = client.locationPath('[PROJECT]', '[LOCATION]');
    * const formattedFolder = client.folderPath('[FOLDER]');
    * const request = {
@@ -6570,7 +6654,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * client.getBookFromAbsolutelyAnywhere({name: formattedName})
    *   .then(responses => {
    *     const response = responses[0];
@@ -6624,7 +6708,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * const indexName = 'default index';
    * const indexMapItem = '';
    * const indexMap = {'default_key' : indexMapItem};
@@ -6676,7 +6760,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.shelfPath('[SHELF_ID]');
+   * const formattedName = client.shelfPath('[SHELF]');
    * client.streamShelves({name: formattedName}).on('data', response => {
    *   // doThingsWith(response)
    * });
@@ -6744,7 +6828,7 @@ class LibraryServiceClient {
    * const stream = client.discussBook().on('data', response => {
    *   // doThingsWith(response)
    * });
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * const request = {
    *   name: formattedName,
    * };
@@ -6785,7 +6869,7 @@ class LibraryServiceClient {
    *   }
    *   // doThingsWith(response)
    * });
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * const request = {
    *   name: formattedName,
    * };
@@ -6829,7 +6913,7 @@ class LibraryServiceClient {
    *   }
    *   // doThingsWith(response)
    * });
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * const request = {
    *   name: formattedName,
    * };
@@ -7041,7 +7125,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedResource = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedResource = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * const label = '';
    * const request = {
    *   resource: formattedResource,
@@ -7099,7 +7183,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    *
    * // Handle the operation using the promise pattern.
    * client.getBigBook({name: formattedName})
@@ -7118,7 +7202,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    *
    * // Handle the operation using the event emitter pattern.
    * client.getBigBook({name: formattedName})
@@ -7146,7 +7230,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    *
    * // Handle the operation using the await pattern.
    * const [operation] = await client.getBigBook({name: formattedName});
@@ -7196,7 +7280,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    *
    * // Handle the operation using the promise pattern.
    * client.getBigNothing({name: formattedName})
@@ -7215,7 +7299,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    *
    * // Handle the operation using the event emitter pattern.
    * client.getBigNothing({name: formattedName})
@@ -7243,7 +7327,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    *
    * // Handle the operation using the await pattern.
    * const [operation] = await client.getBigNothing({name: formattedName});
@@ -7494,8 +7578,8 @@ class LibraryServiceClient {
    * const requiredSingularString = '';
    * const requiredSingularBytes = Buffer.from('');
    * const requiredSingularMessage = {};
-   * const formattedRequiredSingularResourceName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
-   * const formattedRequiredSingularResourceNameOneof = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+   * const formattedRequiredSingularResourceName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedRequiredSingularResourceNameOneof = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
    * const requiredSingularResourceNameCommon = '';
    * const requiredSingularFixed32 = 0;
    * const requiredSingularFixed64 = 0;
@@ -7627,6 +7711,235 @@ class LibraryServiceClient {
     options = options || {};
 
     return this._innerApiCalls.testOptionalRequiredFlatteningParams(request, options, callback);
+  }
+
+  /**
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.source]
+   * @param {string} [request.destination]
+   * @param {string[]} [request.publishers]
+   * @param {string} [request.project]
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [MoveBooksResponse]{@link google.example.library.v1.MoveBooksResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [MoveBooksResponse]{@link google.example.library.v1.MoveBooksResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.moveBooks({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  moveBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'source': request.source
+      });
+
+    return this._innerApiCalls.moveBooks(request, options, callback);
+  }
+
+  /**
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.source]
+   * @param {string} [request.archive]
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [ArchiveBooksResponse]{@link google.example.library.v1.ArchiveBooksResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [ArchiveBooksResponse]{@link google.example.library.v1.ArchiveBooksResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.archiveBooks({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  archiveBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'source': request.source
+      });
+
+    return this._innerApiCalls.archiveBooks(request, options, callback);
+  }
+
+  /**
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.source]
+   * @param {string} [request.archive]
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/classes/Operation.html} object.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/classes/Operation.html} object.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   *
+   * // Handle the operation using the promise pattern.
+   * client.longRunningArchiveBooks({})
+   *   .then(responses => {
+   *     const [operation, initialApiResponse] = responses;
+   *
+   *     // Operation#promise starts polling for the completion of the LRO.
+   *     return operation.promise();
+   *   })
+   *   .then(responses => {
+   *     const result = responses[0];
+   *     const metadata = responses[1];
+   *     const finalApiResponse = responses[2];
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   *
+   *
+   *
+   * // Handle the operation using the event emitter pattern.
+   * client.longRunningArchiveBooks({})
+   *   .then(responses => {
+   *     const [operation, initialApiResponse] = responses;
+   *
+   *     // Adding a listener for the "complete" event starts polling for the
+   *     // completion of the operation.
+   *     operation.on('complete', (result, metadata, finalApiResponse) => {
+   *       // doSomethingWith(result);
+   *     });
+   *
+   *     // Adding a listener for the "progress" event causes the callback to be
+   *     // called on any change in metadata when the operation is polled.
+   *     operation.on('progress', (metadata, apiResponse) => {
+   *       // doSomethingWith(metadata)
+   *     });
+   *
+   *     // Adding a listener for the "error" event handles any errors found during polling.
+   *     operation.on('error', err => {
+   *       // throw(err);
+   *     });
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   *
+   *
+   *
+   * // Handle the operation using the await pattern.
+   * const [operation] = await client.longRunningArchiveBooks({});
+   *
+   * const [response] = await operation.promise();
+   */
+  longRunningArchiveBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'source': request.source
+      });
+
+    return this._innerApiCalls.longRunningArchiveBooks(request, options, callback);
+  }
+
+  /**
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @returns {Stream}
+   *   An object stream which is both readable and writable. It accepts objects
+   *   representing [ArchiveBooksRequest]{@link google.example.library.v1.ArchiveBooksRequest} for write() method, and
+   *   will emit objects representing [ArchiveBooksResponse]{@link google.example.library.v1.ArchiveBooksResponse} on 'data' event asynchronously.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * const stream = client.streamingArchiveBooks().on('data', response => {
+   *   // doThingsWith(response)
+   * });
+   * const request = {};
+   * // Write request objects.
+   * stream.write(request);
+   */
+  streamingArchiveBooks(options) {
+    options = options || {};
+
+    return this._innerApiCalls.streamingArchiveBooks(options);
   }
 
   /**
@@ -7799,12 +8112,12 @@ class LibraryServiceClient {
   /**
    * Return a fully-qualified shelf resource name string.
    *
-   * @param {String} shelfId
+   * @param {String} shelf
    * @returns {String}
    */
-  shelfPath(shelfId) {
+  shelfPath(shelf) {
     return this._pathTemplates.shelfPathTemplate.render({
-      shelf_id: shelfId,
+      shelf: shelf,
     });
   }
 
@@ -8014,12 +8327,12 @@ class LibraryServiceClient {
    *
    * @param {String} shelfName
    *   A fully-qualified path representing a shelf resources.
-   * @returns {String} - A string representing the shelf_id.
+   * @returns {String} - A string representing the shelf.
    */
-  matchShelfIdFromShelfName(shelfName) {
+  matchShelfFromShelfName(shelfName) {
     return this._pathTemplates.shelfPathTemplate
       .match(shelfName)
-      .shelf_id;
+      .shelf;
   }
 }
 
@@ -8197,6 +8510,26 @@ module.exports = LibraryServiceClient;
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -8644,7 +8977,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const options = 'options-1249474914';
       const request = {
         name: formattedName,
@@ -8681,7 +9014,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const options = 'options-1249474914';
       const request = {
         name: formattedName,
@@ -8769,7 +9102,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -8790,7 +9123,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -8818,8 +9151,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -8855,8 +9188,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -8886,7 +9219,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const book = {};
       const request = {
         name: formattedName,
@@ -8925,7 +9258,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const book = {};
       const request = {
         name: formattedName,
@@ -9031,7 +9364,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9068,7 +9401,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9097,7 +9430,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const filter = 'book-filter-string';
       const request = {
         name: formattedName,
@@ -9133,7 +9466,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const filter = 'book-filter-string';
       const request = {
         name: formattedName,
@@ -9164,7 +9497,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9185,7 +9518,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9213,7 +9546,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const book = {};
       const request = {
         name: formattedName,
@@ -9252,7 +9585,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const book = {};
       const request = {
         name: formattedName,
@@ -9283,8 +9616,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -9322,8 +9655,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
-      const formattedOtherShelfName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
         otherShelfName: formattedOtherShelfName,
@@ -9410,7 +9743,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const comment = '95';
       const stage = 'UNSET';
       const alignment = 'CHAR';
@@ -9441,7 +9774,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const comment = '95';
       const stage = 'UNSET';
       const alignment = 'CHAR';
@@ -9549,8 +9882,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
-      const formattedAltBookName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedAltBookName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const formattedPlace = client.locationPath('[PROJECT]', '[LOCATION]');
       const formattedFolder = client.folderPath('[FOLDER]');
       const request = {
@@ -9592,8 +9925,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
-      const formattedAltBookName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedAltBookName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const formattedPlace = client.locationPath('[PROJECT]', '[LOCATION]');
       const formattedFolder = client.folderPath('[FOLDER]');
       const request = {
@@ -9627,7 +9960,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9664,7 +9997,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9693,7 +10026,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const indexName = 'default index';
       const indexMapItem = 'indexMapItem1918721251';
       const indexMap = {'default_key' : indexMapItem};
@@ -9719,7 +10052,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const indexName = 'default index';
       const indexMapItem = 'indexMapItem1918721251';
       const indexMap = {'default_key' : indexMapItem};
@@ -9752,7 +10085,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -9786,7 +10119,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.shelfPath('[SHELF_ID]');
+      const formattedName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
       };
@@ -9885,7 +10218,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9918,7 +10251,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10015,7 +10348,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedResource = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedResource = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const label = 'label102727412';
       const request = {
         resource: formattedResource,
@@ -10045,7 +10378,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedResource = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedResource = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const label = 'label102727412';
       const request = {
         resource: formattedResource,
@@ -10076,7 +10409,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10114,7 +10447,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10152,7 +10485,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10181,7 +10514,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10228,8 +10561,8 @@ describe('LibraryServiceClient', () => {
       const requiredSingularString = 'requiredSingularString-1949894503';
       const requiredSingularBytes = '-29';
       const requiredSingularMessage = {};
-      const formattedRequiredSingularResourceName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
-      const formattedRequiredSingularResourceNameOneof = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedRequiredSingularResourceName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedRequiredSingularResourceNameOneof = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
       const requiredSingularFixed32 = 720656715;
       const requiredSingularFixed64 = 720656810;
@@ -10376,8 +10709,8 @@ describe('LibraryServiceClient', () => {
       const requiredSingularString = 'requiredSingularString-1949894503';
       const requiredSingularBytes = '-29';
       const requiredSingularMessage = {};
-      const formattedRequiredSingularResourceName = client.bookPath('[BOOK_SHELF]', '[BOOK]');
-      const formattedRequiredSingularResourceNameOneof = client.bookPath('[BOOK_SHELF]', '[BOOK]');
+      const formattedRequiredSingularResourceName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedRequiredSingularResourceNameOneof = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
       const requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
       const requiredSingularFixed32 = 720656715;
       const requiredSingularFixed64 = 720656810;
@@ -10505,6 +10838,231 @@ describe('LibraryServiceClient', () => {
         assert(typeof response === 'undefined');
         done();
       });
+    });
+  });
+
+  describe('moveBooks', () => {
+    it('invokes moveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const success = false;
+      const expectedResponse = {
+        success: success,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.moveBooks = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.moveBooks(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes moveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.moveBooks = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.moveBooks(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('archiveBooks', () => {
+    it('invokes archiveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const success = false;
+      const expectedResponse = {
+        success: success,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.archiveBooks = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.archiveBooks(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes archiveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.archiveBooks = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.archiveBooks(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('longRunningArchiveBooks', function() {
+    it('invokes longRunningArchiveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const success = false;
+      const expectedResponse = {
+        success: success,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.longRunningArchiveBooks = mockLongRunningGrpcMethod(request, expectedResponse);
+
+      client.longRunningArchiveBooks(request).then(responses => {
+        const operation = responses[0];
+        return operation.promise();
+      }).then(responses => {
+        assert.deepStrictEqual(responses[0], expectedResponse);
+        done();
+      }).catch(err => {
+        done(err);
+      });
+    });
+
+    it('invokes longRunningArchiveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.longRunningArchiveBooks = mockLongRunningGrpcMethod(request, null, error);
+
+      client.longRunningArchiveBooks(request).then(responses => {
+        const operation = responses[0];
+        return operation.promise();
+      }).then(() => {
+        assert.fail();
+      }).catch(err => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+
+    it('has longrunning decoder functions', () => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      assert(client._descriptors.longrunning.longRunningArchiveBooks.responseDecoder instanceof Function);
+      assert(client._descriptors.longrunning.longRunningArchiveBooks.metadataDecoder instanceof Function);
+    });
+  });
+
+  describe('streamingArchiveBooks', () => {
+    it('invokes streamingArchiveBooks without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const success = false;
+      const expectedResponse = {
+        success: success,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.streamingArchiveBooks = mockBidiStreamingGrpcMethod(request, expectedResponse);
+
+      const stream = client.streamingArchiveBooks().on('data', response => {
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      }).on('error', err => {
+        done(err);
+      });
+
+      stream.write(request);
+    });
+
+    it('invokes streamingArchiveBooks with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.streamingArchiveBooks = mockBidiStreamingGrpcMethod(request, null, error);
+
+      const stream = client.streamingArchiveBooks().on('data', () => {
+        assert.fail();
+      }).on('error', err => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+
+      stream.write(request);
     });
   });
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -107,7 +107,7 @@ function sampleBabbleAboutBook() {
     // No one replied
     console.log(`No one replied.`);
   });
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
   const request = {
     name: formattedName,
   };
@@ -156,7 +156,7 @@ function sampleBabbleAboutBook() {
       return;
     }
   });
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
   const request = {
     name: formattedName,
   };
@@ -412,7 +412,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 function sampleGetBigBook(shelf) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel\\"`\b\t\n\r';
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'War and Peace');
+  const formattedName = client.bookPath(shelf, 'War and Peace');
 
   // Handle the operation using the event emitter pattern.
   client.getBigBook({name: formattedName})
@@ -507,7 +507,7 @@ function sampleGetBigBook(shelf, bigBookName) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', bigBookName);
+  const formattedName = client.bookPath(shelf, bigBookName);
 
   // Handle the operation using the event emitter pattern.
   client.getBigBook({name: formattedName})
@@ -583,7 +583,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 async function sampleGetBigBook(shelf) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel\\"`\b\t\n\r';
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'War and Peace');
+  const formattedName = client.bookPath(shelf, 'War and Peace');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigBook({name: formattedName});
@@ -660,7 +660,7 @@ async function sampleGetBigBook(shelf, bigBookName) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', bigBookName);
+  const formattedName = client.bookPath(shelf, bigBookName);
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigBook({name: formattedName});
@@ -718,7 +718,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 function sampleGetBigBook(shelf) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel\\"`\b\t\n\r';
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'War and Peace');
+  const formattedName = client.bookPath(shelf, 'War and Peace');
 
   // Handle the operation using the promise pattern.
   client.getBigBook({name: formattedName})
@@ -806,7 +806,7 @@ function sampleGetBigBook(shelf, bigBookName) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel';
   // const bigBookName = 'War and Peace';
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', bigBookName);
+  const formattedName = client.bookPath(shelf, bigBookName);
 
   // Handle the operation using the promise pattern.
   client.getBigBook({name: formattedName})
@@ -874,7 +874,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Handle the operation using the event emitter pattern.
   client.getBigNothing({name: formattedName})
@@ -939,7 +939,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Handle the operation using the event emitter pattern.
   client.getBigNothing({name: formattedName})
@@ -1002,7 +1002,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 async function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigNothing({name: formattedName});
@@ -1049,7 +1049,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 async function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigNothing({name: formattedName});
@@ -1094,7 +1094,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test response handling for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Handle the operation using the promise pattern.
   client.getBigNothing({name: formattedName})
@@ -1152,7 +1152,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 /** Test default response handling is turned off for methods that return empty */
 function sampleGetBigNothing() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
 
   // Handle the operation using the promise pattern.
   client.getBigNothing({name: formattedName})
@@ -1208,7 +1208,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 
 function sampleGetBook() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
   client.getBook({name: formattedName})
     .then(responses => {
       const response = responses[0];
@@ -1306,7 +1306,7 @@ function sampleMonologAboutBook() {
     }
     console.log(`The stage of the comment is: ${response.stage}`);
   });
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
   const request = {
     name: formattedName,
   };
@@ -1785,8 +1785,8 @@ function sampleTestOptionalRequiredFlatteningParams(paramFloat, paramLong) {
   const requiredSingularString = '';
   const requiredSingularBytes = Buffer.from('');
   const requiredSingularMessage = {};
-  const formattedRequiredSingularResourceName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
-  const formattedRequiredSingularResourceNameOneof = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+  const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
   const requiredSingularResourceNameCommon = '';
   const requiredSingularFixed32 = 0;
   const requiredSingularFixed64 = 0;
@@ -1954,7 +1954,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 
 function sampleGetBookFromAbsolutelyAnywhere() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'The ID of the book');
+  const formattedName = client.bookPath('[SHELF]', 'The ID of the book');
   client.getBookFromAbsolutelyAnywhere({name: formattedName})
     .then(responses => {
       const response = responses[0];
@@ -1998,7 +1998,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 
 function sampleGetBookFromAbsolutelyAnywhere() {
   const client = new LibraryServiceClient();
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'The ID of the book');
+  const formattedName = client.bookPath('The Shelf to search for the book', 'The ID of the book');
   client.getBookFromAbsolutelyAnywhere({name: formattedName})
     .then(responses => {
       const response = responses[0];
@@ -2102,7 +2102,7 @@ const {LibraryServiceClient} = require('@google-cloud/library').v1;
 async function sampleGetBigBook(shelf) {
   const client = new LibraryServiceClient();
   // const shelf = 'Novel\\"`\b\t\n\r';
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', 'War and Peace');
+  const formattedName = client.bookPath(shelf, 'War and Peace');
 
   // Create a job whose results you can either wait for now, or get later
   const [operation] = await client.getBigBook({name: formattedName});
@@ -2177,7 +2177,7 @@ function sampleDiscussBook(imageFileName, stage) {
   });
   // const imageFileName = 'image_file.jpg';
   // const stage = 'DRAFT';
-  const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+  const formattedName = client.bookPath('[SHELF]', '[BOOK]');
   const comment = fs.readFileSync('comment_file').toString('base64');
   const comment2 = {
     comment: comment,
@@ -2240,7 +2240,7 @@ describe('LibraryServiceSmokeTest', () => {
       // optional auth parameters.
     });
 
-    const formattedName = client.bookFromArchivePath('[ARCHIVE]', projectId);
+    const formattedName = client.bookPath("testShelf-" + Date.now().toString(), projectId);
     const rating = 'GOOD';
     const book = {
       rating: rating,
@@ -5109,7 +5109,7 @@ class LibraryServiceClient {
         'archives/{archive}/books/{book}'
       ),
       bookPathTemplate: new gaxModule.PathTemplate(
-        'bookShelves/{book_shelf}/books/{book}'
+        'shelves/{shelf}/books/{book}'
       ),
       bookFromArchivePathTemplate: new gaxModule.PathTemplate(
         'archives/{archive}/books/{book}'
@@ -5917,7 +5917,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * client.getBook({name: formattedName})
    *   .then(responses => {
    *     const response = responses[0];
@@ -6142,7 +6142,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * client.deleteBook({name: formattedName}).catch(err => {
    *   console.error(err);
    * });
@@ -6204,7 +6204,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const book = {};
    * const request = {
    *   name: formattedName,
@@ -6264,7 +6264,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const formattedOtherShelfName = client.shelfPath('[SHELF]');
    * const request = {
    *   name: formattedName,
@@ -6464,7 +6464,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const comment = Buffer.from('');
    * const stage = 'UNSET';
    * const alignment = 'CHAR';
@@ -6589,8 +6589,8 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
-   * const formattedAltBookName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+   * const formattedAltBookName = client.bookPath('[SHELF]', '[BOOK]');
    * const formattedPlace = client.locationPath('[PROJECT]', '[LOCATION]');
    * const formattedFolder = client.folderPath('[FOLDER]');
    * const request = {
@@ -6654,7 +6654,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * client.getBookFromAbsolutelyAnywhere({name: formattedName})
    *   .then(responses => {
    *     const response = responses[0];
@@ -6708,7 +6708,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const indexName = 'default index';
    * const indexMapItem = '';
    * const indexMap = {'default_key' : indexMapItem};
@@ -6828,7 +6828,7 @@ class LibraryServiceClient {
    * const stream = client.discussBook().on('data', response => {
    *   // doThingsWith(response)
    * });
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const request = {
    *   name: formattedName,
    * };
@@ -6869,7 +6869,7 @@ class LibraryServiceClient {
    *   }
    *   // doThingsWith(response)
    * });
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const request = {
    *   name: formattedName,
    * };
@@ -6913,7 +6913,7 @@ class LibraryServiceClient {
    *   }
    *   // doThingsWith(response)
    * });
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    * const request = {
    *   name: formattedName,
    * };
@@ -7125,7 +7125,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedResource = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
    * const label = '';
    * const request = {
    *   resource: formattedResource,
@@ -7183,7 +7183,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the promise pattern.
    * client.getBigBook({name: formattedName})
@@ -7202,7 +7202,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the event emitter pattern.
    * client.getBigBook({name: formattedName})
@@ -7230,7 +7230,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the await pattern.
    * const [operation] = await client.getBigBook({name: formattedName});
@@ -7280,7 +7280,7 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the promise pattern.
    * client.getBigNothing({name: formattedName})
@@ -7299,7 +7299,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the event emitter pattern.
    * client.getBigNothing({name: formattedName})
@@ -7327,7 +7327,7 @@ class LibraryServiceClient {
    *     console.error(err);
    *   });
    *
-   * const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
    *
    * // Handle the operation using the await pattern.
    * const [operation] = await client.getBigNothing({name: formattedName});
@@ -7578,8 +7578,8 @@ class LibraryServiceClient {
    * const requiredSingularString = '';
    * const requiredSingularBytes = Buffer.from('');
    * const requiredSingularMessage = {};
-   * const formattedRequiredSingularResourceName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
-   * const formattedRequiredSingularResourceNameOneof = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+   * const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+   * const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
    * const requiredSingularResourceNameCommon = '';
    * const requiredSingularFixed32 = 0;
    * const requiredSingularFixed64 = 0;
@@ -8014,13 +8014,13 @@ class LibraryServiceClient {
    * @deprecated Multi-pattern resource names will have unified formatting and parsing helper functions. This helper function will be deleted in the next major version.
    * Return a fully-qualified book resource name string.
    *
-   * @param {String} bookShelf
+   * @param {String} shelf
    * @param {String} book
    * @returns {String}
    */
-  bookPath(bookShelf, book) {
+  bookPath(shelf, book) {
     return this._pathTemplates.bookPathTemplate.render({
-      book_shelf: bookShelf,
+      shelf: shelf,
       book: book,
     });
   }
@@ -8153,12 +8153,12 @@ class LibraryServiceClient {
    *
    * @param {String} bookName
    *   A fully-qualified path representing a book resources.
-   * @returns {String} - A string representing the book_shelf.
+   * @returns {String} - A string representing the shelf.
    */
-  matchBookShelfFromBookName(bookName) {
+  matchShelfFromBookName(bookName) {
     return this._pathTemplates.bookPathTemplate
       .match(bookName)
-      .book_shelf;
+      .shelf;
   }
 
   /**
@@ -9364,7 +9364,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9401,7 +9401,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9497,7 +9497,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9518,7 +9518,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9546,7 +9546,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const book = {};
       const request = {
         name: formattedName,
@@ -9585,7 +9585,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const book = {};
       const request = {
         name: formattedName,
@@ -9616,7 +9616,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
@@ -9655,7 +9655,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const formattedOtherShelfName = client.shelfPath('[SHELF]');
       const request = {
         name: formattedName,
@@ -9743,7 +9743,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const comment = '95';
       const stage = 'UNSET';
       const alignment = 'CHAR';
@@ -9774,7 +9774,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const comment = '95';
       const stage = 'UNSET';
       const alignment = 'CHAR';
@@ -9882,8 +9882,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
-      const formattedAltBookName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedAltBookName = client.bookPath('[SHELF]', '[BOOK]');
       const formattedPlace = client.locationPath('[PROJECT]', '[LOCATION]');
       const formattedFolder = client.folderPath('[FOLDER]');
       const request = {
@@ -9925,8 +9925,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
-      const formattedAltBookName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedAltBookName = client.bookPath('[SHELF]', '[BOOK]');
       const formattedPlace = client.locationPath('[PROJECT]', '[LOCATION]');
       const formattedFolder = client.folderPath('[FOLDER]');
       const request = {
@@ -9960,7 +9960,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -9997,7 +9997,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10026,7 +10026,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const indexName = 'default index';
       const indexMapItem = 'indexMapItem1918721251';
       const indexMap = {'default_key' : indexMapItem};
@@ -10052,7 +10052,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const indexName = 'default index';
       const indexMapItem = 'indexMapItem1918721251';
       const indexMap = {'default_key' : indexMapItem};
@@ -10218,7 +10218,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10251,7 +10251,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10348,7 +10348,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedResource = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
       const label = 'label102727412';
       const request = {
         resource: formattedResource,
@@ -10378,7 +10378,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedResource = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
       const label = 'label102727412';
       const request = {
         resource: formattedResource,
@@ -10409,7 +10409,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10447,7 +10447,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10485,7 +10485,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10514,7 +10514,7 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
       const request = {
         name: formattedName,
       };
@@ -10561,8 +10561,8 @@ describe('LibraryServiceClient', () => {
       const requiredSingularString = 'requiredSingularString-1949894503';
       const requiredSingularBytes = '-29';
       const requiredSingularMessage = {};
-      const formattedRequiredSingularResourceName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
-      const formattedRequiredSingularResourceNameOneof = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
       const requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
       const requiredSingularFixed32 = 720656715;
       const requiredSingularFixed64 = 720656810;
@@ -10709,8 +10709,8 @@ describe('LibraryServiceClient', () => {
       const requiredSingularString = 'requiredSingularString-1949894503';
       const requiredSingularBytes = '-29';
       const requiredSingularMessage = {};
-      const formattedRequiredSingularResourceName = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
-      const formattedRequiredSingularResourceNameOneof = client.bookFromArchivePath('[ARCHIVE]', '[BOOK]');
+      const formattedRequiredSingularResourceName = client.bookPath('[SHELF]', '[BOOK]');
+      const formattedRequiredSingularResourceNameOneof = client.bookPath('[SHELF]', '[BOOK]');
       const requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
       const requiredSingularFixed32 = 720656715;
       const requiredSingularFixed64 = 720656810;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -57,7 +57,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -116,7 +116,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -173,7 +173,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -229,7 +229,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -496,7 +496,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
+    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -596,7 +596,7 @@ function sampleGetBigBook($shelf, $bigBookName)
 
     // $shelf = 'Novel';
     // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $bigBookName);
+    $formattedName = $libraryServiceClient->bookName($shelf, $bigBookName);
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -676,7 +676,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
+    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -769,7 +769,7 @@ function sampleGetBigBook($shelf, $bigBookName)
 
     // $shelf = 'Novel';
     // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $bigBookName);
+    $formattedName = $libraryServiceClient->bookName($shelf, $bigBookName);
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -841,7 +841,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -903,7 +903,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -965,7 +965,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -1020,7 +1020,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -1076,7 +1076,7 @@ function sampleGetBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $response = $libraryServiceClient->getBook($formattedName);
@@ -1183,7 +1183,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1242,7 +1242,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1760,8 +1760,8 @@ function sampleTestOptionalRequiredFlatteningParams($paramFloat, $paramLong)
     $requiredSingularString = '';
     $requiredSingularBytes = '';
     $requiredSingularMessage = new InnerMessage();
-    $formattedRequiredSingularResourceName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $requiredSingularResourceNameCommon = '';
     $requiredSingularFixed32 = 0;
     $requiredSingularFixed64 = 0;
@@ -1874,7 +1874,7 @@ function sampleGetBookFromAbsolutelyAnywhere()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'The ID of the book');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', 'The ID of the book');
 
     try {
         $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
@@ -1921,7 +1921,7 @@ function sampleGetBookFromAbsolutelyAnywhere()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'The ID of the book');
+    $formattedName = $libraryServiceClient->bookName('The Shelf to search for the book', 'The ID of the book');
 
     try {
         $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
@@ -2027,7 +2027,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
+    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -2117,7 +2117,7 @@ function sampleDiscussBook($imageFileName, $stage)
 
     // $imageFileName = 'image_file.jpg';
     // $stage = Stage::DRAFT;
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $comment = file_get_contents('comment_file');
     $comment2 = new Comment();
     $comment2->setComment($comment);
@@ -2202,7 +2202,7 @@ function sampleDiscussBook($imageFileName, $stage)
 
     // $imageFileName = 'image_file.jpg';
     // $stage = Stage::DRAFT;
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $comment = file_get_contents('comment_file');
     $comment2 = new Comment();
     $comment2->setComment($comment);
@@ -2477,7 +2477,7 @@ class LibraryServiceGapicClient
     private static function getBookNameTemplate()
     {
         if (self::$bookNameTemplate == null) {
-            self::$bookNameTemplate = new PathTemplate('bookShelves/{book_shelf}/books/{book}');
+            self::$bookNameTemplate = new PathTemplate('shelves/{shelf}/books/{book}');
         }
 
         return self::$bookNameTemplate;
@@ -2585,16 +2585,16 @@ class LibraryServiceGapicClient
      * Formats a string containing the fully-qualified path to represent
      * a book resource.
      *
-     * @param string $bookShelf
+     * @param string $shelf
      * @param string $book
      * @return string The formatted book resource.
      * @deprecated Multi-pattern resource names will have unified formatting functions.
      *             This helper function will be deleted in the next major version.
      */
-    public static function bookName($bookShelf, $book)
+    public static function bookName($shelf, $book)
     {
         return self::getBookNameTemplate()->render([
-            'book_shelf' => $bookShelf,
+            'shelf' => $shelf,
             'book' => $book,
         ]);
     }
@@ -2721,7 +2721,7 @@ class LibraryServiceGapicClient
      * The following name formats are supported:
      * Template: Pattern
      * - archivedBook: archives/{archive}/books/{book}
-     * - book: bookShelves/{book_shelf}/books/{book}
+     * - book: shelves/{shelf}/books/{book}
      * - bookFromArchive: archives/{archive}/books/{book}
      * - folder: folders/{folder}
      * - location: projects/{project}/locations/{location}
@@ -3251,7 +3251,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $response = $libraryServiceClient->getBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3385,7 +3385,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $libraryServiceClient->deleteBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3432,7 +3432,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $book = new Book();
      *     $response = $libraryServiceClient->updateBook($formattedName, $book);
      * } finally {
@@ -3499,7 +3499,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF]');
      *     $response = $libraryServiceClient->moveBook($formattedName, $formattedOtherShelfName);
      * } finally {
@@ -3624,7 +3624,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $comment = '';
      *     $stage = Stage::UNSET;
      *     $alignment = Alignment::CHAR;
@@ -3733,8 +3733,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-     *     $formattedAltBookName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $formattedAltBookName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $formattedPlace = $libraryServiceClient->locationName('[PROJECT]', '[LOCATION]');
      *     $formattedFolder = $libraryServiceClient->folderName('[FOLDER]');
      *     $response = $libraryServiceClient->getBookFromAnywhere($formattedName, $formattedAltBookName, $formattedPlace, $formattedFolder);
@@ -3792,7 +3792,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3848,7 +3848,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $indexName = 'default index';
      *     $indexMapItem = '';
      *     $indexMap = ['default_key' => $indexMapItem];
@@ -3992,7 +3992,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write all requests to the server, then read all responses until the
@@ -4058,7 +4058,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write data to server and wait for a response
@@ -4113,7 +4113,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write data to server and wait for a response
@@ -4241,7 +4241,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedResource = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedResource = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $label = '';
      *     $response = $libraryServiceClient->addLabel($formattedResource, $label);
      * } finally {
@@ -4296,7 +4296,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigBook($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -4373,7 +4373,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -4457,8 +4457,8 @@ class LibraryServiceGapicClient
      *     $requiredSingularString = '';
      *     $requiredSingularBytes = '';
      *     $requiredSingularMessage = new InnerMessage();
-     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $requiredSingularResourceNameCommon = '';
      *     $requiredSingularFixed32 = 0;
      *     $requiredSingularFixed64 = 0;
@@ -6237,7 +6237,7 @@ class LibraryServiceSmokeTest extends GeneratedTest
         }
 
         $libraryServiceClient = new LibraryServiceClient();
-        $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $projectId);
+        $formattedName = $libraryServiceClient->bookName('testShelf-'. time(), $projectId);
         $rating = Rating::GOOD;
         $book = new Book();
         $book->setRating($rating);
@@ -6958,7 +6958,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBook($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -6998,7 +6998,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->getBook($formattedName);
@@ -7113,7 +7113,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $client->deleteBook($formattedName);
         $actualRequests = $transport->popReceivedCalls();
@@ -7152,7 +7152,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->deleteBook($formattedName);
@@ -7191,7 +7191,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $book = new Book();
 
         $response = $client->updateBook($formattedName, $book);
@@ -7235,7 +7235,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $book = new Book();
 
         try {
@@ -7275,7 +7275,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         $response = $client->moveBook($formattedName, $formattedOtherShelfName);
@@ -7319,7 +7319,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         try {
@@ -7421,7 +7421,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -7471,7 +7471,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -7602,8 +7602,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-        $formattedAltBookName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedAltBookName = $client->bookName('[SHELF]', '[BOOK]');
         $formattedPlace = $client->locationName('[PROJECT]', '[LOCATION]');
         $formattedFolder = $client->folderName('[FOLDER]');
 
@@ -7654,8 +7654,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-        $formattedAltBookName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedAltBookName = $client->bookName('[SHELF]', '[BOOK]');
         $formattedPlace = $client->locationName('[PROJECT]', '[LOCATION]');
         $formattedFolder = $client->folderName('[FOLDER]');
 
@@ -7696,7 +7696,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBookFromAbsolutelyAnywhere($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -7736,7 +7736,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->getBookFromAbsolutelyAnywhere($formattedName);
@@ -7767,7 +7767,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -7815,7 +7815,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -8074,13 +8074,13 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $request = new DiscussBookRequest();
         $request->setName($formattedName);
-        $formattedName2 = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName2 = $client->bookName('[SHELF]', '[BOOK]');
         $request2 = new DiscussBookRequest();
         $request2->setName($formattedName2);
-        $formattedName3 = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName3 = $client->bookName('[SHELF]', '[BOOK]');
         $request3 = new DiscussBookRequest();
         $request3->setName($formattedName3);
 
@@ -8264,7 +8264,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedResource = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
         $label = 'label102727412';
 
         $response = $client->addLabel($formattedResource, $label);
@@ -8308,7 +8308,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedResource = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
         $label = 'label102727412';
 
         try {
@@ -8368,7 +8368,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -8446,7 +8446,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -8508,7 +8508,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -8586,7 +8586,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -8637,8 +8637,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedRequiredSingularResourceName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF]', '[BOOK]');
         $requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
@@ -8917,8 +8917,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedRequiredSingularResourceName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF]', '[BOOK]');
         $requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -57,7 +57,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -116,7 +116,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -173,7 +173,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -229,7 +229,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -282,7 +282,7 @@ function sampleDeleteShelf()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $formattedName = $libraryServiceClient->shelfName('[SHELF]');
 
     try {
         $libraryServiceClient->deleteShelf($formattedName);
@@ -332,7 +332,7 @@ function sampleDeleteShelf()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $formattedName = $libraryServiceClient->shelfName('[SHELF]');
 
     try {
         $libraryServiceClient->deleteShelf($formattedName);
@@ -496,7 +496,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -596,7 +596,7 @@ function sampleGetBigBook($shelf, $bigBookName)
 
     // $shelf = 'Novel';
     // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $bigBookName);
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -676,7 +676,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -769,7 +769,7 @@ function sampleGetBigBook($shelf, $bigBookName)
 
     // $shelf = 'Novel';
     // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $bigBookName);
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -841,7 +841,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -903,7 +903,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -965,7 +965,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -1020,7 +1020,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -1076,7 +1076,7 @@ function sampleGetBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
     try {
         $response = $libraryServiceClient->getBook($formattedName);
@@ -1183,7 +1183,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1242,7 +1242,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1633,7 +1633,7 @@ function sampleStreamShelves()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $formattedName = $libraryServiceClient->shelfName('[SHELF]');
 
     try {
         // Read all responses until the stream is complete
@@ -1760,8 +1760,8 @@ function sampleTestOptionalRequiredFlatteningParams($paramFloat, $paramLong)
     $requiredSingularString = '';
     $requiredSingularBytes = '';
     $requiredSingularMessage = new InnerMessage();
-    $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedRequiredSingularResourceName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $requiredSingularResourceNameCommon = '';
     $requiredSingularFixed32 = 0;
     $requiredSingularFixed64 = 0;
@@ -1874,7 +1874,7 @@ function sampleGetBookFromAbsolutelyAnywhere()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'The ID of the book');
 
     try {
         $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
@@ -1921,7 +1921,7 @@ function sampleGetBookFromAbsolutelyAnywhere()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'The ID of the book');
 
     try {
         $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
@@ -2027,7 +2027,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -2117,7 +2117,7 @@ function sampleDiscussBook($imageFileName, $stage)
 
     // $imageFileName = 'image_file.jpg';
     // $stage = Stage::DRAFT;
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $comment = file_get_contents('comment_file');
     $comment2 = new Comment();
     $comment2->setComment($comment);
@@ -2202,7 +2202,7 @@ function sampleDiscussBook($imageFileName, $stage)
 
     // $imageFileName = 'image_file.jpg';
     // $stage = Stage::DRAFT;
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $comment = file_get_contents('comment_file');
     $comment2 = new Comment();
     $comment2->setComment($comment);
@@ -2297,6 +2297,9 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Example\Library\V1\AddCommentsRequest;
+use Google\Example\Library\V1\ArchiveBooksMetadata;
+use Google\Example\Library\V1\ArchiveBooksRequest;
+use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
@@ -2323,6 +2326,8 @@ use Google\Example\Library\V1\ListStringsRequest;
 use Google\Example\Library\V1\ListStringsResponse;
 use Google\Example\Library\V1\MergeShelvesRequest;
 use Google\Example\Library\V1\MoveBookRequest;
+use Google\Example\Library\V1\MoveBooksRequest;
+use Google\Example\Library\V1\MoveBooksResponse;
 use Google\Example\Library\V1\PublishSeriesRequest;
 use Google\Example\Library\V1\PublishSeriesResponse;
 use Google\Example\Library\V1\SeriesUuid;
@@ -2535,7 +2540,7 @@ class LibraryServiceGapicClient
     private static function getShelfNameTemplate()
     {
         if (self::$shelfNameTemplate == null) {
-            self::$shelfNameTemplate = new PathTemplate('shelves/{shelf_id}');
+            self::$shelfNameTemplate = new PathTemplate('shelves/{shelf}');
         }
 
         return self::$shelfNameTemplate;
@@ -2700,14 +2705,14 @@ class LibraryServiceGapicClient
      * Formats a string containing the fully-qualified path to represent
      * a shelf resource.
      *
-     * @param string $shelfId
+     * @param string $shelf
      * @return string The formatted shelf resource.
      * @experimental
      */
-    public static function shelfName($shelfId)
+    public static function shelfName($shelf)
     {
         return self::getShelfNameTemplate()->render([
-            'shelf_id' => $shelfId,
+            'shelf' => $shelf,
         ]);
     }
 
@@ -2723,7 +2728,7 @@ class LibraryServiceGapicClient
      * - project: projects/{project}
      * - projectBook: projects/{project}/books/{book}
      * - publisher: projects/{project}/locations/{location}/publishers/{publisher}
-     * - shelf: shelves/{shelf_id}
+     * - shelf: shelves/{shelf}
      *
      * The optional $template argument can be supplied to specify a particular pattern, and must
      * match one of the templates listed above. If no $template argument is provided, or if the
@@ -2898,7 +2903,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $options = '';
      *     $response = $libraryServiceClient->getShelf($formattedName, $options);
      * } finally {
@@ -3021,7 +3026,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $libraryServiceClient->deleteShelf($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3070,8 +3075,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
-     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
+     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF]');
      *     $response = $libraryServiceClient->mergeShelves($formattedName, $formattedOtherShelfName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3122,7 +3127,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $book = new Book();
      *     $response = $libraryServiceClient->createBook($formattedName, $book);
      * } finally {
@@ -3246,7 +3251,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $response = $libraryServiceClient->getBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3295,7 +3300,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $filter = 'book-filter-string';
      *     // Iterate over pages of elements
      *     $pagedResponse = $libraryServiceClient->listBooks($formattedName, ['filter' => $filter]);
@@ -3380,7 +3385,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $libraryServiceClient->deleteBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3427,7 +3432,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $book = new Book();
      *     $response = $libraryServiceClient->updateBook($formattedName, $book);
      * } finally {
@@ -3494,8 +3499,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF]');
      *     $response = $libraryServiceClient->moveBook($formattedName, $formattedOtherShelfName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3619,7 +3624,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $comment = '';
      *     $stage = Stage::UNSET;
      *     $alignment = Alignment::CHAR;
@@ -3728,8 +3733,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-     *     $formattedAltBookName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedAltBookName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $formattedPlace = $libraryServiceClient->locationName('[PROJECT]', '[LOCATION]');
      *     $formattedFolder = $libraryServiceClient->folderName('[FOLDER]');
      *     $response = $libraryServiceClient->getBookFromAnywhere($formattedName, $formattedAltBookName, $formattedPlace, $formattedFolder);
@@ -3787,7 +3792,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3843,7 +3848,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $indexName = 'default index';
      *     $indexMapItem = '';
      *     $indexMap = ['default_key' => $indexMapItem];
@@ -3898,7 +3903,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     // Read all responses until the stream is complete
      *     $stream = $libraryServiceClient->streamShelves($formattedName);
      *     foreach ($stream->readAll() as $element) {
@@ -3987,7 +3992,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write all requests to the server, then read all responses until the
@@ -4053,7 +4058,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write data to server and wait for a response
@@ -4108,7 +4113,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write data to server and wait for a response
@@ -4236,7 +4241,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedResource = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedResource = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $label = '';
      *     $response = $libraryServiceClient->addLabel($formattedResource, $label);
      * } finally {
@@ -4291,7 +4296,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigBook($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -4368,7 +4373,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -4452,8 +4457,8 @@ class LibraryServiceGapicClient
      *     $requiredSingularString = '';
      *     $requiredSingularBytes = '';
      *     $requiredSingularMessage = new InnerMessage();
-     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $requiredSingularResourceNameCommon = '';
      *     $requiredSingularFixed32 = 0;
      *     $requiredSingularFixed64 = 0;
@@ -4902,6 +4907,268 @@ class LibraryServiceGapicClient
             $optionalArgs,
             $request
         )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $response = $libraryServiceClient->moveBooks();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $destination
+     *     @type string[] $publishers
+     *     @type string $project
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\MoveBooksResponse
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function moveBooks(array $optionalArgs = [])
+    {
+        $request = new MoveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['destination'])) {
+            $request->setDestination($optionalArgs['destination']);
+        }
+        if (isset($optionalArgs['publishers'])) {
+            $request->setPublishers($optionalArgs['publishers']);
+        }
+        if (isset($optionalArgs['project'])) {
+            $request->setProject($optionalArgs['project']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'MoveBooks',
+            MoveBooksResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $response = $libraryServiceClient->archiveBooks();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $archive
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\ArchiveBooksResponse
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function archiveBooks(array $optionalArgs = [])
+    {
+        $request = new ArchiveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['archive'])) {
+            $request->setArchive($optionalArgs['archive']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'ArchiveBooks',
+            ArchiveBooksResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $operationResponse = $libraryServiceClient->longRunningArchiveBooks();
+     *     $operationResponse->pollUntilComplete();
+     *     if ($operationResponse->operationSucceeded()) {
+     *         $result = $operationResponse->getResult();
+     *         // doSomethingWith($result)
+     *     } else {
+     *         $error = $operationResponse->getError();
+     *         // handleError($error)
+     *     }
+     *
+     *
+     *     // Alternatively:
+     *
+     *     // start the operation, keep the operation name, and resume later
+     *     $operationResponse = $libraryServiceClient->longRunningArchiveBooks();
+     *     $operationName = $operationResponse->getName();
+     *     // ... do other work
+     *     $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'longRunningArchiveBooks');
+     *     while (!$newOperationResponse->isDone()) {
+     *         // ... do other work
+     *         $newOperationResponse->reload();
+     *     }
+     *     if ($newOperationResponse->operationSucceeded()) {
+     *       $result = $newOperationResponse->getResult();
+     *       // doSomethingWith($result)
+     *     } else {
+     *       $error = $newOperationResponse->getError();
+     *       // handleError($error)
+     *     }
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $archive
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\ApiCore\OperationResponse
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function longRunningArchiveBooks(array $optionalArgs = [])
+    {
+        $request = new ArchiveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['archive'])) {
+            $request->setArchive($optionalArgs['archive']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startOperationsCall(
+            'LongRunningArchiveBooks',
+            $optionalArgs,
+            $request,
+            $this->getOperationsClient()
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $request = new ArchiveBooksRequest();
+     *     // Write all requests to the server, then read all responses until the
+     *     // stream is complete
+     *     $requests = [$request];
+     *     $stream = $libraryServiceClient->streamingArchiveBooks();
+     *     $stream->writeAll($requests);
+     *     foreach ($stream->closeWriteAndReadAll() as $element) {
+     *         // doSomethingWith($element);
+     *     }
+     *
+     *
+     *     // Alternatively:
+     *
+     *     // Write requests individually, making read() calls if
+     *     // required. Call closeWrite() once writes are complete, and read the
+     *     // remaining responses from the server.
+     *     $requests = [$request];
+     *     $stream = $libraryServiceClient->streamingArchiveBooks();
+     *     foreach ($requests as $request) {
+     *         $stream->write($request);
+     *         // if required, read a single response from the stream
+     *         $element = $stream->read();
+     *         // doSomethingWith($element)
+     *     }
+     *     $stream->closeWrite();
+     *     $element = $stream->read();
+     *     while (!is_null($element)) {
+     *         // doSomethingWith($element)
+     *         $element = $stream->read();
+     *     }
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type int $timeoutMillis
+     *          Timeout to use for this call.
+     * }
+     *
+     * @return \Google\ApiCore\BidiStream
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function streamingArchiveBooks(array $optionalArgs = [])
+    {
+        return $this->startCall(
+            'StreamingArchiveBooks',
+            ArchiveBooksResponse::class,
+            $optionalArgs,
+            null,
+            Call::BIDI_STREAMING_CALL
+        );
     }
 
     /**
@@ -5420,6 +5687,24 @@ class MyProtoClient extends MyProtoGapicClient
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
+          "timeout_millis": 60000
+        },
         "PrivateListShelves": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -5454,6 +5739,16 @@ return [
                     'pollDelayMultiplier' => '1.3',
                     'maxPollDelayMillis' => '60000',
                     'totalPollTimeoutMillis' => '600000',
+                ]
+            ],
+            'LongRunningArchiveBooks' => [
+                'longRunning' => [
+                    'operationReturnType' => '\Google\Example\Library\V1\ArchiveBooksResponse',
+                    'metadataReturnType' => '\Google\Example\Library\V1\ArchiveBooksMetadata',
+                    'initialPollDelayMillis' => '500',
+                    'pollDelayMultiplier' => '1.5',
+                    'maxPollDelayMillis' => '5000',
+                    'totalPollTimeoutMillis' => '300000',
                 ]
             ],
             'ListShelves' => [
@@ -5518,6 +5813,11 @@ return [
             'BabbleAboutBook' => [
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'ClientStreaming',
+                ]
+            ],
+            'StreamingArchiveBooks' => [
+                'grpcStreaming' => [
+                    'grpcStreamingType' => 'BidiStreaming',
                 ]
             ],
         ]
@@ -5772,6 +6072,42 @@ return [
                 'uriTemplate' => '/v1/testofp',
                 'body' => '*',
             ],
+            'MoveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:move',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
+            'ArchiveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:archive',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
+            'LongRunningArchiveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:longrunningmove',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
             'PrivateListShelves' => [
                 'method' => 'get',
                 'uriTemplate' => '/v1/bookShelves',
@@ -5895,9 +6231,13 @@ class LibraryServiceSmokeTest extends GeneratedTest
      */
     public function updateBookTest()
     {
+        $projectId = getenv('PROJECT_ID');
+        if ($projectId === false) {
+            $this->fail('Environment variable PROJECT_ID must be set for smoke test');
+        }
 
         $libraryServiceClient = new LibraryServiceClient();
-        $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $projectId);
         $rating = Rating::GOOD;
         $book = new Book();
         $book->setRating($rating);
@@ -5938,6 +6278,8 @@ use Google\ApiCore\ServerStream;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Example\Library\V1\AddCommentsRequest;
+use Google\Example\Library\V1\ArchiveBooksRequest;
+use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
@@ -5964,6 +6306,8 @@ use Google\Example\Library\V1\ListStringsRequest;
 use Google\Example\Library\V1\ListStringsResponse;
 use Google\Example\Library\V1\MergeShelvesRequest;
 use Google\Example\Library\V1\MoveBookRequest;
+use Google\Example\Library\V1\MoveBooksRequest;
+use Google\Example\Library\V1\MoveBooksResponse;
 use Google\Example\Library\V1\PublishSeriesRequest;
 use Google\Example\Library\V1\PublishSeriesResponse;
 use Google\Example\Library\V1\SeriesUuid;
@@ -6136,7 +6480,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $options = 'options-1249474914';
 
         $response = $client->getShelf($formattedName, $options);
@@ -6180,7 +6524,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $options = 'options-1249474914';
 
         try {
@@ -6282,7 +6626,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $client->deleteShelf($formattedName);
         $actualRequests = $transport->popReceivedCalls();
@@ -6321,7 +6665,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         try {
             $client->deleteShelf($formattedName);
@@ -6358,8 +6702,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         $response = $client->mergeShelves($formattedName, $formattedOtherShelfName);
         $this->assertEquals($expectedResponse, $response);
@@ -6402,8 +6746,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         try {
             $client->mergeShelves($formattedName, $formattedOtherShelfName);
@@ -6442,7 +6786,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $book = new Book();
 
         $response = $client->createBook($formattedName, $book);
@@ -6486,7 +6830,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $book = new Book();
 
         try {
@@ -6614,7 +6958,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBook($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -6654,7 +6998,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         try {
             $client->getBook($formattedName);
@@ -6690,7 +7034,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $filter = 'book-filter-string';
 
         $response = $client->listBooks($formattedName, ['filter' => $filter]);
@@ -6737,7 +7081,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $filter = 'book-filter-string';
 
         try {
@@ -6769,7 +7113,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $client->deleteBook($formattedName);
         $actualRequests = $transport->popReceivedCalls();
@@ -6808,7 +7152,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         try {
             $client->deleteBook($formattedName);
@@ -6847,7 +7191,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $book = new Book();
 
         $response = $client->updateBook($formattedName, $book);
@@ -6891,7 +7235,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $book = new Book();
 
         try {
@@ -6931,8 +7275,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         $response = $client->moveBook($formattedName, $formattedOtherShelfName);
         $this->assertEquals($expectedResponse, $response);
@@ -6975,8 +7319,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         try {
             $client->moveBook($formattedName, $formattedOtherShelfName);
@@ -7077,7 +7421,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -7127,7 +7471,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -7258,8 +7602,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedAltBookName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedAltBookName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $formattedPlace = $client->locationName('[PROJECT]', '[LOCATION]');
         $formattedFolder = $client->folderName('[FOLDER]');
 
@@ -7310,8 +7654,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedAltBookName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedAltBookName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $formattedPlace = $client->locationName('[PROJECT]', '[LOCATION]');
         $formattedFolder = $client->folderName('[FOLDER]');
 
@@ -7352,7 +7696,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBookFromAbsolutelyAnywhere($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -7392,7 +7736,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         try {
             $client->getBookFromAbsolutelyAnywhere($formattedName);
@@ -7423,7 +7767,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -7471,7 +7815,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -7518,7 +7862,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $serverStream = $client->streamShelves($formattedName);
         $this->assertInstanceOf(ServerStream::class, $serverStream);
@@ -7568,7 +7912,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $serverStream = $client->streamShelves($formattedName);
         $results = $serverStream->readAll();
@@ -7730,13 +8074,13 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $request = new DiscussBookRequest();
         $request->setName($formattedName);
-        $formattedName2 = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName2 = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $request2 = new DiscussBookRequest();
         $request2->setName($formattedName2);
-        $formattedName3 = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName3 = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $request3 = new DiscussBookRequest();
         $request3->setName($formattedName3);
 
@@ -7920,7 +8264,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedResource = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedResource = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $label = 'label102727412';
 
         $response = $client->addLabel($formattedResource, $label);
@@ -7964,7 +8308,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedResource = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedResource = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $label = 'label102727412';
 
         try {
@@ -8024,7 +8368,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -8102,7 +8446,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -8164,7 +8508,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -8242,7 +8586,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -8293,8 +8637,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
@@ -8573,8 +8917,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
@@ -8631,6 +8975,375 @@ class LibraryServiceClientTest extends GeneratedTest
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function moveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new MoveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->moveBooks();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/MoveBooks', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function moveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->moveBooks();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function archiveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new ArchiveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->archiveBooks();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/ArchiveBooks', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function archiveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->archiveBooks();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function longRunningArchiveBooksTest()
+    {
+        $operationsTransport = $this->createTransport();
+        $operationsClient = new OperationsClient([
+            'serviceAddress' => '',
+            'transport' => $operationsTransport,
+            'credentials' => $this->createCredentials(),
+        ]);
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+            'operationsClient' => $operationsClient
+        ]);
+
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+
+        // Mock response
+        $incompleteOperation = new Operation();
+        $incompleteOperation->setName('operations/longRunningArchiveBooksTest');
+        $incompleteOperation->setDone(false);
+        $transport->addResponse($incompleteOperation);
+        $success = false;
+        $expectedResponse = new ArchiveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $anyResponse = new Any();
+        $anyResponse->setValue($expectedResponse->serializeToString());
+        $completeOperation = new Operation();
+        $completeOperation->setName('operations/longRunningArchiveBooksTest');
+        $completeOperation->setDone(true);
+        $completeOperation->setResponse($anyResponse);
+        $operationsTransport->addResponse($completeOperation);
+
+        $response = $client->longRunningArchiveBooks();
+        $this->assertFalse($response->isDone());
+        $this->assertNull($response->getResult());
+        $apiRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($apiRequests));
+        $operationsRequestsEmpty = $operationsTransport->popReceivedCalls();
+        $this->assertSame(0, count($operationsRequestsEmpty));
+
+        $actualApiFuncCall = $apiRequests[0]->getFuncCall();
+        $actualApiRequestObject = $apiRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/LongRunningArchiveBooks', $actualApiFuncCall);
+
+        $expectedOperationsRequestObject = new GetOperationRequest();
+        $expectedOperationsRequestObject->setName('operations/longRunningArchiveBooksTest');
+
+        $response->pollUntilComplete([
+            'initialPollDelayMillis' => 1,
+        ]);
+        $this->assertTrue($response->isDone());
+        $this->assertEquals($expectedResponse, $response->getResult());
+        $apiRequestsEmpty = $transport->popReceivedCalls();
+        $this->assertSame(0, count($apiRequestsEmpty));
+        $operationsRequests = $operationsTransport->popReceivedCalls();
+        $this->assertSame(1, count($operationsRequests));
+
+        $actualOperationsFuncCall = $operationsRequests[0]->getFuncCall();
+        $actualOperationsRequestObject = $operationsRequests[0]->getRequestObject();
+        $this->assertSame('/google.longrunning.Operations/GetOperation', $actualOperationsFuncCall);
+        $this->assertEquals($expectedOperationsRequestObject, $actualOperationsRequestObject);
+
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function longRunningArchiveBooksExceptionTest()
+    {
+        $operationsTransport = $this->createTransport();
+        $operationsClient = new OperationsClient([
+            'serviceAddress' => '',
+            'transport' => $operationsTransport,
+            'credentials' => $this->createCredentials(),
+        ]);
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+            'operationsClient' => $operationsClient
+        ]);
+
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+
+        // Mock response
+        $incompleteOperation = new Operation();
+        $incompleteOperation->setName('operations/longRunningArchiveBooksTest');
+        $incompleteOperation->setDone(false);
+        $transport->addResponse($incompleteOperation);
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $operationsTransport->addResponse(null, $status);
+
+        $response = $client->longRunningArchiveBooks();
+        $this->assertFalse($response->isDone());
+        $this->assertNull($response->getResult());
+
+        $expectedOperationsRequestObject = new GetOperationRequest();
+        $expectedOperationsRequestObject->setName('operations/longRunningArchiveBooksTest');
+
+        try {
+            $response->pollUntilComplete([
+                'initialPollDelayMillis' => 1,
+            ]);
+            // If the pollUntilComplete() method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stubs are exhausted
+        $transport->popReceivedCalls();
+        $operationsTransport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function streamingArchiveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new ArchiveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+        $success2 = true;
+        $expectedResponse2 = new ArchiveBooksResponse();
+        $expectedResponse2->setSuccess($success2);
+        $transport->addResponse($expectedResponse2);
+        $success3 = false;
+        $expectedResponse3 = new ArchiveBooksResponse();
+        $expectedResponse3->setSuccess($success3);
+        $transport->addResponse($expectedResponse3);
+
+        // Mock request
+        $request = new ArchiveBooksRequest();
+        $request2 = new ArchiveBooksRequest();
+        $request3 = new ArchiveBooksRequest();
+
+        $bidi = $client->streamingArchiveBooks();
+        $this->assertInstanceOf(BidiStream::class, $bidi);
+
+        $bidi->write($request);
+        $responses = [];
+        $responses[] = $bidi->read();
+
+        $bidi->writeAll([$request2, $request3]);
+        foreach ($bidi->closeWriteAndReadAll() as $response) {
+            $responses[] = $response;
+        }
+
+        $expectedResponses = [];
+        $expectedResponses[] = $expectedResponse;
+        $expectedResponses[] = $expectedResponse2;
+        $expectedResponses[] = $expectedResponse3;
+        $this->assertEquals($expectedResponses, $responses);
+
+        $createStreamRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($createStreamRequests));
+        $streamFuncCall = $createStreamRequests[0]->getFuncCall();
+        $streamRequestObject = $createStreamRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/StreamingArchiveBooks', $streamFuncCall);
+        $this->assertNull($streamRequestObject);
+
+        $callObjects = $transport->popCallObjects();
+        $this->assertSame(1, count($callObjects));
+        $bidiCall = $callObjects[0];
+
+        $writeRequests = $bidiCall->popReceivedCalls();
+        $expectedRequests = [];
+        $expectedRequests[] = $request;
+        $expectedRequests[] = $request2;
+        $expectedRequests[] = $request3;
+        $this->assertEquals($expectedRequests, $writeRequests);
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function streamingArchiveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+
+        $transport->setStreamingStatus($status);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $bidi = $client->streamingArchiveBooks();
+        $results = $bidi->closeWriteAndReadAll();
+
+        try {
+            iterator_to_array($results);
+            // If the close stream method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        }  catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -57,7 +57,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -116,7 +116,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -173,7 +173,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -229,7 +229,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -496,7 +496,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
+    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -596,7 +596,7 @@ function sampleGetBigBook($shelf, $bigBookName)
 
     // $shelf = 'Novel';
     // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $bigBookName);
+    $formattedName = $libraryServiceClient->bookName($shelf, $bigBookName);
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -676,7 +676,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
+    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -769,7 +769,7 @@ function sampleGetBigBook($shelf, $bigBookName)
 
     // $shelf = 'Novel';
     // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $bigBookName);
+    $formattedName = $libraryServiceClient->bookName($shelf, $bigBookName);
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -841,7 +841,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -903,7 +903,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -965,7 +965,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -1020,7 +1020,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -1076,7 +1076,7 @@ function sampleGetBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
 
     try {
         $response = $libraryServiceClient->getBook($formattedName);
@@ -1183,7 +1183,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1242,7 +1242,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1760,8 +1760,8 @@ function sampleTestOptionalRequiredFlatteningParams($paramFloat, $paramLong)
     $requiredSingularString = '';
     $requiredSingularBytes = '';
     $requiredSingularMessage = new InnerMessage();
-    $formattedRequiredSingularResourceName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $requiredSingularResourceNameCommon = '';
     $requiredSingularFixed32 = 0;
     $requiredSingularFixed64 = 0;
@@ -1874,7 +1874,7 @@ function sampleGetBookFromAbsolutelyAnywhere()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'The ID of the book');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', 'The ID of the book');
 
     try {
         $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
@@ -1921,7 +1921,7 @@ function sampleGetBookFromAbsolutelyAnywhere()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'The ID of the book');
+    $formattedName = $libraryServiceClient->bookName('The Shelf to search for the book', 'The ID of the book');
 
     try {
         $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
@@ -2027,7 +2027,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
+    $formattedName = $libraryServiceClient->bookName($shelf, 'War and Peace');
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -2117,7 +2117,7 @@ function sampleDiscussBook($imageFileName, $stage)
 
     // $imageFileName = 'image_file.jpg';
     // $stage = Stage::DRAFT;
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $comment = file_get_contents('comment_file');
     $comment2 = new Comment();
     $comment2->setComment($comment);
@@ -2202,7 +2202,7 @@ function sampleDiscussBook($imageFileName, $stage)
 
     // $imageFileName = 'image_file.jpg';
     // $stage = Stage::DRAFT;
-    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
     $comment = file_get_contents('comment_file');
     $comment2 = new Comment();
     $comment2->setComment($comment);
@@ -2477,7 +2477,7 @@ class LibraryServiceGapicClient
     private static function getBookNameTemplate()
     {
         if (self::$bookNameTemplate == null) {
-            self::$bookNameTemplate = new PathTemplate('bookShelves/{book_shelf}/books/{book}');
+            self::$bookNameTemplate = new PathTemplate('shelves/{shelf}/books/{book}');
         }
 
         return self::$bookNameTemplate;
@@ -2585,16 +2585,16 @@ class LibraryServiceGapicClient
      * Formats a string containing the fully-qualified path to represent
      * a book resource.
      *
-     * @param string $bookShelf
+     * @param string $shelf
      * @param string $book
      * @return string The formatted book resource.
      * @deprecated Multi-pattern resource names will have unified formatting functions.
      *             This helper function will be deleted in the next major version.
      */
-    public static function bookName($bookShelf, $book)
+    public static function bookName($shelf, $book)
     {
         return self::getBookNameTemplate()->render([
-            'book_shelf' => $bookShelf,
+            'shelf' => $shelf,
             'book' => $book,
         ]);
     }
@@ -2721,7 +2721,7 @@ class LibraryServiceGapicClient
      * The following name formats are supported:
      * Template: Pattern
      * - archivedBook: archives/{archive}/books/{book}
-     * - book: bookShelves/{book_shelf}/books/{book}
+     * - book: shelves/{shelf}/books/{book}
      * - bookFromArchive: archives/{archive}/books/{book}
      * - folder: folders/{folder}
      * - location: projects/{project}/locations/{location}
@@ -3251,7 +3251,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $response = $libraryServiceClient->getBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3385,7 +3385,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $libraryServiceClient->deleteBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3432,7 +3432,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $book = new Book();
      *     $response = $libraryServiceClient->updateBook($formattedName, $book);
      * } finally {
@@ -3499,7 +3499,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF]');
      *     $response = $libraryServiceClient->moveBook($formattedName, $formattedOtherShelfName);
      * } finally {
@@ -3624,7 +3624,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $comment = '';
      *     $stage = Stage::UNSET;
      *     $alignment = Alignment::CHAR;
@@ -3733,8 +3733,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-     *     $formattedAltBookName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $formattedAltBookName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $formattedPlace = $libraryServiceClient->locationName('[PROJECT]', '[LOCATION]');
      *     $formattedFolder = $libraryServiceClient->folderName('[FOLDER]');
      *     $response = $libraryServiceClient->getBookFromAnywhere($formattedName, $formattedAltBookName, $formattedPlace, $formattedFolder);
@@ -3792,7 +3792,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3848,7 +3848,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $indexName = 'default index';
      *     $indexMapItem = '';
      *     $indexMap = ['default_key' => $indexMapItem];
@@ -3992,7 +3992,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write all requests to the server, then read all responses until the
@@ -4058,7 +4058,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write data to server and wait for a response
@@ -4113,7 +4113,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write data to server and wait for a response
@@ -4241,7 +4241,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedResource = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedResource = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $label = '';
      *     $response = $libraryServiceClient->addLabel($formattedResource, $label);
      * } finally {
@@ -4296,7 +4296,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigBook($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -4373,7 +4373,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -4457,8 +4457,8 @@ class LibraryServiceGapicClient
      *     $requiredSingularString = '';
      *     $requiredSingularBytes = '';
      *     $requiredSingularMessage = new InnerMessage();
-     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
      *     $requiredSingularResourceNameCommon = '';
      *     $requiredSingularFixed32 = 0;
      *     $requiredSingularFixed64 = 0;
@@ -6262,7 +6262,7 @@ class LibraryServiceSmokeTest extends GeneratedTest
         }
 
         $libraryServiceClient = new LibraryServiceClient();
-        $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $projectId);
+        $formattedName = $libraryServiceClient->bookName('testShelf-'. time(), $projectId);
         $rating = Rating::GOOD;
         $book = new Book();
         $book->setRating($rating);
@@ -6983,7 +6983,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBook($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -7023,7 +7023,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->getBook($formattedName);
@@ -7138,7 +7138,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $client->deleteBook($formattedName);
         $actualRequests = $transport->popReceivedCalls();
@@ -7177,7 +7177,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->deleteBook($formattedName);
@@ -7216,7 +7216,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $book = new Book();
 
         $response = $client->updateBook($formattedName, $book);
@@ -7260,7 +7260,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $book = new Book();
 
         try {
@@ -7300,7 +7300,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         $response = $client->moveBook($formattedName, $formattedOtherShelfName);
@@ -7344,7 +7344,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         try {
@@ -7446,7 +7446,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -7496,7 +7496,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -7627,8 +7627,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-        $formattedAltBookName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedAltBookName = $client->bookName('[SHELF]', '[BOOK]');
         $formattedPlace = $client->locationName('[PROJECT]', '[LOCATION]');
         $formattedFolder = $client->folderName('[FOLDER]');
 
@@ -7679,8 +7679,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-        $formattedAltBookName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedAltBookName = $client->bookName('[SHELF]', '[BOOK]');
         $formattedPlace = $client->locationName('[PROJECT]', '[LOCATION]');
         $formattedFolder = $client->folderName('[FOLDER]');
 
@@ -7721,7 +7721,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBookFromAbsolutelyAnywhere($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -7761,7 +7761,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         try {
             $client->getBookFromAbsolutelyAnywhere($formattedName);
@@ -7792,7 +7792,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -7840,7 +7840,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -8099,13 +8099,13 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
         $request = new DiscussBookRequest();
         $request->setName($formattedName);
-        $formattedName2 = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName2 = $client->bookName('[SHELF]', '[BOOK]');
         $request2 = new DiscussBookRequest();
         $request2->setName($formattedName2);
-        $formattedName3 = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName3 = $client->bookName('[SHELF]', '[BOOK]');
         $request3 = new DiscussBookRequest();
         $request3->setName($formattedName3);
 
@@ -8289,7 +8289,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedResource = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
         $label = 'label102727412';
 
         $response = $client->addLabel($formattedResource, $label);
@@ -8333,7 +8333,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedResource = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
         $label = 'label102727412';
 
         try {
@@ -8393,7 +8393,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -8471,7 +8471,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -8533,7 +8533,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -8611,7 +8611,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -8662,8 +8662,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedRequiredSingularResourceName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF]', '[BOOK]');
         $requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
@@ -8942,8 +8942,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedRequiredSingularResourceName = $client->bookName('[SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookName('[SHELF]', '[BOOK]');
         $requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -57,7 +57,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -116,7 +116,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -173,7 +173,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -229,7 +229,7 @@ function sampleBabbleAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -282,7 +282,7 @@ function sampleDeleteShelf()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $formattedName = $libraryServiceClient->shelfName('[SHELF]');
 
     try {
         $libraryServiceClient->deleteShelf($formattedName);
@@ -332,7 +332,7 @@ function sampleDeleteShelf()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $formattedName = $libraryServiceClient->shelfName('[SHELF]');
 
     try {
         $libraryServiceClient->deleteShelf($formattedName);
@@ -496,7 +496,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -596,7 +596,7 @@ function sampleGetBigBook($shelf, $bigBookName)
 
     // $shelf = 'Novel';
     // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $bigBookName);
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -676,7 +676,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -769,7 +769,7 @@ function sampleGetBigBook($shelf, $bigBookName)
 
     // $shelf = 'Novel';
     // $bigBookName = 'War and Peace';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $bigBookName);
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -841,7 +841,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -903,7 +903,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
     try {
         // start the operation, keep the operation name, and resume later
@@ -965,7 +965,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -1020,7 +1020,7 @@ function sampleGetBigNothing()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
     try {
         $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
@@ -1076,7 +1076,7 @@ function sampleGetBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
     try {
         $response = $libraryServiceClient->getBook($formattedName);
@@ -1183,7 +1183,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1242,7 +1242,7 @@ function sampleMonologAboutBook()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $request = new DiscussBookRequest();
     $request->setName($formattedName);
 
@@ -1633,7 +1633,7 @@ function sampleStreamShelves()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+    $formattedName = $libraryServiceClient->shelfName('[SHELF]');
 
     try {
         // Read all responses until the stream is complete
@@ -1760,8 +1760,8 @@ function sampleTestOptionalRequiredFlatteningParams($paramFloat, $paramLong)
     $requiredSingularString = '';
     $requiredSingularBytes = '';
     $requiredSingularMessage = new InnerMessage();
-    $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedRequiredSingularResourceName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+    $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $requiredSingularResourceNameCommon = '';
     $requiredSingularFixed32 = 0;
     $requiredSingularFixed64 = 0;
@@ -1874,7 +1874,7 @@ function sampleGetBookFromAbsolutelyAnywhere()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'The ID of the book');
 
     try {
         $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
@@ -1921,7 +1921,7 @@ function sampleGetBookFromAbsolutelyAnywhere()
 {
     $libraryServiceClient = new LibraryServiceClient();
 
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'The ID of the book');
 
     try {
         $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
@@ -2027,7 +2027,7 @@ function sampleGetBigBook($shelf)
     $libraryServiceClient = new LibraryServiceClient();
 
     // $shelf = 'Novel\\"`\b\t\n\r';
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', 'War and Peace');
 
     try {
         $operationResponse = $libraryServiceClient->getBigBook($formattedName);
@@ -2117,7 +2117,7 @@ function sampleDiscussBook($imageFileName, $stage)
 
     // $imageFileName = 'image_file.jpg';
     // $stage = Stage::DRAFT;
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $comment = file_get_contents('comment_file');
     $comment2 = new Comment();
     $comment2->setComment($comment);
@@ -2202,7 +2202,7 @@ function sampleDiscussBook($imageFileName, $stage)
 
     // $imageFileName = 'image_file.jpg';
     // $stage = Stage::DRAFT;
-    $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+    $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
     $comment = file_get_contents('comment_file');
     $comment2 = new Comment();
     $comment2->setComment($comment);
@@ -2297,6 +2297,9 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Example\Library\V1\AddCommentsRequest;
+use Google\Example\Library\V1\ArchiveBooksMetadata;
+use Google\Example\Library\V1\ArchiveBooksRequest;
+use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
@@ -2323,6 +2326,8 @@ use Google\Example\Library\V1\ListStringsRequest;
 use Google\Example\Library\V1\ListStringsResponse;
 use Google\Example\Library\V1\MergeShelvesRequest;
 use Google\Example\Library\V1\MoveBookRequest;
+use Google\Example\Library\V1\MoveBooksRequest;
+use Google\Example\Library\V1\MoveBooksResponse;
 use Google\Example\Library\V1\PublishSeriesRequest;
 use Google\Example\Library\V1\PublishSeriesResponse;
 use Google\Example\Library\V1\SeriesUuid;
@@ -2535,7 +2540,7 @@ class LibraryServiceGapicClient
     private static function getShelfNameTemplate()
     {
         if (self::$shelfNameTemplate == null) {
-            self::$shelfNameTemplate = new PathTemplate('shelves/{shelf_id}');
+            self::$shelfNameTemplate = new PathTemplate('shelves/{shelf}');
         }
 
         return self::$shelfNameTemplate;
@@ -2700,14 +2705,14 @@ class LibraryServiceGapicClient
      * Formats a string containing the fully-qualified path to represent
      * a shelf resource.
      *
-     * @param string $shelfId
+     * @param string $shelf
      * @return string The formatted shelf resource.
      * @experimental
      */
-    public static function shelfName($shelfId)
+    public static function shelfName($shelf)
     {
         return self::getShelfNameTemplate()->render([
-            'shelf_id' => $shelfId,
+            'shelf' => $shelf,
         ]);
     }
 
@@ -2723,7 +2728,7 @@ class LibraryServiceGapicClient
      * - project: projects/{project}
      * - projectBook: projects/{project}/books/{book}
      * - publisher: projects/{project}/locations/{location}/publishers/{publisher}
-     * - shelf: shelves/{shelf_id}
+     * - shelf: shelves/{shelf}
      *
      * The optional $template argument can be supplied to specify a particular pattern, and must
      * match one of the templates listed above. If no $template argument is provided, or if the
@@ -2898,7 +2903,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $options = '';
      *     $response = $libraryServiceClient->getShelf($formattedName, $options);
      * } finally {
@@ -3021,7 +3026,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $libraryServiceClient->deleteShelf($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3070,8 +3075,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
-     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
+     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF]');
      *     $response = $libraryServiceClient->mergeShelves($formattedName, $formattedOtherShelfName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3122,7 +3127,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $book = new Book();
      *     $response = $libraryServiceClient->createBook($formattedName, $book);
      * } finally {
@@ -3246,7 +3251,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $response = $libraryServiceClient->getBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3295,7 +3300,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     $filter = 'book-filter-string';
      *     // Iterate over pages of elements
      *     $pagedResponse = $libraryServiceClient->listBooks($formattedName, ['filter' => $filter]);
@@ -3380,7 +3385,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $libraryServiceClient->deleteBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3427,7 +3432,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $book = new Book();
      *     $response = $libraryServiceClient->updateBook($formattedName, $book);
      * } finally {
@@ -3494,8 +3499,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedOtherShelfName = $libraryServiceClient->shelfName('[SHELF]');
      *     $response = $libraryServiceClient->moveBook($formattedName, $formattedOtherShelfName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3619,7 +3624,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $comment = '';
      *     $stage = Stage::UNSET;
      *     $alignment = Alignment::CHAR;
@@ -3728,8 +3733,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-     *     $formattedAltBookName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedAltBookName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $formattedPlace = $libraryServiceClient->locationName('[PROJECT]', '[LOCATION]');
      *     $formattedFolder = $libraryServiceClient->folderName('[FOLDER]');
      *     $response = $libraryServiceClient->getBookFromAnywhere($formattedName, $formattedAltBookName, $formattedPlace, $formattedFolder);
@@ -3787,7 +3792,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $response = $libraryServiceClient->getBookFromAbsolutelyAnywhere($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
@@ -3843,7 +3848,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $indexName = 'default index';
      *     $indexMapItem = '';
      *     $indexMap = ['default_key' => $indexMapItem];
@@ -3898,7 +3903,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->shelfName('[SHELF_ID]');
+     *     $formattedName = $libraryServiceClient->shelfName('[SHELF]');
      *     // Read all responses until the stream is complete
      *     $stream = $libraryServiceClient->streamShelves($formattedName);
      *     foreach ($stream->readAll() as $element) {
@@ -3987,7 +3992,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write all requests to the server, then read all responses until the
@@ -4053,7 +4058,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write data to server and wait for a response
@@ -4108,7 +4113,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $request = new DiscussBookRequest();
      *     $request->setName($formattedName);
      *     // Write data to server and wait for a response
@@ -4236,7 +4241,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedResource = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedResource = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $label = '';
      *     $response = $libraryServiceClient->addLabel($formattedResource, $label);
      * } finally {
@@ -4291,7 +4296,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigBook($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -4368,7 +4373,7 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $operationResponse = $libraryServiceClient->getBigNothing($formattedName);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -4452,8 +4457,8 @@ class LibraryServiceGapicClient
      *     $requiredSingularString = '';
      *     $requiredSingularBytes = '';
      *     $requiredSingularMessage = new InnerMessage();
-     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
-     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+     *     $formattedRequiredSingularResourceName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+     *     $formattedRequiredSingularResourceNameOneof = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
      *     $requiredSingularResourceNameCommon = '';
      *     $requiredSingularFixed32 = 0;
      *     $requiredSingularFixed64 = 0;
@@ -4902,6 +4907,268 @@ class LibraryServiceGapicClient
             $optionalArgs,
             $request
         )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $response = $libraryServiceClient->moveBooks();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $destination
+     *     @type string[] $publishers
+     *     @type string $project
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\MoveBooksResponse
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function moveBooks(array $optionalArgs = [])
+    {
+        $request = new MoveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['destination'])) {
+            $request->setDestination($optionalArgs['destination']);
+        }
+        if (isset($optionalArgs['publishers'])) {
+            $request->setPublishers($optionalArgs['publishers']);
+        }
+        if (isset($optionalArgs['project'])) {
+            $request->setProject($optionalArgs['project']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'MoveBooks',
+            MoveBooksResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $response = $libraryServiceClient->archiveBooks();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $archive
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\ArchiveBooksResponse
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function archiveBooks(array $optionalArgs = [])
+    {
+        $request = new ArchiveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['archive'])) {
+            $request->setArchive($optionalArgs['archive']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'ArchiveBooks',
+            ArchiveBooksResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $operationResponse = $libraryServiceClient->longRunningArchiveBooks();
+     *     $operationResponse->pollUntilComplete();
+     *     if ($operationResponse->operationSucceeded()) {
+     *         $result = $operationResponse->getResult();
+     *         // doSomethingWith($result)
+     *     } else {
+     *         $error = $operationResponse->getError();
+     *         // handleError($error)
+     *     }
+     *
+     *
+     *     // Alternatively:
+     *
+     *     // start the operation, keep the operation name, and resume later
+     *     $operationResponse = $libraryServiceClient->longRunningArchiveBooks();
+     *     $operationName = $operationResponse->getName();
+     *     // ... do other work
+     *     $newOperationResponse = $libraryServiceClient->resumeOperation($operationName, 'longRunningArchiveBooks');
+     *     while (!$newOperationResponse->isDone()) {
+     *         // ... do other work
+     *         $newOperationResponse->reload();
+     *     }
+     *     if ($newOperationResponse->operationSucceeded()) {
+     *       $result = $newOperationResponse->getResult();
+     *       // doSomethingWith($result)
+     *     } else {
+     *       $error = $newOperationResponse->getError();
+     *       // handleError($error)
+     *     }
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $source
+     *     @type string $archive
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\ApiCore\OperationResponse
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function longRunningArchiveBooks(array $optionalArgs = [])
+    {
+        $request = new ArchiveBooksRequest();
+        if (isset($optionalArgs['source'])) {
+            $request->setSource($optionalArgs['source']);
+        }
+        if (isset($optionalArgs['archive'])) {
+            $request->setArchive($optionalArgs['archive']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'source' => $request->getSource(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startOperationsCall(
+            'LongRunningArchiveBooks',
+            $optionalArgs,
+            $request,
+            $this->getOperationsClient()
+        )->wait();
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $request = new ArchiveBooksRequest();
+     *     // Write all requests to the server, then read all responses until the
+     *     // stream is complete
+     *     $requests = [$request];
+     *     $stream = $libraryServiceClient->streamingArchiveBooks();
+     *     $stream->writeAll($requests);
+     *     foreach ($stream->closeWriteAndReadAll() as $element) {
+     *         // doSomethingWith($element);
+     *     }
+     *
+     *
+     *     // Alternatively:
+     *
+     *     // Write requests individually, making read() calls if
+     *     // required. Call closeWrite() once writes are complete, and read the
+     *     // remaining responses from the server.
+     *     $requests = [$request];
+     *     $stream = $libraryServiceClient->streamingArchiveBooks();
+     *     foreach ($requests as $request) {
+     *         $stream->write($request);
+     *         // if required, read a single response from the stream
+     *         $element = $stream->read();
+     *         // doSomethingWith($element)
+     *     }
+     *     $stream->closeWrite();
+     *     $element = $stream->read();
+     *     while (!is_null($element)) {
+     *         // doSomethingWith($element)
+     *         $element = $stream->read();
+     *     }
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type int $timeoutMillis
+     *          Timeout to use for this call.
+     * }
+     *
+     * @return \Google\ApiCore\BidiStream
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function streamingArchiveBooks(array $optionalArgs = [])
+    {
+        return $this->startCall(
+            'StreamingArchiveBooks',
+            ArchiveBooksResponse::class,
+            $optionalArgs,
+            null,
+            Call::BIDI_STREAMING_CALL
+        );
     }
 
     /**
@@ -5439,6 +5706,24 @@ class MyProtoClient extends MyProtoGapicClient
           "retry_codes_name": "no_retry_1_codes",
           "retry_params_name": "no_retry_1_params"
         },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "retry_policy_1_codes",
+          "retry_params_name": "retry_policy_1_params"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "retry_policy_1_codes",
+          "retry_params_name": "retry_policy_1_params"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "retry_policy_1_codes",
+          "retry_params_name": "retry_policy_1_params"
+        },
+        "StreamingArchiveBooks": {
+          "timeout_millis": 60000
+        },
         "PrivateListShelves": {
           "timeout_millis": 60000,
           "retry_codes_name": "retry_policy_1_codes",
@@ -5473,6 +5758,16 @@ return [
                     'pollDelayMultiplier' => '1.3',
                     'maxPollDelayMillis' => '60000',
                     'totalPollTimeoutMillis' => '600000',
+                ]
+            ],
+            'LongRunningArchiveBooks' => [
+                'longRunning' => [
+                    'operationReturnType' => '\Google\Example\Library\V1\ArchiveBooksResponse',
+                    'metadataReturnType' => '\Google\Example\Library\V1\ArchiveBooksMetadata',
+                    'initialPollDelayMillis' => '500',
+                    'pollDelayMultiplier' => '1.5',
+                    'maxPollDelayMillis' => '5000',
+                    'totalPollTimeoutMillis' => '300000',
                 ]
             ],
             'ListShelves' => [
@@ -5537,6 +5832,11 @@ return [
             'BabbleAboutBook' => [
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'ClientStreaming',
+                ]
+            ],
+            'StreamingArchiveBooks' => [
+                'grpcStreaming' => [
+                    'grpcStreamingType' => 'BidiStreaming',
                 ]
             ],
         ]
@@ -5791,6 +6091,42 @@ return [
                 'uriTemplate' => '/v1/testofp',
                 'body' => '*',
             ],
+            'MoveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:move',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
+            'ArchiveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:archive',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
+            'LongRunningArchiveBooks' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{source=**}:longrunningmove',
+                'body' => '*',
+                'placeholders' => [
+                    'source' => [
+                        'getters' => [
+                            'getSource',
+                        ],
+                    ],
+                ]
+            ],
             'PrivateListShelves' => [
                 'method' => 'get',
                 'uriTemplate' => '/v1/bookShelves',
@@ -5920,9 +6256,13 @@ class LibraryServiceSmokeTest extends GeneratedTest
      */
     public function updateBookTest()
     {
+        $projectId = getenv('PROJECT_ID');
+        if ($projectId === false) {
+            $this->fail('Environment variable PROJECT_ID must be set for smoke test');
+        }
 
         $libraryServiceClient = new LibraryServiceClient();
-        $formattedName = $libraryServiceClient->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $libraryServiceClient->bookFromArchiveName('[ARCHIVE]', $projectId);
         $rating = Rating::GOOD;
         $book = new Book();
         $book->setRating($rating);
@@ -5963,6 +6303,8 @@ use Google\ApiCore\ServerStream;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Example\Library\V1\AddCommentsRequest;
+use Google\Example\Library\V1\ArchiveBooksRequest;
+use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
@@ -5989,6 +6331,8 @@ use Google\Example\Library\V1\ListStringsRequest;
 use Google\Example\Library\V1\ListStringsResponse;
 use Google\Example\Library\V1\MergeShelvesRequest;
 use Google\Example\Library\V1\MoveBookRequest;
+use Google\Example\Library\V1\MoveBooksRequest;
+use Google\Example\Library\V1\MoveBooksResponse;
 use Google\Example\Library\V1\PublishSeriesRequest;
 use Google\Example\Library\V1\PublishSeriesResponse;
 use Google\Example\Library\V1\SeriesUuid;
@@ -6161,7 +6505,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $options = 'options-1249474914';
 
         $response = $client->getShelf($formattedName, $options);
@@ -6205,7 +6549,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $options = 'options-1249474914';
 
         try {
@@ -6307,7 +6651,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $client->deleteShelf($formattedName);
         $actualRequests = $transport->popReceivedCalls();
@@ -6346,7 +6690,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         try {
             $client->deleteShelf($formattedName);
@@ -6383,8 +6727,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         $response = $client->mergeShelves($formattedName, $formattedOtherShelfName);
         $this->assertEquals($expectedResponse, $response);
@@ -6427,8 +6771,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         try {
             $client->mergeShelves($formattedName, $formattedOtherShelfName);
@@ -6467,7 +6811,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $book = new Book();
 
         $response = $client->createBook($formattedName, $book);
@@ -6511,7 +6855,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $book = new Book();
 
         try {
@@ -6639,7 +6983,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBook($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -6679,7 +7023,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         try {
             $client->getBook($formattedName);
@@ -6715,7 +7059,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $filter = 'book-filter-string';
 
         $response = $client->listBooks($formattedName, ['filter' => $filter]);
@@ -6762,7 +7106,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
         $filter = 'book-filter-string';
 
         try {
@@ -6794,7 +7138,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $client->deleteBook($formattedName);
         $actualRequests = $transport->popReceivedCalls();
@@ -6833,7 +7177,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         try {
             $client->deleteBook($formattedName);
@@ -6872,7 +7216,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $book = new Book();
 
         $response = $client->updateBook($formattedName, $book);
@@ -6916,7 +7260,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $book = new Book();
 
         try {
@@ -6956,8 +7300,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         $response = $client->moveBook($formattedName, $formattedOtherShelfName);
         $this->assertEquals($expectedResponse, $response);
@@ -7000,8 +7344,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedOtherShelfName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedOtherShelfName = $client->shelfName('[SHELF]');
 
         try {
             $client->moveBook($formattedName, $formattedOtherShelfName);
@@ -7102,7 +7446,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -7152,7 +7496,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $comment = '95';
         $stage = Stage::UNSET;
         $alignment = Alignment::CHAR;
@@ -7283,8 +7627,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedAltBookName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedAltBookName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $formattedPlace = $client->locationName('[PROJECT]', '[LOCATION]');
         $formattedFolder = $client->folderName('[FOLDER]');
 
@@ -7335,8 +7679,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedAltBookName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedAltBookName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $formattedPlace = $client->locationName('[PROJECT]', '[LOCATION]');
         $formattedFolder = $client->folderName('[FOLDER]');
 
@@ -7377,7 +7721,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBookFromAbsolutelyAnywhere($formattedName);
         $this->assertEquals($expectedResponse, $response);
@@ -7417,7 +7761,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         try {
             $client->getBookFromAbsolutelyAnywhere($formattedName);
@@ -7448,7 +7792,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -7496,7 +7840,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $indexName = 'default index';
         $indexMapItem = 'indexMapItem1918721251';
         $indexMap = ['default_key' => $indexMapItem];
@@ -7543,7 +7887,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $serverStream = $client->streamShelves($formattedName);
         $this->assertInstanceOf(ServerStream::class, $serverStream);
@@ -7593,7 +7937,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
 
         // Mock request
-        $formattedName = $client->shelfName('[SHELF_ID]');
+        $formattedName = $client->shelfName('[SHELF]');
 
         $serverStream = $client->streamShelves($formattedName);
         $results = $serverStream->readAll();
@@ -7755,13 +8099,13 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse3);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $request = new DiscussBookRequest();
         $request->setName($formattedName);
-        $formattedName2 = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName2 = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $request2 = new DiscussBookRequest();
         $request2->setName($formattedName2);
-        $formattedName3 = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName3 = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $request3 = new DiscussBookRequest();
         $request3->setName($formattedName3);
 
@@ -7945,7 +8289,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedResource = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedResource = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $label = 'label102727412';
 
         $response = $client->addLabel($formattedResource, $label);
@@ -7989,7 +8333,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedResource = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedResource = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $label = 'label102727412';
 
         try {
@@ -8049,7 +8393,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -8127,7 +8471,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBigBook($formattedName);
         $this->assertFalse($response->isDone());
@@ -8189,7 +8533,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -8267,7 +8611,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
 
         // Mock request
-        $formattedName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
 
         $response = $client->getBigNothing($formattedName);
         $this->assertFalse($response->isDone());
@@ -8318,8 +8662,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
@@ -8598,8 +8942,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularString = 'requiredSingularString-1949894503';
         $requiredSingularBytes = '-29';
         $requiredSingularMessage = new InnerMessage();
-        $formattedRequiredSingularResourceName = $client->bookName('[BOOK_SHELF]', '[BOOK]');
-        $formattedRequiredSingularResourceNameOneof = $client->bookName('[BOOK_SHELF]', '[BOOK]');
+        $formattedRequiredSingularResourceName = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
+        $formattedRequiredSingularResourceNameOneof = $client->bookFromArchiveName('[ARCHIVE]', '[BOOK]');
         $requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
@@ -8656,6 +9000,375 @@ class LibraryServiceClientTest extends GeneratedTest
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function moveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new MoveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->moveBooks();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/MoveBooks', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function moveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->moveBooks();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function archiveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new ArchiveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->archiveBooks();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/ArchiveBooks', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function archiveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->archiveBooks();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function longRunningArchiveBooksTest()
+    {
+        $operationsTransport = $this->createTransport();
+        $operationsClient = new OperationsClient([
+            'serviceAddress' => '',
+            'transport' => $operationsTransport,
+            'credentials' => $this->createCredentials(),
+        ]);
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+            'operationsClient' => $operationsClient
+        ]);
+
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+
+        // Mock response
+        $incompleteOperation = new Operation();
+        $incompleteOperation->setName('operations/longRunningArchiveBooksTest');
+        $incompleteOperation->setDone(false);
+        $transport->addResponse($incompleteOperation);
+        $success = false;
+        $expectedResponse = new ArchiveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $anyResponse = new Any();
+        $anyResponse->setValue($expectedResponse->serializeToString());
+        $completeOperation = new Operation();
+        $completeOperation->setName('operations/longRunningArchiveBooksTest');
+        $completeOperation->setDone(true);
+        $completeOperation->setResponse($anyResponse);
+        $operationsTransport->addResponse($completeOperation);
+
+        $response = $client->longRunningArchiveBooks();
+        $this->assertFalse($response->isDone());
+        $this->assertNull($response->getResult());
+        $apiRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($apiRequests));
+        $operationsRequestsEmpty = $operationsTransport->popReceivedCalls();
+        $this->assertSame(0, count($operationsRequestsEmpty));
+
+        $actualApiFuncCall = $apiRequests[0]->getFuncCall();
+        $actualApiRequestObject = $apiRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/LongRunningArchiveBooks', $actualApiFuncCall);
+
+        $expectedOperationsRequestObject = new GetOperationRequest();
+        $expectedOperationsRequestObject->setName('operations/longRunningArchiveBooksTest');
+
+        $response->pollUntilComplete([
+            'initialPollDelayMillis' => 1,
+        ]);
+        $this->assertTrue($response->isDone());
+        $this->assertEquals($expectedResponse, $response->getResult());
+        $apiRequestsEmpty = $transport->popReceivedCalls();
+        $this->assertSame(0, count($apiRequestsEmpty));
+        $operationsRequests = $operationsTransport->popReceivedCalls();
+        $this->assertSame(1, count($operationsRequests));
+
+        $actualOperationsFuncCall = $operationsRequests[0]->getFuncCall();
+        $actualOperationsRequestObject = $operationsRequests[0]->getRequestObject();
+        $this->assertSame('/google.longrunning.Operations/GetOperation', $actualOperationsFuncCall);
+        $this->assertEquals($expectedOperationsRequestObject, $actualOperationsRequestObject);
+
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function longRunningArchiveBooksExceptionTest()
+    {
+        $operationsTransport = $this->createTransport();
+        $operationsClient = new OperationsClient([
+            'serviceAddress' => '',
+            'transport' => $operationsTransport,
+            'credentials' => $this->createCredentials(),
+        ]);
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+            'operationsClient' => $operationsClient
+        ]);
+
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+
+        // Mock response
+        $incompleteOperation = new Operation();
+        $incompleteOperation->setName('operations/longRunningArchiveBooksTest');
+        $incompleteOperation->setDone(false);
+        $transport->addResponse($incompleteOperation);
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $operationsTransport->addResponse(null, $status);
+
+        $response = $client->longRunningArchiveBooks();
+        $this->assertFalse($response->isDone());
+        $this->assertNull($response->getResult());
+
+        $expectedOperationsRequestObject = new GetOperationRequest();
+        $expectedOperationsRequestObject->setName('operations/longRunningArchiveBooksTest');
+
+        try {
+            $response->pollUntilComplete([
+                'initialPollDelayMillis' => 1,
+            ]);
+            // If the pollUntilComplete() method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stubs are exhausted
+        $transport->popReceivedCalls();
+        $operationsTransport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function streamingArchiveBooksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $success = false;
+        $expectedResponse = new ArchiveBooksResponse();
+        $expectedResponse->setSuccess($success);
+        $transport->addResponse($expectedResponse);
+        $success2 = true;
+        $expectedResponse2 = new ArchiveBooksResponse();
+        $expectedResponse2->setSuccess($success2);
+        $transport->addResponse($expectedResponse2);
+        $success3 = false;
+        $expectedResponse3 = new ArchiveBooksResponse();
+        $expectedResponse3->setSuccess($success3);
+        $transport->addResponse($expectedResponse3);
+
+        // Mock request
+        $request = new ArchiveBooksRequest();
+        $request2 = new ArchiveBooksRequest();
+        $request3 = new ArchiveBooksRequest();
+
+        $bidi = $client->streamingArchiveBooks();
+        $this->assertInstanceOf(BidiStream::class, $bidi);
+
+        $bidi->write($request);
+        $responses = [];
+        $responses[] = $bidi->read();
+
+        $bidi->writeAll([$request2, $request3]);
+        foreach ($bidi->closeWriteAndReadAll() as $response) {
+            $responses[] = $response;
+        }
+
+        $expectedResponses = [];
+        $expectedResponses[] = $expectedResponse;
+        $expectedResponses[] = $expectedResponse2;
+        $expectedResponses[] = $expectedResponse3;
+        $this->assertEquals($expectedResponses, $responses);
+
+        $createStreamRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($createStreamRequests));
+        $streamFuncCall = $createStreamRequests[0]->getFuncCall();
+        $streamRequestObject = $createStreamRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/StreamingArchiveBooks', $streamFuncCall);
+        $this->assertNull($streamRequestObject);
+
+        $callObjects = $transport->popCallObjects();
+        $this->assertSame(1, count($callObjects));
+        $bidiCall = $callObjects[0];
+
+        $writeRequests = $bidiCall->popReceivedCalls();
+        $expectedRequests = [];
+        $expectedRequests[] = $request;
+        $expectedRequests[] = $request2;
+        $expectedRequests[] = $request3;
+        $this->assertEquals($expectedRequests, $writeRequests);
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function streamingArchiveBooksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+
+        $transport->setStreamingStatus($status);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $bidi = $client->streamingArchiveBooks();
+        $results = $bidi->closeWriteAndReadAll();
+
+        try {
+            iterator_to_array($results);
+            // If the close stream method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        }  catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -284,7 +284,7 @@ LibraryServiceClient
 
     client = library_v1.LibraryServiceClient()
 
-    name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+    name = client.book_path('[SHELF]', '[BOOK]')
 
     # TODO: Initialize `book`:
     book = {}
@@ -744,7 +744,7 @@ LibraryServiceClient
 
     client = library_v1.LibraryServiceClient()
 
-    name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+    name = client.book_path('[SHELF]', '[BOOK]')
 
     # TODO: Initialize `book`:
     book = {}
@@ -1165,11 +1165,11 @@ class LibraryServiceClient(object):
         )
 
     @classmethod
-    def book_path(cls, book_shelf, book):
+    def book_path(cls, shelf, book):
         """Return a fully-qualified book string."""
         return google.api_core.path_template.expand(
-            'bookShelves/{book_shelf}/books/{book}',
-            book_shelf=book_shelf,
+            'shelves/{shelf}/books/{book}',
+            shelf=shelf,
             book=book,
         )
 
@@ -1862,7 +1862,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_book(name)
 
@@ -2024,7 +2024,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> client.delete_book(name)
 
@@ -2089,7 +2089,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> # TODO: Initialize `book`:
             >>> book = {}
@@ -2174,7 +2174,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> other_shelf_name = client.shelf_path('[SHELF]')
             >>>
             >>> response = client.move_book(name, other_shelf_name)
@@ -2324,7 +2324,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> comment = b''
             >>> stage = enums.Comment.Stage.UNSET
             >>> alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -2465,8 +2465,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
-            >>> alt_book_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
+            >>> alt_book_name = client.book_path('[SHELF]', '[BOOK]')
             >>> place = client.location_path('[PROJECT]', '[LOCATION]')
             >>> folder = client.folder_path('[FOLDER]')
             >>>
@@ -2540,7 +2540,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_book_from_absolutely_anywhere(name)
 
@@ -2609,7 +2609,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> index_name = 'default index'
             >>>
             >>> # TODO: Initialize `index_map_item`:
@@ -2794,7 +2794,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -2851,7 +2851,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -2907,7 +2907,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -3048,7 +3048,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> resource = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> resource = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> # TODO: Initialize `label`:
             >>> label = ''
@@ -3118,7 +3118,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_big_book(name)
             >>>
@@ -3197,7 +3197,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> response = client.get_big_nothing(name)
             >>>
@@ -3424,8 +3424,8 @@ class LibraryServiceClient(object):
             >>>
             >>> # TODO: Initialize `required_singular_message`:
             >>> required_singular_message = {}
-            >>> required_singular_resource_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
-            >>> required_singular_resource_name_oneof = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+            >>> required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
             >>>
             >>> # TODO: Initialize `required_singular_resource_name_common`:
             >>> required_singular_resource_name_common = ''
@@ -5684,7 +5684,7 @@ def sample_babble_about_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+  name = client.book_path('[SHELF]', '[BOOK]')
   request = {'name': name}
 
   requests = [request]
@@ -5733,7 +5733,7 @@ def sample_babble_about_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+  name = client.book_path('[SHELF]', '[BOOK]')
   request = {'name': name}
 
   requests = [request]
@@ -5976,7 +5976,7 @@ def sample_get_big_book(shelf):
   client = library_v1.LibraryServiceClient()
 
   # shelf = 'Novel\\"`\b\t\n\r'
-  name = client.book_from_archive_path('[ARCHIVE]', 'War and Peace')
+  name = client.book_path(shelf, 'War and Peace')
 
   operation = client.get_big_book(name)
 
@@ -6054,7 +6054,7 @@ def sample_get_big_book(shelf, big_book_name):
 
   # shelf = 'Novel'
   # big_book_name = 'War and Peace'
-  name = client.book_from_archive_path('[ARCHIVE]', big_book_name)
+  name = client.book_path(shelf, big_book_name)
 
   operation = client.get_big_book(name)
 
@@ -6111,7 +6111,7 @@ def sample_get_big_nothing():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+  name = client.book_path('[SHELF]', '[BOOK]')
 
   operation = client.get_big_nothing(name)
 
@@ -6162,7 +6162,7 @@ def sample_get_big_nothing():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+  name = client.book_path('[SHELF]', '[BOOK]')
 
   operation = client.get_big_nothing(name)
 
@@ -6212,7 +6212,7 @@ def sample_get_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+  name = client.book_path('[SHELF]', '[BOOK]')
 
   response = client.get_book(name)
   int_key_val = response.map_string_value[123]
@@ -6309,7 +6309,7 @@ def sample_monolog_about_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+  name = client.book_path('[SHELF]', '[BOOK]')
   request = {'name': name}
 
   requests = [request]
@@ -6756,8 +6756,8 @@ def sample_test_optional_required_flattening_params(param_float, param_long):
   required_singular_string = ''
   required_singular_bytes = b''
   required_singular_message = {}
-  required_singular_resource_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
-  required_singular_resource_name_oneof = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+  required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+  required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
   required_singular_resource_name_common = ''
   required_singular_fixed32 = 0
   required_singular_fixed64 = 0
@@ -6858,7 +6858,7 @@ def sample_get_book_from_absolutely_anywhere():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_from_archive_path('[ARCHIVE]', 'The ID of the book')
+  name = client.book_path('[SHELF]', 'The ID of the book')
 
   response = client.get_book_from_absolutely_anywhere(name)
   print(u'Archived book found.')
@@ -6902,7 +6902,7 @@ def sample_get_book_from_absolutely_anywhere():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_from_archive_path('[ARCHIVE]', 'The ID of the book')
+  name = client.book_path('The Shelf to search for the book', 'The ID of the book')
 
   response = client.get_book_from_absolutely_anywhere(name)
   print(u'Book on shelf found.')
@@ -7000,7 +7000,7 @@ def sample_get_big_book(shelf):
   client = library_v1.LibraryServiceClient()
 
   # shelf = 'Novel\\"`\b\t\n\r'
-  name = client.book_from_archive_path('[ARCHIVE]', 'War and Peace')
+  name = client.book_path(shelf, 'War and Peace')
 
   operation = client.get_big_book(name)
 
@@ -7073,7 +7073,7 @@ def sample_discuss_book(image_file_name, stage):
 
   # image_file_name = 'image_file.jpg'
   # stage = enums.Comment.Stage.DRAFT
-  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+  name = client.book_path('[SHELF]', '[BOOK]')
   with io.open('comment_file', 'rb') as f:
     comment = f.read()
   comment_2 = {'comment': comment, 'stage': stage}
@@ -7217,7 +7217,7 @@ class TestSystemLibraryService(object):
         project_id = os.environ['PROJECT_ID']
 
         client = library_v1.LibraryServiceClient()
-        name = client.book_from_archive_path('[ARCHIVE]', project_id)
+        name = client.book_path('testShelf-{0}'.format(time.time()), project_id)
         rating = enums.Book.Rating.GOOD
         book = {'rating': rating}
         response = client.update_book(name, book)
@@ -7607,7 +7607,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_book(name)
         assert expected_response == response
@@ -7626,7 +7626,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.get_book(name)
@@ -7684,7 +7684,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         client.delete_book(name)
 
@@ -7702,7 +7702,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.delete_book(name)
@@ -7724,7 +7724,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         book = {}
 
         response = client.update_book(name, book)
@@ -7744,7 +7744,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         book = {}
 
         with pytest.raises(CustomException):
@@ -7767,7 +7767,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         other_shelf_name = client.shelf_path('[SHELF]')
 
         response = client.move_book(name, other_shelf_name)
@@ -7787,7 +7787,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         other_shelf_name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
@@ -7838,7 +7838,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         comment = b'95'
         stage = enums.Comment.Stage.UNSET
         alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -7861,7 +7861,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         comment = b'95'
         stage = enums.Comment.Stage.UNSET
         alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -7931,8 +7931,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
-        alt_book_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
+        alt_book_name = client.book_path('[SHELF]', '[BOOK]')
         place = client.location_path('[PROJECT]', '[LOCATION]')
         folder = client.folder_path('[FOLDER]')
 
@@ -7953,8 +7953,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
-        alt_book_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
+        alt_book_name = client.book_path('[SHELF]', '[BOOK]')
         place = client.location_path('[PROJECT]', '[LOCATION]')
         folder = client.folder_path('[FOLDER]')
 
@@ -7978,7 +7978,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_book_from_absolutely_anywhere(name)
         assert expected_response == response
@@ -7997,7 +7997,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.get_book_from_absolutely_anywhere(name)
@@ -8010,7 +8010,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         index_name = 'default index'
         index_map_item = 'indexMapItem1918721251'
         index_map = {'default_key': index_map_item}
@@ -8031,7 +8031,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         index_name = 'default index'
         index_map_item = 'indexMapItem1918721251'
         index_map = {'default_key': index_map_item}
@@ -8140,7 +8140,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -8165,7 +8165,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)
@@ -8189,7 +8189,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -8212,7 +8212,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)
@@ -8230,7 +8230,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -8252,7 +8252,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)
@@ -8321,7 +8321,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        resource = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        resource = client.book_path('[SHELF]', '[BOOK]')
         label = 'label102727412'
 
         response = client.add_label(resource, label)
@@ -8341,7 +8341,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        resource = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        resource = client.book_path('[SHELF]', '[BOOK]')
         label = 'label102727412'
 
         with pytest.raises(CustomException):
@@ -8366,7 +8366,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_book(name)
         result = response.result()
@@ -8392,7 +8392,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_book(name)
         exception = response.exception()
@@ -8413,7 +8413,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_nothing(name)
         result = response.result()
@@ -8439,7 +8439,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        name = client.book_path('[SHELF]', '[BOOK]')
 
         response = client.get_big_nothing(name)
         exception = response.exception()
@@ -8467,8 +8467,8 @@ class TestLibraryServiceClient(object):
         required_singular_string = 'requiredSingularString-1949894503'
         required_singular_bytes = b'-29'
         required_singular_message = {}
-        required_singular_resource_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
-        required_singular_resource_name_oneof = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+        required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
         required_singular_resource_name_common = 'requiredSingularResourceNameCommon-1126805002'
         required_singular_fixed32 = 720656715
         required_singular_fixed64 = 720656810
@@ -8546,8 +8546,8 @@ class TestLibraryServiceClient(object):
         required_singular_string = 'requiredSingularString-1949894503'
         required_singular_bytes = b'-29'
         required_singular_message = {}
-        required_singular_resource_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
-        required_singular_resource_name_oneof = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        required_singular_resource_name = client.book_path('[SHELF]', '[BOOK]')
+        required_singular_resource_name_oneof = client.book_path('[SHELF]', '[BOOK]')
         required_singular_resource_name_common = 'requiredSingularResourceNameCommon-1126805002'
         required_singular_fixed32 = 720656715
         required_singular_fixed64 = 720656810

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -284,7 +284,7 @@ LibraryServiceClient
 
     client = library_v1.LibraryServiceClient()
 
-    name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+    name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
     # TODO: Initialize `book`:
     book = {}
@@ -744,7 +744,7 @@ LibraryServiceClient
 
     client = library_v1.LibraryServiceClient()
 
-    name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+    name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
     # TODO: Initialize `book`:
     book = {}
@@ -1227,11 +1227,11 @@ class LibraryServiceClient(object):
         )
 
     @classmethod
-    def shelf_path(cls, shelf_id):
+    def shelf_path(cls, shelf):
         """Return a fully-qualified shelf string."""
         return google.api_core.path_template.expand(
-            'shelves/{shelf_id}',
-            shelf_id=shelf_id,
+            'shelves/{shelf}',
+            shelf=shelf,
         )
 
     def __init__(self, transport=None, channel=None, credentials=None,
@@ -1410,7 +1410,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> # TODO: Initialize `options_`:
             >>> options_ = ''
@@ -1557,7 +1557,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> client.delete_shelf(name)
 
@@ -1621,8 +1621,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
-            >>> other_shelf_name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
+            >>> other_shelf_name = client.shelf_path('[SHELF]')
             >>>
             >>> response = client.merge_shelves(name, other_shelf_name)
 
@@ -1689,7 +1689,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> # TODO: Initialize `book`:
             >>> book = {}
@@ -1862,7 +1862,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>>
             >>> response = client.get_book(name)
 
@@ -1928,7 +1928,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>> filter_ = 'book-filter-string'
             >>>
             >>> # Iterate over all results
@@ -2024,7 +2024,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>>
             >>> client.delete_book(name)
 
@@ -2089,7 +2089,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>>
             >>> # TODO: Initialize `book`:
             >>> book = {}
@@ -2174,8 +2174,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
-            >>> other_shelf_name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> other_shelf_name = client.shelf_path('[SHELF]')
             >>>
             >>> response = client.move_book(name, other_shelf_name)
 
@@ -2324,7 +2324,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>> comment = b''
             >>> stage = enums.Comment.Stage.UNSET
             >>> alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -2465,8 +2465,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
-            >>> alt_book_name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> alt_book_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>> place = client.location_path('[PROJECT]', '[LOCATION]')
             >>> folder = client.folder_path('[FOLDER]')
             >>>
@@ -2540,7 +2540,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>>
             >>> response = client.get_book_from_absolutely_anywhere(name)
 
@@ -2609,7 +2609,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>> index_name = 'default index'
             >>>
             >>> # TODO: Initialize `index_map_item`:
@@ -2680,7 +2680,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.shelf_path('[SHELF_ID]')
+            >>> name = client.shelf_path('[SHELF]')
             >>>
             >>> for element in client.stream_shelves(name):
             ...     # process element
@@ -2794,7 +2794,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -2851,7 +2851,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -2907,7 +2907,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>> request = {'name': name}
             >>>
             >>> requests = [request]
@@ -3048,7 +3048,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> resource = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> resource = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>>
             >>> # TODO: Initialize `label`:
             >>> label = ''
@@ -3118,7 +3118,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>>
             >>> response = client.get_big_book(name)
             >>>
@@ -3197,7 +3197,7 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>>
             >>> response = client.get_big_nothing(name)
             >>>
@@ -3424,8 +3424,8 @@ class LibraryServiceClient(object):
             >>>
             >>> # TODO: Initialize `required_singular_message`:
             >>> required_singular_message = {}
-            >>> required_singular_resource_name = client.book_path('[BOOK_SHELF]', '[BOOK]')
-            >>> required_singular_resource_name_oneof = client.book_path('[BOOK_SHELF]', '[BOOK]')
+            >>> required_singular_resource_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+            >>> required_singular_resource_name_oneof = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
             >>>
             >>> # TODO: Initialize `required_singular_resource_name_common`:
             >>> required_singular_resource_name_common = ''
@@ -3992,6 +3992,274 @@ class LibraryServiceClient(object):
         )
         return self._inner_api_calls['test_optional_required_flattening_params'](request, retry=retry, timeout=timeout, metadata=metadata)
 
+    def move_books(
+            self,
+            source=None,
+            destination=None,
+            publishers=None,
+            project=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> response = client.move_books()
+
+        Args:
+            source (str)
+            destination (str)
+            publishers (list[str])
+            project (str)
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.MoveBooksResponse` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'move_books' not in self._inner_api_calls:
+            self._inner_api_calls['move_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.move_books,
+                default_retry=self._method_configs['MoveBooks'].retry,
+                default_timeout=self._method_configs['MoveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.MoveBooksRequest(
+            source=source,
+            destination=destination,
+            publishers=publishers,
+            project=project,
+        )
+        if metadata is None:
+            metadata = []
+        metadata = list(metadata)
+        try:
+            routing_header = [('source', source)]
+        except AttributeError:
+            pass
+        else:
+            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
+            metadata.append(routing_metadata)
+
+        return self._inner_api_calls['move_books'](request, retry=retry, timeout=timeout, metadata=metadata)
+
+    def archive_books(
+            self,
+            source=None,
+            archive=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> response = client.archive_books()
+
+        Args:
+            source (str)
+            archive (str)
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.ArchiveBooksResponse` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'archive_books' not in self._inner_api_calls:
+            self._inner_api_calls['archive_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.archive_books,
+                default_retry=self._method_configs['ArchiveBooks'].retry,
+                default_timeout=self._method_configs['ArchiveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.ArchiveBooksRequest(
+            source=source,
+            archive=archive,
+        )
+        if metadata is None:
+            metadata = []
+        metadata = list(metadata)
+        try:
+            routing_header = [('source', source)]
+        except AttributeError:
+            pass
+        else:
+            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
+            metadata.append(routing_metadata)
+
+        return self._inner_api_calls['archive_books'](request, retry=retry, timeout=timeout, metadata=metadata)
+
+    def long_running_archive_books(
+            self,
+            source=None,
+            archive=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> response = client.long_running_archive_books()
+            >>>
+            >>> def callback(operation_future):
+            ...     # Handle result.
+            ...     result = operation_future.result()
+            >>>
+            >>> response.add_done_callback(callback)
+            >>>
+            >>> # Handle metadata.
+            >>> metadata = response.metadata()
+
+        Args:
+            source (str)
+            archive (str)
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types._OperationFuture` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'long_running_archive_books' not in self._inner_api_calls:
+            self._inner_api_calls['long_running_archive_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.long_running_archive_books,
+                default_retry=self._method_configs['LongRunningArchiveBooks'].retry,
+                default_timeout=self._method_configs['LongRunningArchiveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.ArchiveBooksRequest(
+            source=source,
+            archive=archive,
+        )
+        if metadata is None:
+            metadata = []
+        metadata = list(metadata)
+        try:
+            routing_header = [('source', source)]
+        except AttributeError:
+            pass
+        else:
+            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
+            metadata.append(routing_metadata)
+
+        operation = self._inner_api_calls['long_running_archive_books'](request, retry=retry, timeout=timeout, metadata=metadata)
+        return google.api_core.operation.from_gapic(
+            operation,
+            self.transport._operations_client,
+            library_pb2.ArchiveBooksResponse,
+            metadata_type=library_pb2.ArchiveBooksMetadata,
+        )
+
+    def streaming_archive_books(
+            self,
+            requests,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+
+        EXPERIMENTAL: This method interface might change in the future.
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> request = {}
+            >>>
+            >>> requests = [request]
+            >>> for element in client.streaming_archive_books(requests):
+            ...     # process element
+            ...     pass
+
+        Args:
+            requests (iterator[dict|google.cloud.example.library_v1.proto.library_pb2.ArchiveBooksRequest]): The input objects. If a dict is provided, it must be of the
+                same form as the protobuf message :class:`~google.cloud.example.library_v1.types.ArchiveBooksRequest`
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            Iterable[~google.cloud.example.library_v1.types.ArchiveBooksResponse].
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'streaming_archive_books' not in self._inner_api_calls:
+            self._inner_api_calls['streaming_archive_books'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.streaming_archive_books,
+                default_retry=self._method_configs['StreamingArchiveBooks'].retry,
+                default_timeout=self._method_configs['StreamingArchiveBooks'].timeout,
+                client_info=self._client_info,
+            )
+
+        return self._inner_api_calls['streaming_archive_books'](requests, retry=retry, timeout=timeout, metadata=metadata)
+
     def private_list_shelves(
             self,
             page_token=None,
@@ -4217,6 +4485,26 @@ config = {
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -5011,6 +5299,54 @@ class LibraryServiceGrpcTransport(object):
         return self._stubs['library_service_stub'].TestOptionalRequiredFlatteningParams
 
     @property
+    def move_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.move_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].MoveBooks
+
+    @property
+    def archive_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.archive_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].ArchiveBooks
+
+    @property
+    def long_running_archive_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.long_running_archive_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].LongRunningArchiveBooks
+
+    @property
+    def streaming_archive_books(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.streaming_archive_books`.
+
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].StreamingArchiveBooks
+
+    @property
     def private_list_shelves(self):
         """Return the gRPC stub for :meth:`LibraryServiceClient.private_list_shelves`.
 
@@ -5348,7 +5684,7 @@ def sample_babble_about_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
   request = {'name': name}
 
   requests = [request]
@@ -5397,7 +5733,7 @@ def sample_babble_about_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
   request = {'name': name}
 
   requests = [request]
@@ -5444,7 +5780,7 @@ def sample_delete_shelf():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.shelf_path('[SHELF_ID]')
+  name = client.shelf_path('[SHELF]')
 
   client.delete_shelf(name)
   # Shelf deleted
@@ -5491,7 +5827,7 @@ def sample_delete_shelf():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.shelf_path('[SHELF_ID]')
+  name = client.shelf_path('[SHELF]')
 
   client.delete_shelf(name)
 # [END sample]
@@ -5640,7 +5976,7 @@ def sample_get_big_book(shelf):
   client = library_v1.LibraryServiceClient()
 
   # shelf = 'Novel\\"`\b\t\n\r'
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', 'War and Peace')
 
   operation = client.get_big_book(name)
 
@@ -5718,7 +6054,7 @@ def sample_get_big_book(shelf, big_book_name):
 
   # shelf = 'Novel'
   # big_book_name = 'War and Peace'
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', big_book_name)
 
   operation = client.get_big_book(name)
 
@@ -5775,7 +6111,7 @@ def sample_get_big_nothing():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
   operation = client.get_big_nothing(name)
 
@@ -5826,7 +6162,7 @@ def sample_get_big_nothing():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
   operation = client.get_big_nothing(name)
 
@@ -5876,7 +6212,7 @@ def sample_get_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
   response = client.get_book(name)
   int_key_val = response.map_string_value[123]
@@ -5973,7 +6309,7 @@ def sample_monolog_about_book():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
   request = {'name': name}
 
   requests = [request]
@@ -6321,7 +6657,7 @@ def sample_stream_shelves():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.shelf_path('[SHELF_ID]')
+  name = client.shelf_path('[SHELF]')
 
   for response_item in client.stream_shelves(name):
     print(response_item)
@@ -6420,8 +6756,8 @@ def sample_test_optional_required_flattening_params(param_float, param_long):
   required_singular_string = ''
   required_singular_bytes = b''
   required_singular_message = {}
-  required_singular_resource_name = client.book_path('[BOOK_SHELF]', '[BOOK]')
-  required_singular_resource_name_oneof = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  required_singular_resource_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+  required_singular_resource_name_oneof = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
   required_singular_resource_name_common = ''
   required_singular_fixed32 = 0
   required_singular_fixed64 = 0
@@ -6522,7 +6858,7 @@ def sample_get_book_from_absolutely_anywhere():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', 'The ID of the book')
 
   response = client.get_book_from_absolutely_anywhere(name)
   print(u'Archived book found.')
@@ -6566,7 +6902,7 @@ def sample_get_book_from_absolutely_anywhere():
 
   client = library_v1.LibraryServiceClient()
 
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', 'The ID of the book')
 
   response = client.get_book_from_absolutely_anywhere(name)
   print(u'Book on shelf found.')
@@ -6664,7 +7000,7 @@ def sample_get_big_book(shelf):
   client = library_v1.LibraryServiceClient()
 
   # shelf = 'Novel\\"`\b\t\n\r'
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', 'War and Peace')
 
   operation = client.get_big_book(name)
 
@@ -6737,7 +7073,7 @@ def sample_discuss_book(image_file_name, stage):
 
   # image_file_name = 'image_file.jpg'
   # stage = enums.Comment.Stage.DRAFT
-  name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+  name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
   with io.open('comment_file', 'rb') as f:
     comment = f.read()
   comment_2 = {'comment': comment, 'stage': stage}
@@ -6865,6 +7201,7 @@ setuptools.setup(
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import time
 
 from google.cloud.example import library_v1
@@ -6877,9 +7214,10 @@ from google.protobuf import field_mask_pb2 as protobuf_field_mask_pb2
 class TestSystemLibraryService(object):
 
     def test_update_book(self):
+        project_id = os.environ['PROJECT_ID']
 
         client = library_v1.LibraryServiceClient()
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', project_id)
         rating = enums.Book.Rating.GOOD
         book = {'rating': rating}
         response = client.update_book(name, book)
@@ -7028,7 +7366,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         options_ = 'options-1249474914'
 
         response = client.get_shelf(name, options_)
@@ -7048,7 +7386,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         options_ = 'options-1249474914'
 
         with pytest.raises(CustomException):
@@ -7099,7 +7437,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         client.delete_shelf(name)
 
@@ -7117,7 +7455,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.delete_shelf(name)
@@ -7138,8 +7476,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         response = client.merge_shelves(name, other_shelf_name)
         assert expected_response == response
@@ -7158,8 +7496,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.merge_shelves(name, other_shelf_name)
@@ -7181,7 +7519,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         book = {}
 
         response = client.create_book(name, book)
@@ -7201,7 +7539,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         book = {}
 
         with pytest.raises(CustomException):
@@ -7269,7 +7607,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
         response = client.get_book(name)
         assert expected_response == response
@@ -7288,7 +7626,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.get_book(name)
@@ -7309,7 +7647,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         filter_ = 'book-filter-string'
 
         paged_list_response = client.list_books(name, filter=filter_)
@@ -7331,7 +7669,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
         filter_ = 'book-filter-string'
 
         paged_list_response = client.list_books(name, filter=filter_)
@@ -7346,7 +7684,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
         client.delete_book(name)
 
@@ -7364,7 +7702,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.delete_book(name)
@@ -7386,7 +7724,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         book = {}
 
         response = client.update_book(name, book)
@@ -7406,7 +7744,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         book = {}
 
         with pytest.raises(CustomException):
@@ -7429,8 +7767,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         response = client.move_book(name, other_shelf_name)
         assert expected_response == response
@@ -7449,8 +7787,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
-        other_shelf_name = client.shelf_path('[SHELF_ID]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        other_shelf_name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.move_book(name, other_shelf_name)
@@ -7500,7 +7838,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         comment = b'95'
         stage = enums.Comment.Stage.UNSET
         alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -7523,7 +7861,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         comment = b'95'
         stage = enums.Comment.Stage.UNSET
         alignment = enums.SomeMessage2.SomeMessage3.Alignment.CHAR
@@ -7593,8 +7931,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
-        alt_book_name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        alt_book_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         place = client.location_path('[PROJECT]', '[LOCATION]')
         folder = client.folder_path('[FOLDER]')
 
@@ -7615,8 +7953,8 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
-        alt_book_name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        alt_book_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         place = client.location_path('[PROJECT]', '[LOCATION]')
         folder = client.folder_path('[FOLDER]')
 
@@ -7640,7 +7978,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
         response = client.get_book_from_absolutely_anywhere(name)
         assert expected_response == response
@@ -7659,7 +7997,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
         with pytest.raises(CustomException):
             client.get_book_from_absolutely_anywhere(name)
@@ -7672,7 +8010,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         index_name = 'default index'
         index_map_item = 'indexMapItem1918721251'
         index_map = {'default_key': index_map_item}
@@ -7693,7 +8031,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         index_name = 'default index'
         index_map_item = 'indexMapItem1918721251'
         index_map = {'default_key': index_map_item}
@@ -7717,7 +8055,7 @@ class TestLibraryServiceClient(object):
 
 
         # Setup Request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         response = client.stream_shelves(name)
         resources = list(response)
@@ -7738,7 +8076,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.shelf_path('[SHELF_ID]')
+        name = client.shelf_path('[SHELF]')
 
         with pytest.raises(CustomException):
             client.stream_shelves(name)
@@ -7802,7 +8140,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -7827,7 +8165,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)
@@ -7851,7 +8189,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -7874,7 +8212,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)
@@ -7892,7 +8230,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         request = {'name': name}
         request = library_pb2.DiscussBookRequest(**request)
         requests = [request]
@@ -7914,7 +8252,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         request = {'name': name}
 
         request = library_pb2.DiscussBookRequest(**request)
@@ -7983,7 +8321,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        resource = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        resource = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         label = 'label102727412'
 
         response = client.add_label(resource, label)
@@ -8003,7 +8341,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        resource = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        resource = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         label = 'label102727412'
 
         with pytest.raises(CustomException):
@@ -8028,7 +8366,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
         response = client.get_big_book(name)
         result = response.result()
@@ -8054,7 +8392,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
         response = client.get_big_book(name)
         exception = response.exception()
@@ -8075,7 +8413,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
         response = client.get_big_nothing(name)
         result = response.result()
@@ -8101,7 +8439,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        name = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
 
         response = client.get_big_nothing(name)
         exception = response.exception()
@@ -8129,8 +8467,8 @@ class TestLibraryServiceClient(object):
         required_singular_string = 'requiredSingularString-1949894503'
         required_singular_bytes = b'-29'
         required_singular_message = {}
-        required_singular_resource_name = client.book_path('[BOOK_SHELF]', '[BOOK]')
-        required_singular_resource_name_oneof = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        required_singular_resource_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        required_singular_resource_name_oneof = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         required_singular_resource_name_common = 'requiredSingularResourceNameCommon-1126805002'
         required_singular_fixed32 = 720656715
         required_singular_fixed64 = 720656810
@@ -8208,8 +8546,8 @@ class TestLibraryServiceClient(object):
         required_singular_string = 'requiredSingularString-1949894503'
         required_singular_bytes = b'-29'
         required_singular_message = {}
-        required_singular_resource_name = client.book_path('[BOOK_SHELF]', '[BOOK]')
-        required_singular_resource_name_oneof = client.book_path('[BOOK_SHELF]', '[BOOK]')
+        required_singular_resource_name = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
+        required_singular_resource_name_oneof = client.book_from_archive_path('[ARCHIVE]', '[BOOK]')
         required_singular_resource_name_common = 'requiredSingularResourceNameCommon-1126805002'
         required_singular_fixed32 = 720656715
         required_singular_fixed64 = 720656810
@@ -8263,6 +8601,158 @@ class TestLibraryServiceClient(object):
 
         with pytest.raises(CustomException):
             client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map, required_any_value, required_struct_value, required_value_value, required_list_value_value, required_time_value, required_duration_value, required_field_mask_value, required_int32_value, required_uint32_value, required_int64_value, required_uint64_value, required_float_value, required_double_value, required_string_value, required_bool_value, required_bytes_value, required_repeated_any_value, required_repeated_struct_value, required_repeated_value_value, required_repeated_list_value_value, required_repeated_time_value, required_repeated_duration_value, required_repeated_field_mask_value, required_repeated_int32_value, required_repeated_uint32_value, required_repeated_int64_value, required_repeated_uint64_value, required_repeated_float_value, required_repeated_double_value, required_repeated_string_value, required_repeated_bool_value, required_repeated_bytes_value)
+
+    def test_move_books(self):
+        # Setup Expected Response
+        success = False
+        expected_response = {'success': success}
+        expected_response = library_pb2.MoveBooksResponse(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        response = client.move_books()
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.MoveBooksRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_move_books_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        with pytest.raises(CustomException):
+            client.move_books()
+
+    def test_archive_books(self):
+        # Setup Expected Response
+        success = False
+        expected_response = {'success': success}
+        expected_response = library_pb2.ArchiveBooksResponse(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        response = client.archive_books()
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.ArchiveBooksRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_archive_books_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        with pytest.raises(CustomException):
+            client.archive_books()
+
+    def test_long_running_archive_books(self):
+        # Setup Expected Response
+        success = False
+        expected_response = {'success': success}
+        expected_response = library_pb2.ArchiveBooksResponse(**expected_response)
+        operation = operations_pb2.Operation(name='operations/test_long_running_archive_books', done=True)
+        operation.response.Pack(expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses=[operation])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        response = client.long_running_archive_books()
+        result = response.result()
+        assert expected_response == result
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.ArchiveBooksRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+
+    def test_long_running_archive_books_exception(self):
+        # Setup Response
+        error = status_pb2.Status()
+        operation = operations_pb2.Operation(name='operations/test_long_running_archive_books_exception', done=True)
+        operation.error.CopyFrom(error)
+
+        # Mock the API response
+        channel = ChannelStub(responses=[operation])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        response = client.long_running_archive_books()
+        exception = response.exception()
+        assert exception.errors[0] == error
+
+    def test_streaming_archive_books(self):
+        # Setup Expected Response
+        success = False
+        expected_response = {'success': success}
+        expected_response = library_pb2.ArchiveBooksResponse(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [iter([expected_response])])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        # Setup Request
+        request = {}
+        request = library_pb2.ArchiveBooksRequest(**request)
+        requests = [request]
+
+        response = client.streaming_archive_books(requests)
+        resources = list(response)
+        assert len(resources) == 1
+        assert expected_response == resources[0]
+
+        assert len(channel.requests) == 1
+        actual_requests = channel.requests[0][1]
+        assert len(actual_requests) == 1
+        actual_request = list(actual_requests)[0]
+        assert request == actual_request
+
+    def test_streaming_archive_books_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        # Setup request
+        request = {}
+
+        request = library_pb2.ArchiveBooksRequest(**request)
+        requests = [request]
+
+        with pytest.raises(CustomException):
+            client.streaming_archive_books(requests)
 
     def test_private_list_shelves(self):
         # Setup Expected Response

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -289,7 +289,7 @@ $ gem install library
 require "library"
 
 library_client = Library::Library.new
-formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", project_id)
+formatted_name = Library::V1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
 rating = :GOOD
 book = { rating: rating }
 response = library_client.update_book(formatted_name, book)
@@ -567,7 +567,7 @@ describe "LibraryServiceSmokeTest v1" do
     project_id = ENV["LIBRARY_TEST_PROJECT"].freeze
 
     library_client = Library::Library.new(version: :v1)
-    formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", project_id)
+    formatted_name = Library::V1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
     rating = :GOOD
     book = { rating: rating }
     response = library_client.update_book(formatted_name, book)
@@ -621,7 +621,7 @@ require "pathname"
 # require "library"
 #
 # library_client = Library::Library.new
-# formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", project_id)
+# formatted_name = Library::V1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
 # rating = :GOOD
 # book = { rating: rating }
 # response = library_client.update_book(formatted_name, book)
@@ -837,7 +837,7 @@ module Library
   # require "library"
   #
   # library_client = Library::Library.new(version: :v1)
-  # formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", project_id)
+  # formatted_name = Library::V1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
   # rating = :GOOD
   # book = { rating: rating }
   # response = library_client.update_book(formatted_name, book)
@@ -3028,7 +3028,7 @@ module Library
       private_constant :ARCHIVED_BOOK_PATH_TEMPLATE
 
       BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "bookShelves/{book_shelf}/books/{book}"
+        "shelves/{shelf}/books/{book}"
       )
 
       private_constant :BOOK_PATH_TEMPLATE
@@ -3089,12 +3089,12 @@ module Library
       # Returns a fully-qualified book resource name string.
       # @deprecated Multi-pattern resource names will have unified creation and parsing helper functions.
       # This helper function will be deleted in the next major version.
-      # @param book_shelf [String]
+      # @param shelf [String]
       # @param book [String]
       # @return [String]
-      def self.book_path book_shelf, book
+      def self.book_path shelf, book
         BOOK_PATH_TEMPLATE.render(
-          :"book_shelf" => book_shelf,
+          :"shelf" => shelf,
           :"book" => book
         )
       end
@@ -3838,7 +3838,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   response = library_client.get_book(formatted_name)
 
       def get_book \
@@ -3926,7 +3926,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   library_client.delete_book(formatted_name)
 
       def delete_book \
@@ -3971,7 +3971,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # TODO: Initialize `book`:
       #   book = {}
@@ -4014,7 +4014,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   response = library_client.move_book(formatted_name, formatted_other_shelf_name)
 
@@ -4100,7 +4100,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   comment = ''
       #   stage = :UNSET
       #   alignment = :CHAR
@@ -4181,8 +4181,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
-      #   formatted_alt_book_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      #   formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   formatted_place = Library::V1::LibraryServiceClient.location_path("[PROJECT]", "[LOCATION]")
       #   formatted_folder = Library::V1::LibraryServiceClient.folder_path("[FOLDER]")
       #   response = library_client.get_book_from_anywhere(formatted_name, formatted_alt_book_name, formatted_place, formatted_folder)
@@ -4223,7 +4223,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   response = library_client.get_book_from_absolutely_anywhere(formatted_name)
 
       def get_book_from_absolutely_anywhere \
@@ -4258,7 +4258,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   index_name = "default index"
       #
       #   # TODO: Initialize `index_map_item`:
@@ -4367,7 +4367,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   request = { name: formatted_name }
       #   requests = [request]
       #   library_client.discuss_book(requests).each do |element|
@@ -4400,7 +4400,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   request = { name: formatted_name }
       #   requests = [request]
       #   response = library_client.monolog_about_book(requests)
@@ -4431,7 +4431,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #   request = { name: formatted_name }
       #   requests = [request]
       #   library_client.babble_about_book(requests)
@@ -4523,7 +4523,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_resource = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # TODO: Initialize `label`:
       #   label = ''
@@ -4555,7 +4555,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # Register a callback during the method call.
       #   operation = library_client.get_big_book(formatted_name) do |op|
@@ -4615,7 +4615,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # Register a callback during the method call.
       #   operation = library_client.get_big_nothing(formatted_name) do |op|
@@ -4961,8 +4961,8 @@ module Library
       #
       #   # TODO: Initialize `required_singular_message`:
       #   required_singular_message = {}
-      #   formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
-      #   formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      #   formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       #
       #   # TODO: Initialize `required_singular_resource_name_common`:
       #   required_singular_resource_name_common = ''
@@ -6072,7 +6072,7 @@ def sample_babble_about_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
   request = { name: formatted_name }
 
   requests = [request]
@@ -6121,7 +6121,7 @@ def sample_babble_about_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
   request = { name: formatted_name }
 
   requests = [request]
@@ -6364,7 +6364,7 @@ def sample_get_big_book shelf
   library_client = Library::Library.new version: :v1
 
   # shelf = "Novel\\\"`\b\t\n\r"
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "War and Peace")
+  formatted_name = library_client.class.book_path(shelf, "War and Peace")
 
   # Make the long-running operation request
   operation = library_client.get_big_book(formatted_name)
@@ -6449,7 +6449,7 @@ def sample_get_big_book shelf, big_book_name
 
   # shelf = "Novel"
   # big_book_name = "War and Peace"
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", big_book_name)
+  formatted_name = library_client.class.book_path(shelf, big_book_name)
 
   # Make the long-running operation request
   operation = library_client.get_big_book(formatted_name)
@@ -6514,7 +6514,7 @@ def sample_get_big_nothing
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
 
   # Make the long-running operation request
   operation = library_client.get_big_nothing(formatted_name)
@@ -6569,7 +6569,7 @@ def sample_get_big_nothing
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
 
   # Make the long-running operation request
   operation = library_client.get_big_nothing(formatted_name)
@@ -6621,7 +6621,7 @@ def sample_get_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
 
   response = library_client.get_book(formatted_name)
   int_key_val = response.map_string_value[123]
@@ -6716,7 +6716,7 @@ def sample_monolog_about_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
   request = { name: formatted_name }
 
   requests = [request]
@@ -7162,8 +7162,8 @@ def sample_test_optional_required_flattening_params param_float, param_long
   required_singular_string = ''
   required_singular_bytes = ''
   required_singular_message = {}
-  formatted_required_singular_resource_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
-  formatted_required_singular_resource_name_oneof = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+  formatted_required_singular_resource_name = library_client.class.book_path("[SHELF]", "[BOOK]")
+  formatted_required_singular_resource_name_oneof = library_client.class.book_path("[SHELF]", "[BOOK]")
   required_singular_resource_name_common = ''
   required_singular_fixed32 = 0
   required_singular_fixed64 = 0
@@ -7267,7 +7267,7 @@ def sample_get_book_from_absolutely_anywhere
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "The ID of the book")
+  formatted_name = library_client.class.book_path("[SHELF]", "The ID of the book")
 
   response = library_client.get_book_from_absolutely_anywhere(formatted_name)
   puts "Archived book found."
@@ -7310,7 +7310,7 @@ def sample_get_book_from_absolutely_anywhere
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "The ID of the book")
+  formatted_name = library_client.class.book_path("The Shelf to search for the book", "The ID of the book")
 
   response = library_client.get_book_from_absolutely_anywhere(formatted_name)
   puts "Book on shelf found."
@@ -7406,7 +7406,7 @@ def sample_get_big_book shelf
   library_client = Library::Library.new version: :v1
 
   # shelf = "Novel\\\"`\b\t\n\r"
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "War and Peace")
+  formatted_name = library_client.class.book_path(shelf, "War and Peace")
 
   # Make the long-running operation request
   operation = library_client.get_big_book(formatted_name)
@@ -7487,7 +7487,7 @@ def sample_discuss_book image_file_name, stage
 
   # image_file_name = "image_file.jpg"
   # stage = :DRAFT
-  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+  formatted_name = library_client.class.book_path("[SHELF]", "[BOOK]")
   comment = File.binread "comment_file"
   comment_2 = { comment: comment, stage: stage }
   image = File.binread image_file_name
@@ -8167,7 +8167,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -8215,7 +8215,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8325,7 +8325,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8360,7 +8360,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8394,7 +8394,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       book = {}
 
       # Create expected grpc response
@@ -8444,7 +8444,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       book = {}
 
       # Mock Grpc layer
@@ -8480,7 +8480,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes move_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
@@ -8530,7 +8530,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes move_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
@@ -8628,7 +8628,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_comments without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       comment = ''
       stage = :UNSET
       alignment = :CHAR
@@ -8676,7 +8676,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_comments with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       comment = ''
       stage = :UNSET
       alignment = :CHAR
@@ -8809,8 +8809,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_anywhere without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
-      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       formatted_place = Library::V1::LibraryServiceClient.location_path("[PROJECT]", "[LOCATION]")
       formatted_folder = Library::V1::LibraryServiceClient.folder_path("[FOLDER]")
 
@@ -8873,8 +8873,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_anywhere with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
-      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       formatted_place = Library::V1::LibraryServiceClient.location_path("[PROJECT]", "[LOCATION]")
       formatted_folder = Library::V1::LibraryServiceClient.folder_path("[FOLDER]")
 
@@ -8918,7 +8918,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_absolutely_anywhere without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -8966,7 +8966,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_absolutely_anywhere with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -9000,7 +9000,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book_index without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       index_name = "default index"
       index_map_item = ''
       index_map = { "default_key" => index_map_item }
@@ -9048,7 +9048,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book_index with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       index_name = "default index"
       index_map_item = ''
       index_map = { "default_key" => index_map_item }
@@ -9236,7 +9236,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes discuss_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Create expected grpc response
@@ -9273,7 +9273,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes discuss_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -9309,7 +9309,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes monolog_about_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Create expected grpc response
@@ -9345,7 +9345,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes monolog_about_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -9381,7 +9381,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes babble_about_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -9411,7 +9411,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes babble_about_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -9525,7 +9525,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label without error' do
       # Create request parameters
-      formatted_resource = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       label = ''
 
       # Create expected grpc response
@@ -9566,7 +9566,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label with error' do
       # Create request parameters
-      formatted_resource = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       label = ''
 
       # Mock Grpc layer
@@ -9602,7 +9602,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -9650,7 +9650,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book and returns an operation error.' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
@@ -9689,7 +9689,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -9723,7 +9723,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       expected_response = {}
@@ -9762,7 +9762,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing and returns an operation error.' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
@@ -9801,7 +9801,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -9844,8 +9844,8 @@ describe Library::V1::LibraryServiceClient do
       required_singular_string = ''
       required_singular_bytes = ''
       required_singular_message = {}
-      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
-      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       required_singular_resource_name_common = ''
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0
@@ -10178,8 +10178,8 @@ describe Library::V1::LibraryServiceClient do
       required_singular_string = ''
       required_singular_bytes = ''
       required_singular_message = {}
-      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
-      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
       required_singular_resource_name_common = ''
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -289,7 +289,7 @@ $ gem install library
 require "library"
 
 library_client = Library::Library.new
-formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", project_id)
 rating = :GOOD
 book = { rating: rating }
 response = library_client.update_book(formatted_name, book)
@@ -561,9 +561,13 @@ require "library"
 
 describe "LibraryServiceSmokeTest v1" do
   it "runs one smoke test with update_book" do
+    unless ENV["LIBRARY_TEST_PROJECT"]
+      fail "LIBRARY_TEST_PROJECT environment variable must be defined"
+    end
+    project_id = ENV["LIBRARY_TEST_PROJECT"].freeze
 
     library_client = Library::Library.new(version: :v1)
-    formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+    formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", project_id)
     rating = :GOOD
     book = { rating: rating }
     response = library_client.update_book(formatted_name, book)
@@ -617,7 +621,7 @@ require "pathname"
 # require "library"
 #
 # library_client = Library::Library.new
-# formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+# formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", project_id)
 # rating = :GOOD
 # book = { rating: rating }
 # response = library_client.update_book(formatted_name, book)
@@ -833,7 +837,7 @@ module Library
   # require "library"
   #
   # library_client = Library::Library.new(version: :v1)
-  # formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+  # formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", project_id)
   # rating = :GOOD
   # book = { rating: rating }
   # response = library_client.update_book(formatted_name, book)
@@ -2217,7 +2221,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name of the shelf.
-        #     Shelf names have the form `bookShelves/{shelf_id}`.
+        #     Shelf names have the form `shelves/{shelf}`.
         # @!attribute [rw] theme
         #   @return [String]
         #     The theme of the shelf
@@ -2806,6 +2810,34 @@ module Google
         end
 
         class TestOptionalRequiredFlatteningParamsResponse; end
+
+        # @!attribute [rw] source
+        #   @return [String]
+        # @!attribute [rw] destination
+        #   @return [String]
+        # @!attribute [rw] publishers
+        #   @return [Array<String>]
+        # @!attribute [rw] project
+        #   @return [String]
+        class MoveBooksRequest; end
+
+        # @!attribute [rw] success
+        #   @return [true, false]
+        class MoveBooksResponse; end
+
+        # @!attribute [rw] source
+        #   @return [String]
+        # @!attribute [rw] archive
+        #   @return [String]
+        class ArchiveBooksRequest; end
+
+        # @!attribute [rw] success
+        #   @return [true, false]
+        class ArchiveBooksResponse; end
+
+        # @!attribute [rw] percentage
+        #   @return [Float]
+        class ArchiveBooksMetadata; end
       end
     end
   end
@@ -3038,7 +3070,7 @@ module Library
       private_constant :PUBLISHER_PATH_TEMPLATE
 
       SHELF_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "shelves/{shelf_id}"
+        "shelves/{shelf}"
       )
 
       private_constant :SHELF_PATH_TEMPLATE
@@ -3136,11 +3168,11 @@ module Library
       end
 
       # Returns a fully-qualified shelf resource name string.
-      # @param shelf_id [String]
+      # @param shelf [String]
       # @return [String]
-      def self.shelf_path shelf_id
+      def self.shelf_path shelf
         SHELF_PATH_TEMPLATE.render(
-          :"shelf_id" => shelf_id
+          :"shelf" => shelf
         )
       end
 
@@ -3463,6 +3495,35 @@ module Library
           defaults["test_optional_required_flattening_params"],
           exception_transformer: exception_transformer
         )
+        @move_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:move_books),
+          defaults["move_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:archive_books),
+          defaults["archive_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @long_running_archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:long_running_archive_books),
+          defaults["long_running_archive_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @streaming_archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:streaming_archive_books),
+          defaults["streaming_archive_books"],
+          exception_transformer: exception_transformer
+        )
         @private_list_shelves = Google::Gax.create_api_call(
           @library_service_stub.method(:private_list_shelves),
           defaults["private_list_shelves"],
@@ -3532,7 +3593,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #
       #   # TODO: Initialize `options_`:
       #   options_ = ''
@@ -3607,7 +3668,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   library_client.delete_shelf(formatted_name)
 
       def delete_shelf \
@@ -3642,8 +3703,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   response = library_client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
       def merge_shelves \
@@ -3679,7 +3740,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #
       #   # TODO: Initialize `book`:
       #   book = {}
@@ -3777,7 +3838,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #   response = library_client.get_book(formatted_name)
 
       def get_book \
@@ -3819,7 +3880,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   filter = "book-filter-string"
       #
       #   # Iterate over all results.
@@ -3865,7 +3926,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #   library_client.delete_book(formatted_name)
 
       def delete_book \
@@ -3910,7 +3971,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #
       #   # TODO: Initialize `book`:
       #   book = {}
@@ -3953,8 +4014,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
-      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   response = library_client.move_book(formatted_name, formatted_other_shelf_name)
 
       def move_book \
@@ -4039,7 +4100,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #   comment = ''
       #   stage = :UNSET
       #   alignment = :CHAR
@@ -4120,8 +4181,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
-      #   formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_alt_book_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #   formatted_place = Library::V1::LibraryServiceClient.location_path("[PROJECT]", "[LOCATION]")
       #   formatted_folder = Library::V1::LibraryServiceClient.folder_path("[FOLDER]")
       #   response = library_client.get_book_from_anywhere(formatted_name, formatted_alt_book_name, formatted_place, formatted_folder)
@@ -4162,7 +4223,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #   response = library_client.get_book_from_absolutely_anywhere(formatted_name)
 
       def get_book_from_absolutely_anywhere \
@@ -4197,7 +4258,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #   index_name = "default index"
       #
       #   # TODO: Initialize `index_map_item`:
@@ -4237,7 +4298,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   library_client.stream_shelves(formatted_name).each do |element|
       #     # Process element.
       #   end
@@ -4306,7 +4367,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #   request = { name: formatted_name }
       #   requests = [request]
       #   library_client.discuss_book(requests).each do |element|
@@ -4339,7 +4400,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #   request = { name: formatted_name }
       #   requests = [request]
       #   response = library_client.monolog_about_book(requests)
@@ -4370,7 +4431,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #   request = { name: formatted_name }
       #   requests = [request]
       #   library_client.babble_about_book(requests)
@@ -4462,7 +4523,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_resource = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #
       #   # TODO: Initialize `label`:
       #   label = ''
@@ -4494,7 +4555,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #
       #   # Register a callback during the method call.
       #   operation = library_client.get_big_book(formatted_name) do |op|
@@ -4554,7 +4615,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #
       #   # Register a callback during the method call.
       #   operation = library_client.get_big_nothing(formatted_name) do |op|
@@ -4900,8 +4961,8 @@ module Library
       #
       #   # TODO: Initialize `required_singular_message`:
       #   required_singular_message = {}
-      #   formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
-      #   formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      #   formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      #   formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       #
       #   # TODO: Initialize `required_singular_resource_name_common`:
       #   required_singular_resource_name_common = ''
@@ -5307,6 +5368,161 @@ module Library
         @test_optional_required_flattening_params.call(req, options, &block)
       end
 
+      # @param source [String]
+      # @param destination [String]
+      # @param publishers [Array<String>]
+      # @param project [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::MoveBooksResponse]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::MoveBooksResponse]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   response = library_client.move_books
+
+      def move_books \
+          source: nil,
+          destination: nil,
+          publishers: nil,
+          project: nil,
+          options: nil,
+          &block
+        req = {
+          source: source,
+          destination: destination,
+          publishers: publishers,
+          project: project
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MoveBooksRequest)
+        @move_books.call(req, options, &block)
+      end
+
+      # @param source [String]
+      # @param archive [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::ArchiveBooksResponse]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::ArchiveBooksResponse]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   response = library_client.archive_books
+
+      def archive_books \
+          source: nil,
+          archive: nil,
+          options: nil,
+          &block
+        req = {
+          source: source,
+          archive: archive
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        @archive_books.call(req, options, &block)
+      end
+
+      # @param source [String]
+      # @param archive [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @return [Google::Gax::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #
+      #   # Register a callback during the method call.
+      #   operation = library_client.long_running_archive_books do |op|
+      #     raise op.results.message if op.error?
+      #     op_results = op.results
+      #     # Process the results.
+      #
+      #     metadata = op.metadata
+      #     # Process the metadata.
+      #   end
+      #
+      #   # Or use the return value to register a callback.
+      #   operation.on_done do |op|
+      #     raise op.results.message if op.error?
+      #     op_results = op.results
+      #     # Process the results.
+      #
+      #     metadata = op.metadata
+      #     # Process the metadata.
+      #   end
+      #
+      #   # Manually reload the operation.
+      #   operation.reload!
+      #
+      #   # Or block until the operation completes, triggering callbacks on
+      #   # completion.
+      #   operation.wait_until_done!
+
+      def long_running_archive_books \
+          source: nil,
+          archive: nil,
+          options: nil
+        req = {
+          source: source,
+          archive: archive
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        operation = Google::Gax::Operation.new(
+          @long_running_archive_books.call(req, options),
+          @operations_client,
+          Google::Example::Library::V1::ArchiveBooksResponse,
+          Google::Example::Library::V1::ArchiveBooksMetadata,
+          call_options: options
+        )
+        operation.on_done { |operation| yield(operation) } if block_given?
+        operation
+      end
+
+      # @param reqs [Enumerable<Google::Example::Library::V1::ArchiveBooksRequest>]
+      #   The input requests.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @return [Enumerable<Google::Example::Library::V1::ArchiveBooksResponse>]
+      #   An enumerable of Google::Example::Library::V1::ArchiveBooksResponse instances.
+      #
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      #
+      # @note
+      #   EXPERIMENTAL:
+      #     Streaming requests are still undergoing review.
+      #     This method interface might change in the future.
+      #
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   request = {}
+      #   requests = [request]
+      #   library_client.streaming_archive_books(requests).each do |element|
+      #     # Process element.
+      #   end
+
+      def streaming_archive_books reqs, options: nil
+        request_protos = reqs.lazy.map do |req|
+          Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        end
+        @streaming_archive_books.call(request_protos, options)
+      end
+
       # This method is not exposed in the GAPIC config. It should be generated.
       #
       # @param page_token [String]
@@ -5513,6 +5729,26 @@ end
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -5836,7 +6072,7 @@ def sample_babble_about_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
   request = { name: formatted_name }
 
   requests = [request]
@@ -5885,7 +6121,7 @@ def sample_babble_about_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
   request = { name: formatted_name }
 
   requests = [request]
@@ -5931,7 +6167,7 @@ def sample_delete_shelf
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.shelf_path("[SHELF_ID]")
+  formatted_name = library_client.class.shelf_path("[SHELF]")
 
   library_client.delete_shelf(formatted_name)
 
@@ -5978,7 +6214,7 @@ def sample_delete_shelf
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.shelf_path("[SHELF_ID]")
+  formatted_name = library_client.class.shelf_path("[SHELF]")
 
   library_client.delete_shelf(formatted_name)
 end
@@ -6128,7 +6364,7 @@ def sample_get_big_book shelf
   library_client = Library::Library.new version: :v1
 
   # shelf = "Novel\\\"`\b\t\n\r"
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "War and Peace")
 
   # Make the long-running operation request
   operation = library_client.get_big_book(formatted_name)
@@ -6213,7 +6449,7 @@ def sample_get_big_book shelf, big_book_name
 
   # shelf = "Novel"
   # big_book_name = "War and Peace"
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", big_book_name)
 
   # Make the long-running operation request
   operation = library_client.get_big_book(formatted_name)
@@ -6278,7 +6514,7 @@ def sample_get_big_nothing
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
   # Make the long-running operation request
   operation = library_client.get_big_nothing(formatted_name)
@@ -6333,7 +6569,7 @@ def sample_get_big_nothing
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
   # Make the long-running operation request
   operation = library_client.get_big_nothing(formatted_name)
@@ -6385,7 +6621,7 @@ def sample_get_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
   response = library_client.get_book(formatted_name)
   int_key_val = response.map_string_value[123]
@@ -6480,7 +6716,7 @@ def sample_monolog_about_book
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
   request = { name: formatted_name }
 
   requests = [request]
@@ -6828,7 +7064,7 @@ def sample_stream_shelves
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.shelf_path("[SHELF_ID]")
+  formatted_name = library_client.class.shelf_path("[SHELF]")
 
   library_client.stream_shelves(formatted_name).each do |element|
     puts element.inspect
@@ -6926,8 +7162,8 @@ def sample_test_optional_required_flattening_params param_float, param_long
   required_singular_string = ''
   required_singular_bytes = ''
   required_singular_message = {}
-  formatted_required_singular_resource_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
-  formatted_required_singular_resource_name_oneof = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_required_singular_resource_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+  formatted_required_singular_resource_name_oneof = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
   required_singular_resource_name_common = ''
   required_singular_fixed32 = 0
   required_singular_fixed64 = 0
@@ -7031,7 +7267,7 @@ def sample_get_book_from_absolutely_anywhere
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "The ID of the book")
 
   response = library_client.get_book_from_absolutely_anywhere(formatted_name)
   puts "Archived book found."
@@ -7074,7 +7310,7 @@ def sample_get_book_from_absolutely_anywhere
   # Instantiate a client
   library_client = Library::Library.new version: :v1
 
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "The ID of the book")
 
   response = library_client.get_book_from_absolutely_anywhere(formatted_name)
   puts "Book on shelf found."
@@ -7170,7 +7406,7 @@ def sample_get_big_book shelf
   library_client = Library::Library.new version: :v1
 
   # shelf = "Novel\\\"`\b\t\n\r"
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "War and Peace")
 
   # Make the long-running operation request
   operation = library_client.get_big_book(formatted_name)
@@ -7251,7 +7487,7 @@ def sample_discuss_book image_file_name, stage
 
   # image_file_name = "image_file.jpg"
   # stage = :DRAFT
-  formatted_name = library_client.class.book_path("[BOOK_SHELF]", "[BOOK]")
+  formatted_name = library_client.class.book_from_archive_path("[ARCHIVE]", "[BOOK]")
   comment = File.binread "comment_file"
   comment_2 = { comment: comment, stage: stage }
   image = File.binread image_file_name
@@ -7443,7 +7679,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_shelf without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       options_ = ''
 
       # Create expected grpc response
@@ -7491,7 +7727,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_shelf with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       options_ = ''
 
       # Mock Grpc layer
@@ -7589,7 +7825,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_shelf without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7624,7 +7860,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_shelf with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7658,8 +7894,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes merge_shelves without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -7706,8 +7942,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes merge_shelves with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7742,7 +7978,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       book = {}
 
       # Create expected grpc response
@@ -7792,7 +8028,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       book = {}
 
       # Mock Grpc layer
@@ -7931,7 +8167,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -7979,7 +8215,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8013,7 +8249,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes list_books without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       filter = "book-filter-string"
 
       # Create expected grpc response
@@ -8053,7 +8289,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes list_books with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       filter = "book-filter-string"
 
       # Mock Grpc layer
@@ -8089,7 +8325,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8124,7 +8360,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8158,7 +8394,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       book = {}
 
       # Create expected grpc response
@@ -8208,7 +8444,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       book = {}
 
       # Mock Grpc layer
@@ -8244,8 +8480,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes move_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -8294,8 +8530,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes move_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8392,7 +8628,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_comments without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       comment = ''
       stage = :UNSET
       alignment = :CHAR
@@ -8440,7 +8676,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_comments with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       comment = ''
       stage = :UNSET
       alignment = :CHAR
@@ -8573,8 +8809,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_anywhere without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
-      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       formatted_place = Library::V1::LibraryServiceClient.location_path("[PROJECT]", "[LOCATION]")
       formatted_folder = Library::V1::LibraryServiceClient.folder_path("[FOLDER]")
 
@@ -8637,8 +8873,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_anywhere with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
-      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       formatted_place = Library::V1::LibraryServiceClient.location_path("[PROJECT]", "[LOCATION]")
       formatted_folder = Library::V1::LibraryServiceClient.folder_path("[FOLDER]")
 
@@ -8682,7 +8918,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_absolutely_anywhere without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -8730,7 +8966,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_absolutely_anywhere with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -8764,7 +9000,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book_index without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       index_name = "default index"
       index_map_item = ''
       index_map = { "default_key" => index_map_item }
@@ -8812,7 +9048,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book_index with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       index_name = "default index"
       index_map_item = ''
       index_map = { "default_key" => index_map_item }
@@ -8855,7 +9091,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       shelves_element = {}
@@ -8890,7 +9126,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -9000,7 +9236,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes discuss_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       request = { name: formatted_name }
 
       # Create expected grpc response
@@ -9037,7 +9273,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes discuss_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -9073,7 +9309,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes monolog_about_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       request = { name: formatted_name }
 
       # Create expected grpc response
@@ -9109,7 +9345,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes monolog_about_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -9145,7 +9381,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes babble_about_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -9175,7 +9411,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes babble_about_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       request = { name: formatted_name }
 
       # Mock Grpc layer
@@ -9289,7 +9525,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label without error' do
       # Create request parameters
-      formatted_resource = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       label = ''
 
       # Create expected grpc response
@@ -9330,7 +9566,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label with error' do
       # Create request parameters
-      formatted_resource = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       label = ''
 
       # Mock Grpc layer
@@ -9366,7 +9602,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -9414,7 +9650,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book and returns an operation error.' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
@@ -9453,7 +9689,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -9487,7 +9723,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Create expected grpc response
       expected_response = {}
@@ -9526,7 +9762,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing and returns an operation error.' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
@@ -9565,7 +9801,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -9608,8 +9844,8 @@ describe Library::V1::LibraryServiceClient do
       required_singular_string = ''
       required_singular_bytes = ''
       required_singular_message = {}
-      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
-      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       required_singular_resource_name_common = ''
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0
@@ -9942,8 +10178,8 @@ describe Library::V1::LibraryServiceClient do
       required_singular_string = ''
       required_singular_bytes = ''
       required_singular_message = {}
-      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
-      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_path("[BOOK_SHELF]", "[BOOK]")
+      formatted_required_singular_resource_name = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
+      formatted_required_singular_resource_name_oneof = Library::V1::LibraryServiceClient.book_from_archive_path("[ARCHIVE]", "[BOOK]")
       required_singular_resource_name_common = ''
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0
@@ -10186,6 +10422,297 @@ describe Library::V1::LibraryServiceClient do
               required_repeated_bool_value,
               required_repeated_bytes_value
             )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'move_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#move_books."
+
+    it 'invokes move_books without error' do
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::MoveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:move_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("move_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.move_books
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.move_books do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes move_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:move_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("move_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.move_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#archive_books."
+
+    it 'invokes archive_books without error' do
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ArchiveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.archive_books
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.archive_books do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes archive_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.archive_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'long_running_archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#long_running_archive_books."
+
+    it 'invokes long_running_archive_books without error' do
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ArchiveBooksResponse)
+      result = Google::Protobuf::Any.new
+      result.pack(expected_response)
+      operation = Google::Longrunning::Operation.new(
+        name: 'operations/long_running_archive_books_test',
+        done: true,
+        response: result
+      )
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: operation)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:long_running_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("long_running_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.long_running_archive_books
+
+          # Verify the response
+          assert_equal(expected_response, response.response)
+        end
+      end
+    end
+
+    it 'invokes long_running_archive_books and returns an operation error.' do
+      # Create expected grpc response
+      operation_error = Google::Rpc::Status.new(
+        message: 'Operation error for Library::V1::LibraryServiceClient#long_running_archive_books.'
+      )
+      operation = Google::Longrunning::Operation.new(
+        name: 'operations/long_running_archive_books_test',
+        done: true,
+        error: operation_error
+      )
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: operation)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:long_running_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("long_running_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.long_running_archive_books
+
+          # Verify the response
+          assert(response.error?)
+          assert_equal(operation_error, response.error)
+        end
+      end
+    end
+
+    it 'invokes long_running_archive_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:long_running_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("long_running_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.long_running_archive_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'streaming_archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#streaming_archive_books."
+
+    it 'invokes streaming_archive_books without error' do
+      # Create request parameters
+      request = {}
+
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ArchiveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do |requests|
+        request = requests.first
+        OpenStruct.new(execute: [expected_response])
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:streaming_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("streaming_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.streaming_archive_books([request])
+
+          # Verify the response
+          assert_equal(1, response.count)
+          assert_equal(expected_response, response.first)
+        end
+      end
+    end
+
+    it 'invokes streaming_archive_books with error' do
+      # Create request parameters
+      request = {}
+
+      # Mock Grpc layer
+      mock_method = proc do |requests|
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:streaming_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("streaming_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.streaming_archive_books([request])
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -2101,7 +2101,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name of the shelf.
-        #     Shelf names have the form `bookShelves/{shelf_id}`.
+        #     Shelf names have the form `shelves/{shelf}`.
         # @!attribute [rw] theme
         #   @return [String]
         #     The theme of the shelf
@@ -2690,6 +2690,34 @@ module Google
         end
 
         class TestOptionalRequiredFlatteningParamsResponse; end
+
+        # @!attribute [rw] source
+        #   @return [String]
+        # @!attribute [rw] destination
+        #   @return [String]
+        # @!attribute [rw] publishers
+        #   @return [Array<String>]
+        # @!attribute [rw] project
+        #   @return [String]
+        class MoveBooksRequest; end
+
+        # @!attribute [rw] success
+        #   @return [true, false]
+        class MoveBooksResponse; end
+
+        # @!attribute [rw] source
+        #   @return [String]
+        # @!attribute [rw] archive
+        #   @return [String]
+        class ArchiveBooksRequest; end
+
+        # @!attribute [rw] success
+        #   @return [true, false]
+        class ArchiveBooksResponse; end
+
+        # @!attribute [rw] percentage
+        #   @return [Float]
+        class ArchiveBooksMetadata; end
       end
     end
   end
@@ -2880,7 +2908,7 @@ module Library
       private_constant :PUBLISHER_PATH_TEMPLATE
 
       SHELF_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "shelves/{shelf_id}"
+        "shelves/{shelf}"
       )
 
       private_constant :SHELF_PATH_TEMPLATE
@@ -2939,11 +2967,11 @@ module Library
       end
 
       # Returns a fully-qualified shelf resource name string.
-      # @param shelf_id [String]
+      # @param shelf [String]
       # @return [String]
-      def self.shelf_path shelf_id
+      def self.shelf_path shelf
         SHELF_PATH_TEMPLATE.render(
-          :"shelf_id" => shelf_id
+          :"shelf" => shelf
         )
       end
 
@@ -3249,6 +3277,35 @@ module Library
             {'name' => request.name}
           end
         )
+        @move_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:move_books),
+          defaults["move_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:archive_books),
+          defaults["archive_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @long_running_archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:long_running_archive_books),
+          defaults["long_running_archive_books"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'source' => request.source}
+          end
+        )
+        @streaming_archive_books = Google::Gax.create_api_call(
+          @library_service_stub.method(:streaming_archive_books),
+          defaults["streaming_archive_books"],
+          exception_transformer: exception_transformer
+        )
         @test_optional_required_flattening_params = Google::Gax.create_api_call(
           @library_service_stub.method(:test_optional_required_flattening_params),
           defaults["test_optional_required_flattening_params"],
@@ -3323,7 +3380,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #
       #   # TODO: Initialize `options_`:
       #   options_ = ''
@@ -3393,7 +3450,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   library_client.delete_shelf(formatted_name)
 
       def delete_shelf \
@@ -3428,8 +3485,8 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   response = library_client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
       def merge_shelves \
@@ -3465,7 +3522,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #
       #   # TODO: Initialize `book`:
       #   book = {}
@@ -3608,7 +3665,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #
       #   # Iterate over all results.
       #   library_client.list_books(formatted_name).each do |element|
@@ -3748,7 +3805,7 @@ module Library
       #
       #   # TODO: Initialize `name`:
       #   name = ''
-      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   response = library_client.move_book(name, formatted_other_shelf_name)
 
       def move_book \
@@ -4036,7 +4093,7 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       #   library_client.stream_shelves(formatted_name).each do |element|
       #     # Process element.
       #   end
@@ -4409,6 +4466,161 @@ module Library
         )
         operation.on_done { |operation| yield(operation) } if block_given?
         operation
+      end
+
+      # @param source [String]
+      # @param destination [String]
+      # @param publishers [Array<String>]
+      # @param project [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::MoveBooksResponse]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::MoveBooksResponse]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   response = library_client.move_books
+
+      def move_books \
+          source: nil,
+          destination: nil,
+          publishers: nil,
+          project: nil,
+          options: nil,
+          &block
+        req = {
+          source: source,
+          destination: destination,
+          publishers: publishers,
+          project: project
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MoveBooksRequest)
+        @move_books.call(req, options, &block)
+      end
+
+      # @param source [String]
+      # @param archive [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::ArchiveBooksResponse]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::ArchiveBooksResponse]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   response = library_client.archive_books
+
+      def archive_books \
+          source: nil,
+          archive: nil,
+          options: nil,
+          &block
+        req = {
+          source: source,
+          archive: archive
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        @archive_books.call(req, options, &block)
+      end
+
+      # @param source [String]
+      # @param archive [String]
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @return [Google::Gax::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #
+      #   # Register a callback during the method call.
+      #   operation = library_client.long_running_archive_books do |op|
+      #     raise op.results.message if op.error?
+      #     op_results = op.results
+      #     # Process the results.
+      #
+      #     metadata = op.metadata
+      #     # Process the metadata.
+      #   end
+      #
+      #   # Or use the return value to register a callback.
+      #   operation.on_done do |op|
+      #     raise op.results.message if op.error?
+      #     op_results = op.results
+      #     # Process the results.
+      #
+      #     metadata = op.metadata
+      #     # Process the metadata.
+      #   end
+      #
+      #   # Manually reload the operation.
+      #   operation.reload!
+      #
+      #   # Or block until the operation completes, triggering callbacks on
+      #   # completion.
+      #   operation.wait_until_done!
+
+      def long_running_archive_books \
+          source: nil,
+          archive: nil,
+          options: nil
+        req = {
+          source: source,
+          archive: archive
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        operation = Google::Gax::Operation.new(
+          @long_running_archive_books.call(req, options),
+          @operations_client,
+          Google::Example::Library::V1::ArchiveBooksResponse,
+          Google::Example::Library::V1::ArchiveBooksMetadata,
+          call_options: options
+        )
+        operation.on_done { |operation| yield(operation) } if block_given?
+        operation
+      end
+
+      # @param reqs [Enumerable<Google::Example::Library::V1::ArchiveBooksRequest>]
+      #   The input requests.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @return [Enumerable<Google::Example::Library::V1::ArchiveBooksResponse>]
+      #   An enumerable of Google::Example::Library::V1::ArchiveBooksResponse instances.
+      #
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      #
+      # @note
+      #   EXPERIMENTAL:
+      #     Streaming requests are still undergoing review.
+      #     This method interface might change in the future.
+      #
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   request = {}
+      #   requests = [request]
+      #   library_client.streaming_archive_books(requests).each do |element|
+      #     # Process element.
+      #   end
+
+      def streaming_archive_books reqs, options: nil
+        request_protos = reqs.lazy.map do |req|
+          Google::Gax::to_proto(req, Google::Example::Library::V1::ArchiveBooksRequest)
+        end
+        @streaming_archive_books.call(request_protos, options)
       end
 
       # Test optional flattening parameters of all types
@@ -5314,6 +5526,26 @@ end
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "MoveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "LongRunningArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "TestOptionalRequiredFlatteningParams": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
@@ -5759,7 +5991,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_shelf without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       options_ = ''
 
       # Create expected grpc response
@@ -5807,7 +6039,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_shelf with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       options_ = ''
 
       # Mock Grpc layer
@@ -5907,7 +6139,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_shelf without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -5942,7 +6174,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_shelf with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -5976,8 +6208,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes merge_shelves without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -6024,8 +6256,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes merge_shelves with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -6060,7 +6292,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_book without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       book = {}
 
       # Create expected grpc response
@@ -6110,7 +6342,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_book with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
       book = {}
 
       # Mock Grpc layer
@@ -6327,7 +6559,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes list_books without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       next_page_token = ""
@@ -6365,7 +6597,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes list_books with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -6555,7 +6787,7 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes move_book without error' do
       # Create request parameters
       name = ''
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
@@ -6605,7 +6837,7 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes move_book with error' do
       # Create request parameters
       name = ''
-      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7147,7 +7379,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves without error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Create expected grpc response
       expected_response = {}
@@ -7180,7 +7412,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves with error' do
       # Create request parameters
-      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -7873,6 +8105,297 @@ describe Library::V1::LibraryServiceClient do
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.get_big_nothing(name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'move_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#move_books."
+
+    it 'invokes move_books without error' do
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::MoveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:move_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("move_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.move_books
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.move_books do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes move_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:move_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("move_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.move_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#archive_books."
+
+    it 'invokes archive_books without error' do
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ArchiveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.archive_books
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.archive_books do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes archive_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.archive_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'long_running_archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#long_running_archive_books."
+
+    it 'invokes long_running_archive_books without error' do
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ArchiveBooksResponse)
+      result = Google::Protobuf::Any.new
+      result.pack(expected_response)
+      operation = Google::Longrunning::Operation.new(
+        name: 'operations/long_running_archive_books_test',
+        done: true,
+        response: result
+      )
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: operation)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:long_running_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("long_running_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.long_running_archive_books
+
+          # Verify the response
+          assert_equal(expected_response, response.response)
+        end
+      end
+    end
+
+    it 'invokes long_running_archive_books and returns an operation error.' do
+      # Create expected grpc response
+      operation_error = Google::Rpc::Status.new(
+        message: 'Operation error for Library::V1::LibraryServiceClient#long_running_archive_books.'
+      )
+      operation = Google::Longrunning::Operation.new(
+        name: 'operations/long_running_archive_books_test',
+        done: true,
+        error: operation_error
+      )
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: operation)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:long_running_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("long_running_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.long_running_archive_books
+
+          # Verify the response
+          assert(response.error?)
+          assert_equal(operation_error, response.error)
+        end
+      end
+    end
+
+    it 'invokes long_running_archive_books with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:long_running_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("long_running_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.long_running_archive_books
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'streaming_archive_books' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#streaming_archive_books."
+
+    it 'invokes streaming_archive_books without error' do
+      # Create request parameters
+      request = {}
+
+      # Create expected grpc response
+      success = false
+      expected_response = { success: success }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ArchiveBooksResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do |requests|
+        request = requests.first
+        OpenStruct.new(execute: [expected_response])
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:streaming_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("streaming_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.streaming_archive_books([request])
+
+          # Verify the response
+          assert_equal(1, response.count)
+          assert_equal(expected_response, response.first)
+        end
+      end
+    end
+
+    it 'invokes streaming_archive_books with error' do
+      # Create request parameters
+      request = {}
+
+      # Mock Grpc layer
+      mock_method = proc do |requests|
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:streaming_archive_books, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("streaming_archive_books")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.streaming_archive_books([request])
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/testsrc/common/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library.proto
@@ -32,6 +32,11 @@ option (google.api.resource_definition) = {
   pattern: "projects/{project}/locations/{location}/publishers/{publisher}"
 };
 
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/Archive",
+  pattern: "archives/{archive}"
+};
+
 // This API represents a simple digital library.  It lets you manage Shelf
 // resources and Book resources in the library. It defines the following
 // resource model:
@@ -255,6 +260,29 @@ service LibraryService {
     };
   }
 
+  rpc MoveBooks(MoveBooksRequest) returns (MoveBooksResponse) {
+    option (google.api.http) = {post: "/v1/{source=**}:move" body: "*"};
+    option (google.api.method_signature) = "source,destination,publishers,project";
+  }
+
+  rpc ArchiveBooks(ArchiveBooksRequest) returns (ArchiveBooksResponse) {
+    option (google.api.http) = {post: "/v1/{source=**}:archive" body: "*"};
+    option (google.api.method_signature) = "source,archive";
+  }
+
+  rpc LongRunningArchiveBooks(ArchiveBooksRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {post: "/v1/{source=**}:longrunningmove" body: "*"};
+    option (google.api.method_signature) = "source,archive";
+    option (google.longrunning.operation_info) = {
+      response_type: "ArchiveBooksResponse",
+      metadata_type: "ArchiveBooksMetadata"
+    };
+  }
+
+  rpc StreamingArchiveBooks(stream ArchiveBooksRequest) returns (stream ArchiveBooksResponse) {
+    option (google.api.method_signature) = "source,archive";
+  }
+
   // Test optional flattening parameters of all types
   rpc TestOptionalRequiredFlatteningParams(TestOptionalRequiredFlatteningParamsRequest) returns (TestOptionalRequiredFlatteningParamsResponse) {
     option (google.api.http) = { post: "/v1/testofp" body: "*" };
@@ -396,7 +424,7 @@ service LibraryService {
 message Book {
   option (google.api.resource) = {
     type: "library.googleapis.com/Book",
-    pattern: "bookShelves/{book_shelf}/books/{book}",
+    pattern: "shelves/{shelf}/books/{book}",
     pattern: "archives/{archive}/books/{book}",
     pattern: "projects/{project}/books/{book}"
     history: ORIGINALLY_SINGLE_PATTERN,
@@ -535,10 +563,10 @@ message SomeMessage2 {
 message Shelf {
   option (google.api.resource) = {
     type: "library.googleapis.com/Shelf",
-    pattern: "shelves/{shelf_id}",
+    pattern: "shelves/{shelf}",
   };
   // The resource name of the shelf.
-  // Shelf names have the form `bookShelves/{shelf_id}`.
+  // Shelf names have the form `shelves/{shelf}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED
   ];
@@ -1103,4 +1131,34 @@ message TestOptionalRequiredFlatteningParamsRequest {
 }
 
 message TestOptionalRequiredFlatteningParamsResponse {
+}
+
+message MoveBooksRequest {
+
+  string source = 1;
+
+  string destination = 2;
+
+  repeated string publishers = 3;
+
+  string project = 4;
+}
+
+message MoveBooksResponse {
+  bool success = 1;
+}
+
+message ArchiveBooksRequest {
+
+  string source = 1;
+
+  string archive = 2;
+}
+
+message ArchiveBooksResponse {
+  bool success = 1;
+}
+
+message ArchiveBooksMetadata {
+  double percentage = 1;
 }

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_gapic.yaml
@@ -31,11 +31,11 @@ license_header:
   copyright_file: copyright-google.txt # Test that the deprecated field is still parseable.
   license_file: license-header-apache-2.0.txt # Test that the deprecated field is still parseable.
 collections:
-  - name_pattern: shelves/{shelf_id}
+  - name_pattern: shelves/{shelf}
     entity_name: shelf
   # This pattern is present here and not in the interface configuration to test
   # the restriction of generated parse/format methods
-  - name_pattern: archives/{archive_path}/books/{book_id=**}
+  - name_pattern: archives/{archive_path}/books/{book=**}
     entity_name: archived_book
   - name_pattern: _deleted-book_
     entity_name: deleted_book
@@ -102,9 +102,9 @@ interfaces:
     max_rpc_timeout_millis: 3000
     total_timeout_millis: 30000
   collections:
-  - name_pattern: shelves/{shelf_id}
+  - name_pattern: shelves/{shelf}
     entity_name: shelf
-  - name_pattern: shelves/{shelf_id}/books/{book_id}
+  - name_pattern: shelves/{shelf}/books/{book}
     entity_name: book
     language_overrides:
     - language: java
@@ -119,8 +119,8 @@ interfaces:
   smoke_test:
     method: UpdateBook
     init_fields:
-      - name%shelf_id="testShelf-$RANDOM"
-      - name%book_id=$PROJECT_ID
+      - name%shelf="testShelf-$RANDOM"
+      - name%book=$PROJECT_ID
       - book . rating=GOOD
   methods:
   - name: CreateShelf
@@ -159,7 +159,7 @@ interfaces:
       description: "Test default calling forms for unary methods."
       parameters:
         defaults:
-        - name%shelf_id="my-shelf"
+        - name%shelf="my-shelf"
       on_success:
       - print:
           - "The theme of the shelf is: %s"
@@ -169,7 +169,7 @@ interfaces:
       description: "Test setting up empty objects in the request objects."
       parameters:
         defaults:
-        - name%shelf_id="my-shelf"
+        - name%shelf="my-shelf"
         - message={}
         - string_builder={}
         attributes:
@@ -371,7 +371,7 @@ interfaces:
       description: "Test request object field comments"
       parameters:
         defaults:
-        - shelf.name%shelf_id="math"
+        - shelf.name%shelf="math"
         - shelf.theme=Math
         - shelf.internal_theme=Statistics
         - series_uuid.series_bytes="xyz3141592654"
@@ -387,7 +387,7 @@ interfaces:
           # TODO(hzyi): this comment is currently not generated because resource name 
           # entities are inline literals. We need to revisit this issue when we start
           # looking at making inline literals configurable
-        - parameter: shelf.name%shelf_id
+        - parameter: shelf.name%shelf
           description: "Comment on a resource name entity"
         - parameter: shelf.name
           description: "Comment on a resource name"
@@ -650,14 +650,14 @@ interfaces:
       parameters:
         defaults:
         - name%archive_path="The archive to search for the book"
-        - name%book_id="The ID of the book"
+        - name%book="The ID of the book"
       on_success:
       - print: ["Archived book found."]
     - id: test_resource_name_oneof_2
       parameters:
         defaults:
-        - name%shelf_id="The Shelf to search for the book"
-        - name%book_id="The ID of the book"
+        - name%shelf="The Shelf to search for the book"
+        - name%book="The ID of the book"
       on_success:
       - print: ["Book on shelf found."]
     samples:
@@ -869,8 +869,8 @@ interfaces:
     sample_code_init_fields:
     - names[0]
     # TODO(michaelbausor): support %-entity notation for list elements
-    #- names[1]%shelf_id=my_shelf
-    #- names[1]%book_id=my_first_book
+    #- names[1]%shelf=my_shelf
+    #- names[1]%book=my_first_book
     sample_value_sets:
       # callingFormCheck: odyssey java: FlattenedPaged RequestPaged CallableList CallablePaged
       # callingFormCheck: odyssey nodejs: RequestAsyncPaged RequestAsyncPagedAll
@@ -970,10 +970,10 @@ interfaces:
       description: "Testing calling forms"
       parameters:
         defaults:
-        - name%shelf_id="Novel\\\"`\b\t\n\r"
-        - name%book_id="War and Peace"
+        - name%shelf="Novel\\\"`\b\t\n\r"
+        - name%book="War and Peace"
         attributes:
-        - parameter: name%shelf_id
+        - parameter: name%shelf
           sample_argument_name: shelf
       on_success:
       - comment:
@@ -1016,13 +1016,13 @@ interfaces:
       description: "Testing resource name overlap"
       parameters:
         defaults:
-        - name%shelf_id=Novel
-        - name%book_id="War and Peace"
+        - name%shelf=Novel
+        - name%book="War and Peace"
         attributes:
-        - parameter: name%shelf_id
+        - parameter: name%shelf
           sample_argument_name: shelf
           description: "Test word wrapping for long lines. This is a long comment. The name of the shelf to retrieve the big book from."
-        - parameter: name%book_id
+        - parameter: name%book
           sample_argument_name: big_book_name
           description: "The name of the book."
     samples:

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_v2_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_v2_gapic.yaml
@@ -65,7 +65,7 @@ interfaces:
     - entity_name: book_from_archive
       name_pattern: "archives/{archive}/books/{book}"
     - entity_name: book
-      name_pattern: "bookShelves/{book_shelf}/books/{book}"
+      name_pattern: "shelves/{shelf}/books/{book}"
       language_overrides:
       - language: java
         entity_name: shelf_book

--- a/src/test/java/com/google/api/codegen/testsrc/common/library_v2_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library_v2_gapic.yaml
@@ -72,8 +72,8 @@ interfaces:
     smoke_test:
       method: UpdateBook
       init_fields:
-        - name%shelf_id="testShelf-$RANDOM"
-        - name%book_id=$PROJECT_ID
+        - name%shelf="testShelf-$RANDOM"
+        - name%book=$PROJECT_ID
         - book . rating=GOOD
     methods:
       - name: CreateShelf
@@ -88,7 +88,7 @@ interfaces:
           description: "Test default calling forms for unary methods."
           parameters:
             defaults:
-            - name%shelf_id="my-shelf"
+            - name%shelf="my-shelf"
           on_success:
           - print:
               - "The theme of the shelf is: %s"
@@ -98,7 +98,7 @@ interfaces:
           description: "Test setting up empty objects in the request objects."
           parameters:
             defaults:
-            - name%shelf_id="my-shelf"
+            - name%shelf="my-shelf"
             - message={}
             - string_builder={}
             attributes:
@@ -247,7 +247,7 @@ interfaces:
             description: "Test request object field comments"
             parameters:
               defaults:
-                - shelf.name%shelf_id="math"
+                - shelf.name%shelf="math"
                 - shelf.theme=Math
                 - shelf.internal_theme=Statistics
                 - series_uuid.series_bytes="xyz3141592654"
@@ -263,7 +263,7 @@ interfaces:
                   # TODO(hzyi): this comment is currently not generated because resource name
                   # entities are inline literals. We need to revisit this issue when we start
                   # looking at making inline literals configurable
-                - parameter: shelf.name%shelf_id
+                - parameter: shelf.name%shelf
                   description: "Comment on a resource name entity"
                 - parameter: shelf.name
                   description: "Comment on a resource name"
@@ -397,14 +397,14 @@ interfaces:
           parameters:
             defaults:
             - name%archive_path="The archive to search for the book"
-            - name%book_id="The ID of the book"
+            - name%book="The ID of the book"
           on_success:
           - print: ["Archived book found."]
         - id: test_resource_name_oneof_2
           parameters:
             defaults:
-            - name%shelf_id="The Shelf to search for the book"
-            - name%book_id="The ID of the book"
+            - name%shelf="The Shelf to search for the book"
+            - name%book="The ID of the book"
           on_success:
           - print: ["Book on shelf found."]
         samples:
@@ -557,8 +557,8 @@ interfaces:
         sample_code_init_fields:
           - names[0]
         # TODO(michaelbausor): support %-entity notation for list elements
-        #- names[1]%shelf_id=my_shelf
-        #- names[1]%book_id=my_first_book
+        #- names[1]%shelf=my_shelf
+        #- names[1]%book=my_first_book
         sample_value_sets:
           # callingFormCheck: odyssey java: FlattenedPaged RequestPaged CallableList CallablePaged
           # callingFormCheck: odyssey nodejs: RequestAsyncPaged RequestAsyncPagedAll
@@ -626,10 +626,10 @@ interfaces:
             description: "Testing calling forms"
             parameters:
               defaults:
-                - name%shelf_id="Novel\\\"`\b\t\n\r"
-                - name%book_id="War and Peace"
+                - name%shelf="Novel\\\"`\b\t\n\r"
+                - name%book="War and Peace"
               attributes:
-                - parameter: name%shelf_id
+                - parameter: name%shelf
                   sample_argument_name: shelf
             on_success:
               - comment:
@@ -672,13 +672,13 @@ interfaces:
             description: "Testing resource name overlap"
             parameters:
               defaults:
-                - name%shelf_id=Novel
-                - name%book_id="War and Peace"
+                - name%shelf=Novel
+                - name%book="War and Peace"
               attributes:
-                - parameter: name%shelf_id
+                - parameter: name%shelf
                   sample_argument_name: shelf
                   description: "Test word wrapping for long lines. This is a long comment. The name of the shelf to retrieve the big book from."
-                - parameter: name%book_id
+                - parameter: name%book
                   sample_argument_name: big_book_name
                   description: "The name of the book."
         samples:

--- a/src/test/java/com/google/api/codegen/testsrc/common/samplegen_config_migration_library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/samplegen_config_migration_library_gapic.yaml
@@ -33,11 +33,11 @@ license_header:
   copyright_file: copyright-google.txt # Test that the deprecated field is still parseable.
   license_file: license-header-apache-2.0.txt # Test that the deprecated field is still parseable.
 collections:
-  - name_pattern: shelves/{shelf_id}
+  - name_pattern: shelves/{shelf}
     entity_name: shelf
   # This pattern is present here and not in the interface configuration to test
   # the restriction of generated parse/format methods
-  - name_pattern: archives/{archive_path}/books/{book_id=**}
+  - name_pattern: archives/{archive_path}/books/{book=**}
     entity_name: archived_book
   - name_pattern: _deleted-book_
     entity_name: deleted_book
@@ -91,9 +91,9 @@ interfaces:
     max_rpc_timeout_millis: 3000
     total_timeout_millis: 30000
   collections:
-  - name_pattern: shelves/{shelf_id}
+  - name_pattern: shelves/{shelf}
     entity_name: shelf
-  - name_pattern: shelves/{shelf_id}/books/{book_id}
+  - name_pattern: shelves/{shelf}/books/{book}
     entity_name: book
     language_overrides:
     - language: java
@@ -108,8 +108,8 @@ interfaces:
   smoke_test:
     method: UpdateBook
     init_fields:
-      - name%shelf_id="testShelf-$RANDOM"
-      - name%book_id=$PROJECT_ID
+      - name%shelf="testShelf-$RANDOM"
+      - name%book=$PROJECT_ID
       - book . rating=GOOD
   methods:
   - name: CreateShelf
@@ -148,7 +148,7 @@ interfaces:
       description: "Test default calling forms for unary methods."
       parameters:
         defaults:
-        - name%shelf_id="my-shelf"
+        - name%shelf="my-shelf"
       on_success:
       - print:
           - "The theme of the shelf is: %s"
@@ -158,7 +158,7 @@ interfaces:
       description: "Test setting up empty objects in the request objects."
       parameters:
         defaults:
-        - name%shelf_id="my-shelf"
+        - name%shelf="my-shelf"
         - message={}
         - string_builder={}
         attributes:
@@ -371,7 +371,7 @@ interfaces:
       description: "Test request object field comments"
       parameters:
         defaults:
-        - shelf.name%shelf_id="math"
+        - shelf.name%shelf="math"
         - shelf.theme=Math
         - shelf.internal_theme=Statistics
         - series_uuid.series_bytes="xyz3141592654"
@@ -387,7 +387,7 @@ interfaces:
           # TODO(hzyi): this comment is currently not generated because resource name 
           # entities are inline literals. We need to revisit this issue when we start
           # looking at making inline literals configurable
-        - parameter: shelf.name%shelf_id
+        - parameter: shelf.name%shelf
           description: "Comment on a resource name entity"
         - parameter: shelf.name
           description: "Comment on a resource name"
@@ -652,14 +652,14 @@ interfaces:
       parameters:
         defaults:
         - name%archive_path="The archive to search for the book"
-        - name%book_id="The ID of the book"
+        - name%book="The ID of the book"
       on_success:
       - print: ["Archived book found."]
     - id: test_resource_name_oneof_2
       parameters:
         defaults:
-        - name%shelf_id="The Shelf to search for the book"
-        - name%book_id="The ID of the book"
+        - name%shelf="The Shelf to search for the book"
+        - name%book="The ID of the book"
       on_success:
       - print: ["Book on shelf found."]
     samples:
@@ -910,8 +910,8 @@ interfaces:
     sample_code_init_fields:
     - names[0]
     # TODO(michaelbausor): support %-entity notation for list elements
-    #- names[1]%shelf_id=my_shelf
-    #- names[1]%book_id=my_first_book
+    #- names[1]%shelf=my_shelf
+    #- names[1]%book=my_first_book
     sample_value_sets:
       # callingFormCheck: odyssey java: RequestPaged
       # callingFormCheck: odyssey nodejs: RequestAsyncPagedAll
@@ -1015,10 +1015,10 @@ interfaces:
       description: "Testing calling forms"
       parameters:
         defaults:
-        - name%shelf_id="Novel\\\"`\b\t\n\r"
-        - name%book_id="War and Peace"
+        - name%shelf="Novel\\\"`\b\t\n\r"
+        - name%book="War and Peace"
         attributes:
-        - parameter: name%shelf_id
+        - parameter: name%shelf
           sample_argument_name: shelf
       on_success:
       - comment:
@@ -1061,13 +1061,13 @@ interfaces:
       description: "Testing resource name overlap"
       parameters:
         defaults:
-        - name%shelf_id=Novel
-        - name%book_id="War and Peace"
+        - name%shelf=Novel
+        - name%book="War and Peace"
         attributes:
-        - parameter: name%shelf_id
+        - parameter: name%shelf
           sample_argument_name: shelf
           description: "Test word wrapping for long lines. This is a long comment. The name of the shelf to retrieve the big book from."
-        - parameter: name%book_id
+        - parameter: name%book
           sample_argument_name: big_book_name
           description: "The name of the book."
     samples:

--- a/src/test/java/com/google/api/codegen/testsrc/common/samples/create_book.sample.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/samples/create_book.sample.yaml
@@ -8,7 +8,7 @@ samples:
   description: "testing maps in request fields"
   region_tag: testing_map
   request:
-  - field: name%shelf_id
+  - field: name%shelf
     value: "my_shelf"
   - field: book.map_string_value{1}
     value: "my_string_value"

--- a/src/test/java/com/google/api/codegen/testsrc/common/samples/get_big_book.sample.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/samples/get_big_book.sample.yaml
@@ -8,10 +8,10 @@ samples:
   description: "Testing calling forms"
   region_tag: hopper
   request:
-  - field: name%shelf_id
+  - field: name%shelf
     value: "Novel\\\"`\b\t\n\r"
     input_parameter: shelf
-  - field: name%book_id
+  - field: name%book
     value: "War and Peace"
   response:
   - comment:
@@ -55,11 +55,11 @@ samples:
   description: "Testing resource name overlap"
   region_tag: this_tag_should_be_the_name_of_the_file
   request:
-  - field: name%shelf_id
+  - field: name%shelf
     value: Novel
     input_parameter: shelf
     comment: "Test word wrapping for long lines. This is a long comment. The name of the shelf to retrieve the big book from."
-  - field: name%book_id
+  - field: name%book
     value: "War and Peace"
     input_parameter: big_book_name
     comment: "The name of the book."

--- a/src/test/java/com/google/api/codegen/testsrc/common/samples/get_book_from_absolutely_anywhere.sample.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/samples/get_book_from_absolutely_anywhere.sample.yaml
@@ -6,9 +6,9 @@ samples:
   rpc: GetBookFromAbsolutelyAnywhere
   region_tag: test_resource_name_oneof
   request:
-  - field: name%archive_path
+  - field: name%archive
     value: "The archive to search for the book"
-  - field: name%book_id
+  - field: name%book
     value: "The ID of the book"
   response:
   - print: ["Archived book found."]
@@ -16,9 +16,9 @@ samples:
   rpc: GetBookFromAbsolutelyAnywhere
   region_tag: test_resource_name_oneof_2
   request:
-  - field: name%shelf_id
+  - field: name%shelf
     value: "The Shelf to search for the book"
-  - field: name%book_id
+  - field: name%book
     value: "The ID of the book"
   response:
   - print: ["Book on shelf found."]

--- a/src/test/java/com/google/api/codegen/testsrc/common/samples/get_shelf.sample.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/samples/get_shelf.sample.yaml
@@ -8,7 +8,7 @@ samples:
   title: test_default_calling_form_unary
   description: "Test default calling forms for unary methods."
   request:
-  - field: name%shelf_id
+  - field: name%shelf
     value: "my-shelf"
   response:
   - print:
@@ -20,7 +20,7 @@ samples:
   title: test_setting_up_empty_objects_in_request
   description: "Test setting up empty objects in the request objects."
   request:
-  - field: name%shelf_id
+  - field: name%shelf
     value: "my-shelf"
   - field: message
     value: "{}"

--- a/src/test/java/com/google/api/codegen/testsrc/common/samples/publish_series.sample.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/common/samples/publish_series.sample.yaml
@@ -75,7 +75,7 @@ samples:
   rpc: PublishSeries
   calling_patterns: [request]
   request:
-  - field: shelf.name%shelf_id
+  - field: shelf.name%shelf
     value: "math"
     # TODO(hzyi): this comment is currently not generated because resource name
     # entities are inline literals. We need to revisit this issue when we start


### PR DESCRIPTION
- add four rpcs for testing multi-pattern resource with child_type, so that the next PR with implementation for this feature will come along with specific diffs with much less noise
- changed a few resource patterns to be more similar to real APIs and make annotations, gapic configs and sample configs consistent

Fix #2536