### PR TITLE
Add multi-pattern resource check for C#

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/DefaultFeatureConfig.java
+++ b/src/main/java/com/google/api/codegen/transformer/DefaultFeatureConfig.java
@@ -16,6 +16,8 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.MethodContext;
+import com.google.api.codegen.config.ResourceNameOneofConfig;
+import com.google.api.codegen.config.ResourceNameType;
 
 public class DefaultFeatureConfig implements FeatureConfig {
 
@@ -37,9 +39,48 @@ public class DefaultFeatureConfig implements FeatureConfig {
   @Override
   public boolean useResourceNameFormatOptionInSample(
       MethodContext context, FieldConfig fieldConfig) {
-    return resourceNameTypesEnabled()
-        && fieldConfig != null
-        && (fieldConfig.useResourceNameType() || fieldConfig.useResourceNameTypeInSampleOnly());
+    boolean hasResourceNameFormatOption =
+        resourceNameTypesEnabled()
+            && fieldConfig != null
+            && (fieldConfig.useResourceNameType() || fieldConfig.useResourceNameTypeInSampleOnly());
+
+    if (!hasResourceNameFormatOption) {
+      return false;
+    }
+
+    // For an any resource name, we choose a random single resource name defined in the API for
+    // sample generation. If there are no single resource names at all in the API, we set this
+    // value to false and use a string literal to instantiate a resource name string.
+    boolean apiHasSingleResources =
+        context.getProductConfig().getSingleResourceNameConfigs().iterator().hasNext();
+    if (fieldConfig.getResourceNameType() == ResourceNameType.ANY && !apiHasSingleResources) {
+      return false;
+    }
+
+    // TODO: support creating resource name strings in tests and samples using creation methods
+    // in the new multi-pattern resource classes.
+    //
+    // This check has to be here for the following purposes:
+    // - make generating new APIs with multi-pattern resource but no gapic config v2 for Java work
+    //   (including java_library_no_gapic_config baseline test).
+    //   We can remove the check for this case after we implement generating samples and tests
+    //   using the new multi-pattern resource class for Java
+    // - make generating new APIs with multi-pattern resource but no gapic config v2 for C# work
+    //   Note such a case does not exist in production as all multi-pattern resource support
+    //   for C# will only be implemented in the micro-generator, but for the time being bazel
+    //   and artman tests still use gapic-generator to generate C# GAPICs.
+    //
+    // Note This check is not needed for generating Java gapics with gapic config v2, because for
+    // those
+    // we can put multi-pattern resource name in deprecated_collections in gapic config v2 so that
+    // the generator can create resource name strings in the old wayg.
+    boolean requiresMultiPatternResourceSupport =
+        fieldConfig.getResourceNameType() == ResourceNameType.ONEOF
+            && ((ResourceNameOneofConfig) fieldConfig.getResourceNameConfig())
+                .getSingleResourceNameConfigs()
+                .isEmpty();
+
+    return !requiresMultiPatternResourceSupport;
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -967,10 +967,6 @@ public class InitCodeTransformer {
     // Return the first one to not break in-code samples and unit tests when
     // there are no matching resource name binding values
     if (matchingConfigs.isEmpty()) {
-      if (oneofConfig.getSingleResourceNameConfigs().size() == 0) {
-        System.out.println("Hahahahha");
-        System.out.println(oneofConfig);
-      }
       return oneofConfig.getSingleResourceNameConfigs().get(0);
     }
     return matchingConfigs.get(0);

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -967,6 +967,10 @@ public class InitCodeTransformer {
     // Return the first one to not break in-code samples and unit tests when
     // there are no matching resource name binding values
     if (matchingConfigs.isEmpty()) {
+      if (oneofConfig.getSingleResourceNameConfigs().size() == 0) {
+        System.out.println("Hahahahha");
+        System.out.println(oneofConfig);
+      }
       return oneofConfig.getSingleResourceNameConfigs().get(0);
     }
     return matchingConfigs.get(0);

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
@@ -18,8 +18,6 @@ import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.MethodContext;
 import com.google.api.codegen.config.ResourceNameMessageConfigs;
-import com.google.api.codegen.config.ResourceNameOneofConfig;
-import com.google.api.codegen.config.ResourceNameType;
 import com.google.api.codegen.transformer.DefaultFeatureConfig;
 import com.google.auto.value.AutoValue;
 
@@ -37,39 +35,8 @@ public abstract class JavaFeatureConfig extends DefaultFeatureConfig {
   @Override
   public boolean useResourceNameFormatOptionInSample(
       MethodContext context, FieldConfig fieldConfig) {
-    boolean hasResourceNameFormatOption =
-        resourceNameTypesEnabled()
-            && fieldConfig != null
-            && (fieldConfig.useResourceNameType() || fieldConfig.useResourceNameTypeInSampleOnly())
-            && !(context.isFlattenedMethodContext() && fieldConfig.getField().isRepeated());
-
-    if (!hasResourceNameFormatOption) {
-      return false;
-    }
-
-    // For an any resource name, we choose a random single resource name defined in the API for
-    // sample generation. If there are no single resource names at all in the API, we set this
-    // value to false and use a string literal to instantiate a resource name string.
-    boolean apiHasSingleResources =
-        context.getProductConfig().getSingleResourceNameConfigs().iterator().hasNext();
-    if (fieldConfig.getResourceNameType() == ResourceNameType.ANY && !apiHasSingleResources) {
-      return false;
-    }
-
-    // TODO: support creating resource name strings in tests and samples using creation methods
-    // in the new multi-pattern resource classes.
-    //
-    // Note this check has to be here temporarily to make java_library_no_gapic_config test pass.
-    // In other tests and in production, we can put multi-pattern resource name in
-    // deprecated_collections in gapic config v2 so that the generator can create resource name
-    // strings in the old way, but not for this specific test without a gapic config.
-    boolean requiresMultiPatternResourceSupport =
-        fieldConfig.getResourceNameType() == ResourceNameType.ONEOF
-            && ((ResourceNameOneofConfig) fieldConfig.getResourceNameConfig())
-                .getSingleResourceNameConfigs()
-                .isEmpty();
-
-    return !requiresMultiPatternResourceSupport;
+    return super.useResourceNameFormatOptionInSample(context, fieldConfig)
+        && !(context.isFlattenedMethodContext() && fieldConfig.getField().isRepeated());
   }
 
   @Override


### PR DESCRIPTION
Use plain strings in C# tests and samples for multi-pattern resource names.

bazel CI exposed a new API with multi-pattern resources ([securitycenter v1p1beta1](https://cs.corp.google.com/piper///depot/google3/third_party/googleapis/google/cloud/securitycenter/v1p1beta1/securitycenter_gapic.yaml?g=0)) which caused C# generation using the monolith to fail.

Though we won't be generating C# gapics for APIs like this using gapic-generator in production any more, artman and bazel CI will continue to try doing so for a while, so I think it's still worth fixing.

(The scenario is hard to demonstrate in baseline and there isn't an existing gapic for the API so I can't really show the diff here, apologies in advance.)