### PR TITLE
Create multi-pattern resource using the new static create/format methods in samples and tests

### DIFF
--- a/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
@@ -160,7 +160,11 @@ public abstract class ResourceDescriptorConfig {
             oneOfId,
             Name.anyCamel(oneOfId),
             ImmutableList.copyOf(resourceNameConfigs.build().values()),
-            getAssignedProtoFile());
+            getAssignedProtoFile(),
+            getPatterns()
+                .stream()
+                .map(ResourceNamePatternConfig::new)
+                .collect(ImmutableList.toImmutableList()));
     resourceNameConfigs.put(oneOfId, oneofConfig);
     return resourceNameConfigs.build();
   }

--- a/src/main/java/com/google/api/codegen/config/ResourceNameOneofConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameOneofConfig.java
@@ -21,6 +21,7 @@ import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.ProtoFile;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,6 +45,8 @@ public abstract class ResourceNameOneofConfig implements ResourceNameConfig {
   public String getCommonResourceName() {
     return null;
   }
+
+  public abstract List<ResourceNamePatternConfig> getPatterns();
 
   public List<SingleResourceNameConfig> getSingleResourceNameConfigs() {
     return getResourceNameConfigs()
@@ -100,7 +103,11 @@ public abstract class ResourceNameOneofConfig implements ResourceNameConfig {
     }
 
     return new AutoValue_ResourceNameOneofConfig(
-        oneofName, ResourceNameMessageConfig.entityNameToName(oneofName), configList, file);
+        oneofName,
+        ResourceNameMessageConfig.entityNameToName(oneofName),
+        configList,
+        file,
+        ImmutableList.of());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/ResourceNamePatternConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNamePatternConfig.java
@@ -68,8 +68,8 @@ public class ResourceNamePatternConfig {
       return builder.toString();
     }
 
-    // PathTemplate uses an ImmutableMap to keep track of bindings, which
-    // preserves the correct order of binding variables
+    // PathTemplate uses an ImmutableMap to keep track of bindings, so we
+    // can count on it to give us the correct order of binding variables
     return getBindingVariables().stream().collect(Collectors.joining("_"));
   }
 }

--- a/src/main/java/com/google/api/codegen/config/ResourceNamePatternConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNamePatternConfig.java
@@ -1,0 +1,75 @@
+/* Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.config;
+
+import com.google.api.codegen.util.Name;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.common.collect.ImmutableSet;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/** ResourceNamePatternConfig represents the configuration a resource name pattern. */
+public class ResourceNamePatternConfig {
+
+  private final String pattern;
+  @Nullable private final PathTemplate template;
+
+  public ResourceNamePatternConfig(String pattern) {
+    this.pattern = pattern;
+    this.template = PathTemplate.create(pattern);
+  }
+
+  public ImmutableSet<String> getBindingVariables() {
+    if (isFixedPattern()) {
+      return ImmutableSet.of();
+    }
+    return ImmutableSet.copyOf(template.vars());
+  }
+
+  public boolean isFixedPattern() {
+    return pattern.indexOf('{') == -1 && pattern.indexOf('}') == -1;
+  }
+
+  public String getCreateMethodName() {
+    return Name.anyLower("of", getPatternNameLowerUnderscore(), "name").toLowerCamel();
+  }
+
+  public String getFormatMethodName() {
+    return Name.anyLower("format", getPatternNameLowerUnderscore(), "name").toLowerCamel();
+  }
+
+  private String getPatternNameLowerUnderscore() {
+    if (isFixedPattern()) {
+      StringBuilder builder = new StringBuilder();
+      boolean requiresUnderscore = false;
+      for (char c : pattern.toCharArray()) {
+        if (!Character.isAlphabetic((int) c)) {
+          requiresUnderscore = true;
+          continue;
+        }
+        if (requiresUnderscore) {
+          builder.append('_');
+          requiresUnderscore = false;
+        }
+        builder.append(c);
+      }
+      return builder.toString();
+    }
+
+    // PathTemplate uses an ImmutableMap to keep track of bindings, which
+    // preserves the correct order of binding variables
+    return getBindingVariables().stream().collect(Collectors.joining("_"));
+  }
+}

--- a/src/main/java/com/google/api/codegen/config/ResourceNamePatternConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNamePatternConfig.java
@@ -31,6 +31,7 @@ public class ResourceNamePatternConfig {
     this.template = PathTemplate.create(pattern);
   }
 
+  /** The binding variables of the pattern, usually in curly braces. */
   public ImmutableSet<String> getBindingVariables() {
     if (isFixedPattern()) {
       return ImmutableSet.of();
@@ -61,20 +62,10 @@ public class ResourceNamePatternConfig {
 
   private String getPatternNameLowerUnderscore() {
     if (isFixedPattern()) {
-      StringBuilder builder = new StringBuilder();
-      boolean requiresUnderscore = false;
-      for (char c : pattern.toCharArray()) {
-        if (!Character.isAlphabetic((int) c)) {
-          requiresUnderscore = true;
-          continue;
-        }
-        if (requiresUnderscore) {
-          builder.append('_');
-          requiresUnderscore = false;
-        }
-        builder.append(c);
-      }
-      return builder.toString();
+      String name = pattern.replaceAll("^[^a-zA-Z]+", "");
+      name = name.replaceAll("[^a-zA-Z]$", "");
+      name = name.replaceAll("[^a-zA-Z]+", "_");
+      return name;
     }
 
     // PathTemplate uses an ImmutableMap to keep track of bindings, so we

--- a/src/main/java/com/google/api/codegen/config/ResourceNamePatternConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNamePatternConfig.java
@@ -38,14 +38,23 @@ public class ResourceNamePatternConfig {
     return ImmutableSet.copyOf(template.vars());
   }
 
+  /** Returns true if the pattern does not have binding variables. */
   public boolean isFixedPattern() {
     return pattern.indexOf('{') == -1 && pattern.indexOf('}') == -1;
   }
 
+  /**
+   * Returns the name of the static method that creates an instance of the resource name class
+   * representing this pattern, such as ofProjectBookName.
+   */
   public String getCreateMethodName() {
     return Name.anyLower("of", getPatternNameLowerUnderscore(), "name").toLowerCamel();
   }
 
+  /**
+   * Returns the name of the static method that returns a formatted string using this pattern, such
+   * as formatProjectBookName.
+   */
   public String getFormatMethodName() {
     return Name.anyLower("format", getPatternNameLowerUnderscore(), "name").toLowerCamel();
   }

--- a/src/main/java/com/google/api/codegen/transformer/DefaultFeatureConfig.java
+++ b/src/main/java/com/google/api/codegen/transformer/DefaultFeatureConfig.java
@@ -113,6 +113,11 @@ public class DefaultFeatureConfig implements FeatureConfig {
   }
 
   @Override
+  public boolean useStaticCreateMethodForOneofs() {
+    return false;
+  }
+
+  @Override
   public boolean enableMixins() {
     return false;
   }

--- a/src/main/java/com/google/api/codegen/transformer/DefaultFeatureConfig.java
+++ b/src/main/java/com/google/api/codegen/transformer/DefaultFeatureConfig.java
@@ -60,20 +60,15 @@ public class DefaultFeatureConfig implements FeatureConfig {
     // TODO: support creating resource name strings in tests and samples using creation methods
     // in the new multi-pattern resource classes.
     //
-    // This check has to be here for the following purposes:
-    // - make generating new APIs with multi-pattern resource but no gapic config v2 for Java work
-    //   (including java_library_no_gapic_config baseline test).
-    //   We can remove the check for this case after we implement generating samples and tests
-    //   using the new multi-pattern resource class for Java
+    // This check has to be here for the following purpose:
     // - make generating new APIs with multi-pattern resource but no gapic config v2 for C# work
-    //   Note such a case does not exist in production as all multi-pattern resource support
+    //   Note such a case does not exist in production as all. Multi-pattern resource support
     //   for C# will only be implemented in the micro-generator, but for the time being bazel
     //   and artman tests still use gapic-generator to generate C# GAPICs.
     //
     // Note This check is not needed for generating Java gapics with gapic config v2, because for
-    // those
-    // we can put multi-pattern resource name in deprecated_collections in gapic config v2 so that
-    // the generator can create resource name strings in the old wayg.
+    // those we can put multi-pattern resource name in deprecated_collections in gapic config v2
+    // so that the generator can create resource name strings in the old way.
     boolean requiresMultiPatternResourceSupport =
         fieldConfig.getResourceNameType() == ResourceNameType.ONEOF
             && ((ResourceNameOneofConfig) fieldConfig.getResourceNameConfig())

--- a/src/main/java/com/google/api/codegen/transformer/FeatureConfig.java
+++ b/src/main/java/com/google/api/codegen/transformer/FeatureConfig.java
@@ -61,7 +61,7 @@ public interface FeatureConfig {
   boolean useResourceNameFormatOptionInSampleOnly(FieldConfig fieldConfig);
 
   /**
-   * Returns true if the clients support static create methods for multi-pattern resource names.
+   * Returns true if the client support static create methods for multi-pattern resource names.
    * Returns true only when the client is generated from proto annotations. Only used in Java.
    */
   boolean useStaticCreateMethodForOneofs();

--- a/src/main/java/com/google/api/codegen/transformer/FeatureConfig.java
+++ b/src/main/java/com/google/api/codegen/transformer/FeatureConfig.java
@@ -60,6 +60,12 @@ public interface FeatureConfig {
    */
   boolean useResourceNameFormatOptionInSampleOnly(FieldConfig fieldConfig);
 
+  /**
+   * Returns true if the clients support static create methods for multi-pattern resource names.
+   * Returns true only when the client is generated from proto annotations. Only used in Java.
+   */
+  boolean useStaticCreateMethodForOneofs();
+
   boolean useInheritanceForOneofs();
 
   /** Returns true if mixin APIs are supported. */

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -199,7 +199,7 @@ public class InitCodeTransformer {
           } else if (fieldConfig.getResourceNameConfig().getResourceNameType()
               == ResourceNameType.ONEOF) {
             actualTransformFunction =
-                namer.getResourceTypeParentParseMethod(methodContext.getTypeTable(), fieldConfig);
+                namer.getResourceTypeParentParseMethod(methodContext, fieldConfig);
           } else {
             actualTransformFunction =
                 namer.getResourceTypeParseMethodName(methodContext.getTypeTable(), fieldConfig);

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -550,7 +550,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The name of the create method for the resource one-of for the given field config */
   public String getResourceTypeParentParseMethod(
-      ImportTypeTable typeTable, FieldConfig resourceFieldConfig) {
+      MethodContext context, FieldConfig resourceFieldConfig) {
     return getNotImplementedString("SurfaceNamer.getResourceTypeParentParseMethod");
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -441,7 +441,9 @@ public class TestCaseTransformer {
         ResourceNameOneofInitValueView initValue =
             (ResourceNameOneofInitValueView) simpleLine.initValue();
         ResourceNameInitValueView subValue = initValue.specificResourceNameView();
-        return subValue.formatArgs().contains(projectVarName);
+        return subValue == null
+            ? initValue.formatArgs().contains(projectVarName)
+            : subValue.formatArgs().contains(projectVarName);
       } else if (simpleLine.initValue() instanceof SimpleInitValueView) {
         SimpleInitValueView initValue = (SimpleInitValueView) simpleLine.initValue();
         return initValue.initialValue().equals(projectVarName);

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
@@ -28,6 +28,9 @@ public abstract class JavaFeatureConfig extends DefaultFeatureConfig {
   public abstract boolean enableStringFormatFunctions();
 
   @Override
+  public abstract boolean useStaticCreateMethodForOneofs();
+
+  @Override
   public boolean resourceNameTypesEnabled() {
     return true;
   }
@@ -71,6 +74,8 @@ public abstract class JavaFeatureConfig extends DefaultFeatureConfig {
 
     abstract Builder enableStringFormatFunctions(boolean value);
 
+    abstract Builder useStaticCreateMethodForOneofs(boolean value);
+
     abstract JavaFeatureConfig build();
   }
 
@@ -88,6 +93,7 @@ public abstract class JavaFeatureConfig extends DefaultFeatureConfig {
     }
     return JavaFeatureConfig.newBuilder()
         .enableStringFormatFunctions(enableStringFormatFunctions)
+        .useStaticCreateMethodForOneofs(productConfig.getProtoParser().isProtoAnnotationsEnabled())
         .build();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaFeatureConfig.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.MethodContext;
 import com.google.api.codegen.config.ResourceNameMessageConfigs;
+import com.google.api.codegen.config.ResourceNameType;
 import com.google.api.codegen.transformer.DefaultFeatureConfig;
 import com.google.auto.value.AutoValue;
 
@@ -38,8 +39,25 @@ public abstract class JavaFeatureConfig extends DefaultFeatureConfig {
   @Override
   public boolean useResourceNameFormatOptionInSample(
       MethodContext context, FieldConfig fieldConfig) {
-    return super.useResourceNameFormatOptionInSample(context, fieldConfig)
-        && !(context.isFlattenedMethodContext() && fieldConfig.getField().isRepeated());
+    boolean hasResourceNameFormatOption =
+        resourceNameTypesEnabled()
+            && fieldConfig != null
+            && (fieldConfig.useResourceNameType() || fieldConfig.useResourceNameTypeInSampleOnly());
+
+    if (!hasResourceNameFormatOption) {
+      return false;
+    }
+
+    // For an any resource name, we choose a random single resource name defined in the API for
+    // sample generation. If there are no single resource names at all in the API, we set this
+    // value to false and use a string literal to instantiate a resource name string.
+    boolean apiHasSingleResources =
+        context.getProductConfig().getSingleResourceNameConfigs().iterator().hasNext();
+    if (fieldConfig.getResourceNameType() == ResourceNameType.ANY && !apiHasSingleResources) {
+      return false;
+    }
+
+    return !(context.isFlattenedMethodContext() && fieldConfig.getField().isRepeated());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -205,11 +205,13 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   /** The name of the create method for the resource one-of for the given field config */
-  public String getResourceTypeParentParseMethod(
-      ImportTypeTable typeTable, FieldConfig fieldConfig) {
-    return getAndSaveResourceTypeFactoryName(typeTable, fieldConfig.getMessageFieldConfig())
-        + "."
-        + publicMethodName(Name.from("parse"));
+  public String getResourceTypeParentParseMethod(MethodContext context, FieldConfig fieldConfig) {
+    ImportTypeTable typeTable = context.getTypeTable();
+    String resourceClass =
+        context.getFeatureConfig().useStaticCreateMethodForOneofs()
+            ? getAndSaveResourceTypeName(typeTable, fieldConfig.getMessageFieldConfig())
+            : getAndSaveResourceTypeFactoryName(typeTable, fieldConfig.getMessageFieldConfig());
+    return resourceClass + "." + publicMethodName(Name.from("parse"));
   }
 
   private String getAndSaveResourceTypeFactoryName(

--- a/src/main/java/com/google/api/codegen/viewmodel/ResourceNameOneofInitValueView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ResourceNameOneofInitValueView.java
@@ -15,13 +15,26 @@
 package com.google.api.codegen.viewmodel;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class ResourceNameOneofInitValueView implements InitValueView {
 
   public abstract String resourceOneofTypeName();
 
+  @Nullable
   public abstract ResourceNameInitValueView specificResourceNameView();
+
+  @Nullable
+  public abstract String createMethodName();
+
+  @Nullable
+  public abstract ImmutableList<String> formatArgs();
+
+  public boolean useStaticCreateMethod() {
+    return createMethodName() != null;
+  }
 
   public String type() {
     return ResourceNameOneofInitValueView.class.getSimpleName();
@@ -37,6 +50,10 @@ public abstract class ResourceNameOneofInitValueView implements InitValueView {
     public abstract Builder resourceOneofTypeName(String val);
 
     public abstract Builder specificResourceNameView(ResourceNameInitValueView val);
+
+    public abstract Builder createMethodName(String val);
+
+    public abstract Builder formatArgs(ImmutableList<String> val);
 
     public abstract ResourceNameOneofInitValueView build();
   }

--- a/src/main/resources/com/google/api/codegen/java/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/java/initcode.snip
@@ -106,7 +106,7 @@
     {@renderResourceName(initValue)}
   @case "ResourceNameOneofInitValueView"
     @if initValue.useStaticCreateMethod
-      {@initValue.resourceOneofTypeName}.{@initValue.createMethodName}({@argList(initValue.formatArgs)});
+      {@initValue.resourceOneofTypeName}.{@initValue.createMethodName}({@argList(initValue.formatArgs)})
     @else
       {@renderResourceName(initValue.specificResourceNameView)}
     @end

--- a/src/main/resources/com/google/api/codegen/java/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/java/initcode.snip
@@ -105,7 +105,11 @@
   @case "ResourceNameInitValueView"
     {@renderResourceName(initValue)}
   @case "ResourceNameOneofInitValueView"
-    {@renderResourceName(initValue.specificResourceNameView)}
+    @if initValue.useStaticCreateMethod
+      {@initValue.resourceOneofTypeName}.{@initValue.createMethodName}({@argList(initValue.formatArgs)});
+    @else
+      {@renderResourceName(initValue.specificResourceNameView)}
+    @end
   @case "RepeatedResourceNameInitValueView"
     new ArrayList<>()
   @default

--- a/src/test/java/com/google/api/codegen/config/FeatureConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/FeatureConfigTest.java
@@ -18,11 +18,13 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.codegen.transformer.csharp.CSharpFeatureConfig;
 import com.google.api.codegen.transformer.java.JavaFeatureConfig;
+import com.google.api.codegen.util.ProtoParser;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class FeatureConfigTest {
   private GapicProductConfig productConfig = Mockito.mock(GapicProductConfig.class);
+  private ProtoParser protoParser = new ProtoParser(true);
   private ResourceNameMessageConfigs resourceNameMessageConfigs =
       Mockito.mock(ResourceNameMessageConfigs.class);
 
@@ -31,6 +33,8 @@ public class FeatureConfigTest {
     Mockito.doReturn(resourceNameMessageConfigs)
         .when(productConfig)
         .getResourceNameMessageConfigs();
+
+    Mockito.doReturn(protoParser).when(productConfig).getProtoParser();
 
     Mockito.doReturn(null).when(productConfig).enableStringFormattingFunctionsOverride();
     assertThat(JavaFeatureConfig.create(productConfig).enableStringFormatFunctions()).isFalse();

--- a/src/test/java/com/google/api/codegen/config/ResourceNamePatternConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceNamePatternConfigTest.java
@@ -1,0 +1,44 @@
+/* Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.config;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+public class ResourceNamePatternConfigTest {
+
+  @Test
+  public void testIsFixedPattern() {
+    assertThat(new ResourceNamePatternConfig("_deleted_topic_").isFixedPattern()).isEqualTo(true);
+    assertThat(new ResourceNamePatternConfig("states/{state}/cities/{city}").isFixedPattern())
+        .isEqualTo(false);
+  }
+
+  @Test
+  public void testGetCreateMethodName() {
+    assertThat(new ResourceNamePatternConfig("_deleted_topic_").getCreateMethodName())
+        .isEqualTo("ofDeletedTopicName");
+    assertThat(new ResourceNamePatternConfig("states/{state}/cities/{city}").getCreateMethodName())
+        .isEqualTo("ofStateCityName");
+  }
+
+  @Test
+  public void testGetBindingVariables() {
+    assertThat(new ResourceNamePatternConfig("_deleted_topic_").getBindingVariables()).isEmpty();
+    assertThat(new ResourceNamePatternConfig("states/{state}/cities/{city}").getBindingVariables())
+        .containsExactly("state", "city");
+  }
+}

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -15310,7 +15310,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -15397,7 +15397,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     DeleteBookRequest actualRequest = (DeleteBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -15446,7 +15446,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     UpdateBookRequest actualRequest = (UpdateBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(book, actualRequest.getBook());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -15500,7 +15500,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     UpdateBookRequest actualRequest = (UpdateBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(optionalFoo, actualRequest.getOptionalFoo());
     Assert.assertEquals(book, actualRequest.getBook());
     Assert.assertEquals(updateMask, actualRequest.getUpdateMask());
@@ -15557,7 +15557,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     MoveBookRequest actualRequest = (MoveBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(otherShelfName, ShelfName.parse(actualRequest.getOtherShelfName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -15702,7 +15702,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     AddCommentsRequest actualRequest = (AddCommentsRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(comments, actualRequest.getCommentsList());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -15814,8 +15814,8 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookFromAnywhereRequest actualRequest = (GetBookFromAnywhereRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
-    Assert.assertEquals(altBookName, BookNames.parse(actualRequest.getAltBookName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
+    Assert.assertEquals(altBookName, BookName.parse(actualRequest.getAltBookName()));
     Assert.assertEquals(place, LocationName.parse(actualRequest.getPlace()));
     Assert.assertEquals(folder, FolderName.parse(actualRequest.getFolder()));
     Assert.assertTrue(
@@ -15868,7 +15868,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookFromAbsolutelyAnywhereRequest actualRequest = (GetBookFromAbsolutelyAnywhereRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -15909,7 +15909,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     UpdateBookIndexRequest actualRequest = (UpdateBookIndexRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(indexName, actualRequest.getIndexName());
     Assert.assertEquals(indexMap, actualRequest.getIndexMapMap());
     Assert.assertTrue(
@@ -16181,7 +16181,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     AddLabelRequest actualRequest = (AddLabelRequest)actualRequests.get(0);
 
-    Assert.assertEquals(resource, BookNames.parse(actualRequest.getResource()));
+    Assert.assertEquals(resource, BookName.parse(actualRequest.getResource()));
     Assert.assertEquals(label, actualRequest.getLabel());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -16241,7 +16241,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -16289,7 +16289,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -16495,8 +16495,8 @@ public class LibraryClientTest {
     Assert.assertEquals(requiredSingularString, actualRequest.getRequiredSingularString());
     Assert.assertEquals(requiredSingularBytes, actualRequest.getRequiredSingularBytes());
     Assert.assertEquals(requiredSingularMessage, actualRequest.getRequiredSingularMessage());
-    Assert.assertEquals(requiredSingularResourceName, BookNames.parse(actualRequest.getRequiredSingularResourceName()));
-    Assert.assertEquals(requiredSingularResourceNameOneof, BookNames.parse(actualRequest.getRequiredSingularResourceNameOneof()));
+    Assert.assertEquals(requiredSingularResourceName, BookName.parse(actualRequest.getRequiredSingularResourceName()));
+    Assert.assertEquals(requiredSingularResourceNameOneof, BookName.parse(actualRequest.getRequiredSingularResourceNameOneof()));
     Assert.assertEquals(requiredSingularResourceNameCommon, actualRequest.getRequiredSingularResourceNameCommon());
     Assert.assertEquals(requiredSingularFixed32, actualRequest.getRequiredSingularFixed32());
     Assert.assertEquals(requiredSingularFixed64, actualRequest.getRequiredSingularFixed64());
@@ -16556,8 +16556,8 @@ public class LibraryClientTest {
     Assert.assertEquals(optionalSingularString, actualRequest.getOptionalSingularString());
     Assert.assertEquals(optionalSingularBytes, actualRequest.getOptionalSingularBytes());
     Assert.assertEquals(optionalSingularMessage, actualRequest.getOptionalSingularMessage());
-    Assert.assertEquals(optionalSingularResourceName, BookNames.parse(actualRequest.getOptionalSingularResourceName()));
-    Assert.assertEquals(optionalSingularResourceNameOneof, BookNames.parse(actualRequest.getOptionalSingularResourceNameOneof()));
+    Assert.assertEquals(optionalSingularResourceName, BookName.parse(actualRequest.getOptionalSingularResourceName()));
+    Assert.assertEquals(optionalSingularResourceNameOneof, BookName.parse(actualRequest.getOptionalSingularResourceNameOneof()));
     Assert.assertEquals(optionalSingularResourceNameCommon, actualRequest.getOptionalSingularResourceNameCommon());
     Assert.assertEquals(optionalSingularFixed32, actualRequest.getOptionalSingularFixed32());
     Assert.assertEquals(optionalSingularFixed64, actualRequest.getOptionalSingularFixed64());

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -212,7 +212,6 @@ import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithResponseHandling {
   // [START sample]
@@ -223,7 +222,6 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test response handling for methods that return empty */
@@ -250,7 +248,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -293,7 +291,6 @@ import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithoutResponseHandling {
   // [START sample]
@@ -304,7 +301,6 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test default response handling is turned off for methods that return empty */
@@ -328,7 +324,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -715,7 +711,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -729,7 +724,6 @@ public class FindRelatedBooksCallableCallableListOdyssey {
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -738,7 +732,7 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -867,7 +861,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -882,7 +875,6 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -891,7 +883,7 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -944,7 +936,6 @@ package com.google.example.examples.library.v1;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -957,7 +948,6 @@ public class FindRelatedBooksRequestPagedOdyssey {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -966,7 +956,7 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -1021,7 +1011,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1035,7 +1024,6 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1049,7 +1037,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, "War and Peace");
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1127,7 +1115,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
   // [START hopper]
@@ -1139,7 +1126,6 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1158,7 +1144,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, bigBookName);
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1226,7 +1212,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1241,7 +1226,6 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1255,7 +1239,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, "War and Peace");
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1337,7 +1321,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
   // [START hopper]
@@ -1350,7 +1333,6 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1369,7 +1351,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, bigBookName);
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1438,7 +1420,6 @@ import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 import com.google.protobuf.ListValue;
 import java.util.Map;
@@ -1452,7 +1433,6 @@ public class GetBigBookCallableCallableWap {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
@@ -1467,7 +1447,7 @@ public class GetBigBookCallableCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, "War and Peace");
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1548,7 +1528,6 @@ import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigBookCallableCallableWap2 {
@@ -1560,7 +1539,6 @@ public class GetBigBookCallableCallableWap2 {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
@@ -1580,7 +1558,7 @@ public class GetBigBookCallableCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, bigBookName);
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1652,7 +1630,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1667,7 +1644,6 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1681,7 +1657,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, "War and Peace");
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1764,7 +1740,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookOperationCallableLongRunningCallableWap2 {
   // [START hopper]
@@ -1777,7 +1752,6 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1796,7 +1770,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, bigBookName);
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1862,7 +1836,6 @@ import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithResponseHandling {
@@ -1874,14 +1847,13 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1926,7 +1898,6 @@ import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -1938,14 +1909,13 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1989,7 +1959,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithResponseHandling {
@@ -2002,14 +1971,13 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2058,7 +2026,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -2071,14 +2038,13 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2124,7 +2090,6 @@ import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling {
@@ -2136,14 +2101,13 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2192,7 +2156,6 @@ import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2204,14 +2167,13 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2259,7 +2221,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithResponseHandling {
@@ -2272,14 +2233,13 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2329,7 +2289,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2342,14 +2301,13 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2399,7 +2357,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookCallableCallableTestOnSuccessMap {
   // [START sample]
@@ -2411,12 +2368,11 @@ public class GetBookCallableCallableTestOnSuccessMap {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2468,7 +2424,6 @@ package com.google.example.examples.library.v1;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookFlattenedTestOnSuccessMap {
   // [START sample]
@@ -2478,12 +2433,11 @@ public class GetBookFlattenedTestOnSuccessMap {
    * import com.google.example.library.v1.Book;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       Book response = libraryClient.getBook(name.toString());
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
@@ -2529,7 +2483,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookRequestTestOnSuccessMap {
   // [START sample]
@@ -2540,12 +2493,11 @@ public class GetBookRequestTestOnSuccessMap {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2594,7 +2546,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class MonologAboutBookCallableCallableStreamingClientProg {
   // [START sample]
@@ -2606,7 +2557,6 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Testing calling forms */
@@ -2632,7 +2582,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3662,7 +3612,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3695,7 +3644,6 @@ public class TestFloatAndInt64 {
    *
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3738,8 +3686,8 @@ public class TestFloatAndInt64 {
       String requiredSingularString = "";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String requiredSingularResourceNameCommon = "";
       int requiredSingularFixed32 = 0;
       long requiredSingularFixed64 = 0L;
@@ -3916,7 +3864,6 @@ import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof {
   // [START test_resource_name_oneof]
@@ -3927,12 +3874,11 @@ public class TestResourceNameOneof {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "The ID of the book");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "The ID of the book");;
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3975,7 +3921,6 @@ import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof2 {
   // [START test_resource_name_oneof_2]
@@ -3986,12 +3931,11 @@ public class TestResourceNameOneof2 {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("The Shelf to search for the book", "The ID of the book");
+      BookName name = BookName.ofShelfBookName("The Shelf to search for the book", "The ID of the book");;
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4110,7 +4054,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -4125,7 +4068,6 @@ public class ThisTagShouldBeTheNameOfTheFile {
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -4139,7 +4081,7 @@ public class ThisTagShouldBeTheNameOfTheFile {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, "War and Peace");
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4220,7 +4162,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ByteString;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -4236,7 +4177,6 @@ public class TuringProgCallableStreamingBidi {
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ByteString;
    * import java.nio.file.Files;
    * import java.nio.file.Path;
@@ -4256,7 +4196,7 @@ public class TuringProgCallableStreamingBidi {
       BidiStream<DiscussBookRequest, Comment> bidiStream =
           libraryClient.discussBookCallable().call();
 
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       Path path = Paths.get("comment_file");
       byte[] data = Files.readAllBytes(path);
       ByteString comment = ByteString.copyFrom(data);
@@ -5672,7 +5612,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryClient.getBook(name);
    * }
    * </code></pre>
@@ -5695,7 +5635,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -5718,7 +5658,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5740,7 +5680,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5901,7 +5841,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryClient.deleteBook(name);
    * }
    * </code></pre>
@@ -5924,7 +5864,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -5947,7 +5887,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5969,7 +5909,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5990,7 +5930,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name, book);
    * }
@@ -6016,7 +5956,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name.toString(), book);
    * }
@@ -6042,7 +5982,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6077,7 +6017,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6112,7 +6052,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6136,7 +6076,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6159,7 +6099,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name, otherShelfName);
    * }
@@ -6185,7 +6125,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name.toString(), otherShelfName.toString());
    * }
@@ -6211,7 +6151,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6235,7 +6175,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6398,7 +6338,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6432,7 +6372,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6466,7 +6406,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6498,7 +6438,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6628,8 +6568,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name, altBookName, place, folder);
@@ -6661,8 +6601,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name.toString(), altBookName.toString(), place.toString(), folder.toString());
@@ -6694,8 +6634,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6722,8 +6662,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6749,7 +6689,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -6772,7 +6712,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -6795,7 +6735,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6817,7 +6757,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6838,7 +6778,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6869,7 +6809,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6900,7 +6840,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6928,7 +6868,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -7006,7 +6946,7 @@ public class LibraryClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryClient.discussBookCallable().call();
    *
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7048,7 +6988,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7088,7 +7028,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7136,7 +7076,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7164,7 +7104,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7190,7 +7130,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7223,7 +7163,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7248,7 +7188,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7272,7 +7212,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -7296,7 +7236,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7320,7 +7260,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7343,7 +7283,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7365,7 +7305,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7386,7 +7326,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -7410,7 +7350,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7434,7 +7374,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7457,7 +7397,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7479,7 +7419,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7528,8 +7468,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7589,8 +7529,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -7914,8 +7854,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7975,8 +7915,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -8300,8 +8240,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8442,8 +8382,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -15236,7 +15176,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15348,7 +15288,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15360,7 +15300,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     Book actualResponse =
         client.getBook(name);
@@ -15384,7 +15324,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -15449,7 +15389,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     client.deleteBook(name);
 
@@ -15471,7 +15411,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -15483,7 +15423,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15495,7 +15435,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -15521,7 +15461,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -15534,7 +15474,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15546,7 +15486,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15578,7 +15518,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15594,7 +15534,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15606,7 +15546,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
@@ -15632,7 +15572,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
@@ -15745,7 +15685,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     ByteString comment = ByteString.copyFromUtf8("95");
     Comment.Stage stage = Comment.Stage.UNSET;
     SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15777,7 +15717,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       ByteString comment = ByteString.copyFromUtf8("95");
       Comment.Stage stage = Comment.Stage.UNSET;
       SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15849,7 +15789,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15861,8 +15801,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-    BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
     FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15891,8 +15831,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-      BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
       FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15906,7 +15846,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15918,7 +15858,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -15942,7 +15882,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -15957,7 +15897,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String indexName = "default index";
     String indexMapItem = "indexMapItem1918721251";
     Map<String, String> indexMap = new HashMap<>();
@@ -15985,7 +15925,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String indexName = "default index";
       String indexMapItem = "indexMapItem1918721251";
       Map<String, String> indexMap = new HashMap<>();
@@ -16052,7 +15992,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -16115,7 +16055,7 @@ public class LibraryClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -16140,7 +16080,7 @@ public class LibraryClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -16168,7 +16108,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    BookName namesElement2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName namesElement2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     List<BookName> names2 = Arrays.asList(namesElement2);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -16226,7 +16166,7 @@ public class LibraryClientTest {
     AddLabelResponse expectedResponse = AddLabelResponse.newBuilder().build();
     mockLabeler.addResponse(expectedResponse);
 
-    BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String label = "label102727412";
     AddLabelRequest request = AddLabelRequest.newBuilder()
       .setResource(resource.toString())
@@ -16256,7 +16196,7 @@ public class LibraryClientTest {
     mockLabeler.addException(exception);
 
     try {
-      BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String label = "label102727412";
       AddLabelRequest request = AddLabelRequest.newBuilder()
         .setResource(resource.toString())
@@ -16273,7 +16213,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -16291,7 +16231,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -16315,7 +16255,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -16339,7 +16279,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -16363,7 +16303,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -16424,8 +16364,8 @@ public class LibraryClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-    BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -16485,8 +16425,8 @@ public class LibraryClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-    BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -16690,8 +16630,8 @@ public class LibraryClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -16751,8 +16691,8 @@ public class LibraryClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-      BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -17015,7 +16955,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void privateListShelvesTest() {
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -17107,7 +17047,7 @@ public class LibrarySmokeTest {
 
   public static void executeNoCatch(String projectId) throws Exception {
     try (LibraryClient client = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("testShelf-" + System.currentTimeMillis(), projectId);
+      BookName name = BookName.ofShelfBookName("testShelf-" + System.currentTimeMillis(), projectId);;
       Book.Rating rating = Book.Rating.GOOD;
       Book book = Book.newBuilder()
         .setRating(rating)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -248,7 +248,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -324,7 +324,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -732,7 +732,7 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -883,7 +883,7 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -956,7 +956,7 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -1037,7 +1037,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1144,7 +1144,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1239,7 +1239,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1351,7 +1351,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1447,7 +1447,7 @@ public class GetBigBookCallableCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1558,7 +1558,7 @@ public class GetBigBookCallableCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1657,7 +1657,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1770,7 +1770,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1853,7 +1853,7 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1915,7 +1915,7 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1977,7 +1977,7 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2044,7 +2044,7 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2107,7 +2107,7 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2173,7 +2173,7 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2239,7 +2239,7 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2307,7 +2307,7 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2372,7 +2372,7 @@ public class GetBookCallableCallableTestOnSuccessMap {
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2437,7 +2437,7 @@ public class GetBookFlattenedTestOnSuccessMap {
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       Book response = libraryClient.getBook(name.toString());
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
@@ -2497,7 +2497,7 @@ public class GetBookRequestTestOnSuccessMap {
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2582,7 +2582,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3686,8 +3686,8 @@ public class TestFloatAndInt64 {
       String requiredSingularString = "";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String requiredSingularResourceNameCommon = "";
       int requiredSingularFixed32 = 0;
       long requiredSingularFixed64 = 0L;
@@ -3878,7 +3878,7 @@ public class TestResourceNameOneof {
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "The ID of the book");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3935,7 +3935,7 @@ public class TestResourceNameOneof2 {
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("The Shelf to search for the book", "The ID of the book");;
+      BookName name = BookName.ofShelfBookName("The Shelf to search for the book", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4081,7 +4081,7 @@ public class ThisTagShouldBeTheNameOfTheFile {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4196,7 +4196,7 @@ public class TuringProgCallableStreamingBidi {
       BidiStream<DiscussBookRequest, Comment> bidiStream =
           libraryClient.discussBookCallable().call();
 
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       Path path = Paths.get("comment_file");
       byte[] data = Files.readAllBytes(path);
       ByteString comment = ByteString.copyFrom(data);
@@ -5612,7 +5612,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name);
    * }
    * </code></pre>
@@ -5635,7 +5635,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -5658,7 +5658,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5680,7 +5680,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5841,7 +5841,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name);
    * }
    * </code></pre>
@@ -5864,7 +5864,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -5887,7 +5887,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5909,7 +5909,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5930,7 +5930,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name, book);
    * }
@@ -5956,7 +5956,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name.toString(), book);
    * }
@@ -5982,7 +5982,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6017,7 +6017,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6052,7 +6052,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6076,7 +6076,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6099,7 +6099,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name, otherShelfName);
    * }
@@ -6125,7 +6125,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name.toString(), otherShelfName.toString());
    * }
@@ -6151,7 +6151,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6175,7 +6175,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6338,7 +6338,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6372,7 +6372,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6406,7 +6406,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6438,7 +6438,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6568,8 +6568,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name, altBookName, place, folder);
@@ -6601,8 +6601,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name.toString(), altBookName.toString(), place.toString(), folder.toString());
@@ -6634,8 +6634,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6662,8 +6662,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6689,7 +6689,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -6712,7 +6712,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -6735,7 +6735,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6757,7 +6757,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6778,7 +6778,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6809,7 +6809,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6840,7 +6840,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6868,7 +6868,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6946,7 +6946,7 @@ public class LibraryClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryClient.discussBookCallable().call();
    *
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6988,7 +6988,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7028,7 +7028,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7076,7 +7076,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7104,7 +7104,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7130,7 +7130,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7163,7 +7163,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7188,7 +7188,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7212,7 +7212,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -7236,7 +7236,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7260,7 +7260,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7283,7 +7283,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7305,7 +7305,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7326,7 +7326,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -7350,7 +7350,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7374,7 +7374,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7397,7 +7397,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7419,7 +7419,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7468,8 +7468,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7529,8 +7529,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -7854,8 +7854,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7915,8 +7915,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -8240,8 +8240,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8382,8 +8382,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -15176,7 +15176,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15288,7 +15288,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15300,7 +15300,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBook(name);
@@ -15324,7 +15324,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -15389,7 +15389,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     client.deleteBook(name);
 
@@ -15411,7 +15411,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -15423,7 +15423,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15435,7 +15435,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -15461,7 +15461,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -15474,7 +15474,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15486,7 +15486,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15518,7 +15518,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15534,7 +15534,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15546,7 +15546,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
@@ -15572,7 +15572,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
@@ -15685,7 +15685,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     ByteString comment = ByteString.copyFromUtf8("95");
     Comment.Stage stage = Comment.Stage.UNSET;
     SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15717,7 +15717,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       ByteString comment = ByteString.copyFromUtf8("95");
       Comment.Stage stage = Comment.Stage.UNSET;
       SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15789,7 +15789,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15801,8 +15801,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-    BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
     FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15831,8 +15831,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-      BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
       FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15846,7 +15846,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15858,7 +15858,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -15882,7 +15882,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -15897,7 +15897,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String indexName = "default index";
     String indexMapItem = "indexMapItem1918721251";
     Map<String, String> indexMap = new HashMap<>();
@@ -15925,7 +15925,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String indexName = "default index";
       String indexMapItem = "indexMapItem1918721251";
       Map<String, String> indexMap = new HashMap<>();
@@ -15992,7 +15992,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -16055,7 +16055,7 @@ public class LibraryClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -16080,7 +16080,7 @@ public class LibraryClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -16108,7 +16108,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    BookName namesElement2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName namesElement2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     List<BookName> names2 = Arrays.asList(namesElement2);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -16166,7 +16166,7 @@ public class LibraryClientTest {
     AddLabelResponse expectedResponse = AddLabelResponse.newBuilder().build();
     mockLabeler.addResponse(expectedResponse);
 
-    BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String label = "label102727412";
     AddLabelRequest request = AddLabelRequest.newBuilder()
       .setResource(resource.toString())
@@ -16196,7 +16196,7 @@ public class LibraryClientTest {
     mockLabeler.addException(exception);
 
     try {
-      BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String label = "label102727412";
       AddLabelRequest request = AddLabelRequest.newBuilder()
         .setResource(resource.toString())
@@ -16213,7 +16213,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -16231,7 +16231,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -16255,7 +16255,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -16279,7 +16279,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -16303,7 +16303,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -16364,8 +16364,8 @@ public class LibraryClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-    BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -16425,8 +16425,8 @@ public class LibraryClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-    BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -16630,8 +16630,8 @@ public class LibraryClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -16691,8 +16691,8 @@ public class LibraryClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-      BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -16955,7 +16955,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void privateListShelvesTest() {
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -17047,7 +17047,7 @@ public class LibrarySmokeTest {
 
   public static void executeNoCatch(String projectId) throws Exception {
     try (LibraryClient client = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("testShelf-" + System.currentTimeMillis(), projectId);;
+      BookName name = BookName.ofShelfBookName("testShelf-" + System.currentTimeMillis(), projectId);
       Book.Rating rating = Book.Rating.GOOD;
       Book book = Book.newBuilder()
         .setRating(rating)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -1052,7 +1052,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryServiceClient.getBook(name);
    * }
    * </code></pre>
@@ -1075,7 +1075,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryServiceClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -1098,7 +1098,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -1120,7 +1120,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -1275,7 +1275,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryServiceClient.deleteBook(name);
    * }
    * </code></pre>
@@ -1298,7 +1298,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryServiceClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -1321,7 +1321,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -1343,7 +1343,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -1364,7 +1364,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryServiceClient.updateBook(name, book);
    * }
@@ -1390,7 +1390,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryServiceClient.updateBook(name.toString(), book);
    * }
@@ -1416,7 +1416,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -1451,7 +1451,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -1486,7 +1486,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -1510,7 +1510,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -1533,7 +1533,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryServiceClient.moveBook(name, otherShelfName);
    * }
@@ -1559,7 +1559,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryServiceClient.moveBook(name.toString(), otherShelfName.toString());
    * }
@@ -1585,7 +1585,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -1609,7 +1609,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -1772,7 +1772,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   List&lt;Comment&gt; comments = new ArrayList&lt;&gt;();
    *   libraryServiceClient.addComments(name, comments);
    * }
@@ -1798,7 +1798,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   List&lt;Comment&gt; comments = new ArrayList&lt;&gt;();
    *   libraryServiceClient.addComments(name.toString(), comments);
    * }
@@ -1824,7 +1824,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   List&lt;Comment&gt; comments = new ArrayList&lt;&gt;();
    *   AddCommentsRequest request = AddCommentsRequest.newBuilder()
    *     .setName(name.toString())
@@ -1848,7 +1848,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   List&lt;Comment&gt; comments = new ArrayList&lt;&gt;();
    *   AddCommentsRequest request = AddCommentsRequest.newBuilder()
    *     .setName(name.toString())
@@ -1970,8 +1970,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryServiceClient.getBookFromAnywhere(name, altBookName, place, folder);
@@ -2003,8 +2003,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryServiceClient.getBookFromAnywhere(name.toString(), altBookName.toString(), place.toString(), folder.toString());
@@ -2036,8 +2036,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -2064,8 +2064,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -2091,7 +2091,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryServiceClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -2114,7 +2114,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryServiceClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -2137,7 +2137,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2159,7 +2159,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2180,7 +2180,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
    *   libraryServiceClient.updateBookIndex(name, indexName, indexMap);
@@ -2209,7 +2209,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
    *   libraryServiceClient.updateBookIndex(name.toString(), indexName, indexMap);
@@ -2238,7 +2238,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
    *   UpdateBookIndexRequest request = UpdateBookIndexRequest.newBuilder()
@@ -2264,7 +2264,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
    *   UpdateBookIndexRequest request = UpdateBookIndexRequest.newBuilder()
@@ -2340,7 +2340,7 @@ public class LibraryServiceClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryServiceClient.discussBookCallable().call();
    *
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2382,7 +2382,7 @@ public class LibraryServiceClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryServiceClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2422,7 +2422,7 @@ public class LibraryServiceClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryServiceClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2654,7 +2654,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryServiceClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -2678,7 +2678,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryServiceClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -2702,7 +2702,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2725,7 +2725,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2747,7 +2747,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2768,7 +2768,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryServiceClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -2792,7 +2792,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryServiceClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -2816,7 +2816,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2839,7 +2839,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2861,7 +2861,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -3595,8 +3595,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -3656,8 +3656,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -3981,8 +3981,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -4042,8 +4042,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -4367,8 +4367,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -4509,8 +4509,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -10290,7 +10290,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10392,7 +10392,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10404,7 +10404,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBook(name);
@@ -10428,7 +10428,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -10493,7 +10493,7 @@ public class LibraryServiceClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     client.deleteBook(name);
 
@@ -10515,7 +10515,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -10527,7 +10527,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10539,7 +10539,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -10565,7 +10565,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -10578,7 +10578,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10590,7 +10590,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -10622,7 +10622,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -10638,7 +10638,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10650,7 +10650,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
@@ -10676,7 +10676,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
@@ -10789,7 +10789,7 @@ public class LibraryServiceClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     List<Comment> comments = new ArrayList<>();
 
     client.addComments(name, comments);
@@ -10813,7 +10813,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       List<Comment> comments = new ArrayList<>();
 
       client.addComments(name, comments);
@@ -10877,7 +10877,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10889,8 +10889,8 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-    BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
     FolderName folder = FolderName.of("[FOLDER]");
 
@@ -10919,8 +10919,8 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-      BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
       FolderName folder = FolderName.of("[FOLDER]");
 
@@ -10934,7 +10934,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10946,7 +10946,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -10970,7 +10970,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -10985,7 +10985,7 @@ public class LibraryServiceClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String indexName = "indexName746962392";
     Map<String, String> indexMap = new HashMap<>();
 
@@ -11011,7 +11011,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String indexName = "indexName746962392";
       Map<String, String> indexMap = new HashMap<>();
 
@@ -11072,7 +11072,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -11135,7 +11135,7 @@ public class LibraryServiceClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -11160,7 +11160,7 @@ public class LibraryServiceClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -11188,7 +11188,7 @@ public class LibraryServiceClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     List<BookName> names2 = Arrays.asList(namesElement);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -11283,7 +11283,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -11301,7 +11301,7 @@ public class LibraryServiceClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -11325,7 +11325,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -11349,7 +11349,7 @@ public class LibraryServiceClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -11373,7 +11373,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -11635,8 +11635,8 @@ public class LibraryServiceClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-    BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -11696,8 +11696,8 @@ public class LibraryServiceClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-    BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -11901,8 +11901,8 @@ public class LibraryServiceClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -11962,8 +11962,8 @@ public class LibraryServiceClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-      BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -12025,7 +12025,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void privateListShelvesTest() {
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -10414,7 +10414,7 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -10501,7 +10501,7 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(1, actualRequests.size());
     DeleteBookRequest actualRequest = (DeleteBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -10550,7 +10550,7 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(1, actualRequests.size());
     UpdateBookRequest actualRequest = (UpdateBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(book, actualRequest.getBook());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -10604,7 +10604,7 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(1, actualRequests.size());
     UpdateBookRequest actualRequest = (UpdateBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(optionalFoo, actualRequest.getOptionalFoo());
     Assert.assertEquals(book, actualRequest.getBook());
     Assert.assertEquals(updateMask, actualRequest.getUpdateMask());
@@ -10661,7 +10661,7 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(1, actualRequests.size());
     MoveBookRequest actualRequest = (MoveBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(otherShelfName, ShelfName.parse(actualRequest.getOtherShelfName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -10798,7 +10798,7 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(1, actualRequests.size());
     AddCommentsRequest actualRequest = (AddCommentsRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(comments, actualRequest.getCommentsList());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -10902,8 +10902,8 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookFromAnywhereRequest actualRequest = (GetBookFromAnywhereRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
-    Assert.assertEquals(altBookName, BookNames.parse(actualRequest.getAltBookName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
+    Assert.assertEquals(altBookName, BookName.parse(actualRequest.getAltBookName()));
     Assert.assertEquals(place, LocationName.parse(actualRequest.getPlace()));
     Assert.assertEquals(folder, FolderName.parse(actualRequest.getFolder()));
     Assert.assertTrue(
@@ -10956,7 +10956,7 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookFromAbsolutelyAnywhereRequest actualRequest = (GetBookFromAbsolutelyAnywhereRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -10995,7 +10995,7 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(1, actualRequests.size());
     UpdateBookIndexRequest actualRequest = (UpdateBookIndexRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(indexName, actualRequest.getIndexName());
     Assert.assertEquals(indexMap, actualRequest.getIndexMapMap());
     Assert.assertTrue(
@@ -11311,7 +11311,7 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -11359,7 +11359,7 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -11766,8 +11766,8 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(requiredSingularString, actualRequest.getRequiredSingularString());
     Assert.assertEquals(requiredSingularBytes, actualRequest.getRequiredSingularBytes());
     Assert.assertEquals(requiredSingularMessage, actualRequest.getRequiredSingularMessage());
-    Assert.assertEquals(requiredSingularResourceName, BookNames.parse(actualRequest.getRequiredSingularResourceName()));
-    Assert.assertEquals(requiredSingularResourceNameOneof, BookNames.parse(actualRequest.getRequiredSingularResourceNameOneof()));
+    Assert.assertEquals(requiredSingularResourceName, BookName.parse(actualRequest.getRequiredSingularResourceName()));
+    Assert.assertEquals(requiredSingularResourceNameOneof, BookName.parse(actualRequest.getRequiredSingularResourceNameOneof()));
     Assert.assertEquals(requiredSingularResourceNameCommon, actualRequest.getRequiredSingularResourceNameCommon());
     Assert.assertEquals(requiredSingularFixed32, actualRequest.getRequiredSingularFixed32());
     Assert.assertEquals(requiredSingularFixed64, actualRequest.getRequiredSingularFixed64());
@@ -11827,8 +11827,8 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(optionalSingularString, actualRequest.getOptionalSingularString());
     Assert.assertEquals(optionalSingularBytes, actualRequest.getOptionalSingularBytes());
     Assert.assertEquals(optionalSingularMessage, actualRequest.getOptionalSingularMessage());
-    Assert.assertEquals(optionalSingularResourceName, BookNames.parse(actualRequest.getOptionalSingularResourceName()));
-    Assert.assertEquals(optionalSingularResourceNameOneof, BookNames.parse(actualRequest.getOptionalSingularResourceNameOneof()));
+    Assert.assertEquals(optionalSingularResourceName, BookName.parse(actualRequest.getOptionalSingularResourceName()));
+    Assert.assertEquals(optionalSingularResourceNameOneof, BookName.parse(actualRequest.getOptionalSingularResourceNameOneof()));
     Assert.assertEquals(optionalSingularResourceNameCommon, actualRequest.getOptionalSingularResourceNameCommon());
     Assert.assertEquals(optionalSingularFixed32, actualRequest.getOptionalSingularFixed32());
     Assert.assertEquals(optionalSingularFixed64, actualRequest.getOptionalSingularFixed64());

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -1052,7 +1052,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryServiceClient.getBook(name);
    * }
    * </code></pre>
@@ -1075,7 +1075,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryServiceClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -1098,7 +1098,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -1120,7 +1120,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -1275,7 +1275,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryServiceClient.deleteBook(name);
    * }
    * </code></pre>
@@ -1298,7 +1298,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryServiceClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -1321,7 +1321,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -1343,7 +1343,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -1364,7 +1364,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryServiceClient.updateBook(name, book);
    * }
@@ -1390,7 +1390,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryServiceClient.updateBook(name.toString(), book);
    * }
@@ -1416,7 +1416,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -1451,7 +1451,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -1486,7 +1486,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -1510,7 +1510,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -1533,7 +1533,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryServiceClient.moveBook(name, otherShelfName);
    * }
@@ -1559,7 +1559,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryServiceClient.moveBook(name.toString(), otherShelfName.toString());
    * }
@@ -1585,7 +1585,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -1609,7 +1609,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -1772,7 +1772,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   List&lt;Comment&gt; comments = new ArrayList&lt;&gt;();
    *   libraryServiceClient.addComments(name, comments);
    * }
@@ -1798,7 +1798,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   List&lt;Comment&gt; comments = new ArrayList&lt;&gt;();
    *   libraryServiceClient.addComments(name.toString(), comments);
    * }
@@ -1824,7 +1824,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   List&lt;Comment&gt; comments = new ArrayList&lt;&gt;();
    *   AddCommentsRequest request = AddCommentsRequest.newBuilder()
    *     .setName(name.toString())
@@ -1848,7 +1848,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   List&lt;Comment&gt; comments = new ArrayList&lt;&gt;();
    *   AddCommentsRequest request = AddCommentsRequest.newBuilder()
    *     .setName(name.toString())
@@ -1970,8 +1970,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
-   *   String altBookName = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryServiceClient.getBookFromAnywhere(name, altBookName, place, folder);
@@ -2003,8 +2003,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
-   *   String altBookName = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryServiceClient.getBookFromAnywhere(name.toString(), altBookName.toString(), place.toString(), folder.toString());
@@ -2036,8 +2036,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
-   *   String altBookName = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -2064,8 +2064,8 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
-   *   String altBookName = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -2091,7 +2091,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   BookFromAnywhere response = libraryServiceClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -2114,7 +2114,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   BookFromAnywhere response = libraryServiceClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -2137,7 +2137,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2159,7 +2159,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2180,7 +2180,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
    *   libraryServiceClient.updateBookIndex(name, indexName, indexMap);
@@ -2209,7 +2209,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
    *   libraryServiceClient.updateBookIndex(name.toString(), indexName, indexMap);
@@ -2238,7 +2238,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
    *   UpdateBookIndexRequest request = UpdateBookIndexRequest.newBuilder()
@@ -2264,7 +2264,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
    *   UpdateBookIndexRequest request = UpdateBookIndexRequest.newBuilder()
@@ -2340,7 +2340,7 @@ public class LibraryServiceClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryServiceClient.discussBookCallable().call();
    *
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2382,7 +2382,7 @@ public class LibraryServiceClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryServiceClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2422,7 +2422,7 @@ public class LibraryServiceClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryServiceClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2469,7 +2469,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   List&lt;String&gt; names = new ArrayList&lt;&gt;();
+   *   List&lt;BookName&gt; names = new ArrayList&lt;&gt;();
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
    *     .addAllNames(BookName.toStringList(names))
@@ -2496,7 +2496,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   List&lt;String&gt; names = new ArrayList&lt;&gt;();
+   *   List&lt;BookName&gt; names = new ArrayList&lt;&gt;();
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
    *     .addAllNames(BookName.toStringList(names))
@@ -2521,7 +2521,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   List&lt;String&gt; names = new ArrayList&lt;&gt;();
+   *   List&lt;BookName&gt; names = new ArrayList&lt;&gt;();
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
    *     .addAllNames(BookName.toStringList(names))
@@ -2654,7 +2654,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryServiceClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -2678,7 +2678,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryServiceClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -2702,7 +2702,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2725,7 +2725,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2747,7 +2747,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2768,7 +2768,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryServiceClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -2792,7 +2792,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryServiceClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -2816,7 +2816,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2839,7 +2839,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -2861,7 +2861,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
-   *   String name = "";
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -3595,8 +3595,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String requiredSingularResourceName = "";
-   *   String requiredSingularResourceNameOneof = "";
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -3656,8 +3656,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String optionalSingularResourceName = "";
-   *   String optionalSingularResourceNameOneof = "";
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -3981,8 +3981,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String requiredSingularResourceName = "";
-   *   String requiredSingularResourceNameOneof = "";
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -4042,8 +4042,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String optionalSingularResourceName = "";
-   *   String optionalSingularResourceNameOneof = "";
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -4367,8 +4367,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String requiredSingularResourceName = "";
-   *   String requiredSingularResourceNameOneof = "";
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -4381,8 +4381,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   List&lt;String&gt; requiredRepeatedString = new ArrayList&lt;&gt;();
    *   List&lt;ByteString&gt; requiredRepeatedBytes = new ArrayList&lt;&gt;();
    *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
-   *   List&lt;String&gt; requiredRepeatedResourceName = new ArrayList&lt;&gt;();
-   *   List&lt;String&gt; requiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;BookName&gt; requiredRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;BookName&gt; requiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
    *   List&lt;String&gt; requiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
    *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
    *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
@@ -4509,8 +4509,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   String requiredSingularResourceName = "";
-   *   String requiredSingularResourceNameOneof = "";
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -4523,8 +4523,8 @@ public class LibraryServiceClient implements BackgroundResource {
    *   List&lt;String&gt; requiredRepeatedString = new ArrayList&lt;&gt;();
    *   List&lt;ByteString&gt; requiredRepeatedBytes = new ArrayList&lt;&gt;();
    *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
-   *   List&lt;String&gt; requiredRepeatedResourceName = new ArrayList&lt;&gt;();
-   *   List&lt;String&gt; requiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;BookName&gt; requiredRepeatedResourceName = new ArrayList&lt;&gt;();
+   *   List&lt;BookName&gt; requiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
    *   List&lt;String&gt; requiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
    *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
    *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
@@ -10290,7 +10290,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    String name2 = "name2-1052831874";
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10392,7 +10392,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    String name2 = "name2-1052831874";
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10404,7 +10404,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     Book actualResponse =
         client.getBook(name);
@@ -10428,7 +10428,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String name = "name3373707";
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -10493,7 +10493,7 @@ public class LibraryServiceClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     client.deleteBook(name);
 
@@ -10515,7 +10515,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String name = "name3373707";
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -10527,7 +10527,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    String name2 = "name2-1052831874";
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10539,7 +10539,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -10565,7 +10565,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String name = "name3373707";
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -10578,7 +10578,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    String name2 = "name2-1052831874";
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10590,7 +10590,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -10622,7 +10622,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String name = "name3373707";
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -10638,7 +10638,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    String name2 = "name2-1052831874";
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10650,7 +10650,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
@@ -10676,7 +10676,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String name = "name3373707";
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
@@ -10789,7 +10789,7 @@ public class LibraryServiceClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     List<Comment> comments = new ArrayList<>();
 
     client.addComments(name, comments);
@@ -10813,7 +10813,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String name = "name3373707";
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       List<Comment> comments = new ArrayList<>();
 
       client.addComments(name, comments);
@@ -10877,7 +10877,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    String name2 = "name2-1052831874";
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10889,8 +10889,8 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String name = "name3373707";
-    String altBookName = "altBookName908498699";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
     FolderName folder = FolderName.of("[FOLDER]");
 
@@ -10919,8 +10919,8 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String name = "name3373707";
-      String altBookName = "altBookName908498699";
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
       FolderName folder = FolderName.of("[FOLDER]");
 
@@ -10934,7 +10934,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    String name2 = "name2-1052831874";
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -10946,7 +10946,7 @@ public class LibraryServiceClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -10970,7 +10970,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String name = "name3373707";
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -10985,7 +10985,7 @@ public class LibraryServiceClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String indexName = "indexName746962392";
     Map<String, String> indexMap = new HashMap<>();
 
@@ -11011,7 +11011,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String name = "name3373707";
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String indexName = "indexName746962392";
       Map<String, String> indexMap = new HashMap<>();
 
@@ -11072,7 +11072,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    String name2 = "name2-1052831874";
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -11135,7 +11135,7 @@ public class LibraryServiceClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -11160,7 +11160,7 @@ public class LibraryServiceClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -11188,8 +11188,8 @@ public class LibraryServiceClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    String namesElement = "namesElement-249113339";
-    List<String> names2 = Arrays.asList(namesElement);
+    BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    List<BookName> names2 = Arrays.asList(namesElement);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
       .addAllNames(BookName.toStringList(names2))
@@ -11283,7 +11283,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    String name2 = "name2-1052831874";
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -11301,7 +11301,7 @@ public class LibraryServiceClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -11325,7 +11325,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String name = "name3373707";
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -11349,7 +11349,7 @@ public class LibraryServiceClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -11373,7 +11373,7 @@ public class LibraryServiceClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      String name = "name3373707";
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -11635,8 +11635,8 @@ public class LibraryServiceClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    String requiredSingularResourceName = "requiredSingularResourceName-1701575020";
-    String requiredSingularResourceNameOneof = "requiredSingularResourceNameOneof-25303726";
+    BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -11696,8 +11696,8 @@ public class LibraryServiceClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    String optionalSingularResourceName = "optionalSingularResourceName-1254834765";
-    String optionalSingularResourceNameOneof = "optionalSingularResourceNameOneof-1655011023";
+    BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -11901,8 +11901,8 @@ public class LibraryServiceClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      String requiredSingularResourceName = "requiredSingularResourceName-1701575020";
-      String requiredSingularResourceNameOneof = "requiredSingularResourceNameOneof-25303726";
+      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -11962,8 +11962,8 @@ public class LibraryServiceClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      String optionalSingularResourceName = "optionalSingularResourceName-1254834765";
-      String optionalSingularResourceNameOneof = "optionalSingularResourceNameOneof-1655011023";
+      BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -12025,7 +12025,7 @@ public class LibraryServiceClientTest {
   @Test
   @SuppressWarnings("all")
   public void privateListShelvesTest() {
-    String name = "name3373707";
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -212,7 +212,6 @@ import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithResponseHandling {
   // [START sample]
@@ -223,7 +222,6 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test response handling for methods that return empty */
@@ -250,7 +248,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -293,7 +291,6 @@ import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWithoutResponseHandling {
   // [START sample]
@@ -304,7 +301,6 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Test default response handling is turned off for methods that return empty */
@@ -328,7 +324,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -715,7 +711,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -729,7 +724,6 @@ public class FindRelatedBooksCallableCallableListOdyssey {
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -738,7 +732,7 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -867,7 +861,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -882,7 +875,6 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.FindRelatedBooksResponse;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -891,7 +883,7 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -944,7 +936,6 @@ package com.google.example.examples.library.v1;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.ShelfName;
 import java.util.Arrays;
 import java.util.List;
@@ -957,7 +948,6 @@ public class FindRelatedBooksRequestPagedOdyssey {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.FindRelatedBooksRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.ShelfName;
    * import java.util.Arrays;
    * import java.util.List;
@@ -966,7 +956,7 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -1021,7 +1011,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1035,7 +1024,6 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1049,7 +1037,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, "War and Peace");
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1127,7 +1115,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
   // [START hopper]
@@ -1139,7 +1126,6 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1158,7 +1144,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, bigBookName);
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1226,7 +1212,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1241,7 +1226,6 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1255,7 +1239,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, "War and Peace");
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1337,7 +1321,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
   // [START hopper]
@@ -1350,7 +1333,6 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1369,7 +1351,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, bigBookName);
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1438,7 +1420,6 @@ import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 import com.google.protobuf.ListValue;
 import java.util.Map;
@@ -1452,7 +1433,6 @@ public class GetBigBookCallableCallableWap {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
@@ -1467,7 +1447,7 @@ public class GetBigBookCallableCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, "War and Peace");
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1548,7 +1528,6 @@ import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigBookCallableCallableWap2 {
@@ -1560,7 +1539,6 @@ public class GetBigBookCallableCallableWap2 {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
@@ -1580,7 +1558,7 @@ public class GetBigBookCallableCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, bigBookName);
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1652,7 +1630,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -1667,7 +1644,6 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -1681,7 +1657,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, "War and Peace");
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1764,7 +1740,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBigBookOperationCallableLongRunningCallableWap2 {
   // [START hopper]
@@ -1777,7 +1752,6 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBigBook() {
@@ -1796,7 +1770,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, bigBookName);
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1862,7 +1836,6 @@ import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithResponseHandling {
@@ -1874,14 +1847,13 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1926,7 +1898,6 @@ import com.google.api.gax.longrunning.OperationFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -1938,14 +1909,13 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1989,7 +1959,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithResponseHandling {
@@ -2002,14 +1971,13 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2058,7 +2026,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutResponseHandling {
@@ -2071,14 +2038,13 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2124,7 +2090,6 @@ import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling {
@@ -2136,14 +2101,13 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2192,7 +2156,6 @@ import com.google.api.core.ApiFuture;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.longrunning.Operation;
 
 public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2204,14 +2167,13 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.longrunning.Operation;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2259,7 +2221,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithResponseHandling {
@@ -2272,14 +2233,13 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2329,7 +2289,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.Empty;
 
 public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeWithoutResponseHandling {
@@ -2342,14 +2301,13 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.Empty;
    */
 
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2399,7 +2357,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookCallableCallableTestOnSuccessMap {
   // [START sample]
@@ -2411,12 +2368,11 @@ public class GetBookCallableCallableTestOnSuccessMap {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2468,7 +2424,6 @@ package com.google.example.examples.library.v1;
 import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookFlattenedTestOnSuccessMap {
   // [START sample]
@@ -2478,12 +2433,11 @@ public class GetBookFlattenedTestOnSuccessMap {
    * import com.google.example.library.v1.Book;
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       Book response = libraryClient.getBook(name.toString());
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
@@ -2529,7 +2483,6 @@ import com.google.example.library.v1.Book;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class GetBookRequestTestOnSuccessMap {
   // [START sample]
@@ -2540,12 +2493,11 @@ public class GetBookRequestTestOnSuccessMap {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2594,7 +2546,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class MonologAboutBookCallableCallableStreamingClientProg {
   // [START sample]
@@ -2606,7 +2557,6 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   /** Testing calling forms */
@@ -2632,7 +2582,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3662,7 +3612,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3695,7 +3644,6 @@ public class TestFloatAndInt64 {
    *
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
    * import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
@@ -3738,8 +3686,8 @@ public class TestFloatAndInt64 {
       String requiredSingularString = "";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String requiredSingularResourceNameCommon = "";
       int requiredSingularFixed32 = 0;
       long requiredSingularFixed64 = 0L;
@@ -3916,7 +3864,6 @@ import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof {
   // [START test_resource_name_oneof]
@@ -3927,12 +3874,11 @@ public class TestResourceNameOneof {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("[SHELF]", "The ID of the book");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "The ID of the book");;
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3975,7 +3921,6 @@ import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 
 public class TestResourceNameOneof2 {
   // [START test_resource_name_oneof_2]
@@ -3986,12 +3931,11 @@ public class TestResourceNameOneof2 {
    * import com.google.example.library.v1.BookName;
    * import com.google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    */
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("The Shelf to search for the book", "The ID of the book");
+      BookName name = BookName.ofShelfBookName("The Shelf to search for the book", "The ID of the book");;
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4110,7 +4054,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.GetBigBookMetadata;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ListValue;
 import java.util.Map;
 
@@ -4125,7 +4068,6 @@ public class ThisTagShouldBeTheNameOfTheFile {
    * import com.google.example.library.v1.GetBigBookMetadata;
    * import com.google.example.library.v1.GetBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ListValue;
    * import java.util.Map;
    */
@@ -4139,7 +4081,7 @@ public class ThisTagShouldBeTheNameOfTheFile {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = ShelfBookName.of(shelf, "War and Peace");
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4220,7 +4162,6 @@ import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.LibraryClient;
-import com.google.example.library.v1.ShelfBookName;
 import com.google.protobuf.ByteString;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -4236,7 +4177,6 @@ public class TuringProgCallableStreamingBidi {
    * import com.google.example.library.v1.Comment;
    * import com.google.example.library.v1.DiscussBookRequest;
    * import com.google.example.library.v1.LibraryClient;
-   * import com.google.example.library.v1.ShelfBookName;
    * import com.google.protobuf.ByteString;
    * import java.nio.file.Files;
    * import java.nio.file.Path;
@@ -4256,7 +4196,7 @@ public class TuringProgCallableStreamingBidi {
       BidiStream<DiscussBookRequest, Comment> bidiStream =
           libraryClient.discussBookCallable().call();
 
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       Path path = Paths.get("comment_file");
       byte[] data = Files.readAllBytes(path);
       ByteString comment = ByteString.copyFrom(data);
@@ -5672,7 +5612,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryClient.getBook(name);
    * }
    * </code></pre>
@@ -5695,7 +5635,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -5718,7 +5658,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5740,7 +5680,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5901,7 +5841,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryClient.deleteBook(name);
    * }
    * </code></pre>
@@ -5924,7 +5864,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -5947,7 +5887,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5969,7 +5909,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5990,7 +5930,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name, book);
    * }
@@ -6016,7 +5956,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name.toString(), book);
    * }
@@ -6042,7 +5982,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6077,7 +6017,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6112,7 +6052,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6136,7 +6076,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6159,7 +6099,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name, otherShelfName);
    * }
@@ -6185,7 +6125,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name.toString(), otherShelfName.toString());
    * }
@@ -6211,7 +6151,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6235,7 +6175,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6398,7 +6338,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6432,7 +6372,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6466,7 +6406,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6498,7 +6438,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6628,8 +6568,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name, altBookName, place, folder);
@@ -6661,8 +6601,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name.toString(), altBookName.toString(), place.toString(), folder.toString());
@@ -6694,8 +6634,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6722,8 +6662,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6749,7 +6689,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -6772,7 +6712,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -6795,7 +6735,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6817,7 +6757,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6838,7 +6778,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6869,7 +6809,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6900,7 +6840,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6928,7 +6868,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -7006,7 +6946,7 @@ public class LibraryClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryClient.discussBookCallable().call();
    *
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7048,7 +6988,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7088,7 +7028,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7136,7 +7076,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7164,7 +7104,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7190,7 +7130,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7223,7 +7163,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7248,7 +7188,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7272,7 +7212,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -7296,7 +7236,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   Book response = libraryClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7320,7 +7260,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7343,7 +7283,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7365,7 +7305,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7386,7 +7326,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -7410,7 +7350,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   libraryClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7434,7 +7374,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7457,7 +7397,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7479,7 +7419,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7528,8 +7468,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7589,8 +7529,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -7914,8 +7854,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7975,8 +7915,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -8300,8 +8240,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8442,8 +8382,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-   *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -15240,7 +15180,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15352,7 +15292,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15364,7 +15304,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     Book actualResponse =
         client.getBook(name);
@@ -15388,7 +15328,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -15453,7 +15393,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     client.deleteBook(name);
 
@@ -15475,7 +15415,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -15487,7 +15427,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15499,7 +15439,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -15525,7 +15465,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -15538,7 +15478,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15550,7 +15490,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15582,7 +15522,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15598,7 +15538,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15610,7 +15550,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
@@ -15636,7 +15576,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
@@ -15749,7 +15689,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     ByteString comment = ByteString.copyFromUtf8("95");
     Comment.Stage stage = Comment.Stage.UNSET;
     SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15781,7 +15721,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       ByteString comment = ByteString.copyFromUtf8("95");
       Comment.Stage stage = Comment.Stage.UNSET;
       SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15853,7 +15793,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15865,8 +15805,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-    BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
     FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15895,8 +15835,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
-      BookName altBookName = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
       FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15910,7 +15850,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15922,7 +15862,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -15946,7 +15886,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -15961,7 +15901,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String indexName = "default index";
     String indexMapItem = "indexMapItem1918721251";
     Map<String, String> indexMap = new HashMap<>();
@@ -15989,7 +15929,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String indexName = "default index";
       String indexMapItem = "indexMapItem1918721251";
       Map<String, String> indexMap = new HashMap<>();
@@ -16056,7 +15996,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -16119,7 +16059,7 @@ public class LibraryClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -16144,7 +16084,7 @@ public class LibraryClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -16172,7 +16112,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    BookName namesElement2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName namesElement2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     List<BookName> names2 = Arrays.asList(namesElement2);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -16230,7 +16170,7 @@ public class LibraryClientTest {
     AddLabelResponse expectedResponse = AddLabelResponse.newBuilder().build();
     mockLabeler.addResponse(expectedResponse);
 
-    BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String label = "label102727412";
     AddLabelRequest request = AddLabelRequest.newBuilder()
       .setResource(resource.toString())
@@ -16260,7 +16200,7 @@ public class LibraryClientTest {
     mockLabeler.addException(exception);
 
     try {
-      BookName resource = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String label = "label102727412";
       AddLabelRequest request = AddLabelRequest.newBuilder()
         .setResource(resource.toString())
@@ -16277,7 +16217,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    BookName name2 = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -16295,7 +16235,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -16319,7 +16259,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -16343,7 +16283,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -16367,7 +16307,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -16428,8 +16368,8 @@ public class LibraryClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-    BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -16489,8 +16429,8 @@ public class LibraryClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-    BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -16694,8 +16634,8 @@ public class LibraryClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-      BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -16755,8 +16695,8 @@ public class LibraryClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName optionalSingularResourceName = ShelfBookName.of("[SHELF]", "[BOOK]");
-      BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF]", "[BOOK]");
+      BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
       String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -17019,7 +16959,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void privateListShelvesTest() {
-    BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -17111,7 +17051,7 @@ public class LibrarySmokeTest {
 
   public static void executeNoCatch(String projectId) throws Exception {
     try (LibraryClient client = LibraryClient.create()) {
-      BookName name = ShelfBookName.of("testShelf-" + System.currentTimeMillis(), projectId);
+      BookName name = BookName.ofShelfBookName("testShelf-" + System.currentTimeMillis(), projectId);;
       Book.Rating rating = Book.Rating.GOOD;
       Book book = Book.newBuilder()
         .setRating(rating)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -248,7 +248,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -324,7 +324,7 @@ public class BabbleAboutBookCallableCallableStreamingClientEmptyResponseTypeWith
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -732,7 +732,7 @@ public class FindRelatedBooksCallableCallableListOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -883,7 +883,7 @@ public class FindRelatedBooksPagedCallableCallablePagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -956,7 +956,7 @@ public class FindRelatedBooksRequestPagedOdyssey {
   /** Testing calling forms */
   public static void sampleFindRelatedBooks() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       List<BookName> names = Arrays.asList(namesElement);
       ShelfName shelvesElement = ShelfName.of("[SHELF]");
       List<ShelfName> shelves = Arrays.asList(shelvesElement);
@@ -1037,7 +1037,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1144,7 +1144,7 @@ public class GetBigBookAsyncLongRunningFlattenedAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);
       OperationFuture<Book, GetBigBookMetadata> future = libraryClient.getBigBookAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1239,7 +1239,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1351,7 +1351,7 @@ public class GetBigBookAsyncLongRunningRequestAsyncWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1447,7 +1447,7 @@ public class GetBigBookCallableCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1558,7 +1558,7 @@ public class GetBigBookCallableCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1657,7 +1657,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1770,7 +1770,7 @@ public class GetBigBookOperationCallableLongRunningCallableWap2 {
    */
   public static void sampleGetBigBook(String shelf, String bigBookName) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, bigBookName);;
+      BookName name = BookName.ofShelfBookName(shelf, bigBookName);
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -1853,7 +1853,7 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithRes
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1915,7 +1915,7 @@ public class GetBigNothingAsyncLongRunningFlattenedAsyncEmptyResponseTypeWithout
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       OperationFuture<Empty, GetBigBookMetadata> future = libraryClient.getBigNothingAsync(name.toString());
 
       System.out.println("Waiting for operation to complete...");
@@ -1977,7 +1977,7 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithRespo
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2044,7 +2044,7 @@ public class GetBigNothingAsyncLongRunningRequestAsyncEmptyResponseTypeWithoutRe
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2107,7 +2107,7 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithResponseHandling 
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2173,7 +2173,7 @@ public class GetBigNothingCallableCallableEmptyResponseTypeWithoutResponseHandli
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2239,7 +2239,7 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
   /** Test response handling for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2307,7 +2307,7 @@ public class GetBigNothingOperationCallableLongRunningCallableEmptyResponseTypeW
   /** Test default response handling is turned off for methods that return empty */
   public static void sampleGetBigNothing() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2372,7 +2372,7 @@ public class GetBookCallableCallableTestOnSuccessMap {
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2437,7 +2437,7 @@ public class GetBookFlattenedTestOnSuccessMap {
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       Book response = libraryClient.getBook(name.toString());
       String intKeyVal = response.getMapStringValueMap().get(123);
       String booleanKeyVal = response.getMapBoolKeyMap().get(true);
@@ -2497,7 +2497,7 @@ public class GetBookRequestTestOnSuccessMap {
 
   public static void sampleGetBook() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -2582,7 +2582,7 @@ public class MonologAboutBookCallableCallableStreamingClientProg {
       ApiStreamObserver<DiscussBookRequest> requestObserver =
           libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
 
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       DiscussBookRequest request = DiscussBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3686,8 +3686,8 @@ public class TestFloatAndInt64 {
       String requiredSingularString = "";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String requiredSingularResourceNameCommon = "";
       int requiredSingularFixed32 = 0;
       long requiredSingularFixed64 = 0L;
@@ -3878,7 +3878,7 @@ public class TestResourceNameOneof {
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "The ID of the book");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -3935,7 +3935,7 @@ public class TestResourceNameOneof2 {
 
   public static void sampleGetBookFromAbsolutelyAnywhere() {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("The Shelf to search for the book", "The ID of the book");;
+      BookName name = BookName.ofShelfBookName("The Shelf to search for the book", "The ID of the book");
       GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4081,7 +4081,7 @@ public class ThisTagShouldBeTheNameOfTheFile {
   /** Testing calling forms */
   public static void sampleGetBigBook(String shelf) {
     try (LibraryClient libraryClient = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");;
+      BookName name = BookName.ofShelfBookName(shelf, "War and Peace");
       GetBookRequest request = GetBookRequest.newBuilder()
         .setName(name.toString())
         .build();
@@ -4196,7 +4196,7 @@ public class TuringProgCallableStreamingBidi {
       BidiStream<DiscussBookRequest, Comment> bidiStream =
           libraryClient.discussBookCallable().call();
 
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       Path path = Paths.get("comment_file");
       byte[] data = Files.readAllBytes(path);
       ByteString comment = ByteString.copyFrom(data);
@@ -5612,7 +5612,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name);
    * }
    * </code></pre>
@@ -5635,7 +5635,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBook(name.toString());
    * }
    * </code></pre>
@@ -5658,7 +5658,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5680,7 +5680,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5841,7 +5841,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name);
    * }
    * </code></pre>
@@ -5864,7 +5864,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryClient.deleteBook(name.toString());
    * }
    * </code></pre>
@@ -5887,7 +5887,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5909,7 +5909,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DeleteBookRequest request = DeleteBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -5930,7 +5930,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name, book);
    * }
@@ -5956,7 +5956,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   Book response = libraryClient.updateBook(name.toString(), book);
    * }
@@ -5982,7 +5982,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6017,7 +6017,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalFoo = "";
    *   Book book = Book.newBuilder().build();
    *   FieldMask updateMask = FieldMask.newBuilder().build();
@@ -6052,7 +6052,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6076,7 +6076,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book book = Book.newBuilder().build();
    *   UpdateBookRequest request = UpdateBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6099,7 +6099,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name, otherShelfName);
    * }
@@ -6125,7 +6125,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   Book response = libraryClient.moveBook(name.toString(), otherShelfName.toString());
    * }
@@ -6151,7 +6151,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6175,7 +6175,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ShelfName otherShelfName = ShelfName.of("[SHELF]");
    *   MoveBookRequest request = MoveBookRequest.newBuilder()
    *     .setName(name.toString())
@@ -6338,7 +6338,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6372,7 +6372,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6406,7 +6406,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6438,7 +6438,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   ByteString comment = ByteString.copyFromUtf8("");
    *   Comment.Stage stage = Comment.Stage.UNSET;
    *   SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -6568,8 +6568,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name, altBookName, place, folder);
@@ -6601,8 +6601,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   BookFromAnywhere response = libraryClient.getBookFromAnywhere(name.toString(), altBookName.toString(), place.toString(), folder.toString());
@@ -6634,8 +6634,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6662,8 +6662,8 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
    *   FolderName folder = FolderName.of("[FOLDER]");
    *   GetBookFromAnywhereRequest request = GetBookFromAnywhereRequest.newBuilder()
@@ -6689,7 +6689,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name);
    * }
    * </code></pre>
@@ -6712,7 +6712,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   BookFromAnywhere response = libraryClient.getBookFromAbsolutelyAnywhere(name.toString());
    * }
    * </code></pre>
@@ -6735,7 +6735,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6757,7 +6757,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookFromAbsolutelyAnywhereRequest request = GetBookFromAbsolutelyAnywhereRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6778,7 +6778,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6809,7 +6809,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6840,7 +6840,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6868,7 +6868,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
    *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
@@ -6946,7 +6946,7 @@ public class LibraryClient implements BackgroundResource {
    *   BidiStream&lt;DiscussBookRequest, Comment&gt; bidiStream =
    *       libraryClient.discussBookCallable().call();
    *
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -6988,7 +6988,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.monologAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7028,7 +7028,7 @@ public class LibraryClient implements BackgroundResource {
    *   ApiStreamObserver&lt;DiscussBookRequest&gt; requestObserver =
    *       libraryClient.babbleAboutBookCallable().clientStreamingCall(responseObserver);
    *
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   DiscussBookRequest request = DiscussBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7076,7 +7076,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7104,7 +7104,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7130,7 +7130,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName namesElement = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   List&lt;BookName&gt; names = Arrays.asList(namesElement);
    *   List&lt;ShelfName&gt; shelves = new ArrayList&lt;&gt;();
    *   FindRelatedBooksRequest request = FindRelatedBooksRequest.newBuilder()
@@ -7163,7 +7163,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7188,7 +7188,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7212,7 +7212,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name).get();
    * }
    * </code></pre>
@@ -7236,7 +7236,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   Book response = libraryClient.getBigBookAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7260,7 +7260,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7283,7 +7283,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7305,7 +7305,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7326,7 +7326,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name).get();
    * }
    * </code></pre>
@@ -7350,7 +7350,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   libraryClient.getBigNothingAsync(name.toString()).get();
    * }
    * </code></pre>
@@ -7374,7 +7374,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7397,7 +7397,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7419,7 +7419,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   GetBookRequest request = GetBookRequest.newBuilder()
    *     .setName(name.toString())
    *     .build();
@@ -7468,8 +7468,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7529,8 +7529,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -7854,8 +7854,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -7915,8 +7915,8 @@ public class LibraryClient implements BackgroundResource {
    *   String optionalSingularString = "";
    *   ByteString optionalSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String optionalSingularResourceNameCommon = "";
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
@@ -8240,8 +8240,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -8382,8 +8382,8 @@ public class LibraryClient implements BackgroundResource {
    *   String requiredSingularString = "";
    *   ByteString requiredSingularBytes = ByteString.copyFromUtf8("");
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+   *   BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
    *   String requiredSingularResourceNameCommon = "";
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
@@ -15180,7 +15180,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void createBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15292,7 +15292,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15304,7 +15304,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBook(name);
@@ -15328,7 +15328,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBook(name);
       Assert.fail("No exception raised");
@@ -15393,7 +15393,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     client.deleteBook(name);
 
@@ -15415,7 +15415,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.deleteBook(name);
       Assert.fail("No exception raised");
@@ -15427,7 +15427,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15439,7 +15439,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     Book book = Book.newBuilder().build();
 
     Book actualResponse =
@@ -15465,7 +15465,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       Book book = Book.newBuilder().build();
 
       client.updateBook(name, book);
@@ -15478,7 +15478,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void updateBookTest2() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15490,7 +15490,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String optionalFoo = "optionalFoo1822578535";
     Book book = Book.newBuilder().build();
     FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15522,7 +15522,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String optionalFoo = "optionalFoo1822578535";
       Book book = Book.newBuilder().build();
       FieldMask updateMask = FieldMask.newBuilder().build();
@@ -15538,7 +15538,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void moveBookTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15550,7 +15550,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
     Book actualResponse =
@@ -15576,7 +15576,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       ShelfName otherShelfName = ShelfName.of("[SHELF]");
 
       client.moveBook(name, otherShelfName);
@@ -15689,7 +15689,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     ByteString comment = ByteString.copyFromUtf8("95");
     Comment.Stage stage = Comment.Stage.UNSET;
     SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15721,7 +15721,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       ByteString comment = ByteString.copyFromUtf8("95");
       Comment.Stage stage = Comment.Stage.UNSET;
       SomeMessage2.SomeMessage3.Alignment alignment = SomeMessage2.SomeMessage3.Alignment.CHAR;
@@ -15793,7 +15793,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAnywhereTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15805,8 +15805,8 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-    BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
     FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15835,8 +15835,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-      BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      BookName altBookName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       LocationName place = LocationName.of("[PROJECT]", "[LOCATION]");
       FolderName folder = FolderName.of("[FOLDER]");
 
@@ -15850,7 +15850,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBookFromAbsolutelyAnywhereTest() {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -15862,7 +15862,7 @@ public class LibraryClientTest {
       .build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     BookFromAnywhere actualResponse =
         client.getBookFromAbsolutelyAnywhere(name);
@@ -15886,7 +15886,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBookFromAbsolutelyAnywhere(name);
       Assert.fail("No exception raised");
@@ -15901,7 +15901,7 @@ public class LibraryClientTest {
     Empty expectedResponse = Empty.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String indexName = "default index";
     String indexMapItem = "indexMapItem1918721251";
     Map<String, String> indexMap = new HashMap<>();
@@ -15929,7 +15929,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String indexName = "default index";
       String indexMapItem = "indexMapItem1918721251";
       Map<String, String> indexMap = new HashMap<>();
@@ -15996,7 +15996,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamBooksTest() throws Exception {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -16059,7 +16059,7 @@ public class LibraryClientTest {
       .setComment(comment)
       .build();
     mockLibraryService.addResponse(expectedResponse);
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -16084,7 +16084,7 @@ public class LibraryClientTest {
   public void discussBookExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
     mockLibraryService.addException(exception);
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     DiscussBookRequest request = DiscussBookRequest.newBuilder()
       .setName(name.toString())
       .build();
@@ -16112,7 +16112,7 @@ public class LibraryClientTest {
   @SuppressWarnings("all")
   public void findRelatedBooksTest() {
     String nextPageToken = "";
-    BookName namesElement2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName namesElement2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     List<BookName> names2 = Arrays.asList(namesElement2);
     FindRelatedBooksResponse expectedResponse = FindRelatedBooksResponse.newBuilder()
       .setNextPageToken(nextPageToken)
@@ -16170,7 +16170,7 @@ public class LibraryClientTest {
     AddLabelResponse expectedResponse = AddLabelResponse.newBuilder().build();
     mockLabeler.addResponse(expectedResponse);
 
-    BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String label = "label102727412";
     AddLabelRequest request = AddLabelRequest.newBuilder()
       .setResource(resource.toString())
@@ -16200,7 +16200,7 @@ public class LibraryClientTest {
     mockLabeler.addException(exception);
 
     try {
-      BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String label = "label102727412";
       AddLabelRequest request = AddLabelRequest.newBuilder()
         .setResource(resource.toString())
@@ -16217,7 +16217,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void getBigBookTest() throws Exception {
-    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name2 = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -16235,7 +16235,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     Book actualResponse =
         client.getBigBookAsync(name).get();
@@ -16259,7 +16259,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBigBookAsync(name).get();
       Assert.fail("No exception raised");
@@ -16283,7 +16283,7 @@ public class LibraryClientTest {
             .build();
     mockLibraryService.addResponse(resultOperation);
 
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
     Empty actualResponse =
         client.getBigNothingAsync(name).get();
@@ -16307,7 +16307,7 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
 
       client.getBigNothingAsync(name).get();
       Assert.fail("No exception raised");
@@ -16368,8 +16368,8 @@ public class LibraryClientTest {
     String requiredSingularString = "requiredSingularString-1949894503";
     ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-    BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
@@ -16429,8 +16429,8 @@ public class LibraryClientTest {
     String optionalSingularString = "optionalSingularString1852995162";
     ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-    BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-    BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
@@ -16634,8 +16634,8 @@ public class LibraryClientTest {
       String requiredSingularString = "requiredSingularString-1949894503";
       ByteString requiredSingularBytes = ByteString.copyFromUtf8("-29");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName requiredSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      BookName requiredSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String requiredSingularResourceNameCommon = "requiredSingularResourceNameCommon-1126805002";
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
@@ -16695,8 +16695,8 @@ public class LibraryClientTest {
       String optionalSingularString = "optionalSingularString1852995162";
       ByteString optionalSingularBytes = ByteString.copyFromUtf8("2");
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
-      BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
-      BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+      BookName optionalSingularResourceName = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      BookName optionalSingularResourceNameOneof = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
       String optionalSingularResourceNameCommon = "optionalSingularResourceNameCommon-108123657";
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
@@ -16959,7 +16959,7 @@ public class LibraryClientTest {
   @Test
   @SuppressWarnings("all")
   public void privateListShelvesTest() {
-    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");;
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
     String title = "title110371416";
     boolean read = true;
@@ -17051,7 +17051,7 @@ public class LibrarySmokeTest {
 
   public static void executeNoCatch(String projectId) throws Exception {
     try (LibraryClient client = LibraryClient.create()) {
-      BookName name = BookName.ofShelfBookName("testShelf-" + System.currentTimeMillis(), projectId);;
+      BookName name = BookName.ofShelfBookName("testShelf-" + System.currentTimeMillis(), projectId);
       Book.Rating rating = Book.Rating.GOOD;
       Book book = Book.newBuilder()
         .setRating(rating)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -15314,7 +15314,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -15401,7 +15401,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     DeleteBookRequest actualRequest = (DeleteBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -15450,7 +15450,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     UpdateBookRequest actualRequest = (UpdateBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(book, actualRequest.getBook());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -15504,7 +15504,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     UpdateBookRequest actualRequest = (UpdateBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(optionalFoo, actualRequest.getOptionalFoo());
     Assert.assertEquals(book, actualRequest.getBook());
     Assert.assertEquals(updateMask, actualRequest.getUpdateMask());
@@ -15561,7 +15561,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     MoveBookRequest actualRequest = (MoveBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(otherShelfName, ShelfName.parse(actualRequest.getOtherShelfName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -15706,7 +15706,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     AddCommentsRequest actualRequest = (AddCommentsRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(comments, actualRequest.getCommentsList());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -15818,8 +15818,8 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookFromAnywhereRequest actualRequest = (GetBookFromAnywhereRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
-    Assert.assertEquals(altBookName, BookNames.parse(actualRequest.getAltBookName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
+    Assert.assertEquals(altBookName, BookName.parse(actualRequest.getAltBookName()));
     Assert.assertEquals(place, LocationName.parse(actualRequest.getPlace()));
     Assert.assertEquals(folder, FolderName.parse(actualRequest.getFolder()));
     Assert.assertTrue(
@@ -15872,7 +15872,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookFromAbsolutelyAnywhereRequest actualRequest = (GetBookFromAbsolutelyAnywhereRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -15913,7 +15913,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     UpdateBookIndexRequest actualRequest = (UpdateBookIndexRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertEquals(indexName, actualRequest.getIndexName());
     Assert.assertEquals(indexMap, actualRequest.getIndexMapMap());
     Assert.assertTrue(
@@ -16185,7 +16185,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     AddLabelRequest actualRequest = (AddLabelRequest)actualRequests.get(0);
 
-    Assert.assertEquals(resource, BookNames.parse(actualRequest.getResource()));
+    Assert.assertEquals(resource, BookName.parse(actualRequest.getResource()));
     Assert.assertEquals(label, actualRequest.getLabel());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -16245,7 +16245,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -16293,7 +16293,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, BookNames.parse(actualRequest.getName()));
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -16499,8 +16499,8 @@ public class LibraryClientTest {
     Assert.assertEquals(requiredSingularString, actualRequest.getRequiredSingularString());
     Assert.assertEquals(requiredSingularBytes, actualRequest.getRequiredSingularBytes());
     Assert.assertEquals(requiredSingularMessage, actualRequest.getRequiredSingularMessage());
-    Assert.assertEquals(requiredSingularResourceName, BookNames.parse(actualRequest.getRequiredSingularResourceName()));
-    Assert.assertEquals(requiredSingularResourceNameOneof, BookNames.parse(actualRequest.getRequiredSingularResourceNameOneof()));
+    Assert.assertEquals(requiredSingularResourceName, BookName.parse(actualRequest.getRequiredSingularResourceName()));
+    Assert.assertEquals(requiredSingularResourceNameOneof, BookName.parse(actualRequest.getRequiredSingularResourceNameOneof()));
     Assert.assertEquals(requiredSingularResourceNameCommon, actualRequest.getRequiredSingularResourceNameCommon());
     Assert.assertEquals(requiredSingularFixed32, actualRequest.getRequiredSingularFixed32());
     Assert.assertEquals(requiredSingularFixed64, actualRequest.getRequiredSingularFixed64());
@@ -16560,8 +16560,8 @@ public class LibraryClientTest {
     Assert.assertEquals(optionalSingularString, actualRequest.getOptionalSingularString());
     Assert.assertEquals(optionalSingularBytes, actualRequest.getOptionalSingularBytes());
     Assert.assertEquals(optionalSingularMessage, actualRequest.getOptionalSingularMessage());
-    Assert.assertEquals(optionalSingularResourceName, BookNames.parse(actualRequest.getOptionalSingularResourceName()));
-    Assert.assertEquals(optionalSingularResourceNameOneof, BookNames.parse(actualRequest.getOptionalSingularResourceNameOneof()));
+    Assert.assertEquals(optionalSingularResourceName, BookName.parse(actualRequest.getOptionalSingularResourceName()));
+    Assert.assertEquals(optionalSingularResourceNameOneof, BookName.parse(actualRequest.getOptionalSingularResourceNameOneof()));
     Assert.assertEquals(optionalSingularResourceNameCommon, actualRequest.getOptionalSingularResourceNameCommon());
     Assert.assertEquals(optionalSingularFixed32, actualRequest.getOptionalSingularFixed32());
     Assert.assertEquals(optionalSingularFixed64, actualRequest.getOptionalSingularFixed64());


### PR DESCRIPTION
In Java, for libraries generated from gapic v2 + annotations, use the new static create methods (e.g., `ofShelfBookName`) to create resource names in samples and tests.