### PR TITLE
feat: set x-goog-user-project header for Ruby

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -197,6 +197,9 @@
     google_api_client.freeze
 
     headers = { :"x-goog-api-client" => google_api_client }
+    if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+      headers[:"x-goog-user-project"] = credentials.quota_project_id
+    end
     headers.merge!(metadata) unless metadata.nil?
     {@constructDefaults(xapiClass)}
     

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -3212,6 +3212,9 @@ module Library
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+          headers[:"x-goog-user-project"] = credentials.quota_project_id
+        end
         headers.merge!(metadata) unless metadata.nil?
         client_config_file = Pathname.new(__dir__).join(
           "library_service_client_config.json"
@@ -5830,6 +5833,9 @@ module Library
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+          headers[:"x-goog-user-project"] = credentials.quota_project_id
+        end
         headers.merge!(metadata) unless metadata.nil?
         client_config_file = Pathname.new(__dir__).join(
           "my_proto_client_config.json"

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_longrunning.baseline
@@ -1277,6 +1277,9 @@ module Google
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+          headers[:"x-goog-user-project"] = credentials.quota_project_id
+        end
         headers.merge!(metadata) unless metadata.nil?
         client_config_file = Pathname.new(__dir__).join(
           "operations_client_config.json"

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_multiple_services.baseline
@@ -1064,6 +1064,9 @@ module Google
             google_api_client.freeze
 
             headers = { :"x-goog-api-client" => google_api_client }
+            if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+              headers[:"x-goog-user-project"] = credentials.quota_project_id
+            end
             headers.merge!(metadata) unless metadata.nil?
             client_config_file = Pathname.new(__dir__).join(
               "decrementer_service_client_config.json"
@@ -1358,6 +1361,9 @@ module Google
             google_api_client.freeze
 
             headers = { :"x-goog-api-client" => google_api_client }
+            if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+              headers[:"x-goog-user-project"] = credentials.quota_project_id
+            end
             headers.merge!(metadata) unless metadata.nil?
             client_config_file = Pathname.new(__dir__).join(
               "incrementer_service_client_config.json"

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_samplegen_config_migration_library.baseline
@@ -3163,6 +3163,9 @@ module Library
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+          headers[:"x-goog-user-project"] = credentials.quota_project_id
+        end
         headers.merge!(metadata) unless metadata.nil?
         client_config_file = Pathname.new(__dir__).join(
           "library_service_client_config.json"
@@ -5682,6 +5685,9 @@ module Library
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+          headers[:"x-goog-user-project"] = credentials.quota_project_id
+        end
         headers.merge!(metadata) unless metadata.nil?
         client_config_file = Pathname.new(__dir__).join(
           "my_proto_client_config.json"

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -3273,6 +3273,9 @@ module Library
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+          headers[:"x-goog-user-project"] = credentials.quota_project_id
+        end
         headers.merge!(metadata) unless metadata.nil?
         client_config_file = Pathname.new(__dir__).join(
           "library_service_client_config.json"
@@ -5905,6 +5908,9 @@ module Library
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+          headers[:"x-goog-user-project"] = credentials.quota_project_id
+        end
         headers.merge!(metadata) unless metadata.nil?
         client_config_file = Pathname.new(__dir__).join(
           "my_proto_client_config.json"

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -3071,6 +3071,9 @@ module Library
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+          headers[:"x-goog-user-project"] = credentials.quota_project_id
+        end
         headers.merge!(metadata) unless metadata.nil?
         client_config_file = Pathname.new(__dir__).join(
           "library_service_client_config.json"
@@ -5703,6 +5706,9 @@ module Library
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        if credentials.respond_to?(:quota_project_id) && credentials.quota_project_id
+          headers[:"x-goog-user-project"] = credentials.quota_project_id
+        end
         headers.merge!(metadata) unless metadata.nil?
         client_config_file = Pathname.new(__dir__).join(
           "my_proto_client_config.json"


### PR DESCRIPTION
Sets the `X-Goog-User-Project` header for outgoing calls if the given credentials object has an appropriately set :quota_project_id field. (See googleapis/google-auth-library-ruby#254 for corresponding change to the Ruby googleauth library. There is no ordering dependency: this change will use the auth library field if present, or fall back to existing behavior if absent.)

See also internal link go/x-goog-user-project-impl for more info.