### PR TITLE
feat: adds reserved name support for PHP and reserved name tests

### DIFF
--- a/src/main/java/com/google/api/codegen/util/php/PhpTypeTable.java
+++ b/src/main/java/com/google/api/codegen/util/php/PhpTypeTable.java
@@ -28,6 +28,18 @@ public class PhpTypeTable implements TypeTable {
 
   private final DynamicLangTypeTable dynamicTypeTable;
 
+  private TypeName wrapIfKeywordOrBuiltIn(TypeName typeName) {
+    if (RESERVED_IDENTIFIER_SET.contains(typeName.getNickname().toLowerCase())) {
+      int lastSeparatorIndex = typeName.getFullName().lastIndexOf(dynamicTypeTable.getSeparator());
+      if (lastSeparatorIndex > 0) {
+        String namespace = typeName.getFullName().substring(0, lastSeparatorIndex);
+        String nickname = "PB" + typeName.getNickname();
+        return new TypeName(namespace + dynamicTypeTable.getSeparator() + nickname, nickname);
+      }
+    }
+    return typeName;
+  }
+
   public PhpTypeTable(String implicitPackageName) {
     dynamicTypeTable = new DynamicLangTypeTable(implicitPackageName, "\\");
   }
@@ -64,12 +76,12 @@ public class PhpTypeTable implements TypeTable {
 
   @Override
   public String getAndSaveNicknameFor(String fullName) {
-    return dynamicTypeTable.getAndSaveNicknameFor(fullName);
+    return getAndSaveNicknameFor(getTypeName(fullName));
   }
 
   @Override
   public String getAndSaveNicknameFor(TypeName typeName) {
-    return dynamicTypeTable.getAndSaveNicknameFor(typeName);
+    return dynamicTypeTable.getAndSaveNicknameFor(wrapIfKeywordOrBuiltIn(typeName));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/util/php/PhpTypeTable.java
+++ b/src/main/java/com/google/api/codegen/util/php/PhpTypeTable.java
@@ -56,7 +56,7 @@ public class PhpTypeTable implements TypeTable {
 
   @Override
   public TypeName getTypeName(String fullName) {
-    return dynamicTypeTable.getTypeName(fullName);
+    return wrapIfKeywordOrBuiltIn(dynamicTypeTable.getTypeName(fullName));
   }
 
   @Override
@@ -76,7 +76,7 @@ public class PhpTypeTable implements TypeTable {
 
   @Override
   public String getAndSaveNicknameFor(String fullName) {
-    return getAndSaveNicknameFor(getTypeName(fullName));
+    return dynamicTypeTable.getAndSaveNicknameFor(getTypeName(fullName));
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
@@ -1006,3 +1006,23 @@ interfaces:
     retry_params_name: default
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  - name: GetNamespace
+    # FIXME: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - mylist
+        - myfield
+        - secondfield
+    # FIXME: Configure which fields are required.
+    required_fields:
+    - mylist
+    - myfield
+    - secondfield
+    # FIXME: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # FIXME: Configure the retryable params for this method.
+    retry_params_name: default
+    # FIXME: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -7857,6 +7857,33 @@ namespace Google.Example.Library.V1.Snippets
             // End snippet
         }
 
+        /// <summary>Snippet for GetNamespaceAsync</summary>
+        public async Task GetNamespaceAsync_RequestObject()
+        {
+            // Snippet: GetNamespaceAsync(MethodRequest,CallSettings)
+            // Additional: GetNamespaceAsync(MethodRequest,CancellationToken)
+            // Create client
+            MyProtoClient myProtoClient = await MyProtoClient.CreateAsync();
+            // Initialize request argument(s)
+            MethodRequest request = new MethodRequest();
+            // Make the request
+            Namespace response = await myProtoClient.GetNamespaceAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for GetNamespace</summary>
+        public void GetNamespace_RequestObject()
+        {
+            // Snippet: GetNamespace(MethodRequest,CallSettings)
+            // Create client
+            MyProtoClient myProtoClient = MyProtoClient.Create();
+            // Initialize request argument(s)
+            MethodRequest request = new MethodRequest();
+            // Make the request
+            Namespace response = myProtoClient.GetNamespace(request);
+            // End snippet
+        }
+
     }
 }
 
@@ -10780,6 +10807,40 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Grpc.Core.AsyncUnaryCall<MethodResponse>(Task.FromResult(expectedResponse), null, null, null, null));
             MyProtoClient client = new MyProtoClientImpl(mockGrpcClient.Object, null);
             MethodResponse response = await client.MyMethodAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void GetNamespace()
+        {
+            Mock<MyProto.MyProtoClient> mockGrpcClient = new Mock<MyProto.MyProtoClient>(MockBehavior.Strict);
+            MethodRequest request = new MethodRequest();
+            Namespace expectedResponse = new Namespace
+            {
+                Value = "value111972721",
+            };
+            mockGrpcClient.Setup(x => x.GetNamespace(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            MyProtoClient client = new MyProtoClientImpl(mockGrpcClient.Object, null);
+            Namespace response = client.GetNamespace(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task GetNamespaceAsync()
+        {
+            Mock<MyProto.MyProtoClient> mockGrpcClient = new Mock<MyProto.MyProtoClient>(MockBehavior.Strict);
+            MethodRequest request = new MethodRequest();
+            Namespace expectedResponse = new Namespace
+            {
+                Value = "value111972721",
+            };
+            mockGrpcClient.Setup(x => x.GetNamespaceAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<Namespace>(Task.FromResult(expectedResponse), null, null, null, null));
+            MyProtoClient client = new MyProtoClientImpl(mockGrpcClient.Object, null);
+            Namespace response = await client.GetNamespaceAsync(request);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
         }
@@ -22780,6 +22841,7 @@ namespace Google.Example.Library.V1
         {
             gax::GaxPreconditions.CheckNotNull(existing, nameof(existing));
             MyMethodSettings = existing.MyMethodSettings;
+            GetNamespaceSettings = existing.GetNamespaceSettings;
             OnCopy(existing);
         }
 
@@ -22871,6 +22933,35 @@ namespace Google.Example.Library.V1
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings MyMethodSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>MyProtoClient.GetNamespace</c> and <c>MyProtoClient.GetNamespaceAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>MyProtoClient.GetNamespace</c> and
+        /// <c>MyProtoClient.GetNamespaceAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.3</description></item>
+        /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 20000 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.0</description></item>
+        /// <item><description>Timeout maximum delay: 20000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 600000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings GetNamespaceSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
@@ -23135,6 +23226,62 @@ namespace Google.Example.Library.V1
             throw new sys::NotImplementedException();
         }
 
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Namespace> GetNamespaceAsync(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Namespace> GetNamespaceAsync(
+            MethodRequest request,
+            st::CancellationToken cancellationToken) => GetNamespaceAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Namespace GetNamespace(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
     }
 
     /// <summary>
@@ -23143,6 +23290,7 @@ namespace Google.Example.Library.V1
     public sealed partial class MyProtoClientImpl : MyProtoClient
     {
         private readonly gaxgrpc::ApiCall<MethodRequest, MethodResponse> _callMyMethod;
+        private readonly gaxgrpc::ApiCall<MethodRequest, Namespace> _callGetNamespace;
 
         /// <summary>
         /// Constructs a client wrapper for the MyProto service, with the specified gRPC client and settings.
@@ -23156,8 +23304,12 @@ namespace Google.Example.Library.V1
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
             _callMyMethod = clientHelper.BuildApiCall<MethodRequest, MethodResponse>(
                 GrpcClient.MyMethodAsync, GrpcClient.MyMethod, effectiveSettings.MyMethodSettings);
+            _callGetNamespace = clientHelper.BuildApiCall<MethodRequest, Namespace>(
+                GrpcClient.GetNamespaceAsync, GrpcClient.GetNamespace, effectiveSettings.GetNamespaceSettings);
             Modify_ApiCall(ref _callMyMethod);
             Modify_MyMethodApiCall(ref _callMyMethod);
+            Modify_ApiCall(ref _callGetNamespace);
+            Modify_GetNamespaceApiCall(ref _callGetNamespace);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);
         }
 
@@ -23172,6 +23324,7 @@ namespace Google.Example.Library.V1
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
         partial void Modify_MyMethodApiCall(ref gaxgrpc::ApiCall<MethodRequest, MethodResponse> call);
+        partial void Modify_GetNamespaceApiCall(ref gaxgrpc::ApiCall<MethodRequest, Namespace> call);
         partial void OnConstruction(MyProto.MyProtoClient grpcClient, MyProtoSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
         /// <summary>
@@ -23222,6 +23375,46 @@ namespace Google.Example.Library.V1
         {
             Modify_MethodRequest(ref request, ref callSettings);
             return _callMyMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<Namespace> GetNamespaceAsync(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MethodRequest(ref request, ref callSettings);
+            return _callGetNamespace.Async(request, callSettings);
+        }
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override Namespace GetNamespace(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MethodRequest(ref request, ref callSettings);
+            return _callGetNamespace.Sync(request, callSettings);
         }
 
     }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_samplegen_config_migration_library.baseline
@@ -4554,6 +4554,33 @@ namespace Google.Example.Library.V1.Snippets
             // End snippet
         }
 
+        /// <summary>Snippet for GetNamespaceAsync</summary>
+        public async Task GetNamespaceAsync_RequestObject()
+        {
+            // Snippet: GetNamespaceAsync(MethodRequest,CallSettings)
+            // Additional: GetNamespaceAsync(MethodRequest,CancellationToken)
+            // Create client
+            MyProtoClient myProtoClient = await MyProtoClient.CreateAsync();
+            // Initialize request argument(s)
+            MethodRequest request = new MethodRequest();
+            // Make the request
+            Namespace response = await myProtoClient.GetNamespaceAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for GetNamespace</summary>
+        public void GetNamespace_RequestObject()
+        {
+            // Snippet: GetNamespace(MethodRequest,CallSettings)
+            // Create client
+            MyProtoClient myProtoClient = MyProtoClient.Create();
+            // Initialize request argument(s)
+            MethodRequest request = new MethodRequest();
+            // Make the request
+            Namespace response = myProtoClient.GetNamespace(request);
+            // End snippet
+        }
+
     }
 }
 
@@ -7267,6 +7294,40 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Grpc.Core.AsyncUnaryCall<MethodResponse>(Task.FromResult(expectedResponse), null, null, null, null));
             MyProtoClient client = new MyProtoClientImpl(mockGrpcClient.Object, null);
             MethodResponse response = await client.MyMethodAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void GetNamespace()
+        {
+            Mock<MyProto.MyProtoClient> mockGrpcClient = new Mock<MyProto.MyProtoClient>(MockBehavior.Strict);
+            MethodRequest request = new MethodRequest();
+            Namespace expectedResponse = new Namespace
+            {
+                Value = "value111972721",
+            };
+            mockGrpcClient.Setup(x => x.GetNamespace(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            MyProtoClient client = new MyProtoClientImpl(mockGrpcClient.Object, null);
+            Namespace response = client.GetNamespace(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task GetNamespaceAsync()
+        {
+            Mock<MyProto.MyProtoClient> mockGrpcClient = new Mock<MyProto.MyProtoClient>(MockBehavior.Strict);
+            MethodRequest request = new MethodRequest();
+            Namespace expectedResponse = new Namespace
+            {
+                Value = "value111972721",
+            };
+            mockGrpcClient.Setup(x => x.GetNamespaceAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<Namespace>(Task.FromResult(expectedResponse), null, null, null, null));
+            MyProtoClient client = new MyProtoClientImpl(mockGrpcClient.Object, null);
+            Namespace response = await client.GetNamespaceAsync(request);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
         }
@@ -18217,6 +18278,7 @@ namespace Google.Example.Library.V1
         {
             gax::GaxPreconditions.CheckNotNull(existing, nameof(existing));
             MyMethodSettings = existing.MyMethodSettings;
+            GetNamespaceSettings = existing.GetNamespaceSettings;
             OnCopy(existing);
         }
 
@@ -18308,6 +18370,35 @@ namespace Google.Example.Library.V1
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings MyMethodSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>MyProtoClient.GetNamespace</c> and <c>MyProtoClient.GetNamespaceAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>MyProtoClient.GetNamespace</c> and
+        /// <c>MyProtoClient.GetNamespaceAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.3</description></item>
+        /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 20000 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.0</description></item>
+        /// <item><description>Timeout maximum delay: 20000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 600000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings GetNamespaceSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
@@ -18572,6 +18663,62 @@ namespace Google.Example.Library.V1
             throw new sys::NotImplementedException();
         }
 
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Namespace> GetNamespaceAsync(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Namespace> GetNamespaceAsync(
+            MethodRequest request,
+            st::CancellationToken cancellationToken) => GetNamespaceAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Namespace GetNamespace(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
     }
 
     /// <summary>
@@ -18580,6 +18727,7 @@ namespace Google.Example.Library.V1
     public sealed partial class MyProtoClientImpl : MyProtoClient
     {
         private readonly gaxgrpc::ApiCall<MethodRequest, MethodResponse> _callMyMethod;
+        private readonly gaxgrpc::ApiCall<MethodRequest, Namespace> _callGetNamespace;
 
         /// <summary>
         /// Constructs a client wrapper for the MyProto service, with the specified gRPC client and settings.
@@ -18593,8 +18741,12 @@ namespace Google.Example.Library.V1
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
             _callMyMethod = clientHelper.BuildApiCall<MethodRequest, MethodResponse>(
                 GrpcClient.MyMethodAsync, GrpcClient.MyMethod, effectiveSettings.MyMethodSettings);
+            _callGetNamespace = clientHelper.BuildApiCall<MethodRequest, Namespace>(
+                GrpcClient.GetNamespaceAsync, GrpcClient.GetNamespace, effectiveSettings.GetNamespaceSettings);
             Modify_ApiCall(ref _callMyMethod);
             Modify_MyMethodApiCall(ref _callMyMethod);
+            Modify_ApiCall(ref _callGetNamespace);
+            Modify_GetNamespaceApiCall(ref _callGetNamespace);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);
         }
 
@@ -18609,6 +18761,7 @@ namespace Google.Example.Library.V1
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
         partial void Modify_MyMethodApiCall(ref gaxgrpc::ApiCall<MethodRequest, MethodResponse> call);
+        partial void Modify_GetNamespaceApiCall(ref gaxgrpc::ApiCall<MethodRequest, Namespace> call);
         partial void OnConstruction(MyProto.MyProtoClient grpcClient, MyProtoSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
         /// <summary>
@@ -18659,6 +18812,46 @@ namespace Google.Example.Library.V1
         {
             Modify_MethodRequest(ref request, ref callSettings);
             return _callMyMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<Namespace> GetNamespaceAsync(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MethodRequest(ref request, ref callSettings);
+            return _callGetNamespace.Async(request, callSettings);
+        }
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override Namespace GetNamespace(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MethodRequest(ref request, ref callSettings);
+            return _callGetNamespace.Sync(request, callSettings);
         }
 
     }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -2503,6 +2503,18 @@ func (s *mockMyProtoServer) MyMethod(ctx context.Context, req *pb.MethodRequest)
     return s.resps[0].(*pb.MethodResponse), nil
 }
 
+func (s *mockMyProtoServer) GetNamespace(ctx context.Context, req *pb.MethodRequest) (*pb.Namespace, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*pb.Namespace), nil
+}
+
 
 // clientOpt is the option tests should use to connect to the test server.
 // It is initialized by TestMain.
@@ -4982,6 +4994,59 @@ func TestMyProtoMyMethodError(t *testing.T) {
     }
     _ = resp
 }
+func TestMyProtoGetNamespace(t *testing.T) {
+    var value string = "value111972721"
+    var expectedResponse = &pb.Namespace{
+        Value: value,
+    }
+
+    mockMyProto.err = nil
+    mockMyProto.reqs = nil
+
+    mockMyProto.resps = append(mockMyProto.resps[:0], expectedResponse)
+
+    var request *pb.MethodRequest = &pb.MethodRequest{}
+
+    c, err := NewMyProtoClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.GetNamespace(context.Background(), request)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockMyProto.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+    if want, got := expectedResponse, resp; !proto.Equal(want, got) {
+        t.Errorf("wrong response %q, want %q)", got, want)
+    }
+}
+
+func TestMyProtoGetNamespaceError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockMyProto.err = gstatus.Error(errCode, "test error")
+
+    var request *pb.MethodRequest = &pb.MethodRequest{}
+
+    c, err := NewMyProtoClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.GetNamespace(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
+    _ = resp
+}
 ============== file: cloud.google.com/go/library/apiv1/my_proto_client.go ==============
 // Copyright 2020 Google LLC
 //
@@ -5016,6 +5081,7 @@ import (
 // MyProtoCallOptions contains the retry settings for each method of MyProtoClient.
 type MyProtoCallOptions struct {
     MyMethod []gax.CallOption
+    GetNamespace []gax.CallOption
 }
 
 func defaultMyProtoClientOptions() []option.ClientOption {
@@ -5032,6 +5098,7 @@ func defaultMyProtoCallOptions() *MyProtoCallOptions {
     }
     return &MyProtoCallOptions{
         MyMethod: retry[[2]string{"default", "non_idempotent"}],
+        GetNamespace: retry[[2]string{"default", "non_idempotent"}],
     }
 }
 
@@ -5106,6 +5173,22 @@ func (c *MyProtoClient) MyMethod(ctx context.Context, req *pb.MethodRequest, opt
     return resp, nil
 }
 
+// GetNamespace define a service with a reserved name
+func (c *MyProtoClient) GetNamespace(ctx context.Context, req *pb.MethodRequest, opts ...gax.CallOption) (*pb.Namespace, error) {
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
+    opts = append(c.CallOptions.GetNamespace[0:len(c.CallOptions.GetNamespace):len(c.CallOptions.GetNamespace)], opts...)
+    var resp *pb.Namespace
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        resp, err = c.myProtoClient.GetNamespace(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
+}
+
 
 
 ============== file: cloud.google.com/go/library/apiv1/my_proto_client_example_test.go ==============
@@ -5155,6 +5238,24 @@ func ExampleMyProtoClient_MyMethod() {
         // TODO: Fill request struct fields.
     }
     resp, err := c.MyMethod(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    // TODO: Use resp.
+    _ = resp
+}
+
+func ExampleMyProtoClient_GetNamespace() {
+    ctx := context.Background()
+    c, err := library.NewMyProtoClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &pb.MethodRequest{
+        // TODO: Fill request struct fields.
+    }
+    resp, err := c.GetNamespace(ctx, req)
     if err != nil {
         // TODO: Handle error.
     }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -9762,6 +9762,7 @@ import com.google.example.library.v1.stub.MyProtoStub;
 import com.google.example.library.v1.stub.MyProtoStubSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
@@ -9979,6 +9980,43 @@ public class MyProtoClient implements BackgroundResource {
     return stub.myMethodCallable();
   }
 
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Define a service with a reserved name
+   *
+   * Sample code:
+   * <pre><code>
+   * try (MyProtoClient myProtoClient = MyProtoClient.create()) {
+   *   MethodRequest request = MethodRequest.newBuilder().build();
+   *   Namespace response = myProtoClient.getNamespace(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Namespace getNamespace(MethodRequest request) {
+    return getNamespaceCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Define a service with a reserved name
+   *
+   * Sample code:
+   * <pre><code>
+   * try (MyProtoClient myProtoClient = MyProtoClient.create()) {
+   *   MethodRequest request = MethodRequest.newBuilder().build();
+   *   ApiFuture&lt;Namespace&gt; future = myProtoClient.getNamespaceCallable().futureCall(request);
+   *   // Do something
+   *   Namespace response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    return stub.getNamespaceCallable();
+  }
+
   @Override
   public final void close() {
     stub.close();
@@ -10057,6 +10095,7 @@ import com.google.common.collect.Sets;
 import com.google.example.library.v1.stub.MyProtoStubSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc;
 import java.io.IOException;
 import java.util.List;
@@ -10104,6 +10143,13 @@ public class MyProtoSettings extends ClientSettings<MyProtoSettings> {
    */
   public UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings() {
     return ((MyProtoStubSettings) getStubSettings()).myMethodSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getNamespace.
+   */
+  public UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings() {
+    return ((MyProtoStubSettings) getStubSettings()).getNamespaceSettings();
   }
 
 
@@ -10225,6 +10271,13 @@ public class MyProtoSettings extends ClientSettings<MyProtoSettings> {
      */
     public UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings() {
       return getStubSettingsBuilder().myMethodSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getNamespace.
+     */
+    public UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings() {
+      return getStubSettingsBuilder().getNamespaceSettings();
     }
 
     @Override
@@ -11545,6 +11598,7 @@ import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
@@ -11649,6 +11703,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.MyProtoSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
@@ -11675,11 +11730,19 @@ public class GrpcMyProtoStub extends MyProtoStub {
           .setRequestMarshaller(ProtoUtils.marshaller(MethodRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(MethodResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<MethodRequest, Namespace> getNamespaceMethodDescriptor =
+      MethodDescriptor.<MethodRequest, Namespace>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.MyProto/GetNamespace")
+          .setRequestMarshaller(ProtoUtils.marshaller(MethodRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Namespace.getDefaultInstance()))
+          .build();
 
 
   private final BackgroundResource backgroundResources;
 
   private final UnaryCallable<MethodRequest, MethodResponse> myMethodCallable;
+  private final UnaryCallable<MethodRequest, Namespace> getNamespaceCallable;
 
   private final GrpcStubCallableFactory callableFactory;
 
@@ -11716,8 +11779,13 @@ public class GrpcMyProtoStub extends MyProtoStub {
         GrpcCallSettings.<MethodRequest, MethodResponse>newBuilder()
             .setMethodDescriptor(myMethodMethodDescriptor)
             .build();
+    GrpcCallSettings<MethodRequest, Namespace> getNamespaceTransportSettings =
+        GrpcCallSettings.<MethodRequest, Namespace>newBuilder()
+            .setMethodDescriptor(getNamespaceMethodDescriptor)
+            .build();
 
     this.myMethodCallable = callableFactory.createUnaryCallable(myMethodTransportSettings,settings.myMethodSettings(), clientContext);
+    this.getNamespaceCallable = callableFactory.createUnaryCallable(getNamespaceTransportSettings,settings.getNamespaceSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
@@ -11725,6 +11793,10 @@ public class GrpcMyProtoStub extends MyProtoStub {
 
   public UnaryCallable<MethodRequest, MethodResponse> myMethodCallable() {
     return myMethodCallable;
+  }
+
+  public UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    return getNamespaceCallable;
   }
 
   @Override
@@ -13673,6 +13745,7 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
@@ -13688,6 +13761,10 @@ public abstract class MyProtoStub implements BackgroundResource {
 
   public UnaryCallable<MethodRequest, MethodResponse> myMethodCallable() {
     throw new UnsupportedOperationException("Not implemented: myMethodCallable()");
+  }
+
+  public UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    throw new UnsupportedOperationException("Not implemented: getNamespaceCallable()");
   }
 
   @Override
@@ -13738,6 +13815,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc;
 import java.io.IOException;
 import java.util.List;
@@ -13789,12 +13867,20 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       .build();
 
   private final UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings;
+  private final UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings;
 
   /**
    * Returns the object with the settings used for calls to myMethod.
    */
   public UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings() {
     return myMethodSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getNamespace.
+   */
+  public UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings() {
+    return getNamespaceSettings;
   }
 
 
@@ -13884,6 +13970,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
     super(settingsBuilder);
 
     myMethodSettings = settingsBuilder.myMethodSettings().build();
+    getNamespaceSettings = settingsBuilder.getNamespaceSettings().build();
   }
 
 
@@ -13896,6 +13983,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
 
     private final UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings;
+    private final UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -13937,8 +14025,11 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
 
       myMethodSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      getNamespaceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-          myMethodSettings
+          myMethodSettings,
+          getNamespaceSettings
       );
 
       initDefaults(this);
@@ -13959,6 +14050,10 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.getNamespaceSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       return builder;
     }
 
@@ -13966,9 +14061,11 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       super(settings);
 
       myMethodSettings = settings.myMethodSettings.toBuilder();
+      getNamespaceSettings = settings.getNamespaceSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-          myMethodSettings
+          myMethodSettings,
+          getNamespaceSettings
       );
     }
 
@@ -13992,6 +14089,13 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
      */
     public UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings() {
       return myMethodSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getNamespace.
+     */
+    public UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings() {
+      return getNamespaceSettings;
     }
 
     @Override
@@ -17181,6 +17285,7 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc.MyProtoImplBase;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
@@ -17235,6 +17340,21 @@ public class MockMyProtoImpl extends MyProtoImplBase {
     }
   }
 
+  @Override
+  public void getNamespace(MethodRequest request,
+    StreamObserver<Namespace> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Namespace) {
+      requests.add(request);
+      responseObserver.onNext((Namespace) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
 }
 ============== file: src/test/java/com/google/example/library/v1/MyProtoClientTest.java ==============
 /*
@@ -17267,6 +17387,7 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -17357,6 +17478,47 @@ public class MyProtoClientTest {
       MethodRequest request = MethodRequest.newBuilder().build();
 
       client.myMethod(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getNamespaceTest() {
+    String value = "value111972721";
+    Namespace expectedResponse = Namespace.newBuilder()
+      .setValue(value)
+      .build();
+    mockMyProto.addResponse(expectedResponse);
+
+    MethodRequest request = MethodRequest.newBuilder().build();
+
+    Namespace actualResponse =
+        client.getNamespace(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockMyProto.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getNamespaceExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockMyProto.addException(exception);
+
+    try {
+      MethodRequest request = MethodRequest.newBuilder().build();
+
+      client.getNamespace(request);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -7259,6 +7259,7 @@ import com.google.example.library.v1.stub.MyProtoStub;
 import com.google.example.library.v1.stub.MyProtoStubSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
@@ -7476,6 +7477,43 @@ public class MyProtoClient implements BackgroundResource {
     return stub.myMethodCallable();
   }
 
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Define a service with a reserved name
+   *
+   * Sample code:
+   * <pre><code>
+   * try (MyProtoClient myProtoClient = MyProtoClient.create()) {
+   *   MethodRequest request = MethodRequest.newBuilder().build();
+   *   Namespace response = myProtoClient.getNamespace(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Namespace getNamespace(MethodRequest request) {
+    return getNamespaceCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Define a service with a reserved name
+   *
+   * Sample code:
+   * <pre><code>
+   * try (MyProtoClient myProtoClient = MyProtoClient.create()) {
+   *   MethodRequest request = MethodRequest.newBuilder().build();
+   *   ApiFuture&lt;Namespace&gt; future = myProtoClient.getNamespaceCallable().futureCall(request);
+   *   // Do something
+   *   Namespace response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    return stub.getNamespaceCallable();
+  }
+
   @Override
   public final void close() {
     stub.close();
@@ -7554,6 +7592,7 @@ import com.google.common.collect.Sets;
 import com.google.example.library.v1.stub.MyProtoStubSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc;
 import java.io.IOException;
 import java.util.List;
@@ -7601,6 +7640,13 @@ public class MyProtoSettings extends ClientSettings<MyProtoSettings> {
    */
   public UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings() {
     return ((MyProtoStubSettings) getStubSettings()).myMethodSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getNamespace.
+   */
+  public UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings() {
+    return ((MyProtoStubSettings) getStubSettings()).getNamespaceSettings();
   }
 
 
@@ -7722,6 +7768,13 @@ public class MyProtoSettings extends ClientSettings<MyProtoSettings> {
      */
     public UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings() {
       return getStubSettingsBuilder().myMethodSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getNamespace.
+     */
+    public UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings() {
+      return getStubSettingsBuilder().getNamespaceSettings();
     }
 
     @Override
@@ -9036,6 +9089,7 @@ import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
@@ -9140,6 +9194,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.MyProtoSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
@@ -9166,11 +9221,19 @@ public class GrpcMyProtoStub extends MyProtoStub {
           .setRequestMarshaller(ProtoUtils.marshaller(MethodRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(MethodResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<MethodRequest, Namespace> getNamespaceMethodDescriptor =
+      MethodDescriptor.<MethodRequest, Namespace>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.MyProto/GetNamespace")
+          .setRequestMarshaller(ProtoUtils.marshaller(MethodRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Namespace.getDefaultInstance()))
+          .build();
 
 
   private final BackgroundResource backgroundResources;
 
   private final UnaryCallable<MethodRequest, MethodResponse> myMethodCallable;
+  private final UnaryCallable<MethodRequest, Namespace> getNamespaceCallable;
 
   private final GrpcStubCallableFactory callableFactory;
 
@@ -9207,8 +9270,13 @@ public class GrpcMyProtoStub extends MyProtoStub {
         GrpcCallSettings.<MethodRequest, MethodResponse>newBuilder()
             .setMethodDescriptor(myMethodMethodDescriptor)
             .build();
+    GrpcCallSettings<MethodRequest, Namespace> getNamespaceTransportSettings =
+        GrpcCallSettings.<MethodRequest, Namespace>newBuilder()
+            .setMethodDescriptor(getNamespaceMethodDescriptor)
+            .build();
 
     this.myMethodCallable = callableFactory.createUnaryCallable(myMethodTransportSettings,settings.myMethodSettings(), clientContext);
+    this.getNamespaceCallable = callableFactory.createUnaryCallable(getNamespaceTransportSettings,settings.getNamespaceSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
@@ -9216,6 +9284,10 @@ public class GrpcMyProtoStub extends MyProtoStub {
 
   public UnaryCallable<MethodRequest, MethodResponse> myMethodCallable() {
     return myMethodCallable;
+  }
+
+  public UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    return getNamespaceCallable;
   }
 
   @Override
@@ -11161,6 +11233,7 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
@@ -11176,6 +11249,10 @@ public abstract class MyProtoStub implements BackgroundResource {
 
   public UnaryCallable<MethodRequest, MethodResponse> myMethodCallable() {
     throw new UnsupportedOperationException("Not implemented: myMethodCallable()");
+  }
+
+  public UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    throw new UnsupportedOperationException("Not implemented: getNamespaceCallable()");
   }
 
   @Override
@@ -11226,6 +11303,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc;
 import java.io.IOException;
 import java.util.List;
@@ -11277,12 +11355,20 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       .build();
 
   private final UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings;
+  private final UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings;
 
   /**
    * Returns the object with the settings used for calls to myMethod.
    */
   public UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings() {
     return myMethodSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getNamespace.
+   */
+  public UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings() {
+    return getNamespaceSettings;
   }
 
 
@@ -11372,6 +11458,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
     super(settingsBuilder);
 
     myMethodSettings = settingsBuilder.myMethodSettings().build();
+    getNamespaceSettings = settingsBuilder.getNamespaceSettings().build();
   }
 
 
@@ -11384,6 +11471,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
 
     private final UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings;
+    private final UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -11425,8 +11513,11 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
 
       myMethodSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      getNamespaceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-          myMethodSettings
+          myMethodSettings,
+          getNamespaceSettings
       );
 
       initDefaults(this);
@@ -11447,6 +11538,10 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.getNamespaceSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       return builder;
     }
 
@@ -11454,9 +11549,11 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       super(settings);
 
       myMethodSettings = settings.myMethodSettings.toBuilder();
+      getNamespaceSettings = settings.getNamespaceSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-          myMethodSettings
+          myMethodSettings,
+          getNamespaceSettings
       );
     }
 
@@ -11480,6 +11577,13 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
      */
     public UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings() {
       return myMethodSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getNamespace.
+     */
+    public UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings() {
+      return getNamespaceSettings;
     }
 
     @Override
@@ -14564,6 +14668,7 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc.MyProtoImplBase;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
@@ -14618,6 +14723,21 @@ public class MockMyProtoImpl extends MyProtoImplBase {
     }
   }
 
+  @Override
+  public void getNamespace(MethodRequest request,
+    StreamObserver<Namespace> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Namespace) {
+      requests.add(request);
+      responseObserver.onNext((Namespace) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
 }
 ============== file: src/test/java/com/google/example/library/v1/MyProtoClientTest.java ==============
 /*
@@ -14650,6 +14770,7 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -14740,6 +14861,47 @@ public class MyProtoClientTest {
       MethodRequest request = MethodRequest.newBuilder().build();
 
       client.myMethod(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getNamespaceTest() {
+    String value = "value111972721";
+    Namespace expectedResponse = Namespace.newBuilder()
+      .setValue(value)
+      .build();
+    mockMyProto.addResponse(expectedResponse);
+
+    MethodRequest request = MethodRequest.newBuilder().build();
+
+    Namespace actualResponse =
+        client.getNamespace(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockMyProto.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getNamespaceExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockMyProto.addException(exception);
+
+    try {
+      MethodRequest request = MethodRequest.newBuilder().build();
+
+      client.getNamespace(request);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -2424,6 +2424,19 @@ const SubMessage = {
 const MethodResponse = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
+
+/**
+ * Define a message with a reserved name
+ *
+ * @property {string} value
+ *
+ * @typedef Namespace
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.Namespace definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/another_service.proto}
+ */
+const Namespace = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
 ============== file: src/v1/doc/google/example/library/v1/doc_book_from_anywhere.js ==============
 // Copyright 2020 Google LLC
 //
@@ -8520,6 +8533,7 @@ class MyProtoClient {
     // and create an API call method for each.
     const myProtoStubMethods = [
       'myMethod',
+      'getNamespace',
     ];
     for (const methodName of myProtoStubMethods) {
       const innerCallPromise = myProtoStub.then(
@@ -8633,6 +8647,57 @@ class MyProtoClient {
     return this._innerApiCalls.myMethod(request, options, callback);
   }
 
+  /**
+   * Define a service with a reserved name
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {Object[]} [request.mylist]
+   *   This object should have the same structure as [SubMessage]{@link google.example.library.v1.SubMessage}
+   * @param {Object} [request.myfield]
+   *   This object should have the same structure as [SubMessage]{@link google.example.library.v1.SubMessage}
+   * @param {Object} [request.secondfield]
+   *   This object should have the same structure as [SubMessage]{@link google.example.library.v1.SubMessage}
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Namespace]{@link google.example.library.v1.Namespace}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Namespace]{@link google.example.library.v1.Namespace}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.MyProtoClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.getNamespace({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  getNamespace(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+
+    return this._innerApiCalls.getNamespace(request, options, callback);
+  }
+
   // --------------------
   // -- Path templates --
   // --------------------
@@ -8721,6 +8786,11 @@ module.exports = MyProtoClient;
       "methods": {
         "MyMethod": {
           "timeout_millis": 1000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
@@ -11075,6 +11145,60 @@ describe('MyProtoClient', () => {
       );
 
       client.myMethod(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('getNamespace', () => {
+    it('invokes getNamespace without error', done => {
+      const client = new libraryModule.v1.MyProtoClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const value = 'value111972721';
+      const expectedResponse = {
+        value: value,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getNamespace = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getNamespace(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getNamespace with error', done => {
+      const client = new libraryModule.v1.MyProtoClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.getNamespace = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getNamespace(request, (err, response) => {
         assert(err instanceof Error);
         assert.strictEqual(err.code, FAKE_STATUS_CODE);
         assert(typeof response === 'undefined');

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
@@ -1670,6 +1670,19 @@ const SubMessage = {
 const MethodResponse = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
+
+/**
+ * Define a message with a reserved name
+ *
+ * @property {string} value
+ *
+ * @typedef Namespace
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.Namespace definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/another_service.proto}
+ */
+const Namespace = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
 ============== file: src/v1/doc/google/example/library/v1/doc_book_from_anywhere.js ==============
 // Copyright 2020 Google LLC
 //
@@ -7579,6 +7592,7 @@ class MyProtoClient {
     // and create an API call method for each.
     const myProtoStubMethods = [
       'myMethod',
+      'getNamespace',
     ];
     for (const methodName of myProtoStubMethods) {
       const innerCallPromise = myProtoStub.then(
@@ -7692,6 +7706,57 @@ class MyProtoClient {
     return this._innerApiCalls.myMethod(request, options, callback);
   }
 
+  /**
+   * Define a service with a reserved name
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {Object[]} [request.mylist]
+   *   This object should have the same structure as [SubMessage]{@link google.example.library.v1.SubMessage}
+   * @param {Object} [request.myfield]
+   *   This object should have the same structure as [SubMessage]{@link google.example.library.v1.SubMessage}
+   * @param {Object} [request.secondfield]
+   *   This object should have the same structure as [SubMessage]{@link google.example.library.v1.SubMessage}
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Namespace]{@link google.example.library.v1.Namespace}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Namespace]{@link google.example.library.v1.Namespace}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.MyProtoClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.getNamespace({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  getNamespace(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+
+    return this._innerApiCalls.getNamespace(request, options, callback);
+  }
+
   // --------------------
   // -- Path templates --
   // --------------------
@@ -7780,6 +7845,11 @@ module.exports = MyProtoClient;
       "methods": {
         "MyMethod": {
           "timeout_millis": 1000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
@@ -9994,6 +10064,60 @@ describe('MyProtoClient', () => {
       );
 
       client.myMethod(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('getNamespace', () => {
+    it('invokes getNamespace without error', done => {
+      const client = new libraryModule.v1.MyProtoClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const value = 'value111972721';
+      const expectedResponse = {
+        value: value,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getNamespace = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getNamespace(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getNamespace with error', done => {
+      const client = new libraryModule.v1.MyProtoClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.getNamespace = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getNamespace(request, (err, response) => {
         assert(err instanceof Error);
         assert.strictEqual(err.code, FAKE_STATUS_CODE);
         assert(typeof response === 'undefined');

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -5158,6 +5158,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use Google\Example\Library\V1\MethodRequest;
 use Google\Example\Library\V1\MethodResponse;
 use Google\Example\Library\V1\MyProtoGrpcClient;
+use Google\Example\Library\V1\PBNamespace;
 use Google\Example\Library\V1\SubMessage;
 
 /**
@@ -5416,6 +5417,57 @@ class MyProtoGapicClient
         return $this->startCall(
             'MyMethod',
             MethodResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     * Define a service with a reserved name
+     *
+     * Sample code:
+     * ```
+     * $myProtoClient = new MyProtoClient();
+     * try {
+     *     $response = $myProtoClient->getNamespace();
+     * } finally {
+     *     $myProtoClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type SubMessage[] $mylist
+     *     @type SubMessage $myfield
+     *     @type SubMessage $secondfield
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\Namespace
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function getNamespace(array $optionalArgs = [])
+    {
+        $request = new MethodRequest();
+        if (isset($optionalArgs['mylist'])) {
+            $request->setMylist($optionalArgs['mylist']);
+        }
+        if (isset($optionalArgs['myfield'])) {
+            $request->setMyfield($optionalArgs['myfield']);
+        }
+        if (isset($optionalArgs['secondfield'])) {
+            $request->setSecondfield($optionalArgs['secondfield']);
+        }
+
+        return $this->startCall(
+            'GetNamespace',
+            PBNamespace::class,
             $optionalArgs,
             $request
         )->wait();
@@ -6125,6 +6177,11 @@ return [
           "timeout_millis": 1000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }
@@ -6148,6 +6205,11 @@ return [
     'interfaces' => [
         'google.example.library.v1.MyProto' => [
             'MyMethod' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/myMethod',
+                'body' => '*',
+            ],
+            'GetNamespace' => [
                 'method' => 'post',
                 'uriTemplate' => '/v1/myMethod',
                 'body' => '*',
@@ -9361,6 +9423,7 @@ use Google\ApiCore\Testing\MockTransport;
 use Google\Example\Library\V1\MethodRequest;
 use Google\Example\Library\V1\MethodResponse;
 use Google\Example\Library\V1\MyProtoGrpcClient;
+use Google\Example\Library\V1\PBNamespace;
 use Google\LongRunning\GetOperationRequest;
 use Google\Protobuf\Any;
 use Google\Protobuf\GPBEmpty;
@@ -9454,6 +9517,70 @@ class MyProtoClientTest extends GeneratedTest
 
         try {
             $client->myMethod();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getNamespaceTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $value = 'value111972721';
+        $expectedResponse = new PBNamespace();
+        $expectedResponse->setValue($value);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->getNamespace();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.MyProto/GetNamespace', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getNamespaceExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->getNamespace();
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -5447,7 +5447,7 @@ class MyProtoGapicClient
      *          {@see Google\ApiCore\RetrySettings} for example usage.
      * }
      *
-     * @return \Google\Example\Library\V1\Namespace
+     * @return \Google\Example\Library\V1\PBNamespace
      *
      * @throws ApiException if the remote call fails
      * @experimental

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_samplegen_config_migration_library.baseline
@@ -4815,7 +4815,7 @@ class MyProtoGapicClient
      *          {@see Google\ApiCore\RetrySettings} for example usage.
      * }
      *
-     * @return \Google\Example\Library\V1\Namespace
+     * @return \Google\Example\Library\V1\PBNamespace
      *
      * @throws ApiException if the remote call fails
      * @experimental

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_samplegen_config_migration_library.baseline
@@ -4526,6 +4526,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use Google\Example\Library\V1\MethodRequest;
 use Google\Example\Library\V1\MethodResponse;
 use Google\Example\Library\V1\MyProtoGrpcClient;
+use Google\Example\Library\V1\PBNamespace;
 use Google\Example\Library\V1\SubMessage;
 
 /**
@@ -4784,6 +4785,57 @@ class MyProtoGapicClient
         return $this->startCall(
             'MyMethod',
             MethodResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     * Define a service with a reserved name
+     *
+     * Sample code:
+     * ```
+     * $myProtoClient = new MyProtoClient();
+     * try {
+     *     $response = $myProtoClient->getNamespace();
+     * } finally {
+     *     $myProtoClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type SubMessage[] $mylist
+     *     @type SubMessage $myfield
+     *     @type SubMessage $secondfield
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\Namespace
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function getNamespace(array $optionalArgs = [])
+    {
+        $request = new MethodRequest();
+        if (isset($optionalArgs['mylist'])) {
+            $request->setMylist($optionalArgs['mylist']);
+        }
+        if (isset($optionalArgs['myfield'])) {
+            $request->setMyfield($optionalArgs['myfield']);
+        }
+        if (isset($optionalArgs['secondfield'])) {
+            $request->setSecondfield($optionalArgs['secondfield']);
+        }
+
+        return $this->startCall(
+            'GetNamespace',
+            PBNamespace::class,
             $optionalArgs,
             $request
         )->wait();
@@ -5493,6 +5545,11 @@ return [
           "timeout_millis": 1000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }
@@ -5516,6 +5573,11 @@ return [
     'interfaces' => [
         'google.example.library.v1.MyProto' => [
             'MyMethod' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/myMethod',
+                'body' => '*',
+            ],
+            'GetNamespace' => [
                 'method' => 'post',
                 'uriTemplate' => '/v1/myMethod',
                 'body' => '*',
@@ -8539,6 +8601,7 @@ use Google\ApiCore\Testing\MockTransport;
 use Google\Example\Library\V1\MethodRequest;
 use Google\Example\Library\V1\MethodResponse;
 use Google\Example\Library\V1\MyProtoGrpcClient;
+use Google\Example\Library\V1\PBNamespace;
 use Google\LongRunning\GetOperationRequest;
 use Google\Protobuf\Any;
 use Google\Protobuf\GPBEmpty;
@@ -8632,6 +8695,70 @@ class MyProtoClientTest extends GeneratedTest
 
         try {
             $client->myMethod();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getNamespaceTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $value = 'value111972721';
+        $expectedResponse = new PBNamespace();
+        $expectedResponse->setValue($value);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->getNamespace();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.MyProto/GetNamespace', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getNamespaceExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->getNamespace();
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -4736,6 +4736,69 @@ class MyProtoClient(object):
         )
         return self._inner_api_calls['my_method'](request, retry=retry, timeout=timeout, metadata=metadata)
 
+    def get_namespace(
+            self,
+            mylist=None,
+            myfield=None,
+            secondfield=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+        Define a service with a reserved name
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.MyProtoClient()
+            >>>
+            >>> response = client.get_namespace()
+
+        Args:
+            mylist (list[Union[dict, ~google.cloud.example.library_v1.types.SubMessage]]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SubMessage`
+            myfield (Union[dict, ~google.cloud.example.library_v1.types.SubMessage]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SubMessage`
+            secondfield (Union[dict, ~google.cloud.example.library_v1.types.SubMessage]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SubMessage`
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.Namespace` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'get_namespace' not in self._inner_api_calls:
+            self._inner_api_calls['get_namespace'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.get_namespace,
+                default_retry=self._method_configs['GetNamespace'].retry,
+                default_timeout=self._method_configs['GetNamespace'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = another_service_pb2.MethodRequest(
+            mylist=mylist,
+            myfield=myfield,
+            secondfield=secondfield,
+        )
+        return self._inner_api_calls['get_namespace'](request, retry=retry, timeout=timeout, metadata=metadata)
+
 ============== file: google/cloud/example/library_v1/gapic/my_proto_client_config.py ==============
 config = {
   "interfaces": {
@@ -4761,6 +4824,11 @@ config = {
       "methods": {
         "MyMethod": {
           "timeout_millis": 1000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
@@ -5454,6 +5522,19 @@ class MyProtoGrpcTransport(object):
                 deserialized response object.
         """
         return self._stubs['my_proto_stub'].MyMethod
+
+    @property
+    def get_namespace(self):
+        """Return the gRPC stub for :meth:`MyProtoClient.get_namespace`.
+
+        Define a service with a reserved name
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['my_proto_stub'].GetNamespace
 ============== file: google/cloud/example/library_v1/types.py ==============
 # -*- coding: utf-8 -*-
 #
@@ -8838,4 +8919,36 @@ class TestMyProtoClient(object):
 
         with pytest.raises(CustomException):
             client.my_method()
+
+    def test_get_namespace(self):
+        # Setup Expected Response
+        value = 'value111972721'
+        expected_response = {'value': value}
+        expected_response = another_service_pb2.Namespace(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.MyProtoClient()
+
+        response = client.get_namespace()
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = another_service_pb2.MethodRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_get_namespace_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.MyProtoClient()
+
+        with pytest.raises(CustomException):
+            client.get_namespace()
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
@@ -4611,6 +4611,69 @@ class MyProtoClient(object):
         )
         return self._inner_api_calls['my_method'](request, retry=retry, timeout=timeout, metadata=metadata)
 
+    def get_namespace(
+            self,
+            mylist=None,
+            myfield=None,
+            secondfield=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+        Define a service with a reserved name
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.MyProtoClient()
+            >>>
+            >>> response = client.get_namespace()
+
+        Args:
+            mylist (list[Union[dict, ~google.cloud.example.library_v1.types.SubMessage]]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SubMessage`
+            myfield (Union[dict, ~google.cloud.example.library_v1.types.SubMessage]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SubMessage`
+            secondfield (Union[dict, ~google.cloud.example.library_v1.types.SubMessage]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SubMessage`
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.Namespace` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'get_namespace' not in self._inner_api_calls:
+            self._inner_api_calls['get_namespace'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.get_namespace,
+                default_retry=self._method_configs['GetNamespace'].retry,
+                default_timeout=self._method_configs['GetNamespace'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = another_service_pb2.MethodRequest(
+            mylist=mylist,
+            myfield=myfield,
+            secondfield=secondfield,
+        )
+        return self._inner_api_calls['get_namespace'](request, retry=retry, timeout=timeout, metadata=metadata)
+
 ============== file: google/cloud/example/library_v1/gapic/my_proto_client_config.py ==============
 config = {
   "interfaces": {
@@ -4636,6 +4699,11 @@ config = {
       "methods": {
         "MyMethod": {
           "timeout_millis": 1000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
@@ -5329,6 +5397,19 @@ class MyProtoGrpcTransport(object):
                 deserialized response object.
         """
         return self._stubs['my_proto_stub'].MyMethod
+
+    @property
+    def get_namespace(self):
+        """Return the gRPC stub for :meth:`MyProtoClient.get_namespace`.
+
+        Define a service with a reserved name
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['my_proto_stub'].GetNamespace
 ============== file: google/cloud/example/library_v1/types.py ==============
 # -*- coding: utf-8 -*-
 #
@@ -8489,4 +8570,36 @@ class TestMyProtoClient(object):
 
         with pytest.raises(CustomException):
             client.my_method()
+
+    def test_get_namespace(self):
+        # Setup Expected Response
+        value = 'value111972721'
+        expected_response = {'value': value}
+        expected_response = another_service_pb2.Namespace(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.MyProtoClient()
+
+        response = client.get_namespace()
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = another_service_pb2.MethodRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_get_namespace_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.MyProtoClient()
+
+        with pytest.raises(CustomException):
+            client.get_namespace()
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -1080,6 +1080,11 @@ module Google
         # @!attribute [rw] myfield
         #   @return [String]
         class MethodResponse; end
+
+        # Define a message with a reserved name
+        # @!attribute [rw] value
+        #   @return [String]
+        class Namespace; end
       end
     end
   end
@@ -5866,6 +5871,11 @@ module Library
           defaults["my_method"],
           exception_transformer: exception_transformer
         )
+        @get_namespace = Google::Gax.create_api_call(
+          @my_proto_stub.method(:get_namespace),
+          defaults["get_namespace"],
+          exception_transformer: exception_transformer
+        )
       end
 
       # Service calls
@@ -5907,6 +5917,46 @@ module Library
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::MethodRequest)
         @my_method.call(req, options, &block)
       end
+
+      # Define a service with a reserved name
+      #
+      # @param mylist [Array<Google::Example::Library::V1::SubMessage | Hash>]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param myfield [Google::Example::Library::V1::SubMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param secondfield [Google::Example::Library::V1::SubMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::Namespace]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::Namespace]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   my_proto_client = Library::MyProto.new(version: :v1)
+      #   response = my_proto_client.get_namespace
+
+      def get_namespace \
+          mylist: nil,
+          myfield: nil,
+          secondfield: nil,
+          options: nil,
+          &block
+        req = {
+          mylist: mylist,
+          myfield: myfield,
+          secondfield: secondfield
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MethodRequest)
+        @get_namespace.call(req, options, &block)
+      end
     end
   end
 end
@@ -5936,6 +5986,11 @@ end
       "methods": {
         "MyMethod": {
           "timeout_millis": 1000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
@@ -10816,6 +10871,70 @@ describe Library::V1::MyProtoClient do
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.my_method
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'get_namespace' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::MyProtoClient#get_namespace."
+
+    it 'invokes get_namespace without error' do
+      # Create expected grpc response
+      value = "value111972721"
+      expected_response = { value: value }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Namespace)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_namespace, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockMyProtoCredentials_v1.new("get_namespace")
+
+      Google::Example::Library::V1::MyProto::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::MyProto.new(version: :v1)
+
+          # Call method
+          response = client.get_namespace
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.get_namespace do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes get_namespace with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_namespace, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockMyProtoCredentials_v1.new("get_namespace")
+
+      Google::Example::Library::V1::MyProto::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::MyProto.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.get_namespace
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_samplegen_config_migration_library.baseline
@@ -1080,6 +1080,11 @@ module Google
         # @!attribute [rw] myfield
         #   @return [String]
         class MethodResponse; end
+
+        # Define a message with a reserved name
+        # @!attribute [rw] value
+        #   @return [String]
+        class Namespace; end
       end
     end
   end
@@ -5718,6 +5723,11 @@ module Library
           defaults["my_method"],
           exception_transformer: exception_transformer
         )
+        @get_namespace = Google::Gax.create_api_call(
+          @my_proto_stub.method(:get_namespace),
+          defaults["get_namespace"],
+          exception_transformer: exception_transformer
+        )
       end
 
       # Service calls
@@ -5759,6 +5769,46 @@ module Library
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::MethodRequest)
         @my_method.call(req, options, &block)
       end
+
+      # Define a service with a reserved name
+      #
+      # @param mylist [Array<Google::Example::Library::V1::SubMessage | Hash>]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param myfield [Google::Example::Library::V1::SubMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param secondfield [Google::Example::Library::V1::SubMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::Namespace]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::Namespace]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   my_proto_client = Library::MyProto.new(version: :v1)
+      #   response = my_proto_client.get_namespace
+
+      def get_namespace \
+          mylist: nil,
+          myfield: nil,
+          secondfield: nil,
+          options: nil,
+          &block
+        req = {
+          mylist: mylist,
+          myfield: myfield,
+          secondfield: secondfield
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MethodRequest)
+        @get_namespace.call(req, options, &block)
+      end
     end
   end
 end
@@ -5788,6 +5838,11 @@ end
       "methods": {
         "MyMethod": {
           "timeout_millis": 1000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
@@ -10161,6 +10216,70 @@ describe Library::V1::MyProtoClient do
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.my_method
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'get_namespace' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::MyProtoClient#get_namespace."
+
+    it 'invokes get_namespace without error' do
+      # Create expected grpc response
+      value = "value111972721"
+      expected_response = { value: value }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Namespace)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_namespace, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockMyProtoCredentials_v1.new("get_namespace")
+
+      Google::Example::Library::V1::MyProto::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::MyProto.new(version: :v1)
+
+          # Call method
+          response = client.get_namespace
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.get_namespace do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes get_namespace with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_namespace, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockMyProtoCredentials_v1.new("get_namespace")
+
+      Google::Example::Library::V1::MyProto::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::MyProto.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.get_namespace
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -8060,6 +8060,33 @@ namespace Google.Example.Library.V1.Snippets
             // End snippet
         }
 
+        /// <summary>Snippet for GetNamespaceAsync</summary>
+        public async Task GetNamespaceAsync_RequestObject()
+        {
+            // Snippet: GetNamespaceAsync(MethodRequest,CallSettings)
+            // Additional: GetNamespaceAsync(MethodRequest,CancellationToken)
+            // Create client
+            MyProtoClient myProtoClient = await MyProtoClient.CreateAsync();
+            // Initialize request argument(s)
+            MethodRequest request = new MethodRequest();
+            // Make the request
+            Namespace response = await myProtoClient.GetNamespaceAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for GetNamespace</summary>
+        public void GetNamespace_RequestObject()
+        {
+            // Snippet: GetNamespace(MethodRequest,CallSettings)
+            // Create client
+            MyProtoClient myProtoClient = MyProtoClient.Create();
+            // Initialize request argument(s)
+            MethodRequest request = new MethodRequest();
+            // Make the request
+            Namespace response = myProtoClient.GetNamespace(request);
+            // End snippet
+        }
+
     }
 }
 
@@ -11108,6 +11135,40 @@ namespace Google.Example.Library.V1.Tests
                 .Returns(new Grpc.Core.AsyncUnaryCall<MethodResponse>(Task.FromResult(expectedResponse), null, null, null, null));
             MyProtoClient client = new MyProtoClientImpl(mockGrpcClient.Object, null);
             MethodResponse response = await client.MyMethodAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void GetNamespace()
+        {
+            Mock<MyProto.MyProtoClient> mockGrpcClient = new Mock<MyProto.MyProtoClient>(MockBehavior.Strict);
+            MethodRequest request = new MethodRequest();
+            Namespace expectedResponse = new Namespace
+            {
+                Value = "value111972721",
+            };
+            mockGrpcClient.Setup(x => x.GetNamespace(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            MyProtoClient client = new MyProtoClientImpl(mockGrpcClient.Object, null);
+            Namespace response = client.GetNamespace(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task GetNamespaceAsync()
+        {
+            Mock<MyProto.MyProtoClient> mockGrpcClient = new Mock<MyProto.MyProtoClient>(MockBehavior.Strict);
+            MethodRequest request = new MethodRequest();
+            Namespace expectedResponse = new Namespace
+            {
+                Value = "value111972721",
+            };
+            mockGrpcClient.Setup(x => x.GetNamespaceAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<Namespace>(Task.FromResult(expectedResponse), null, null, null, null));
+            MyProtoClient client = new MyProtoClientImpl(mockGrpcClient.Object, null);
+            Namespace response = await client.GetNamespaceAsync(request);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
         }
@@ -24928,6 +24989,7 @@ namespace Google.Example.Library.V1
         {
             gax::GaxPreconditions.CheckNotNull(existing, nameof(existing));
             MyMethodSettings = existing.MyMethodSettings;
+            GetNamespaceSettings = existing.GetNamespaceSettings;
             OnCopy(existing);
         }
 
@@ -25019,6 +25081,35 @@ namespace Google.Example.Library.V1
         /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings MyMethodSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>MyProtoClient.GetNamespace</c> and <c>MyProtoClient.GetNamespaceAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>MyProtoClient.GetNamespace</c> and
+        /// <c>MyProtoClient.GetNamespaceAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.3</description></item>
+        /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 20000 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.0</description></item>
+        /// <item><description>Timeout maximum delay: 20000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 600000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings GetNamespaceSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
@@ -25283,6 +25374,62 @@ namespace Google.Example.Library.V1
             throw new sys::NotImplementedException();
         }
 
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Namespace> GetNamespaceAsync(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Namespace> GetNamespaceAsync(
+            MethodRequest request,
+            st::CancellationToken cancellationToken) => GetNamespaceAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Namespace GetNamespace(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
     }
 
     /// <summary>
@@ -25291,6 +25438,7 @@ namespace Google.Example.Library.V1
     public sealed partial class MyProtoClientImpl : MyProtoClient
     {
         private readonly gaxgrpc::ApiCall<MethodRequest, MethodResponse> _callMyMethod;
+        private readonly gaxgrpc::ApiCall<MethodRequest, Namespace> _callGetNamespace;
 
         /// <summary>
         /// Constructs a client wrapper for the MyProto service, with the specified gRPC client and settings.
@@ -25304,8 +25452,12 @@ namespace Google.Example.Library.V1
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
             _callMyMethod = clientHelper.BuildApiCall<MethodRequest, MethodResponse>(
                 GrpcClient.MyMethodAsync, GrpcClient.MyMethod, effectiveSettings.MyMethodSettings);
+            _callGetNamespace = clientHelper.BuildApiCall<MethodRequest, Namespace>(
+                GrpcClient.GetNamespaceAsync, GrpcClient.GetNamespace, effectiveSettings.GetNamespaceSettings);
             Modify_ApiCall(ref _callMyMethod);
             Modify_MyMethodApiCall(ref _callMyMethod);
+            Modify_ApiCall(ref _callGetNamespace);
+            Modify_GetNamespaceApiCall(ref _callGetNamespace);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);
         }
 
@@ -25320,6 +25472,7 @@ namespace Google.Example.Library.V1
         // Partial methods called for each ApiCall on construction.
         // Allows per-RPC-method modification of the underlying ApiCall object.
         partial void Modify_MyMethodApiCall(ref gaxgrpc::ApiCall<MethodRequest, MethodResponse> call);
+        partial void Modify_GetNamespaceApiCall(ref gaxgrpc::ApiCall<MethodRequest, Namespace> call);
         partial void OnConstruction(MyProto.MyProtoClient grpcClient, MyProtoSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
         /// <summary>
@@ -25370,6 +25523,46 @@ namespace Google.Example.Library.V1
         {
             Modify_MethodRequest(ref request, ref callSettings);
             return _callMyMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<Namespace> GetNamespaceAsync(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MethodRequest(ref request, ref callSettings);
+            return _callGetNamespace.Async(request, callSettings);
+        }
+
+        /// <summary>
+        /// Define a service with a reserved name
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override Namespace GetNamespace(
+            MethodRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_MethodRequest(ref request, ref callSettings);
+            return _callGetNamespace.Sync(request, callSettings);
         }
 
     }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -2579,6 +2579,18 @@ func (s *mockMyProtoServer) MyMethod(ctx context.Context, req *pb.MethodRequest)
     return s.resps[0].(*pb.MethodResponse), nil
 }
 
+func (s *mockMyProtoServer) GetNamespace(ctx context.Context, req *pb.MethodRequest) (*pb.Namespace, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*pb.Namespace), nil
+}
+
 
 // clientOpt is the option tests should use to connect to the test server.
 // It is initialized by TestMain.
@@ -5088,6 +5100,59 @@ func TestMyProtoMyMethodError(t *testing.T) {
     }
     _ = resp
 }
+func TestMyProtoGetNamespace(t *testing.T) {
+    var value string = "value111972721"
+    var expectedResponse = &pb.Namespace{
+        Value: value,
+    }
+
+    mockMyProto.err = nil
+    mockMyProto.reqs = nil
+
+    mockMyProto.resps = append(mockMyProto.resps[:0], expectedResponse)
+
+    var request *pb.MethodRequest = &pb.MethodRequest{}
+
+    c, err := NewMyProtoClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.GetNamespace(context.Background(), request)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockMyProto.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+    if want, got := expectedResponse, resp; !proto.Equal(want, got) {
+        t.Errorf("wrong response %q, want %q)", got, want)
+    }
+}
+
+func TestMyProtoGetNamespaceError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockMyProto.err = gstatus.Error(errCode, "test error")
+
+    var request *pb.MethodRequest = &pb.MethodRequest{}
+
+    c, err := NewMyProtoClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.GetNamespace(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
+    _ = resp
+}
 ============== file: cloud.google.com/go/library/apiv1/my_proto_client.go ==============
 // Copyright 2020 Google LLC
 //
@@ -5122,6 +5187,7 @@ import (
 // MyProtoCallOptions contains the retry settings for each method of MyProtoClient.
 type MyProtoCallOptions struct {
     MyMethod []gax.CallOption
+    GetNamespace []gax.CallOption
 }
 
 func defaultMyProtoClientOptions() []option.ClientOption {
@@ -5138,6 +5204,7 @@ func defaultMyProtoCallOptions() *MyProtoCallOptions {
     }
     return &MyProtoCallOptions{
         MyMethod: retry[[2]string{"default", "non_idempotent"}],
+        GetNamespace: retry[[2]string{"default", "non_idempotent"}],
     }
 }
 
@@ -5212,6 +5279,22 @@ func (c *MyProtoClient) MyMethod(ctx context.Context, req *pb.MethodRequest, opt
     return resp, nil
 }
 
+// GetNamespace define a service with a reserved name
+func (c *MyProtoClient) GetNamespace(ctx context.Context, req *pb.MethodRequest, opts ...gax.CallOption) (*pb.Namespace, error) {
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
+    opts = append(c.CallOptions.GetNamespace[0:len(c.CallOptions.GetNamespace):len(c.CallOptions.GetNamespace)], opts...)
+    var resp *pb.Namespace
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        resp, err = c.myProtoClient.GetNamespace(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
+}
+
 
 
 ============== file: cloud.google.com/go/library/apiv1/my_proto_client_example_test.go ==============
@@ -5261,6 +5344,24 @@ func ExampleMyProtoClient_MyMethod() {
         // TODO: Fill request struct fields.
     }
     resp, err := c.MyMethod(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    // TODO: Use resp.
+    _ = resp
+}
+
+func ExampleMyProtoClient_GetNamespace() {
+    ctx := context.Background()
+    c, err := library.NewMyProtoClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &pb.MethodRequest{
+        // TODO: Fill request struct fields.
+    }
+    resp, err := c.GetNamespace(ctx, req)
     if err != nil {
         // TODO: Handle error.
     }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -10483,6 +10483,7 @@ import com.google.example.library.v1.stub.MyProtoStub;
 import com.google.example.library.v1.stub.MyProtoStubSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
@@ -10652,6 +10653,43 @@ public class MyProtoClient implements BackgroundResource {
     return stub.myMethodCallable();
   }
 
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Define a service with a reserved name
+   *
+   * Sample code:
+   * <pre><code>
+   * try (MyProtoClient myProtoClient = MyProtoClient.create()) {
+   *   MethodRequest request = MethodRequest.newBuilder().build();
+   *   Namespace response = myProtoClient.getNamespace(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Namespace getNamespace(MethodRequest request) {
+    return getNamespaceCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Define a service with a reserved name
+   *
+   * Sample code:
+   * <pre><code>
+   * try (MyProtoClient myProtoClient = MyProtoClient.create()) {
+   *   MethodRequest request = MethodRequest.newBuilder().build();
+   *   ApiFuture&lt;Namespace&gt; future = myProtoClient.getNamespaceCallable().futureCall(request);
+   *   // Do something
+   *   Namespace response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    return stub.getNamespaceCallable();
+  }
+
   @Override
   public final void close() {
     stub.close();
@@ -10730,6 +10768,7 @@ import com.google.common.collect.Sets;
 import com.google.example.library.v1.stub.MyProtoStubSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc;
 import java.io.IOException;
 import java.util.List;
@@ -10777,6 +10816,13 @@ public class MyProtoSettings extends ClientSettings<MyProtoSettings> {
    */
   public UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings() {
     return ((MyProtoStubSettings) getStubSettings()).myMethodSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getNamespace.
+   */
+  public UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings() {
+    return ((MyProtoStubSettings) getStubSettings()).getNamespaceSettings();
   }
 
 
@@ -10898,6 +10944,13 @@ public class MyProtoSettings extends ClientSettings<MyProtoSettings> {
      */
     public UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings() {
       return getStubSettingsBuilder().myMethodSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getNamespace.
+     */
+    public UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings() {
+      return getStubSettingsBuilder().getNamespaceSettings();
     }
 
     @Override
@@ -12228,6 +12281,7 @@ import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
@@ -12332,6 +12386,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.MyProtoSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
@@ -12358,11 +12413,19 @@ public class GrpcMyProtoStub extends MyProtoStub {
           .setRequestMarshaller(ProtoUtils.marshaller(MethodRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(MethodResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<MethodRequest, Namespace> getNamespaceMethodDescriptor =
+      MethodDescriptor.<MethodRequest, Namespace>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.MyProto/GetNamespace")
+          .setRequestMarshaller(ProtoUtils.marshaller(MethodRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Namespace.getDefaultInstance()))
+          .build();
 
 
   private final BackgroundResource backgroundResources;
 
   private final UnaryCallable<MethodRequest, MethodResponse> myMethodCallable;
+  private final UnaryCallable<MethodRequest, Namespace> getNamespaceCallable;
 
   private final GrpcStubCallableFactory callableFactory;
 
@@ -12399,8 +12462,13 @@ public class GrpcMyProtoStub extends MyProtoStub {
         GrpcCallSettings.<MethodRequest, MethodResponse>newBuilder()
             .setMethodDescriptor(myMethodMethodDescriptor)
             .build();
+    GrpcCallSettings<MethodRequest, Namespace> getNamespaceTransportSettings =
+        GrpcCallSettings.<MethodRequest, Namespace>newBuilder()
+            .setMethodDescriptor(getNamespaceMethodDescriptor)
+            .build();
 
     this.myMethodCallable = callableFactory.createUnaryCallable(myMethodTransportSettings,settings.myMethodSettings(), clientContext);
+    this.getNamespaceCallable = callableFactory.createUnaryCallable(getNamespaceTransportSettings,settings.getNamespaceSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
@@ -12408,6 +12476,10 @@ public class GrpcMyProtoStub extends MyProtoStub {
 
   public UnaryCallable<MethodRequest, MethodResponse> myMethodCallable() {
     return myMethodCallable;
+  }
+
+  public UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    return getNamespaceCallable;
   }
 
   @Override
@@ -14405,6 +14477,7 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
@@ -14420,6 +14493,10 @@ public abstract class MyProtoStub implements BackgroundResource {
 
   public UnaryCallable<MethodRequest, MethodResponse> myMethodCallable() {
     throw new UnsupportedOperationException("Not implemented: myMethodCallable()");
+  }
+
+  public UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    throw new UnsupportedOperationException("Not implemented: getNamespaceCallable()");
   }
 
   @Override
@@ -14470,6 +14547,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc;
 import java.io.IOException;
 import java.util.List;
@@ -14521,12 +14599,20 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       .build();
 
   private final UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings;
+  private final UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings;
 
   /**
    * Returns the object with the settings used for calls to myMethod.
    */
   public UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings() {
     return myMethodSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getNamespace.
+   */
+  public UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings() {
+    return getNamespaceSettings;
   }
 
 
@@ -14616,6 +14702,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
     super(settingsBuilder);
 
     myMethodSettings = settingsBuilder.myMethodSettings().build();
+    getNamespaceSettings = settingsBuilder.getNamespaceSettings().build();
   }
 
 
@@ -14628,6 +14715,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
 
     private final UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings;
+    private final UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -14669,8 +14757,11 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
 
       myMethodSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      getNamespaceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-          myMethodSettings
+          myMethodSettings,
+          getNamespaceSettings
       );
 
       initDefaults(this);
@@ -14691,6 +14782,10 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.getNamespaceSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       return builder;
     }
 
@@ -14698,9 +14793,11 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       super(settings);
 
       myMethodSettings = settings.myMethodSettings.toBuilder();
+      getNamespaceSettings = settings.getNamespaceSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-          myMethodSettings
+          myMethodSettings,
+          getNamespaceSettings
       );
     }
 
@@ -14724,6 +14821,13 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
      */
     public UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings() {
       return myMethodSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getNamespace.
+     */
+    public UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings() {
+      return getNamespaceSettings;
     }
 
     @Override
@@ -17944,6 +18048,7 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc.MyProtoImplBase;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
@@ -17998,6 +18103,21 @@ public class MockMyProtoImpl extends MyProtoImplBase {
     }
   }
 
+  @Override
+  public void getNamespace(MethodRequest request,
+    StreamObserver<Namespace> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Namespace) {
+      requests.add(request);
+      responseObserver.onNext((Namespace) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
 }
 ============== file: src/test/java/com/google/example/library/v1/MyProtoClientTest.java ==============
 /*
@@ -18030,6 +18150,7 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -18120,6 +18241,47 @@ public class MyProtoClientTest {
       MethodRequest request = MethodRequest.newBuilder().build();
 
       client.myMethod(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getNamespaceTest() {
+    String value = "value111972721";
+    Namespace expectedResponse = Namespace.newBuilder()
+      .setValue(value)
+      .build();
+    mockMyProto.addResponse(expectedResponse);
+
+    MethodRequest request = MethodRequest.newBuilder().build();
+
+    Namespace actualResponse =
+        client.getNamespace(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockMyProto.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getNamespaceExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockMyProto.addException(exception);
+
+    try {
+      MethodRequest request = MethodRequest.newBuilder().build();
+
+      client.getNamespace(request);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -5825,6 +5825,7 @@ import com.google.example.library.v1.stub.MyProtoStub;
 import com.google.example.library.v1.stub.MyProtoStubSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
@@ -5995,6 +5996,43 @@ public class MyProtoClient implements BackgroundResource {
     return stub.myMethodCallable();
   }
 
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Define a service with a reserved name
+   *
+   * Sample code:
+   * <pre><code>
+   * try (MyProtoClient myProtoClient = MyProtoClient.create()) {
+   *   MethodRequest request = MethodRequest.newBuilder().build();
+   *   Namespace response = myProtoClient.getNamespace(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Namespace getNamespace(MethodRequest request) {
+    return getNamespaceCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Define a service with a reserved name
+   *
+   * Sample code:
+   * <pre><code>
+   * try (MyProtoClient myProtoClient = MyProtoClient.create()) {
+   *   MethodRequest request = MethodRequest.newBuilder().build();
+   *   ApiFuture&lt;Namespace&gt; future = myProtoClient.getNamespaceCallable().futureCall(request);
+   *   // Do something
+   *   Namespace response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    return stub.getNamespaceCallable();
+  }
+
   @Override
   public final void close() {
     stub.close();
@@ -6073,6 +6111,7 @@ import com.google.common.collect.Sets;
 import com.google.example.library.v1.stub.MyProtoStubSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc;
 import java.io.IOException;
 import java.util.List;
@@ -6121,6 +6160,13 @@ public class MyProtoSettings extends ClientSettings<MyProtoSettings> {
    */
   public UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings() {
     return ((MyProtoStubSettings) getStubSettings()).myMethodSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getNamespace.
+   */
+  public UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings() {
+    return ((MyProtoStubSettings) getStubSettings()).getNamespaceSettings();
   }
 
 
@@ -6242,6 +6288,13 @@ public class MyProtoSettings extends ClientSettings<MyProtoSettings> {
      */
     public UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings() {
       return getStubSettingsBuilder().myMethodSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getNamespace.
+     */
+    public UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings() {
+      return getStubSettingsBuilder().getNamespaceSettings();
     }
 
     @Override
@@ -7561,6 +7614,7 @@ import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
@@ -7665,6 +7719,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.MyProtoSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
@@ -7691,11 +7746,19 @@ public class GrpcMyProtoStub extends MyProtoStub {
           .setRequestMarshaller(ProtoUtils.marshaller(MethodRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(MethodResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<MethodRequest, Namespace> getNamespaceMethodDescriptor =
+      MethodDescriptor.<MethodRequest, Namespace>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.MyProto/GetNamespace")
+          .setRequestMarshaller(ProtoUtils.marshaller(MethodRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Namespace.getDefaultInstance()))
+          .build();
 
 
   private final BackgroundResource backgroundResources;
 
   private final UnaryCallable<MethodRequest, MethodResponse> myMethodCallable;
+  private final UnaryCallable<MethodRequest, Namespace> getNamespaceCallable;
 
   private final GrpcStubCallableFactory callableFactory;
 
@@ -7732,8 +7795,13 @@ public class GrpcMyProtoStub extends MyProtoStub {
         GrpcCallSettings.<MethodRequest, MethodResponse>newBuilder()
             .setMethodDescriptor(myMethodMethodDescriptor)
             .build();
+    GrpcCallSettings<MethodRequest, Namespace> getNamespaceTransportSettings =
+        GrpcCallSettings.<MethodRequest, Namespace>newBuilder()
+            .setMethodDescriptor(getNamespaceMethodDescriptor)
+            .build();
 
     this.myMethodCallable = callableFactory.createUnaryCallable(myMethodTransportSettings,settings.myMethodSettings(), clientContext);
+    this.getNamespaceCallable = callableFactory.createUnaryCallable(getNamespaceTransportSettings,settings.getNamespaceSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
@@ -7741,6 +7809,10 @@ public class GrpcMyProtoStub extends MyProtoStub {
 
   public UnaryCallable<MethodRequest, MethodResponse> myMethodCallable() {
     return myMethodCallable;
+  }
+
+  public UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    return getNamespaceCallable;
   }
 
   @Override
@@ -9528,6 +9600,7 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
@@ -9543,6 +9616,10 @@ public abstract class MyProtoStub implements BackgroundResource {
 
   public UnaryCallable<MethodRequest, MethodResponse> myMethodCallable() {
     throw new UnsupportedOperationException("Not implemented: myMethodCallable()");
+  }
+
+  public UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    throw new UnsupportedOperationException("Not implemented: getNamespaceCallable()");
   }
 
   @Override
@@ -9593,6 +9670,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc;
 import java.io.IOException;
 import java.util.List;
@@ -9645,12 +9723,20 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       .build();
 
   private final UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings;
+  private final UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings;
 
   /**
    * Returns the object with the settings used for calls to myMethod.
    */
   public UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings() {
     return myMethodSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getNamespace.
+   */
+  public UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings() {
+    return getNamespaceSettings;
   }
 
 
@@ -9740,6 +9826,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
     super(settingsBuilder);
 
     myMethodSettings = settingsBuilder.myMethodSettings().build();
+    getNamespaceSettings = settingsBuilder.getNamespaceSettings().build();
   }
 
 
@@ -9752,6 +9839,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
 
     private final UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings;
+    private final UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -9793,8 +9881,11 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
 
       myMethodSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      getNamespaceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-          myMethodSettings
+          myMethodSettings,
+          getNamespaceSettings
       );
 
       initDefaults(this);
@@ -9815,6 +9906,10 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.getNamespaceSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       return builder;
     }
 
@@ -9822,9 +9917,11 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       super(settings);
 
       myMethodSettings = settings.myMethodSettings.toBuilder();
+      getNamespaceSettings = settings.getNamespaceSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-          myMethodSettings
+          myMethodSettings,
+          getNamespaceSettings
       );
     }
 
@@ -9848,6 +9945,13 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
      */
     public UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings() {
       return myMethodSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getNamespace.
+     */
+    public UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings() {
+      return getNamespaceSettings;
     }
 
     @Override
@@ -12825,6 +12929,7 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc.MyProtoImplBase;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
@@ -12879,6 +12984,21 @@ public class MockMyProtoImpl extends MyProtoImplBase {
     }
   }
 
+  @Override
+  public void getNamespace(MethodRequest request,
+    StreamObserver<Namespace> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Namespace) {
+      requests.add(request);
+      responseObserver.onNext((Namespace) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
 }
 ============== file: src/test/java/com/google/example/library/v1/MyProtoClientTest.java ==============
 /*
@@ -12911,6 +13031,7 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -12999,6 +13120,47 @@ public class MyProtoClientTest {
       MethodRequest request = MethodRequest.newBuilder().build();
 
       client.myMethod(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getNamespaceTest() {
+    String value = "value111972721";
+    Namespace expectedResponse = Namespace.newBuilder()
+      .setValue(value)
+      .build();
+    mockMyProto.addResponse(expectedResponse);
+
+    MethodRequest request = MethodRequest.newBuilder().build();
+
+    Namespace actualResponse =
+        client.getNamespace(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockMyProto.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getNamespaceExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockMyProto.addException(exception);
+
+    try {
+      MethodRequest request = MethodRequest.newBuilder().build();
+
+      client.getNamespace(request);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -10483,6 +10483,7 @@ import com.google.example.library.v1.stub.MyProtoStub;
 import com.google.example.library.v1.stub.MyProtoStubSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
@@ -10652,6 +10653,43 @@ public class MyProtoClient implements BackgroundResource {
     return stub.myMethodCallable();
   }
 
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Define a service with a reserved name
+   *
+   * Sample code:
+   * <pre><code>
+   * try (MyProtoClient myProtoClient = MyProtoClient.create()) {
+   *   MethodRequest request = MethodRequest.newBuilder().build();
+   *   Namespace response = myProtoClient.getNamespace(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Namespace getNamespace(MethodRequest request) {
+    return getNamespaceCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Define a service with a reserved name
+   *
+   * Sample code:
+   * <pre><code>
+   * try (MyProtoClient myProtoClient = MyProtoClient.create()) {
+   *   MethodRequest request = MethodRequest.newBuilder().build();
+   *   ApiFuture&lt;Namespace&gt; future = myProtoClient.getNamespaceCallable().futureCall(request);
+   *   // Do something
+   *   Namespace response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    return stub.getNamespaceCallable();
+  }
+
   @Override
   public final void close() {
     stub.close();
@@ -10730,6 +10768,7 @@ import com.google.common.collect.Sets;
 import com.google.example.library.v1.stub.MyProtoStubSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc;
 import java.io.IOException;
 import java.util.List;
@@ -10777,6 +10816,13 @@ public class MyProtoSettings extends ClientSettings<MyProtoSettings> {
    */
   public UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings() {
     return ((MyProtoStubSettings) getStubSettings()).myMethodSettings();
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getNamespace.
+   */
+  public UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings() {
+    return ((MyProtoStubSettings) getStubSettings()).getNamespaceSettings();
   }
 
 
@@ -10898,6 +10944,13 @@ public class MyProtoSettings extends ClientSettings<MyProtoSettings> {
      */
     public UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings() {
       return getStubSettingsBuilder().myMethodSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getNamespace.
+     */
+    public UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings() {
+      return getStubSettingsBuilder().getNamespaceSettings();
     }
 
     @Override
@@ -12228,6 +12281,7 @@ import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
@@ -12332,6 +12386,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.example.library.v1.MyProtoSettings;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
@@ -12358,11 +12413,19 @@ public class GrpcMyProtoStub extends MyProtoStub {
           .setRequestMarshaller(ProtoUtils.marshaller(MethodRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(MethodResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<MethodRequest, Namespace> getNamespaceMethodDescriptor =
+      MethodDescriptor.<MethodRequest, Namespace>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.MyProto/GetNamespace")
+          .setRequestMarshaller(ProtoUtils.marshaller(MethodRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Namespace.getDefaultInstance()))
+          .build();
 
 
   private final BackgroundResource backgroundResources;
 
   private final UnaryCallable<MethodRequest, MethodResponse> myMethodCallable;
+  private final UnaryCallable<MethodRequest, Namespace> getNamespaceCallable;
 
   private final GrpcStubCallableFactory callableFactory;
 
@@ -12399,8 +12462,13 @@ public class GrpcMyProtoStub extends MyProtoStub {
         GrpcCallSettings.<MethodRequest, MethodResponse>newBuilder()
             .setMethodDescriptor(myMethodMethodDescriptor)
             .build();
+    GrpcCallSettings<MethodRequest, Namespace> getNamespaceTransportSettings =
+        GrpcCallSettings.<MethodRequest, Namespace>newBuilder()
+            .setMethodDescriptor(getNamespaceMethodDescriptor)
+            .build();
 
     this.myMethodCallable = callableFactory.createUnaryCallable(myMethodTransportSettings,settings.myMethodSettings(), clientContext);
+    this.getNamespaceCallable = callableFactory.createUnaryCallable(getNamespaceTransportSettings,settings.getNamespaceSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
@@ -12408,6 +12476,10 @@ public class GrpcMyProtoStub extends MyProtoStub {
 
   public UnaryCallable<MethodRequest, MethodResponse> myMethodCallable() {
     return myMethodCallable;
+  }
+
+  public UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    return getNamespaceCallable;
   }
 
   @Override
@@ -14412,6 +14484,7 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
@@ -14427,6 +14500,10 @@ public abstract class MyProtoStub implements BackgroundResource {
 
   public UnaryCallable<MethodRequest, MethodResponse> myMethodCallable() {
     throw new UnsupportedOperationException("Not implemented: myMethodCallable()");
+  }
+
+  public UnaryCallable<MethodRequest, Namespace> getNamespaceCallable() {
+    throw new UnsupportedOperationException("Not implemented: getNamespaceCallable()");
   }
 
   @Override
@@ -14477,6 +14554,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc;
 import java.io.IOException;
 import java.util.List;
@@ -14528,12 +14606,20 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       .build();
 
   private final UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings;
+  private final UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings;
 
   /**
    * Returns the object with the settings used for calls to myMethod.
    */
   public UnaryCallSettings<MethodRequest, MethodResponse> myMethodSettings() {
     return myMethodSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to getNamespace.
+   */
+  public UnaryCallSettings<MethodRequest, Namespace> getNamespaceSettings() {
+    return getNamespaceSettings;
   }
 
 
@@ -14623,6 +14709,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
     super(settingsBuilder);
 
     myMethodSettings = settingsBuilder.myMethodSettings().build();
+    getNamespaceSettings = settingsBuilder.getNamespaceSettings().build();
   }
 
 
@@ -14635,6 +14722,7 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
     private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
 
     private final UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings;
+    private final UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -14673,8 +14761,11 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
 
       myMethodSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      getNamespaceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-          myMethodSettings
+          myMethodSettings,
+          getNamespaceSettings
       );
 
       initDefaults(this);
@@ -14695,6 +14786,10 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_2_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_2_params"));
 
+      builder.getNamespaceSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
       return builder;
     }
 
@@ -14702,9 +14797,11 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
       super(settings);
 
       myMethodSettings = settings.myMethodSettings.toBuilder();
+      getNamespaceSettings = settings.getNamespaceSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
-          myMethodSettings
+          myMethodSettings,
+          getNamespaceSettings
       );
     }
 
@@ -14728,6 +14825,13 @@ public class MyProtoStubSettings extends StubSettings<MyProtoStubSettings> {
      */
     public UnaryCallSettings.Builder<MethodRequest, MethodResponse> myMethodSettings() {
       return myMethodSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getNamespace.
+     */
+    public UnaryCallSettings.Builder<MethodRequest, Namespace> getNamespaceSettings() {
+      return getNamespaceSettings;
     }
 
     @Override
@@ -17948,6 +18052,7 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import com.google.protos.google.example.library.v1.MyProtoGrpc.MyProtoImplBase;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
@@ -18002,6 +18107,21 @@ public class MockMyProtoImpl extends MyProtoImplBase {
     }
   }
 
+  @Override
+  public void getNamespace(MethodRequest request,
+    StreamObserver<Namespace> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Namespace) {
+      requests.add(request);
+      responseObserver.onNext((Namespace) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
 }
 ============== file: src/test/java/com/google/example/library/v1/MyProtoClientTest.java ==============
 /*
@@ -18034,6 +18154,7 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protos.google.example.library.v1.AnotherService.MethodRequest;
 import com.google.protos.google.example.library.v1.AnotherService.MethodResponse;
+import com.google.protos.google.example.library.v1.AnotherService.Namespace;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
@@ -18124,6 +18245,47 @@ public class MyProtoClientTest {
       MethodRequest request = MethodRequest.newBuilder().build();
 
       client.myMethod(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getNamespaceTest() {
+    String value = "value111972721";
+    Namespace expectedResponse = Namespace.newBuilder()
+      .setValue(value)
+      .build();
+    mockMyProto.addResponse(expectedResponse);
+
+    MethodRequest request = MethodRequest.newBuilder().build();
+
+    Namespace actualResponse =
+        client.getNamespace(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockMyProto.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MethodRequest actualRequest = (MethodRequest)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getNamespaceExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockMyProto.addException(exception);
+
+    try {
+      MethodRequest request = MethodRequest.newBuilder().build();
+
+      client.getNamespace(request);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -2430,6 +2430,19 @@ const SubMessage = {
 const MethodResponse = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
+
+/**
+ * Define a message with a reserved name
+ *
+ * @property {string} value
+ *
+ * @typedef Namespace
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.Namespace definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/another_service.proto}
+ */
+const Namespace = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
 ============== file: src/v1/doc/google/example/library/v1/doc_book_from_anywhere.js ==============
 // Copyright 2020 Google LLC
 //
@@ -8724,6 +8737,7 @@ class MyProtoClient {
     // and create an API call method for each.
     const myProtoStubMethods = [
       'myMethod',
+      'getNamespace',
     ];
     for (const methodName of myProtoStubMethods) {
       const innerCallPromise = myProtoStub.then(
@@ -8836,6 +8850,57 @@ class MyProtoClient {
 
     return this._innerApiCalls.myMethod(request, options, callback);
   }
+
+  /**
+   * Define a service with a reserved name
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {Object[]} [request.mylist]
+   *   This object should have the same structure as [SubMessage]{@link google.example.library.v1.SubMessage}
+   * @param {Object} [request.myfield]
+   *   This object should have the same structure as [SubMessage]{@link google.example.library.v1.SubMessage}
+   * @param {Object} [request.secondfield]
+   *   This object should have the same structure as [SubMessage]{@link google.example.library.v1.SubMessage}
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Namespace]{@link google.example.library.v1.Namespace}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Namespace]{@link google.example.library.v1.Namespace}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.MyProtoClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.getNamespace({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  getNamespace(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+
+    return this._innerApiCalls.getNamespace(request, options, callback);
+  }
 }
 
 
@@ -8866,6 +8931,11 @@ module.exports = MyProtoClient;
       "methods": {
         "MyMethod": {
           "timeout_millis": 1000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
@@ -11228,6 +11298,60 @@ describe('MyProtoClient', () => {
       );
 
       client.myMethod(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('getNamespace', () => {
+    it('invokes getNamespace without error', done => {
+      const client = new libraryModule.v1.MyProtoClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock response
+      const value = 'value111972721';
+      const expectedResponse = {
+        value: value,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getNamespace = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getNamespace(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getNamespace with error', done => {
+      const client = new libraryModule.v1.MyProtoClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.getNamespace = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getNamespace(request, (err, response) => {
         assert(err instanceof Error);
         assert.strictEqual(err.code, FAKE_STATUS_CODE);
         assert(typeof response === 'undefined');

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -5287,6 +5287,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use Google\Example\Library\V1\MethodRequest;
 use Google\Example\Library\V1\MethodResponse;
 use Google\Example\Library\V1\MyProtoGrpcClient;
+use Google\Example\Library\V1\PBNamespace;
 use Google\Example\Library\V1\SubMessage;
 
 /**
@@ -5465,6 +5466,57 @@ class MyProtoGapicClient
         return $this->startCall(
             'MyMethod',
             MethodResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     * Define a service with a reserved name
+     *
+     * Sample code:
+     * ```
+     * $myProtoClient = new MyProtoClient();
+     * try {
+     *     $response = $myProtoClient->getNamespace();
+     * } finally {
+     *     $myProtoClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type SubMessage[] $mylist
+     *     @type SubMessage $myfield
+     *     @type SubMessage $secondfield
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\Namespace
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function getNamespace(array $optionalArgs = [])
+    {
+        $request = new MethodRequest();
+        if (isset($optionalArgs['mylist'])) {
+            $request->setMylist($optionalArgs['mylist']);
+        }
+        if (isset($optionalArgs['myfield'])) {
+            $request->setMyfield($optionalArgs['myfield']);
+        }
+        if (isset($optionalArgs['secondfield'])) {
+            $request->setSecondfield($optionalArgs['secondfield']);
+        }
+
+        return $this->startCall(
+            'GetNamespace',
+            PBNamespace::class,
             $optionalArgs,
             $request
         )->wait();
@@ -6184,6 +6236,11 @@ return [
           "timeout_millis": 1000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }
@@ -6207,6 +6264,11 @@ return [
     'interfaces' => [
         'google.example.library.v1.MyProto' => [
             'MyMethod' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/myMethod',
+                'body' => '*',
+            ],
+            'GetNamespace' => [
                 'method' => 'post',
                 'uriTemplate' => '/v1/myMethod',
                 'body' => '*',
@@ -9487,6 +9549,7 @@ use Google\ApiCore\Testing\MockTransport;
 use Google\Example\Library\V1\MethodRequest;
 use Google\Example\Library\V1\MethodResponse;
 use Google\Example\Library\V1\MyProtoGrpcClient;
+use Google\Example\Library\V1\PBNamespace;
 use Google\LongRunning\GetOperationRequest;
 use Google\Protobuf\Any;
 use Google\Protobuf\GPBEmpty;
@@ -9580,6 +9643,70 @@ class MyProtoClientTest extends GeneratedTest
 
         try {
             $client->myMethod();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getNamespaceTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $value = 'value111972721';
+        $expectedResponse = new PBNamespace();
+        $expectedResponse->setValue($value);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->getNamespace();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.MyProto/GetNamespace', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getNamespaceExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->getNamespace();
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -5496,7 +5496,7 @@ class MyProtoGapicClient
      *          {@see Google\ApiCore\RetrySettings} for example usage.
      * }
      *
-     * @return \Google\Example\Library\V1\Namespace
+     * @return \Google\Example\Library\V1\PBNamespace
      *
      * @throws ApiException if the remote call fails
      * @experimental

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -5287,6 +5287,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use Google\Example\Library\V1\MethodRequest;
 use Google\Example\Library\V1\MethodResponse;
 use Google\Example\Library\V1\MyProtoGrpcClient;
+use Google\Example\Library\V1\PBNamespace;
 use Google\Example\Library\V1\SubMessage;
 
 /**
@@ -5465,6 +5466,57 @@ class MyProtoGapicClient
         return $this->startCall(
             'MyMethod',
             MethodResponse::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
+     * Define a service with a reserved name
+     *
+     * Sample code:
+     * ```
+     * $myProtoClient = new MyProtoClient();
+     * try {
+     *     $response = $myProtoClient->getNamespace();
+     * } finally {
+     *     $myProtoClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type SubMessage[] $mylist
+     *     @type SubMessage $myfield
+     *     @type SubMessage $secondfield
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\Namespace
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function getNamespace(array $optionalArgs = [])
+    {
+        $request = new MethodRequest();
+        if (isset($optionalArgs['mylist'])) {
+            $request->setMylist($optionalArgs['mylist']);
+        }
+        if (isset($optionalArgs['myfield'])) {
+            $request->setMyfield($optionalArgs['myfield']);
+        }
+        if (isset($optionalArgs['secondfield'])) {
+            $request->setSecondfield($optionalArgs['secondfield']);
+        }
+
+        return $this->startCall(
+            'GetNamespace',
+            PBNamespace::class,
             $optionalArgs,
             $request
         )->wait();
@@ -6209,6 +6261,11 @@ return [
           "timeout_millis": 60000,
           "retry_codes_name": "no_retry_2_codes",
           "retry_params_name": "no_retry_2_params"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "no_retry_codes",
+          "retry_params_name": "no_retry_params"
         }
       }
     }
@@ -6232,6 +6289,11 @@ return [
     'interfaces' => [
         'google.example.library.v1.MyProto' => [
             'MyMethod' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/myMethod',
+                'body' => '*',
+            ],
+            'GetNamespace' => [
                 'method' => 'post',
                 'uriTemplate' => '/v1/myMethod',
                 'body' => '*',
@@ -9512,6 +9574,7 @@ use Google\ApiCore\Testing\MockTransport;
 use Google\Example\Library\V1\MethodRequest;
 use Google\Example\Library\V1\MethodResponse;
 use Google\Example\Library\V1\MyProtoGrpcClient;
+use Google\Example\Library\V1\PBNamespace;
 use Google\LongRunning\GetOperationRequest;
 use Google\Protobuf\Any;
 use Google\Protobuf\GPBEmpty;
@@ -9605,6 +9668,70 @@ class MyProtoClientTest extends GeneratedTest
 
         try {
             $client->myMethod();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getNamespaceTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $value = 'value111972721';
+        $expectedResponse = new PBNamespace();
+        $expectedResponse->setValue($value);
+        $transport->addResponse($expectedResponse);
+
+        $response = $client->getNamespace();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.MyProto/GetNamespace', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getNamespaceExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->getNamespace();
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -5496,7 +5496,7 @@ class MyProtoGapicClient
      *          {@see Google\ApiCore\RetrySettings} for example usage.
      * }
      *
-     * @return \Google\Example\Library\V1\Namespace
+     * @return \Google\Example\Library\V1\PBNamespace
      *
      * @throws ApiException if the remote call fails
      * @experimental

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -4769,6 +4769,69 @@ class MyProtoClient(object):
         )
         return self._inner_api_calls['my_method'](request, retry=retry, timeout=timeout, metadata=metadata)
 
+    def get_namespace(
+            self,
+            mylist=None,
+            myfield=None,
+            secondfield=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+        Define a service with a reserved name
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.MyProtoClient()
+            >>>
+            >>> response = client.get_namespace()
+
+        Args:
+            mylist (list[Union[dict, ~google.cloud.example.library_v1.types.SubMessage]]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SubMessage`
+            myfield (Union[dict, ~google.cloud.example.library_v1.types.SubMessage]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SubMessage`
+            secondfield (Union[dict, ~google.cloud.example.library_v1.types.SubMessage]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SubMessage`
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.Namespace` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'get_namespace' not in self._inner_api_calls:
+            self._inner_api_calls['get_namespace'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.get_namespace,
+                default_retry=self._method_configs['GetNamespace'].retry,
+                default_timeout=self._method_configs['GetNamespace'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = another_service_pb2.MethodRequest(
+            mylist=mylist,
+            myfield=myfield,
+            secondfield=secondfield,
+        )
+        return self._inner_api_calls['get_namespace'](request, retry=retry, timeout=timeout, metadata=metadata)
+
 ============== file: google/cloud/example/library_v1/gapic/my_proto_client_config.py ==============
 config = {
   "interfaces": {
@@ -4794,6 +4857,11 @@ config = {
       "methods": {
         "MyMethod": {
           "timeout_millis": 1000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
@@ -5487,6 +5555,19 @@ class MyProtoGrpcTransport(object):
                 deserialized response object.
         """
         return self._stubs['my_proto_stub'].MyMethod
+
+    @property
+    def get_namespace(self):
+        """Return the gRPC stub for :meth:`MyProtoClient.get_namespace`.
+
+        Define a service with a reserved name
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['my_proto_stub'].GetNamespace
 ============== file: google/cloud/example/library_v1/types.py ==============
 # -*- coding: utf-8 -*-
 #
@@ -8884,4 +8965,36 @@ class TestMyProtoClient(object):
 
         with pytest.raises(CustomException):
             client.my_method()
+
+    def test_get_namespace(self):
+        # Setup Expected Response
+        value = 'value111972721'
+        expected_response = {'value': value}
+        expected_response = another_service_pb2.Namespace(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.MyProtoClient()
+
+        response = client.get_namespace()
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = another_service_pb2.MethodRequest()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_get_namespace_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.MyProtoClient()
+
+        with pytest.raises(CustomException):
+            client.get_namespace()
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -1080,6 +1080,11 @@ module Google
         # @!attribute [rw] myfield
         #   @return [String]
         class MethodResponse; end
+
+        # Define a message with a reserved name
+        # @!attribute [rw] value
+        #   @return [String]
+        class Namespace; end
       end
     end
   end
@@ -5941,6 +5946,11 @@ module Library
           defaults["my_method"],
           exception_transformer: exception_transformer
         )
+        @get_namespace = Google::Gax.create_api_call(
+          @my_proto_stub.method(:get_namespace),
+          defaults["get_namespace"],
+          exception_transformer: exception_transformer
+        )
       end
 
       # Service calls
@@ -5982,6 +5992,46 @@ module Library
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::MethodRequest)
         @my_method.call(req, options, &block)
       end
+
+      # Define a service with a reserved name
+      #
+      # @param mylist [Array<Google::Example::Library::V1::SubMessage | Hash>]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param myfield [Google::Example::Library::V1::SubMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param secondfield [Google::Example::Library::V1::SubMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::Namespace]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::Namespace]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   my_proto_client = Library::MyProto.new(version: :v1)
+      #   response = my_proto_client.get_namespace
+
+      def get_namespace \
+          mylist: nil,
+          myfield: nil,
+          secondfield: nil,
+          options: nil,
+          &block
+        req = {
+          mylist: mylist,
+          myfield: myfield,
+          secondfield: secondfield
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MethodRequest)
+        @get_namespace.call(req, options, &block)
+      end
     end
   end
 end
@@ -6011,6 +6061,11 @@ end
       "methods": {
         "MyMethod": {
           "timeout_millis": 1000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetNamespace": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
@@ -10934,6 +10989,70 @@ describe Library::V1::MyProtoClient do
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.my_method
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'get_namespace' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::MyProtoClient#get_namespace."
+
+    it 'invokes get_namespace without error' do
+      # Create expected grpc response
+      value = "value111972721"
+      expected_response = { value: value }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Namespace)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_namespace, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockMyProtoCredentials_v1.new("get_namespace")
+
+      Google::Example::Library::V1::MyProto::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::MyProto.new(version: :v1)
+
+          # Call method
+          response = client.get_namespace
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.get_namespace do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes get_namespace with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_namespace, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockMyProtoCredentials_v1.new("get_namespace")
+
+      Google::Example::Library::V1::MyProto::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::MyProto.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.get_namespace
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -960,6 +960,11 @@ module Google
         # @!attribute [rw] myfield
         #   @return [String]
         class MethodResponse; end
+
+        # Define a message with a reserved name
+        # @!attribute [rw] value
+        #   @return [String]
+        class Namespace; end
       end
     end
   end
@@ -5739,6 +5744,11 @@ module Library
           defaults["my_method"],
           exception_transformer: exception_transformer
         )
+        @get_namespace = Google::Gax.create_api_call(
+          @my_proto_stub.method(:get_namespace),
+          defaults["get_namespace"],
+          exception_transformer: exception_transformer
+        )
       end
 
       # Service calls
@@ -5780,6 +5790,46 @@ module Library
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::MethodRequest)
         @my_method.call(req, options, &block)
       end
+
+      # Define a service with a reserved name
+      #
+      # @param mylist [Array<Google::Example::Library::V1::SubMessage | Hash>]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param myfield [Google::Example::Library::V1::SubMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param secondfield [Google::Example::Library::V1::SubMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::SubMessage`
+      #   can also be provided.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::Namespace]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::Namespace]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   my_proto_client = Library::MyProto.new(version: :v1)
+      #   response = my_proto_client.get_namespace
+
+      def get_namespace \
+          mylist: nil,
+          myfield: nil,
+          secondfield: nil,
+          options: nil,
+          &block
+        req = {
+          mylist: mylist,
+          myfield: myfield,
+          secondfield: secondfield
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MethodRequest)
+        @get_namespace.call(req, options, &block)
+      end
     end
   end
 end
@@ -5808,6 +5858,11 @@ end
       },
       "methods": {
         "MyMethod": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetNamespace": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -9218,6 +9273,70 @@ describe Library::V1::MyProtoClient do
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.my_method
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'get_namespace' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::MyProtoClient#get_namespace."
+
+    it 'invokes get_namespace without error' do
+      # Create expected grpc response
+      value = "value111972721"
+      expected_response = { value: value }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Namespace)
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_namespace, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockMyProtoCredentials_v1.new("get_namespace")
+
+      Google::Example::Library::V1::MyProto::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::MyProto.new(version: :v1)
+
+          # Call method
+          response = client.get_namespace
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.get_namespace do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes get_namespace with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_namespace, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockMyProtoCredentials_v1.new("get_namespace")
+
+      Google::Example::Library::V1::MyProto::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::MyProto.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.get_namespace
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/testsrc/common/another_service.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/another_service.proto
@@ -10,6 +10,11 @@ service MyProto {
   rpc MyMethod(MethodRequest) returns (MethodResponse) {
     option (google.api.http) = { post: "/v1/myMethod" body: "*" };
   };
+
+  // Define a service with a reserved name
+  rpc GetNamespace(MethodRequest) returns (Namespace) {
+    option (google.api.http) = { post: "/v1/myMethod" body: "*" };
+  }
 }
 
 message MethodRequest {
@@ -26,4 +31,9 @@ message SubMessage {
 
 message MethodResponse {
   string myfield = 1;
+}
+
+// Define a message with a reserved name
+message Namespace {
+  string value = 1;
 }


### PR DESCRIPTION
A new API coming out soon has a proto class `Namespace`, which is breaking for PHP client libraries.

See https://github.com/protocolbuffers/protobuf/pull/7268/files, which ensures the protobuf c library follows the same rules