### PR TITLE
Python: remove experimental notices for streaming

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -179,10 +179,6 @@
                     {@line}
                 @end
 
-                @if apiMethod.hasRequestStreaming
-                    EXPERIMENTAL: This method interface might change in the future.
-
-                @end
                 {@exampleInCode(apiMethod)}
 
                 Args:

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -2768,8 +2768,6 @@ class LibraryServiceClient(object):
         """
         Test bidi-streaming.
 
-        EXPERIMENTAL: This method interface might change in the future.
-
         Example:
             >>> from google.cloud.example import library_v1
             >>>
@@ -2825,8 +2823,6 @@ class LibraryServiceClient(object):
         """
         Test client streaming.
 
-        EXPERIMENTAL: This method interface might change in the future.
-
         Example:
             >>> from google.cloud.example import library_v1
             >>>
@@ -2880,8 +2876,6 @@ class LibraryServiceClient(object):
         """
         Test samplegen response handling when a client streaming method returns Empty.
         gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-
-        EXPERIMENTAL: This method interface might change in the future.
 
         Example:
             >>> from google.cloud.example import library_v1
@@ -4175,8 +4169,6 @@ class LibraryServiceClient(object):
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):
         """
-
-        EXPERIMENTAL: This method interface might change in the future.
 
         Example:
             >>> from google.cloud.example import library_v1

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1047,8 +1047,6 @@ class DecrementerServiceClient(object):
         """
         Decrement.
 
-        EXPERIMENTAL: This method interface might change in the future.
-
         Example:
             >>> from google.cloud import example_v1
             >>>

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
@@ -2739,8 +2739,6 @@ class LibraryServiceClient(object):
         """
         Test bidi-streaming.
 
-        EXPERIMENTAL: This method interface might change in the future.
-
         Example:
             >>> from google.cloud.example import library_v1
             >>>
@@ -2796,8 +2794,6 @@ class LibraryServiceClient(object):
         """
         Test client streaming.
 
-        EXPERIMENTAL: This method interface might change in the future.
-
         Example:
             >>> from google.cloud.example import library_v1
             >>>
@@ -2851,8 +2847,6 @@ class LibraryServiceClient(object):
         """
         Test samplegen response handling when a client streaming method returns Empty.
         gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-
-        EXPERIMENTAL: This method interface might change in the future.
 
         Example:
             >>> from google.cloud.example import library_v1
@@ -4050,8 +4044,6 @@ class LibraryServiceClient(object):
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):
         """
-
-        EXPERIMENTAL: This method interface might change in the future.
 
         Example:
             >>> from google.cloud.example import library_v1

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -2795,8 +2795,6 @@ class LibraryServiceClient(object):
         """
         Test bidi-streaming.
 
-        EXPERIMENTAL: This method interface might change in the future.
-
         Example:
             >>> from google.cloud.example import library_v1
             >>>
@@ -2852,8 +2850,6 @@ class LibraryServiceClient(object):
         """
         Test client streaming.
 
-        EXPERIMENTAL: This method interface might change in the future.
-
         Example:
             >>> from google.cloud.example import library_v1
             >>>
@@ -2907,8 +2903,6 @@ class LibraryServiceClient(object):
         """
         Test samplegen response handling when a client streaming method returns Empty.
         gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-
-        EXPERIMENTAL: This method interface might change in the future.
 
         Example:
             >>> from google.cloud.example import library_v1
@@ -4220,8 +4214,6 @@ class LibraryServiceClient(object):
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):
         """
-
-        EXPERIMENTAL: This method interface might change in the future.
 
         Example:
             >>> from google.cloud.example import library_v1

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
@@ -2246,8 +2246,6 @@ class LibraryServiceClient(object):
         """
         Test bidi-streaming.
 
-        EXPERIMENTAL: This method interface might change in the future.
-
         Example:
             >>> from com.google.example import library
             >>>
@@ -2303,8 +2301,6 @@ class LibraryServiceClient(object):
         """
         Test client streaming.
 
-        EXPERIMENTAL: This method interface might change in the future.
-
         Example:
             >>> from com.google.example import library
             >>>
@@ -2358,8 +2354,6 @@ class LibraryServiceClient(object):
         """
         Test samplegen response handling when a client streaming method returns Empty.
         gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-
-        EXPERIMENTAL: This method interface might change in the future.
 
         Example:
             >>> from com.google.example import library


### PR DESCRIPTION
The PubSub python client has been GA since August 2019, so the notice about streaming should be removed.

I believe some of the other references are related to samplegen/tests, so I removed the reference since I believe the experimental notice was placed because of streaming.
Let me know if you disagree and I'll revert those changes.