### PR TITLE
feat (Java): generate tests using the non-flattening overload if an rpc does not have method_signature config

### DIFF
--- a/showcase/java/src/test/java/com/google/api/showcase/ShowcaseTransportChannelProvider.java
+++ b/showcase/java/src/test/java/com/google/api/showcase/ShowcaseTransportChannelProvider.java
@@ -86,6 +86,11 @@ public class ShowcaseTransportChannelProvider implements TransportChannelProvide
   }
 
   @Override
+  public boolean needsCredentials() {
+    return false;
+  }
+
+  @Override
   public TransportChannelProvider withCredentials(Credentials credentials) {
     return this;
   }

--- a/showcase/java/src/test/java/com/google/api/showcase/ShowcaseTransportChannelProvider.java
+++ b/showcase/java/src/test/java/com/google/api/showcase/ShowcaseTransportChannelProvider.java
@@ -21,6 +21,7 @@ import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannel;
 import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.auth.Credentials;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.ManagedChannelBuilder;
 import java.util.Map;
@@ -81,6 +82,11 @@ public class ShowcaseTransportChannelProvider implements TransportChannelProvide
 
   @Override
   public TransportChannelProvider withPoolSize(int size) {
+    return this;
+  }
+
+  @Override
+  public TransportChannelProvider withCredentials(Credentials credentials) {
     return this;
   }
 

--- a/src/main/java/com/google/api/codegen/config/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/MethodConfig.java
@@ -117,7 +117,7 @@ public abstract class MethodConfig {
 
   /** Returns true if this method has flattening configured. */
   public boolean isFlattening() {
-    return getFlatteningConfigs() != null;
+    return getFlatteningConfigs() != null && !getFlatteningConfigs().isEmpty();
   }
 
   /** Returns true if this method has batching configured. */

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.transformer.java;
 
 import com.google.api.codegen.config.ApiModel;
+import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.FlatteningConfigs;
 import com.google.api.codegen.config.GapicProductConfig;
@@ -55,6 +56,7 @@ import com.google.api.codegen.viewmodel.testing.MockServiceImplView;
 import com.google.api.codegen.viewmodel.testing.MockServiceView;
 import com.google.api.codegen.viewmodel.testing.SmokeTestClassView;
 import com.google.api.codegen.viewmodel.testing.TestCaseView;
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -293,20 +295,13 @@ public class JavaSurfaceTestTransformer<ApiModelT extends ApiModel>
                 methodContext, testNameTable, initCodeContext, ClientMethodType.CallableMethod));
       } else if (methodConfig.isFlattening()) {
         MethodContext defaultMethodContext = context.asRequestMethodContext(method);
-        ClientMethodType clientMethodType;
-        if (methodConfig.isPageStreaming()) {
-          clientMethodType = ClientMethodType.PagedFlattenedMethod;
-        } else if (defaultMethodContext.isLongRunningMethodContext()) {
-          clientMethodType = ClientMethodType.AsyncOperationFlattenedMethod;
-        } else {
-          clientMethodType = ClientMethodType.FlattenedMethod;
-        }
         for (FlatteningConfig flatteningGroup :
             FlatteningConfigs.getRepresentativeFlatteningConfigs(
                 FlatteningConfig.withRepeatedResourceInSampleOnly(
                     methodConfig.getFlatteningConfigs()))) {
           MethodContext methodContext =
               context.asFlattenedMethodContext(defaultMethodContext, flatteningGroup);
+          ClientMethodType clientMethodType = getClientMethodType(methodContext);
           InitCodeContext initCodeContext =
               initCodeTransformer.createRequestInitCodeContext(
                   methodContext,
@@ -319,10 +314,22 @@ public class JavaSurfaceTestTransformer<ApiModelT extends ApiModel>
                   methodContext, testNameTable, initCodeContext, clientMethodType));
         }
       } else {
-        // TODO: Add support of non-flattening method
-        // Github issue: https://github.com/googleapis/toolkit/issues/393
-        System.err.println(
-            "Non-flattening method test is not supported yet for " + method.getSimpleName());
+        MethodContext methodContext = context.asRequestMethodContext(method);
+        ClientMethodType clientMethodType = getClientMethodType(methodContext);
+        InitCodeContext initCodeContext =
+            initCodeTransformer.createRequestInitCodeContext(
+                methodContext,
+                new SymbolTable(),
+                ImmutableList.<FieldConfig>builder()
+                    .addAll(methodConfig.getRequiredFieldConfigs())
+                    .addAll(methodConfig.getOptionalFieldConfigs())
+                    .build(),
+                InitCodeOutputType.SingleObject,
+                valueGenerator);
+        TestCaseView testCaseView =
+            testCaseTransformer.createTestCaseView(
+                methodContext, testNameTable, initCodeContext, clientMethodType);
+        testCaseViews.add(testCaseView);
       }
     }
     return testCaseViews;
@@ -503,6 +510,28 @@ public class JavaSurfaceTestTransformer<ApiModelT extends ApiModel>
         default:
           throw new IllegalArgumentException("Invalid streaming type: " + streamingType);
       }
+    }
+  }
+
+  private ClientMethodType getClientMethodType(MethodContext context) {
+    MethodConfig config = context.getMethodConfig();
+
+    if (context.isFlattenedMethodContext()) {
+      if (context.getMethodConfig().isPageStreaming()) {
+        return ClientMethodType.PagedFlattenedMethod;
+      } else if (context.isLongRunningMethodContext()) {
+        return ClientMethodType.AsyncOperationFlattenedMethod;
+      } else {
+        return ClientMethodType.FlattenedMethod;
+      }
+    }
+
+    if (context.getMethodConfig().isPageStreaming()) {
+      return ClientMethodType.PagedRequestObjectMethod;
+    } else if (context.isLongRunningMethodContext()) {
+      return ClientMethodType.AsyncOperationFlattenedMethod;
+    } else {
+      return ClientMethodType.RequestObjectMethod;
     }
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
@@ -15,7 +15,6 @@
 package com.google.api.codegen.transformer.java;
 
 import com.google.api.codegen.config.ApiModel;
-import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.FlatteningConfigs;
 import com.google.api.codegen.config.GapicProductConfig;
@@ -56,7 +55,6 @@ import com.google.api.codegen.viewmodel.testing.MockServiceImplView;
 import com.google.api.codegen.viewmodel.testing.MockServiceView;
 import com.google.api.codegen.viewmodel.testing.SmokeTestClassView;
 import com.google.api.codegen.viewmodel.testing.TestCaseView;
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -320,10 +318,7 @@ public class JavaSurfaceTestTransformer<ApiModelT extends ApiModel>
             initCodeTransformer.createRequestInitCodeContext(
                 methodContext,
                 new SymbolTable(),
-                ImmutableList.<FieldConfig>builder()
-                    .addAll(methodConfig.getRequiredFieldConfigs())
-                    .addAll(methodConfig.getOptionalFieldConfigs())
-                    .build(),
+                methodConfig.getRequiredFieldConfigs(),
                 InitCodeOutputType.SingleObject,
                 valueGenerator);
         TestCaseView testCaseView =

--- a/src/main/resources/com/google/api/codegen/java/grpc_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/grpc_test.snip
@@ -72,6 +72,12 @@
           {@unaryTestCase(test)}
       @case "AsyncOperationFlattenedMethod"
           {@longRunningMethodTestCase(test)}
+      @case "RequestObjectMethod"
+          {@unaryTestCase(test)}
+      @case "PagedRequestObjectMethod"
+          {@unaryTestCase(test)}
+      @case "AsyncOperationRequestObjectMethod"
+          {@longRunningMethodTestCase(test)}
       @end
   @end
 @end
@@ -86,7 +92,18 @@
       {@initCode(test.testCaseInitCode)}
 
     @end
-    {@methodCall(test)}
+    @switch test.clientMethodType
+    @case "PagedFlattenedMethod"
+      {@pagedMethodCall(test)}
+    @case "PagedRequestObjectMethod"
+      {@pagedMethodCall(test)}
+    @case "FlattenedMethod"
+      {@methodCall(test)}
+    @case "RequestObjectMethod"
+      {@methodCall(test)}
+    @default
+      $unhandledCase: {@test.clientMethodType}
+    @end
 
     {@unarySuccessAsserts(test)}
   }
@@ -243,35 +260,32 @@
   {@test.mockServiceVarName}.addException(exception);
 @end
 
-@private methodCall(test)
-  @switch test.clientMethodType
-  @case "PagedFlattenedMethod"
-    {@test.responseTypeName} pagedListResponse = client.{@test.clientMethodName}(\
-      {@sampleMethodCallArgList(test.testCaseInitCode.fieldSettings)});
+@private pagedMethodCall(test)
+  {@test.responseTypeName} pagedListResponse = client.{@test.clientMethodName}(\
+    {@sampleMethodCallArgList(test.testCaseInitCode.fieldSettings)});
 
-    @join pageStreamingResponseView : test.pageStreamingResponseViews
-      List<{@pageStreamingResponseView.resourceTypeName}> {@pageStreamingResponseView.resourcesVarName} = Lists.newArrayList(pagedListResponse.{@pageStreamingResponseView.resourcesIterateMethod}());
-      Assert.assertEquals(1, {@pageStreamingResponseView.resourcesVarName}.size());
-      @if pageStreamingResponseView.hasExpectedValueTransformFunction
-        Assert.assertEquals({@pageStreamingResponseView.expectedValueTransformFunction}(\
-            expectedResponse.{@pageStreamingResponseView.resourcesFieldGetterName}().get(0)),
-            {@pageStreamingResponseView.resourcesVarName}.get(0));
-      @else
-        Assert.assertEquals(expectedResponse.{@pageStreamingResponseView.resourcesFieldGetterName}().get(0), {@pageStreamingResponseView.resourcesVarName}.get(0));
-      @end
-    @end
-  @case "FlattenedMethod"
-    @if test.hasReturnValue
-      {@test.responseTypeName} actualResponse =
-          client.{@test.clientMethodName}(\
-          {@sampleMethodCallArgList(test.testCaseInitCode.fieldSettings)});
-      Assert.assertEquals(expectedResponse, actualResponse);
+  @join pageStreamingResponseView : test.pageStreamingResponseViews
+    List<{@pageStreamingResponseView.resourceTypeName}> {@pageStreamingResponseView.resourcesVarName} = Lists.newArrayList(pagedListResponse.{@pageStreamingResponseView.resourcesIterateMethod}());
+    Assert.assertEquals(1, {@pageStreamingResponseView.resourcesVarName}.size());
+    @if pageStreamingResponseView.hasExpectedValueTransformFunction
+      Assert.assertEquals({@pageStreamingResponseView.expectedValueTransformFunction}(\
+          expectedResponse.{@pageStreamingResponseView.resourcesFieldGetterName}().get(0)),
+          {@pageStreamingResponseView.resourcesVarName}.get(0));
     @else
-      client.{@test.clientMethodName}(\
-            {@sampleMethodCallArgList(test.testCaseInitCode.fieldSettings)});
+      Assert.assertEquals(expectedResponse.{@pageStreamingResponseView.resourcesFieldGetterName}().get(0), {@pageStreamingResponseView.resourcesVarName}.get(0));
     @end
-  @default
-    $unhandledCase: {@test.clientMethodType}$
+  @end
+@end
+
+@private methodCall(test)
+  @if test.hasReturnValue
+    {@test.responseTypeName} actualResponse =
+        client.{@test.clientMethodName}(\
+        {@sampleMethodCallArgList(test.testCaseInitCode.fieldSettings)});
+    Assert.assertEquals(expectedResponse, actualResponse);
+  @else
+    client.{@test.clientMethodName}(\
+          {@sampleMethodCallArgList(test.testCaseInitCode.fieldSettings)});
   @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
+++ b/src/main/resources/com/google/api/codegen/packaging/dependencies.yaml
@@ -32,7 +32,7 @@ grpc_version:
   ruby:
     lower: '1.0'
   java:
-    lower: '1.10.1'
+    lower: '1.27.0'
 
 gax_version:
   python:
@@ -43,13 +43,13 @@ gax_version:
   ruby:
     lower: '1.3'
   java:
-    lower: '1.43.0'
+    lower: '1.53.0'
 
 gax_grpc_version:
   csharp:
     lower: '2.3.0'
   java:
-    lower: '1.43.0'
+    lower: '1.53.0'
 
 gax_http_version:
   java:

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -16011,6 +16011,177 @@ public class LibraryClientTest {
 
   @Test
   @SuppressWarnings("all")
+  public void moveBooksTest() {
+    boolean success = false;
+    MoveBooksResponse expectedResponse = MoveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String destination = "destination-1429847026";
+    List<String> publishers = new ArrayList<>();
+    String project = "project-309310695";
+    MoveBooksRequest request = MoveBooksRequest.newBuilder()
+      .setSource(source)
+      .setDestination(destination)
+      .addAllPublishers(publishers)
+      .setProject(project)
+      .build();
+
+    MoveBooksResponse actualResponse =
+        client.moveBooks(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MoveBooksRequest actualRequest = (MoveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(destination, actualRequest.getDestination());
+    Assert.assertEquals(publishers, actualRequest.getPublishersList());
+    Assert.assertEquals(project, actualRequest.getProject());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void moveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String destination = "destination-1429847026";
+      List<String> publishers = new ArrayList<>();
+      String project = "project-309310695";
+      MoveBooksRequest request = MoveBooksRequest.newBuilder()
+        .setSource(source)
+        .setDestination(destination)
+        .addAllPublishers(publishers)
+        .setProject(project)
+        .build();
+
+      client.moveBooks(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void archiveBooksTest() {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String archive = "archive-748101438";
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
+      .setSource(source)
+      .setArchive(archive)
+      .build();
+
+    ArchiveBooksResponse actualResponse =
+        client.archiveBooks(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(archive, actualRequest.getArchive());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void archiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String archive = "archive-748101438";
+      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
+        .setSource(source)
+        .setArchive(archive)
+        .build();
+
+      client.archiveBooks(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void longRunningArchiveBooksTest() {
+    String name = "name3373707";
+    boolean done = true;
+    Operation expectedResponse = Operation.newBuilder()
+      .setName(name)
+      .setDone(done)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String archive = "archive-748101438";
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
+      .setSource(source)
+      .setArchive(archive)
+      .build();
+
+    Operation actualResponse =
+        client.longRunningArchiveBooks(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(archive, actualRequest.getArchive());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void longRunningArchiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String archive = "archive-748101438";
+      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
+        .setSource(source)
+        .setArchive(archive)
+        .build();
+
+      client.longRunningArchiveBooks(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
   public void streamingArchiveBooksTest() throws Exception {
     boolean success = false;
     ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
@@ -16057,6 +16228,60 @@ public class LibraryClientTest {
       Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
       InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
       Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void privateListShelvesTest() {
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    Book expectedResponse = Book.newBuilder()
+      .setName(name.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String pageToken = "pageToken1630607433";
+    ListShelvesRequest request = ListShelvesRequest.newBuilder()
+      .setPageToken(pageToken)
+      .build();
+
+    Book actualResponse =
+        client.privateListShelves(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListShelvesRequest actualRequest = (ListShelvesRequest)actualRequests.get(0);
+
+    Assert.assertEquals(pageToken, actualRequest.getPageToken());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void privateListShelvesExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String pageToken = "pageToken1630607433";
+      ListShelvesRequest request = ListShelvesRequest.newBuilder()
+        .setPageToken(pageToken)
+        .build();
+
+      client.privateListShelves(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
     }
   }
 
@@ -17093,6 +17318,9 @@ import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
+import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
+import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.SubMessage;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -17146,6 +17374,64 @@ public class MyProtoClientTest {
   @After
   public void tearDown() throws Exception {
     client.close();
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void myMethodTest() {
+    String myfield2 = "myfield2121360129";
+    MethodResponse expectedResponse = MethodResponse.newBuilder()
+      .setMyfield(myfield2)
+      .build();
+    mockMyProto.addResponse(expectedResponse);
+
+    List<SubMessage> mylist = new ArrayList<>();
+    SubMessage myfield = SubMessage.newBuilder().build();
+    SubMessage secondfield = SubMessage.newBuilder().build();
+    MethodRequest request = MethodRequest.newBuilder()
+      .addAllMylist(mylist)
+      .setMyfield(myfield)
+      .setSecondfield(secondfield)
+      .build();
+
+    MethodResponse actualResponse =
+        client.myMethod(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockMyProto.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
+
+    Assert.assertEquals(mylist, actualRequest.getMylistList());
+    Assert.assertEquals(myfield, actualRequest.getMyfield());
+    Assert.assertEquals(secondfield, actualRequest.getSecondfield());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void myMethodExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockMyProto.addException(exception);
+
+    try {
+      List<SubMessage> mylist = new ArrayList<>();
+      SubMessage myfield = SubMessage.newBuilder().build();
+      SubMessage secondfield = SubMessage.newBuilder().build();
+      MethodRequest request = MethodRequest.newBuilder()
+        .addAllMylist(mylist)
+        .setMyfield(myfield)
+        .setSecondfield(secondfield)
+        .build();
+
+      client.myMethod(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
   }
 
 }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -16018,16 +16018,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String source = "source-896505829";
-    String destination = "destination-1429847026";
-    List<String> publishers = new ArrayList<>();
-    String project = "project-309310695";
-    MoveBooksRequest request = MoveBooksRequest.newBuilder()
-      .setSource(source)
-      .setDestination(destination)
-      .addAllPublishers(publishers)
-      .setProject(project)
-      .build();
+    MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
 
     MoveBooksResponse actualResponse =
         client.moveBooks(request);
@@ -16037,10 +16028,6 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     MoveBooksRequest actualRequest = (MoveBooksRequest)actualRequests.get(0);
 
-    Assert.assertEquals(source, actualRequest.getSource());
-    Assert.assertEquals(destination, actualRequest.getDestination());
-    Assert.assertEquals(publishers, actualRequest.getPublishersList());
-    Assert.assertEquals(project, actualRequest.getProject());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -16054,16 +16041,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String source = "source-896505829";
-      String destination = "destination-1429847026";
-      List<String> publishers = new ArrayList<>();
-      String project = "project-309310695";
-      MoveBooksRequest request = MoveBooksRequest.newBuilder()
-        .setSource(source)
-        .setDestination(destination)
-        .addAllPublishers(publishers)
-        .setProject(project)
-        .build();
+      MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
 
       client.moveBooks(request);
       Assert.fail("No exception raised");
@@ -16081,12 +16059,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String source = "source-896505829";
-    String archive = "archive-748101438";
-    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
-      .setSource(source)
-      .setArchive(archive)
-      .build();
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
 
     ArchiveBooksResponse actualResponse =
         client.archiveBooks(request);
@@ -16096,8 +16069,6 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
 
-    Assert.assertEquals(source, actualRequest.getSource());
-    Assert.assertEquals(archive, actualRequest.getArchive());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -16111,12 +16082,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String source = "source-896505829";
-      String archive = "archive-748101438";
-      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
-        .setSource(source)
-        .setArchive(archive)
-        .build();
+      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
 
       client.archiveBooks(request);
       Assert.fail("No exception raised");
@@ -16136,12 +16102,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String source = "source-896505829";
-    String archive = "archive-748101438";
-    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
-      .setSource(source)
-      .setArchive(archive)
-      .build();
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
 
     Operation actualResponse =
         client.longRunningArchiveBooks(request);
@@ -16151,8 +16112,6 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
 
-    Assert.assertEquals(source, actualRequest.getSource());
-    Assert.assertEquals(archive, actualRequest.getArchive());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -16166,12 +16125,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String source = "source-896505829";
-      String archive = "archive-748101438";
-      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
-        .setSource(source)
-        .setArchive(archive)
-        .build();
+      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
 
       client.longRunningArchiveBooks(request);
       Assert.fail("No exception raised");
@@ -16246,10 +16200,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String pageToken = "pageToken1630607433";
-    ListShelvesRequest request = ListShelvesRequest.newBuilder()
-      .setPageToken(pageToken)
-      .build();
+    ListShelvesRequest request = ListShelvesRequest.newBuilder().build();
 
     Book actualResponse =
         client.privateListShelves(request);
@@ -16259,7 +16210,6 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     ListShelvesRequest actualRequest = (ListShelvesRequest)actualRequests.get(0);
 
-    Assert.assertEquals(pageToken, actualRequest.getPageToken());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -16273,10 +16223,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String pageToken = "pageToken1630607433";
-      ListShelvesRequest request = ListShelvesRequest.newBuilder()
-        .setPageToken(pageToken)
-        .build();
+      ListShelvesRequest request = ListShelvesRequest.newBuilder().build();
 
       client.privateListShelves(request);
       Assert.fail("No exception raised");
@@ -17320,7 +17267,6 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
-import com.google.protos.google.example.library.v1.AnotherService.SubMessage;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -17379,20 +17325,13 @@ public class MyProtoClientTest {
   @Test
   @SuppressWarnings("all")
   public void myMethodTest() {
-    String myfield2 = "myfield2121360129";
+    String myfield = "myfield1515208398";
     MethodResponse expectedResponse = MethodResponse.newBuilder()
-      .setMyfield(myfield2)
+      .setMyfield(myfield)
       .build();
     mockMyProto.addResponse(expectedResponse);
 
-    List<SubMessage> mylist = new ArrayList<>();
-    SubMessage myfield = SubMessage.newBuilder().build();
-    SubMessage secondfield = SubMessage.newBuilder().build();
-    MethodRequest request = MethodRequest.newBuilder()
-      .addAllMylist(mylist)
-      .setMyfield(myfield)
-      .setSecondfield(secondfield)
-      .build();
+    MethodRequest request = MethodRequest.newBuilder().build();
 
     MethodResponse actualResponse =
         client.myMethod(request);
@@ -17402,9 +17341,6 @@ public class MyProtoClientTest {
     Assert.assertEquals(1, actualRequests.size());
     MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
 
-    Assert.assertEquals(mylist, actualRequest.getMylistList());
-    Assert.assertEquals(myfield, actualRequest.getMyfield());
-    Assert.assertEquals(secondfield, actualRequest.getSecondfield());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -17418,14 +17354,7 @@ public class MyProtoClientTest {
     mockMyProto.addException(exception);
 
     try {
-      List<SubMessage> mylist = new ArrayList<>();
-      SubMessage myfield = SubMessage.newBuilder().build();
-      SubMessage secondfield = SubMessage.newBuilder().build();
-      MethodRequest request = MethodRequest.newBuilder()
-        .addAllMylist(mylist)
-        .setMyfield(myfield)
-        .setSecondfield(secondfield)
-        .build();
+      MethodRequest request = MethodRequest.newBuilder().build();
 
       client.myMethod(request);
       Assert.fail("No exception raised");

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
@@ -2141,7 +2141,9 @@ import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.collect.Lists;
+import com.google.example.v1.IncrementRequest;
 import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.Empty;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -2193,6 +2195,38 @@ public class IncrementerServiceClientTest {
   @After
   public void tearDown() throws Exception {
     client.close();
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void incrementTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockIncrementerService.addResponse(expectedResponse);
+
+    IncrementRequest request = IncrementRequest.newBuilder().build();
+
+    client.increment(request);
+
+    List<AbstractMessage> actualRequests = mockIncrementerService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    IncrementRequest actualRequest = (IncrementRequest)actualRequests.get(0);
+
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void incrementExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockIncrementerService.addException(exception);
+
+    try {
+      IncrementRequest request = IncrementRequest.newBuilder().build();
+
+      client.increment(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
   }
 
 }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -1220,7 +1220,9 @@ import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.collect.Lists;
+import com.google.example.noPathTemplates.v1.IncrementRequest;
 import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.Empty;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -1270,6 +1272,38 @@ public class NoTemplatesApiServiceClientTest {
   @After
   public void tearDown() throws Exception {
     client.close();
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void incrementTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockNoTemplatesAPIService.addResponse(expectedResponse);
+
+    IncrementRequest request = IncrementRequest.newBuilder().build();
+
+    client.increment(request);
+
+    List<AbstractMessage> actualRequests = mockNoTemplatesAPIService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    IncrementRequest actualRequest = (IncrementRequest)actualRequests.get(0);
+
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void incrementExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockNoTemplatesAPIService.addException(exception);
+
+    try {
+      IncrementRequest request = IncrementRequest.newBuilder().build();
+
+      client.increment(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
   }
 
 }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -13401,16 +13401,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String source = "source-896505829";
-    String destination = "destination-1429847026";
-    List<String> publishers = new ArrayList<>();
-    String project = "project-309310695";
-    MoveBooksRequest request = MoveBooksRequest.newBuilder()
-      .setSource(source)
-      .setDestination(destination)
-      .addAllPublishers(publishers)
-      .setProject(project)
-      .build();
+    MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
 
     MoveBooksResponse actualResponse =
         client.moveBooks(request);
@@ -13420,10 +13411,6 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     MoveBooksRequest actualRequest = (MoveBooksRequest)actualRequests.get(0);
 
-    Assert.assertEquals(source, actualRequest.getSource());
-    Assert.assertEquals(destination, actualRequest.getDestination());
-    Assert.assertEquals(publishers, actualRequest.getPublishersList());
-    Assert.assertEquals(project, actualRequest.getProject());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -13437,16 +13424,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String source = "source-896505829";
-      String destination = "destination-1429847026";
-      List<String> publishers = new ArrayList<>();
-      String project = "project-309310695";
-      MoveBooksRequest request = MoveBooksRequest.newBuilder()
-        .setSource(source)
-        .setDestination(destination)
-        .addAllPublishers(publishers)
-        .setProject(project)
-        .build();
+      MoveBooksRequest request = MoveBooksRequest.newBuilder().build();
 
       client.moveBooks(request);
       Assert.fail("No exception raised");
@@ -13464,12 +13442,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String source = "source-896505829";
-    String archive = "archive-748101438";
-    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
-      .setSource(source)
-      .setArchive(archive)
-      .build();
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
 
     ArchiveBooksResponse actualResponse =
         client.archiveBooks(request);
@@ -13479,8 +13452,6 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
 
-    Assert.assertEquals(source, actualRequest.getSource());
-    Assert.assertEquals(archive, actualRequest.getArchive());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -13494,12 +13465,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String source = "source-896505829";
-      String archive = "archive-748101438";
-      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
-        .setSource(source)
-        .setArchive(archive)
-        .build();
+      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
 
       client.archiveBooks(request);
       Assert.fail("No exception raised");
@@ -13519,12 +13485,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String source = "source-896505829";
-    String archive = "archive-748101438";
-    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
-      .setSource(source)
-      .setArchive(archive)
-      .build();
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
 
     Operation actualResponse =
         client.longRunningArchiveBooks(request);
@@ -13534,8 +13495,6 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
 
-    Assert.assertEquals(source, actualRequest.getSource());
-    Assert.assertEquals(archive, actualRequest.getArchive());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -13549,12 +13508,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String source = "source-896505829";
-      String archive = "archive-748101438";
-      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
-        .setSource(source)
-        .setArchive(archive)
-        .build();
+      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder().build();
 
       client.longRunningArchiveBooks(request);
       Assert.fail("No exception raised");
@@ -13629,10 +13583,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String pageToken = "pageToken1630607433";
-    ListShelvesRequest request = ListShelvesRequest.newBuilder()
-      .setPageToken(pageToken)
-      .build();
+    ListShelvesRequest request = ListShelvesRequest.newBuilder().build();
 
     Book actualResponse =
         client.privateListShelves(request);
@@ -13642,7 +13593,6 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     ListShelvesRequest actualRequest = (ListShelvesRequest)actualRequests.get(0);
 
-    Assert.assertEquals(pageToken, actualRequest.getPageToken());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -13656,10 +13606,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String pageToken = "pageToken1630607433";
-      ListShelvesRequest request = ListShelvesRequest.newBuilder()
-        .setPageToken(pageToken)
-        .build();
+      ListShelvesRequest request = ListShelvesRequest.newBuilder().build();
 
       client.privateListShelves(request);
       Assert.fail("No exception raised");
@@ -14703,7 +14650,6 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
-import com.google.protos.google.example.library.v1.AnotherService.SubMessage;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -14762,20 +14708,13 @@ public class MyProtoClientTest {
   @Test
   @SuppressWarnings("all")
   public void myMethodTest() {
-    String myfield2 = "myfield2121360129";
+    String myfield = "myfield1515208398";
     MethodResponse expectedResponse = MethodResponse.newBuilder()
-      .setMyfield(myfield2)
+      .setMyfield(myfield)
       .build();
     mockMyProto.addResponse(expectedResponse);
 
-    List<SubMessage> mylist = new ArrayList<>();
-    SubMessage myfield = SubMessage.newBuilder().build();
-    SubMessage secondfield = SubMessage.newBuilder().build();
-    MethodRequest request = MethodRequest.newBuilder()
-      .addAllMylist(mylist)
-      .setMyfield(myfield)
-      .setSecondfield(secondfield)
-      .build();
+    MethodRequest request = MethodRequest.newBuilder().build();
 
     MethodResponse actualResponse =
         client.myMethod(request);
@@ -14785,9 +14724,6 @@ public class MyProtoClientTest {
     Assert.assertEquals(1, actualRequests.size());
     MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
 
-    Assert.assertEquals(mylist, actualRequest.getMylistList());
-    Assert.assertEquals(myfield, actualRequest.getMyfield());
-    Assert.assertEquals(secondfield, actualRequest.getSecondfield());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -14801,14 +14737,7 @@ public class MyProtoClientTest {
     mockMyProto.addException(exception);
 
     try {
-      List<SubMessage> mylist = new ArrayList<>();
-      SubMessage myfield = SubMessage.newBuilder().build();
-      SubMessage secondfield = SubMessage.newBuilder().build();
-      MethodRequest request = MethodRequest.newBuilder()
-        .addAllMylist(mylist)
-        .setMyfield(myfield)
-        .setSecondfield(secondfield)
-        .build();
+      MethodRequest request = MethodRequest.newBuilder().build();
 
       client.myMethod(request);
       Assert.fail("No exception raised");

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -13394,6 +13394,177 @@ public class LibraryClientTest {
 
   @Test
   @SuppressWarnings("all")
+  public void moveBooksTest() {
+    boolean success = false;
+    MoveBooksResponse expectedResponse = MoveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String destination = "destination-1429847026";
+    List<String> publishers = new ArrayList<>();
+    String project = "project-309310695";
+    MoveBooksRequest request = MoveBooksRequest.newBuilder()
+      .setSource(source)
+      .setDestination(destination)
+      .addAllPublishers(publishers)
+      .setProject(project)
+      .build();
+
+    MoveBooksResponse actualResponse =
+        client.moveBooks(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MoveBooksRequest actualRequest = (MoveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(destination, actualRequest.getDestination());
+    Assert.assertEquals(publishers, actualRequest.getPublishersList());
+    Assert.assertEquals(project, actualRequest.getProject());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void moveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String destination = "destination-1429847026";
+      List<String> publishers = new ArrayList<>();
+      String project = "project-309310695";
+      MoveBooksRequest request = MoveBooksRequest.newBuilder()
+        .setSource(source)
+        .setDestination(destination)
+        .addAllPublishers(publishers)
+        .setProject(project)
+        .build();
+
+      client.moveBooks(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void archiveBooksTest() {
+    boolean success = false;
+    ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
+      .setSuccess(success)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String archive = "archive-748101438";
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
+      .setSource(source)
+      .setArchive(archive)
+      .build();
+
+    ArchiveBooksResponse actualResponse =
+        client.archiveBooks(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(archive, actualRequest.getArchive());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void archiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String archive = "archive-748101438";
+      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
+        .setSource(source)
+        .setArchive(archive)
+        .build();
+
+      client.archiveBooks(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void longRunningArchiveBooksTest() {
+    String name = "name3373707";
+    boolean done = true;
+    Operation expectedResponse = Operation.newBuilder()
+      .setName(name)
+      .setDone(done)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String source = "source-896505829";
+    String archive = "archive-748101438";
+    ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
+      .setSource(source)
+      .setArchive(archive)
+      .build();
+
+    Operation actualResponse =
+        client.longRunningArchiveBooks(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ArchiveBooksRequest actualRequest = (ArchiveBooksRequest)actualRequests.get(0);
+
+    Assert.assertEquals(source, actualRequest.getSource());
+    Assert.assertEquals(archive, actualRequest.getArchive());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void longRunningArchiveBooksExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String source = "source-896505829";
+      String archive = "archive-748101438";
+      ArchiveBooksRequest request = ArchiveBooksRequest.newBuilder()
+        .setSource(source)
+        .setArchive(archive)
+        .build();
+
+      client.longRunningArchiveBooks(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
   public void streamingArchiveBooksTest() throws Exception {
     boolean success = false;
     ArchiveBooksResponse expectedResponse = ArchiveBooksResponse.newBuilder()
@@ -13440,6 +13611,60 @@ public class LibraryClientTest {
       Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
       InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
       Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void privateListShelvesTest() {
+    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    Book expectedResponse = Book.newBuilder()
+      .setName(name.toString())
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    String pageToken = "pageToken1630607433";
+    ListShelvesRequest request = ListShelvesRequest.newBuilder()
+      .setPageToken(pageToken)
+      .build();
+
+    Book actualResponse =
+        client.privateListShelves(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListShelvesRequest actualRequest = (ListShelvesRequest)actualRequests.get(0);
+
+    Assert.assertEquals(pageToken, actualRequest.getPageToken());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void privateListShelvesExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      String pageToken = "pageToken1630607433";
+      ListShelvesRequest request = ListShelvesRequest.newBuilder()
+        .setPageToken(pageToken)
+        .build();
+
+      client.privateListShelves(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
     }
   }
 
@@ -14476,6 +14701,9 @@ import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
+import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
+import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.SubMessage;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -14529,6 +14757,64 @@ public class MyProtoClientTest {
   @After
   public void tearDown() throws Exception {
     client.close();
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void myMethodTest() {
+    String myfield2 = "myfield2121360129";
+    MethodResponse expectedResponse = MethodResponse.newBuilder()
+      .setMyfield(myfield2)
+      .build();
+    mockMyProto.addResponse(expectedResponse);
+
+    List<SubMessage> mylist = new ArrayList<>();
+    SubMessage myfield = SubMessage.newBuilder().build();
+    SubMessage secondfield = SubMessage.newBuilder().build();
+    MethodRequest request = MethodRequest.newBuilder()
+      .addAllMylist(mylist)
+      .setMyfield(myfield)
+      .setSecondfield(secondfield)
+      .build();
+
+    MethodResponse actualResponse =
+        client.myMethod(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockMyProto.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
+
+    Assert.assertEquals(mylist, actualRequest.getMylistList());
+    Assert.assertEquals(myfield, actualRequest.getMyfield());
+    Assert.assertEquals(secondfield, actualRequest.getSecondfield());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void myMethodExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockMyProto.addException(exception);
+
+    try {
+      List<SubMessage> mylist = new ArrayList<>();
+      SubMessage myfield = SubMessage.newBuilder().build();
+      SubMessage secondfield = SubMessage.newBuilder().build();
+      MethodRequest request = MethodRequest.newBuilder()
+        .addAllMylist(mylist)
+        .setMyfield(myfield)
+        .setSecondfield(secondfield)
+        .build();
+
+      client.myMethod(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
   }
 
 }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -18090,7 +18090,6 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
-import com.google.protos.google.example.library.v1.AnotherService.SubMessage;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -18149,20 +18148,13 @@ public class MyProtoClientTest {
   @Test
   @SuppressWarnings("all")
   public void myMethodTest() {
-    String myfield2 = "myfield2121360129";
+    String myfield = "myfield1515208398";
     MethodResponse expectedResponse = MethodResponse.newBuilder()
-      .setMyfield(myfield2)
+      .setMyfield(myfield)
       .build();
     mockMyProto.addResponse(expectedResponse);
 
-    List<SubMessage> mylist = new ArrayList<>();
-    SubMessage myfield = SubMessage.newBuilder().build();
-    SubMessage secondfield = SubMessage.newBuilder().build();
-    MethodRequest request = MethodRequest.newBuilder()
-      .addAllMylist(mylist)
-      .setMyfield(myfield)
-      .setSecondfield(secondfield)
-      .build();
+    MethodRequest request = MethodRequest.newBuilder().build();
 
     MethodResponse actualResponse =
         client.myMethod(request);
@@ -18172,9 +18164,6 @@ public class MyProtoClientTest {
     Assert.assertEquals(1, actualRequests.size());
     MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
 
-    Assert.assertEquals(mylist, actualRequest.getMylistList());
-    Assert.assertEquals(myfield, actualRequest.getMyfield());
-    Assert.assertEquals(secondfield, actualRequest.getSecondfield());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -18188,14 +18177,7 @@ public class MyProtoClientTest {
     mockMyProto.addException(exception);
 
     try {
-      List<SubMessage> mylist = new ArrayList<>();
-      SubMessage myfield = SubMessage.newBuilder().build();
-      SubMessage secondfield = SubMessage.newBuilder().build();
-      MethodRequest request = MethodRequest.newBuilder()
-        .addAllMylist(mylist)
-        .setMyfield(myfield)
-        .setSecondfield(secondfield)
-        .build();
+      MethodRequest request = MethodRequest.newBuilder().build();
 
       client.myMethod(request);
       Assert.fail("No exception raised");

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -14853,6 +14853,8 @@ import com.google.protobuf.Timestamp;
 import com.google.protobuf.UInt32Value;
 import com.google.protobuf.UInt64Value;
 import com.google.protobuf.Value;
+import com.google.tagger.v1.TaggerProto.AddLabelRequest;
+import com.google.tagger.v1.TaggerProto.AddLabelResponse;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -16212,6 +16214,56 @@ public class LibraryClientTest {
       List<String> formattedShelves = new ArrayList<>();
 
       client.findRelatedBooks(formattedNames, formattedShelves);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addLabelTest() {
+    AddLabelResponse expectedResponse = AddLabelResponse.newBuilder().build();
+    mockLabeler.addResponse(expectedResponse);
+
+    BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+    String label = "label102727412";
+    AddLabelRequest request = AddLabelRequest.newBuilder()
+      .setResource(resource.toString())
+      .setLabel(label)
+      .build();
+
+    AddLabelResponse actualResponse =
+        client.addLabel(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLabeler.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    AddLabelRequest actualRequest = (AddLabelRequest)actualRequests.get(0);
+
+    Assert.assertEquals(resource, BookNames.parse(actualRequest.getResource()));
+    Assert.assertEquals(label, actualRequest.getLabel());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addLabelExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLabeler.addException(exception);
+
+    try {
+      BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+      String label = "label102727412";
+      AddLabelRequest request = AddLabelRequest.newBuilder()
+        .setResource(resource.toString())
+        .setLabel(label)
+        .build();
+
+      client.addLabel(request);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception
@@ -18036,6 +18088,9 @@ import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
+import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
+import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.SubMessage;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -18089,6 +18144,64 @@ public class MyProtoClientTest {
   @After
   public void tearDown() throws Exception {
     client.close();
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void myMethodTest() {
+    String myfield2 = "myfield2121360129";
+    MethodResponse expectedResponse = MethodResponse.newBuilder()
+      .setMyfield(myfield2)
+      .build();
+    mockMyProto.addResponse(expectedResponse);
+
+    List<SubMessage> mylist = new ArrayList<>();
+    SubMessage myfield = SubMessage.newBuilder().build();
+    SubMessage secondfield = SubMessage.newBuilder().build();
+    MethodRequest request = MethodRequest.newBuilder()
+      .addAllMylist(mylist)
+      .setMyfield(myfield)
+      .setSecondfield(secondfield)
+      .build();
+
+    MethodResponse actualResponse =
+        client.myMethod(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockMyProto.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
+
+    Assert.assertEquals(mylist, actualRequest.getMylistList());
+    Assert.assertEquals(myfield, actualRequest.getMyfield());
+    Assert.assertEquals(secondfield, actualRequest.getSecondfield());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void myMethodExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockMyProto.addException(exception);
+
+    try {
+      List<SubMessage> mylist = new ArrayList<>();
+      SubMessage myfield = SubMessage.newBuilder().build();
+      SubMessage secondfield = SubMessage.newBuilder().build();
+      MethodRequest request = MethodRequest.newBuilder()
+        .addAllMylist(mylist)
+        .setMyfield(myfield)
+        .setSecondfield(secondfield)
+        .build();
+
+      client.myMethod(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
   }
 
 }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -12909,6 +12909,9 @@ import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
+import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
+import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.SubMessage;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -12960,6 +12963,64 @@ public class MyProtoClientTest {
   @After
   public void tearDown() throws Exception {
     client.close();
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void myMethodTest() {
+    String myfield2 = "myfield2121360129";
+    MethodResponse expectedResponse = MethodResponse.newBuilder()
+      .setMyfield(myfield2)
+      .build();
+    mockMyProto.addResponse(expectedResponse);
+
+    List<SubMessage> mylist = new ArrayList<>();
+    SubMessage myfield = SubMessage.newBuilder().build();
+    SubMessage secondfield = SubMessage.newBuilder().build();
+    MethodRequest request = MethodRequest.newBuilder()
+      .addAllMylist(mylist)
+      .setMyfield(myfield)
+      .setSecondfield(secondfield)
+      .build();
+
+    MethodResponse actualResponse =
+        client.myMethod(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockMyProto.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
+
+    Assert.assertEquals(mylist, actualRequest.getMylistList());
+    Assert.assertEquals(myfield, actualRequest.getMyfield());
+    Assert.assertEquals(secondfield, actualRequest.getSecondfield());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void myMethodExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockMyProto.addException(exception);
+
+    try {
+      List<SubMessage> mylist = new ArrayList<>();
+      SubMessage myfield = SubMessage.newBuilder().build();
+      SubMessage secondfield = SubMessage.newBuilder().build();
+      MethodRequest request = MethodRequest.newBuilder()
+        .addAllMylist(mylist)
+        .setMyfield(myfield)
+        .setSecondfield(secondfield)
+        .build();
+
+      client.myMethod(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
   }
 
 }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -12911,7 +12911,6 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
-import com.google.protos.google.example.library.v1.AnotherService.SubMessage;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -12968,20 +12967,13 @@ public class MyProtoClientTest {
   @Test
   @SuppressWarnings("all")
   public void myMethodTest() {
-    String myfield2 = "myfield2121360129";
+    String myfield = "myfield1515208398";
     MethodResponse expectedResponse = MethodResponse.newBuilder()
-      .setMyfield(myfield2)
+      .setMyfield(myfield)
       .build();
     mockMyProto.addResponse(expectedResponse);
 
-    List<SubMessage> mylist = new ArrayList<>();
-    SubMessage myfield = SubMessage.newBuilder().build();
-    SubMessage secondfield = SubMessage.newBuilder().build();
-    MethodRequest request = MethodRequest.newBuilder()
-      .addAllMylist(mylist)
-      .setMyfield(myfield)
-      .setSecondfield(secondfield)
-      .build();
+    MethodRequest request = MethodRequest.newBuilder().build();
 
     MethodResponse actualResponse =
         client.myMethod(request);
@@ -12991,9 +12983,6 @@ public class MyProtoClientTest {
     Assert.assertEquals(1, actualRequests.size());
     MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
 
-    Assert.assertEquals(mylist, actualRequest.getMylistList());
-    Assert.assertEquals(myfield, actualRequest.getMyfield());
-    Assert.assertEquals(secondfield, actualRequest.getSecondfield());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -13007,14 +12996,7 @@ public class MyProtoClientTest {
     mockMyProto.addException(exception);
 
     try {
-      List<SubMessage> mylist = new ArrayList<>();
-      SubMessage myfield = SubMessage.newBuilder().build();
-      SubMessage secondfield = SubMessage.newBuilder().build();
-      MethodRequest request = MethodRequest.newBuilder()
-        .addAllMylist(mylist)
-        .setMyfield(myfield)
-        .setSecondfield(secondfield)
-        .build();
+      MethodRequest request = MethodRequest.newBuilder().build();
 
       client.myMethod(request);
       Assert.fail("No exception raised");

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -18094,7 +18094,6 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
-import com.google.protos.google.example.library.v1.AnotherService.SubMessage;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -18153,20 +18152,13 @@ public class MyProtoClientTest {
   @Test
   @SuppressWarnings("all")
   public void myMethodTest() {
-    String myfield2 = "myfield2121360129";
+    String myfield = "myfield1515208398";
     MethodResponse expectedResponse = MethodResponse.newBuilder()
-      .setMyfield(myfield2)
+      .setMyfield(myfield)
       .build();
     mockMyProto.addResponse(expectedResponse);
 
-    List<SubMessage> mylist = new ArrayList<>();
-    SubMessage myfield = SubMessage.newBuilder().build();
-    SubMessage secondfield = SubMessage.newBuilder().build();
-    MethodRequest request = MethodRequest.newBuilder()
-      .addAllMylist(mylist)
-      .setMyfield(myfield)
-      .setSecondfield(secondfield)
-      .build();
+    MethodRequest request = MethodRequest.newBuilder().build();
 
     MethodResponse actualResponse =
         client.myMethod(request);
@@ -18176,9 +18168,6 @@ public class MyProtoClientTest {
     Assert.assertEquals(1, actualRequests.size());
     MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
 
-    Assert.assertEquals(mylist, actualRequest.getMylistList());
-    Assert.assertEquals(myfield, actualRequest.getMyfield());
-    Assert.assertEquals(secondfield, actualRequest.getSecondfield());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -18192,14 +18181,7 @@ public class MyProtoClientTest {
     mockMyProto.addException(exception);
 
     try {
-      List<SubMessage> mylist = new ArrayList<>();
-      SubMessage myfield = SubMessage.newBuilder().build();
-      SubMessage secondfield = SubMessage.newBuilder().build();
-      MethodRequest request = MethodRequest.newBuilder()
-        .addAllMylist(mylist)
-        .setMyfield(myfield)
-        .setSecondfield(secondfield)
-        .build();
+      MethodRequest request = MethodRequest.newBuilder().build();
 
       client.myMethod(request);
       Assert.fail("No exception raised");

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -14857,6 +14857,8 @@ import com.google.protobuf.Timestamp;
 import com.google.protobuf.UInt32Value;
 import com.google.protobuf.UInt64Value;
 import com.google.protobuf.Value;
+import com.google.tagger.v1.TaggerProto.AddLabelRequest;
+import com.google.tagger.v1.TaggerProto.AddLabelResponse;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -16216,6 +16218,56 @@ public class LibraryClientTest {
       List<String> formattedShelves = new ArrayList<>();
 
       client.findRelatedBooks(formattedNames, formattedShelves);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addLabelTest() {
+    AddLabelResponse expectedResponse = AddLabelResponse.newBuilder().build();
+    mockLabeler.addResponse(expectedResponse);
+
+    BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+    String label = "label102727412";
+    AddLabelRequest request = AddLabelRequest.newBuilder()
+      .setResource(resource.toString())
+      .setLabel(label)
+      .build();
+
+    AddLabelResponse actualResponse =
+        client.addLabel(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLabeler.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    AddLabelRequest actualRequest = (AddLabelRequest)actualRequests.get(0);
+
+    Assert.assertEquals(resource, BookNames.parse(actualRequest.getResource()));
+    Assert.assertEquals(label, actualRequest.getLabel());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void addLabelExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLabeler.addException(exception);
+
+    try {
+      BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+      String label = "label102727412";
+      AddLabelRequest request = AddLabelRequest.newBuilder()
+        .setResource(resource.toString())
+        .setLabel(label)
+        .build();
+
+      client.addLabel(request);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception
@@ -18040,6 +18092,9 @@ import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
+import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
+import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.SubMessage;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -18093,6 +18148,64 @@ public class MyProtoClientTest {
   @After
   public void tearDown() throws Exception {
     client.close();
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void myMethodTest() {
+    String myfield2 = "myfield2121360129";
+    MethodResponse expectedResponse = MethodResponse.newBuilder()
+      .setMyfield(myfield2)
+      .build();
+    mockMyProto.addResponse(expectedResponse);
+
+    List<SubMessage> mylist = new ArrayList<>();
+    SubMessage myfield = SubMessage.newBuilder().build();
+    SubMessage secondfield = SubMessage.newBuilder().build();
+    MethodRequest request = MethodRequest.newBuilder()
+      .addAllMylist(mylist)
+      .setMyfield(myfield)
+      .setSecondfield(secondfield)
+      .build();
+
+    MethodResponse actualResponse =
+        client.myMethod(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockMyProto.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
+
+    Assert.assertEquals(mylist, actualRequest.getMylistList());
+    Assert.assertEquals(myfield, actualRequest.getMyfield());
+    Assert.assertEquals(secondfield, actualRequest.getSecondfield());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void myMethodExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockMyProto.addException(exception);
+
+    try {
+      List<SubMessage> mylist = new ArrayList<>();
+      SubMessage myfield = SubMessage.newBuilder().build();
+      SubMessage secondfield = SubMessage.newBuilder().build();
+      MethodRequest request = MethodRequest.newBuilder()
+        .addAllMylist(mylist)
+        .setMyfield(myfield)
+        .setSecondfield(secondfield)
+        .build();
+
+      client.myMethod(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
   }
 
 }

--- a/src/test/java/com/google/api/codegen/testsrc/showcase/artman_showcase.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/showcase/artman_showcase.yaml
@@ -3,8 +3,8 @@ common:
   api_version: v1beta1
   organization_name: google
   service_yaml: showcase.yaml
-  gapic_yaml: showcase_gapic.yaml
+  gapic_yaml: v1beta1/showcase_gapic.yaml
   src_proto_paths:
-  - .
+  - v1beta1
   proto_deps:
   - name: google-common-protos

--- a/src/test/java/com/google/api/codegen/testsrc/showcase/artman_showcase.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/showcase/artman_showcase.yaml
@@ -3,8 +3,8 @@ common:
   api_version: v1beta1
   organization_name: google
   service_yaml: showcase.yaml
-  gapic_yaml: v1beta1/showcase_gapic.yaml
+  gapic_yaml: showcase_gapic.yaml
   src_proto_paths:
-  - v1beta1
+  - .
   proto_deps:
   - name: google-common-protos


### PR DESCRIPTION
Also validated locally that the change would fix accessapproval.