### PR TITLE
fix: honor resource config on name field in method flattening

### DIFF
--- a/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
@@ -269,7 +269,7 @@ public abstract class FlatteningConfig {
               resourceNameConfigs,
               oneofNames,
               method,
-              protoParser.hasResourceReference(method.getInputField(parameter).getProtoField())
+              isParameterResourceName(method, parameter, messageConfigs)
                   ? ResourceNameTreatment.STATIC_TYPES
                   : ResourceNameTreatment.NONE);
       flatteningConfigs = collectFieldConfigs(flatteningConfigs, fieldConfigs, parameter);
@@ -516,5 +516,16 @@ public abstract class FlatteningConfig {
   private static boolean hasSingularResourceNameParameters(
       List<Map<String, FieldConfig>> flatteningGroups) {
     return flatteningGroups.stream().anyMatch(FlatteningConfig::hasSingularResourceNameParameter);
+  }
+
+  private static boolean isParameterResourceName(
+      ProtoMethodModel method, String parameter, ResourceNameMessageConfigs messageConfigs) {
+    String inputFullName = method.getInputFullName();
+    ResourceNameMessageConfig resourceMessageConfig =
+        messageConfigs.getResourceTypeConfigMap().get(inputFullName);
+    if (resourceMessageConfig == null) {
+      return false;
+    }
+    return resourceMessageConfig.fieldEntityMap().containsKey(parameter);
   }
 }

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -297,7 +297,6 @@ public abstract class GapicProductConfig implements ProductConfig {
           ResourceNameMessageConfigs.createFromGapicConfigOnly(
               sourceProtos, configProto, defaultPackage);
     }
-
     if (resourceNameConfigs == null) {
       return null;
     }

--- a/src/test/java/com/google/api/codegen/config/FlatteningConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/FlatteningConfigTest.java
@@ -55,7 +55,6 @@ public class FlatteningConfigTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    when(protoParser.hasResourceReference(any(Field.class))).thenReturn(true);
     doThrow(new IllegalStateException("expect no errors"))
         .when(diagCollector)
         .addDiag(any(Diag.class));
@@ -63,6 +62,8 @@ public class FlatteningConfigTest {
     when(createMigrationRoutes.getInputField("source")).thenReturn(source);
     when(createMigrationRoutes.getInputField("destination")).thenReturn(destination);
     when(createMigrationRoutes.getInputField("animals")).thenReturn(animals);
+    when(createMigrationRoutes.getInputFullName())
+        .thenReturn("google.animal.CreateMigrationRoutesRequest");
 
     when(source.getSimpleName()).thenReturn("source");
     when(source.getParentFullName()).thenReturn("google.animal.CreateMigrationRoutesRequest");

--- a/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/configgen/testdata/library_config.baseline
@@ -751,6 +751,41 @@ interfaces:
     retry_params_name: default
     # FIXME: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  - name: SaveBook
+    # FIXME: Configure which fields are required.
+    required_fields:
+    - name
+    - author
+    - title
+    - read
+    - rating
+    - any_value
+    - struct_value
+    - value_value
+    - list_value_value
+    - map_list_value_value
+    - time_value
+    - duration_value
+    - field_mask_value
+    - int32_value
+    - uint32_value
+    - int64_value
+    - uint64_value
+    - float_value
+    - double_value
+    - string_value
+    - bool_value
+    - bytes_value
+    - map_string_value
+    - map_message_value
+    - resource
+    - map_bool_key
+    # FIXME: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # FIXME: Configure the retryable params for this method.
+    retry_params_name: default
+    # FIXME: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: TestOptionalRequiredFlatteningParams
     # FIXME: Configure which fields are required.
     required_fields:

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -7764,6 +7764,33 @@ namespace Google.Example.Library.V1.Snippets
             // End snippet
         }
 
+        /// <summary>Snippet for SaveBookAsync</summary>
+        public async Task SaveBookAsync_RequestObject()
+        {
+            // Snippet: SaveBookAsync(Book,CallSettings)
+            // Additional: SaveBookAsync(Book,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            Book request = new Book();
+            // Make the request
+            await libraryServiceClient.SaveBookAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for SaveBook</summary>
+        public void SaveBook_RequestObject()
+        {
+            // Snippet: SaveBook(Book,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            Book request = new Book();
+            // Make the request
+            libraryServiceClient.SaveBook(request);
+            // End snippet
+        }
+
         /// <summary>Snippet for PrivateListShelvesAsync</summary>
         public async Task PrivateListShelvesAsync_RequestObject()
         {
@@ -10664,6 +10691,40 @@ namespace Google.Example.Library.V1.Tests
         }
 
         [Fact]
+        public void SaveBook()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            Book request = new Book();
+            Empty expectedResponse = new Empty();
+            mockGrpcClient.Setup(x => x.SaveBook(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            client.SaveBook(request);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task SaveBookAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            Book request = new Book();
+            Empty expectedResponse = new Empty();
+            mockGrpcClient.Setup(x => x.SaveBookAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            await client.SaveBookAsync(request);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
         public void PrivateListShelves()
         {
             Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
@@ -10928,6 +10989,7 @@ namespace Google.Example.Library.V1
             LongRunningArchiveBooksSettings = existing.LongRunningArchiveBooksSettings;
             StreamingArchiveBooksSettings = existing.StreamingArchiveBooksSettings;
             StreamingArchiveBooksStreamingSettings = existing.StreamingArchiveBooksStreamingSettings;
+            SaveBookSettings = existing.SaveBookSettings;
             PrivateListShelvesSettings = existing.PrivateListShelvesSettings;
             OnCopy(existing);
         }
@@ -11862,6 +11924,35 @@ namespace Google.Example.Library.V1
         /// </remarks>
         public gaxgrpc::BidirectionalStreamingSettings StreamingArchiveBooksStreamingSettings { get; set; } =
             new gaxgrpc::BidirectionalStreamingSettings(100);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.SaveBook</c> and <c>LibraryServiceClient.SaveBookAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.SaveBook</c> and
+        /// <c>LibraryServiceClient.SaveBookAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings SaveBookSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -20963,6 +21054,62 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task SaveBookAsync(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task SaveBookAsync(
+            Book request,
+            st::CancellationToken cancellationToken) => SaveBookAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void SaveBook(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
         /// This method is not exposed in the GAPIC config. It should be generated.
         /// </summary>
         /// <param name="request">
@@ -21055,6 +21202,7 @@ namespace Google.Example.Library.V1
         private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> _callArchiveBooks;
         private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> _callLongRunningArchiveBooks;
         private readonly gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> _callStreamingArchiveBooks;
+        private readonly gaxgrpc::ApiCall<Book, pbwkt::Empty> _callSaveBook;
         private readonly gaxgrpc::ApiCall<ListShelvesRequest, Book> _callPrivateListShelves;
 
         /// <summary>
@@ -21154,6 +21302,8 @@ namespace Google.Example.Library.V1
                 .WithGoogleRequestParam("source", request => request.Source);
             _callStreamingArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, ArchiveBooksResponse>(
                 GrpcClient.StreamingArchiveBooks, effectiveSettings.StreamingArchiveBooksSettings, effectiveSettings.StreamingArchiveBooksStreamingSettings);
+            _callSaveBook = clientHelper.BuildApiCall<Book, pbwkt::Empty>(
+                GrpcClient.SaveBookAsync, GrpcClient.SaveBook, effectiveSettings.SaveBookSettings);
             _callPrivateListShelves = clientHelper.BuildApiCall<ListShelvesRequest, Book>(
                 GrpcClient.PrivateListShelvesAsync, GrpcClient.PrivateListShelves, effectiveSettings.PrivateListShelvesSettings);
             Modify_ApiCall(ref _callCreateShelf);
@@ -21216,6 +21366,8 @@ namespace Google.Example.Library.V1
             Modify_LongRunningArchiveBooksApiCall(ref _callLongRunningArchiveBooks);
             Modify_ApiCall(ref _callStreamingArchiveBooks);
             Modify_StreamingArchiveBooksApiCall(ref _callStreamingArchiveBooks);
+            Modify_ApiCall(ref _callSaveBook);
+            Modify_SaveBookApiCall(ref _callSaveBook);
             Modify_ApiCall(ref _callPrivateListShelves);
             Modify_PrivateListShelvesApiCall(ref _callPrivateListShelves);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);
@@ -21267,6 +21419,7 @@ namespace Google.Example.Library.V1
         partial void Modify_ArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
         partial void Modify_LongRunningArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> call);
         partial void Modify_StreamingArchiveBooksApiCall(ref gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
+        partial void Modify_SaveBookApiCall(ref gaxgrpc::ApiCall<Book, pbwkt::Empty> call);
         partial void Modify_PrivateListShelvesApiCall(ref gaxgrpc::ApiCall<ListShelvesRequest, Book> call);
         partial void OnConstruction(LibraryService.LibraryServiceClient grpcClient, LibraryServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
@@ -21305,6 +21458,7 @@ namespace Google.Example.Library.V1
         partial void Modify_TestOptionalRequiredFlatteningParamsRequest(ref TestOptionalRequiredFlatteningParamsRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_MoveBooksRequest(ref MoveBooksRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_ArchiveBooksRequest(ref ArchiveBooksRequest request, ref gaxgrpc::CallSettings settings);
+        partial void Modify_Book(ref Book request, ref gaxgrpc::CallSettings settings);
 
         /// <summary>
         /// Creates a shelf, and returns the new Shelf.
@@ -22604,6 +22758,45 @@ namespace Google.Example.Library.V1
             /// <inheritdoc/>
             public override scg::IAsyncEnumerator<ArchiveBooksResponse> ResponseStream =>
                 GrpcCall.ResponseStream;
+        }
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public override stt::Task SaveBookAsync(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Book(ref request, ref callSettings);
+            return _callSaveBook.Async(request, callSettings);
+        }
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public override void SaveBook(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Book(ref request, ref callSettings);
+            _callSaveBook.Sync(request, callSettings);
         }
 
         /// <summary>

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_samplegen_config_migration_library.baseline
@@ -4461,6 +4461,33 @@ namespace Google.Example.Library.V1.Snippets
             // End snippet
         }
 
+        /// <summary>Snippet for SaveBookAsync</summary>
+        public async Task SaveBookAsync_RequestObject()
+        {
+            // Snippet: SaveBookAsync(Book,CallSettings)
+            // Additional: SaveBookAsync(Book,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            Book request = new Book();
+            // Make the request
+            await libraryServiceClient.SaveBookAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for SaveBook</summary>
+        public void SaveBook_RequestObject()
+        {
+            // Snippet: SaveBook(Book,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            Book request = new Book();
+            // Make the request
+            libraryServiceClient.SaveBook(request);
+            // End snippet
+        }
+
         /// <summary>Snippet for PrivateListShelvesAsync</summary>
         public async Task PrivateListShelvesAsync_RequestObject()
         {
@@ -7151,6 +7178,40 @@ namespace Google.Example.Library.V1.Tests
         }
 
         [Fact]
+        public void SaveBook()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            Book request = new Book();
+            Empty expectedResponse = new Empty();
+            mockGrpcClient.Setup(x => x.SaveBook(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            client.SaveBook(request);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task SaveBookAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            Book request = new Book();
+            Empty expectedResponse = new Empty();
+            mockGrpcClient.Setup(x => x.SaveBookAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            await client.SaveBookAsync(request);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
         public void PrivateListShelves()
         {
             Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
@@ -7415,6 +7476,7 @@ namespace Google.Example.Library.V1
             LongRunningArchiveBooksSettings = existing.LongRunningArchiveBooksSettings;
             StreamingArchiveBooksSettings = existing.StreamingArchiveBooksSettings;
             StreamingArchiveBooksStreamingSettings = existing.StreamingArchiveBooksStreamingSettings;
+            SaveBookSettings = existing.SaveBookSettings;
             PrivateListShelvesSettings = existing.PrivateListShelvesSettings;
             OnCopy(existing);
         }
@@ -8349,6 +8411,35 @@ namespace Google.Example.Library.V1
         /// </remarks>
         public gaxgrpc::BidirectionalStreamingSettings StreamingArchiveBooksStreamingSettings { get; set; } =
             new gaxgrpc::BidirectionalStreamingSettings(100);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.SaveBook</c> and <c>LibraryServiceClient.SaveBookAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.SaveBook</c> and
+        /// <c>LibraryServiceClient.SaveBookAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings SaveBookSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -16400,6 +16491,62 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task SaveBookAsync(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task SaveBookAsync(
+            Book request,
+            st::CancellationToken cancellationToken) => SaveBookAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void SaveBook(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
         /// This method is not exposed in the GAPIC config. It should be generated.
         /// </summary>
         /// <param name="request">
@@ -16492,6 +16639,7 @@ namespace Google.Example.Library.V1
         private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> _callArchiveBooks;
         private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> _callLongRunningArchiveBooks;
         private readonly gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> _callStreamingArchiveBooks;
+        private readonly gaxgrpc::ApiCall<Book, pbwkt::Empty> _callSaveBook;
         private readonly gaxgrpc::ApiCall<ListShelvesRequest, Book> _callPrivateListShelves;
 
         /// <summary>
@@ -16591,6 +16739,8 @@ namespace Google.Example.Library.V1
                 .WithGoogleRequestParam("source", request => request.Source);
             _callStreamingArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, ArchiveBooksResponse>(
                 GrpcClient.StreamingArchiveBooks, effectiveSettings.StreamingArchiveBooksSettings, effectiveSettings.StreamingArchiveBooksStreamingSettings);
+            _callSaveBook = clientHelper.BuildApiCall<Book, pbwkt::Empty>(
+                GrpcClient.SaveBookAsync, GrpcClient.SaveBook, effectiveSettings.SaveBookSettings);
             _callPrivateListShelves = clientHelper.BuildApiCall<ListShelvesRequest, Book>(
                 GrpcClient.PrivateListShelvesAsync, GrpcClient.PrivateListShelves, effectiveSettings.PrivateListShelvesSettings);
             Modify_ApiCall(ref _callCreateShelf);
@@ -16653,6 +16803,8 @@ namespace Google.Example.Library.V1
             Modify_LongRunningArchiveBooksApiCall(ref _callLongRunningArchiveBooks);
             Modify_ApiCall(ref _callStreamingArchiveBooks);
             Modify_StreamingArchiveBooksApiCall(ref _callStreamingArchiveBooks);
+            Modify_ApiCall(ref _callSaveBook);
+            Modify_SaveBookApiCall(ref _callSaveBook);
             Modify_ApiCall(ref _callPrivateListShelves);
             Modify_PrivateListShelvesApiCall(ref _callPrivateListShelves);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);
@@ -16704,6 +16856,7 @@ namespace Google.Example.Library.V1
         partial void Modify_ArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
         partial void Modify_LongRunningArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> call);
         partial void Modify_StreamingArchiveBooksApiCall(ref gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
+        partial void Modify_SaveBookApiCall(ref gaxgrpc::ApiCall<Book, pbwkt::Empty> call);
         partial void Modify_PrivateListShelvesApiCall(ref gaxgrpc::ApiCall<ListShelvesRequest, Book> call);
         partial void OnConstruction(LibraryService.LibraryServiceClient grpcClient, LibraryServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
@@ -16742,6 +16895,7 @@ namespace Google.Example.Library.V1
         partial void Modify_TestOptionalRequiredFlatteningParamsRequest(ref TestOptionalRequiredFlatteningParamsRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_MoveBooksRequest(ref MoveBooksRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_ArchiveBooksRequest(ref ArchiveBooksRequest request, ref gaxgrpc::CallSettings settings);
+        partial void Modify_Book(ref Book request, ref gaxgrpc::CallSettings settings);
 
         /// <summary>
         /// Creates a shelf, and returns the new Shelf.
@@ -18041,6 +18195,45 @@ namespace Google.Example.Library.V1
             /// <inheritdoc/>
             public override scg::IAsyncEnumerator<ArchiveBooksResponse> ResponseStream =>
                 GrpcCall.ResponseStream;
+        }
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public override stt::Task SaveBookAsync(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Book(ref request, ref callSettings);
+            return _callSaveBook.Async(request, callSettings);
+        }
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public override void SaveBook(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Book(ref request, ref callSettings);
+            _callSaveBook.Sync(request, callSettings);
         }
 
         /// <summary>

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -248,6 +248,7 @@ type CallOptions struct {
     ArchiveBooks []gax.CallOption
     LongRunningArchiveBooks []gax.CallOption
     StreamingArchiveBooks []gax.CallOption
+    SaveBook []gax.CallOption
     PrivateListShelves []gax.CallOption
 }
 
@@ -307,6 +308,7 @@ func defaultCallOptions() *CallOptions {
         ArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
         LongRunningArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
         StreamingArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
+        SaveBook: retry[[2]string{"default", "non_idempotent"}],
         PrivateListShelves: retry[[2]string{"default", "idempotent"}],
     }
 }
@@ -995,6 +997,19 @@ func (c *LibClient) StreamingArchiveBooks(ctx context.Context, opts ...gax.CallO
         return nil, err
     }
     return resp, nil
+}
+
+// SaveBook test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+// New APIs should always create a separate message for a request.
+func (c *LibClient) SaveBook(ctx context.Context, req *librarypb.Book, opts ...gax.CallOption) error {
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
+    opts = append(c.CallOptions.SaveBook[0:len(c.CallOptions.SaveBook):len(c.CallOptions.SaveBook)], opts...)
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        _, err = c.client.SaveBook(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    return err
 }
 
 // PrivateListShelves this method is not exposed in the GAPIC config. It should be generated.
@@ -1932,6 +1947,22 @@ func ExampleClient_StreamingArchiveBooks() {
     }
 }
 
+func ExampleClient_SaveBook() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &librarypb.Book{
+        // TODO: Fill request struct fields.
+    }
+    err = c.SaveBook(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+}
+
 func ExampleClient_PrivateListShelves() {
     ctx := context.Background()
     c, err := library.NewClient(ctx)
@@ -2423,6 +2454,18 @@ func (s *mockLibraryServer) StreamingArchiveBooks(stream librarypb.LibraryServic
         }
     }
     return nil
+}
+
+func (s *mockLibraryServer) SaveBook(ctx context.Context, req *librarypb.Book) (*emptypb.Empty, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*emptypb.Empty), nil
 }
 
 func (s *mockLibraryServer) TestOptionalRequiredFlatteningParams(ctx context.Context, req *librarypb.TestOptionalRequiredFlatteningParamsRequest) (*librarypb.TestOptionalRequiredFlatteningParamsResponse, error) {
@@ -4869,6 +4912,52 @@ func TestLibraryServiceStreamingArchiveBooksError(t *testing.T) {
         t.Errorf("got error code %q, want %q", c, errCode)
     }
     _ = resp
+}
+func TestLibraryServiceSaveBook(t *testing.T) {
+    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
+
+    var request *librarypb.Book = &librarypb.Book{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    err = c.SaveBook(context.Background(), request)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+}
+
+func TestLibraryServiceSaveBookError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockLibrary.err = gstatus.Error(errCode, "test error")
+
+    var request *librarypb.Book = &librarypb.Book{}
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    err = c.SaveBook(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
 }
 func TestLibraryServicePrivateListShelves(t *testing.T) {
     var name string = "name3373707"

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -8508,6 +8508,45 @@ public class LibraryClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   Book request = Book.newBuilder().build();
+   *   libraryClient.saveBook(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void saveBook(Book request) {
+    saveBookCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   Book request = Book.newBuilder().build();
+   *   ApiFuture&lt;Void&gt; future = libraryClient.saveBookCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<Book, Empty> saveBookCallable() {
+    return stub.saveBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
    * This method is not exposed in the GAPIC config. It should be generated.
    *
    * Sample code:
@@ -9350,6 +9389,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
   }
 
   /**
+   * Returns the object with the settings used for calls to saveBook.
+   */
+  public UnaryCallSettings<Book, Empty> saveBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).saveBookSettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -9708,6 +9754,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
      */
     public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
       return getStubSettingsBuilder().streamingArchiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to saveBook.
+     */
+    public UnaryCallSettings.Builder<Book, Empty> saveBookSettings() {
+      return getStubSettingsBuilder().saveBookSettings();
     }
 
     /**
@@ -10856,6 +10909,13 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<Book, Empty> saveBookMethodDescriptor =
+      MethodDescriptor.<Book, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/SaveBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(Book.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<ListShelvesRequest, Book> privateListShelvesMethodDescriptor =
       MethodDescriptor.<ListShelvesRequest, Book>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -10906,6 +10966,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable;
   private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
   private final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable;
+  private final UnaryCallable<Book, Empty> saveBookCallable;
   private final UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable;
 
   private final GrpcStubCallableFactory callableFactory;
@@ -11258,6 +11319,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
         GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
             .setMethodDescriptor(streamingArchiveBooksMethodDescriptor)
             .build();
+    GrpcCallSettings<Book, Empty> saveBookTransportSettings =
+        GrpcCallSettings.<Book, Empty>newBuilder()
+            .setMethodDescriptor(saveBookMethodDescriptor)
+            .build();
     GrpcCallSettings<ListShelvesRequest, Book> privateListShelvesTransportSettings =
         GrpcCallSettings.<ListShelvesRequest, Book>newBuilder()
             .setMethodDescriptor(privateListShelvesMethodDescriptor)
@@ -11303,6 +11368,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.archiveBooksCallable = callableFactory.createUnaryCallable(archiveBooksTransportSettings,settings.archiveBooksSettings(), clientContext);
     this.longRunningArchiveBooksCallable = callableFactory.createUnaryCallable(longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksSettings(), clientContext);
     this.streamingArchiveBooksCallable = callableFactory.createBidiStreamingCallable(streamingArchiveBooksTransportSettings,settings.streamingArchiveBooksSettings(), clientContext);
+    this.saveBookCallable = callableFactory.createUnaryCallable(saveBookTransportSettings,settings.saveBookSettings(), clientContext);
     this.privateListShelvesCallable = callableFactory.createUnaryCallable(privateListShelvesTransportSettings,settings.privateListShelvesSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -11465,6 +11531,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
     return streamingArchiveBooksCallable;
+  }
+
+  public UnaryCallable<Book, Empty> saveBookCallable() {
+    return saveBookCallable;
   }
 
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
@@ -12036,6 +12106,10 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: streamingArchiveBooksCallable()");
   }
 
+  public UnaryCallable<Book, Empty> saveBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: saveBookCallable()");
+  }
+
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
     throw new UnsupportedOperationException("Not implemented: privateListShelvesCallable()");
   }
@@ -12244,6 +12318,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
   private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
   private final StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
+  private final UnaryCallSettings<Book, Empty> saveBookSettings;
   private final UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings;
 
   /**
@@ -12487,6 +12562,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to saveBook.
+   */
+  public UnaryCallSettings<Book, Empty> saveBookSettings() {
+    return saveBookSettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -12613,6 +12695,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     archiveBooksSettings = settingsBuilder.archiveBooksSettings().build();
     longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
     streamingArchiveBooksSettings = settingsBuilder.streamingArchiveBooksSettings().build();
+    saveBookSettings = settingsBuilder.saveBookSettings().build();
     privateListShelvesSettings = settingsBuilder.privateListShelvesSettings().build();
   }
 
@@ -12971,6 +13054,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
     private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
     private final StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
+    private final UnaryCallSettings.Builder<Book, Empty> saveBookSettings;
     private final UnaryCallSettings.Builder<ListShelvesRequest, Book> privateListShelvesSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
@@ -13087,6 +13171,8 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       streamingArchiveBooksSettings = StreamingCallSettings.newBuilder();
 
+      saveBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       privateListShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -13116,6 +13202,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
+          saveBookSettings,
           privateListShelvesSettings
       );
 
@@ -13265,6 +13352,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.saveBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       builder.privateListShelvesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
@@ -13349,6 +13440,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       archiveBooksSettings = settings.archiveBooksSettings.toBuilder();
       longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
       streamingArchiveBooksSettings = settings.streamingArchiveBooksSettings.toBuilder();
+      saveBookSettings = settings.saveBookSettings.toBuilder();
       privateListShelvesSettings = settings.privateListShelvesSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -13378,6 +13470,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
+          saveBookSettings,
           privateListShelvesSettings
       );
     }
@@ -13635,6 +13728,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
       return streamingArchiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to saveBook.
+     */
+    public UnaryCallSettings.Builder<Book, Empty> saveBookSettings() {
+      return saveBookSettings;
     }
 
     /**
@@ -16187,6 +16287,42 @@ public class LibraryClientTest {
 
   @Test
   @SuppressWarnings("all")
+  public void saveBookTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    Book request = Book.newBuilder().build();
+
+    client.saveBook(request);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    Book actualRequest = (Book)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void saveBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      Book request = Book.newBuilder().build();
+
+      client.saveBook(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
   public void privateListShelvesTest() {
     BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
@@ -17067,6 +17203,21 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
       }
     };
     return requestObserver;
+  }
+
+  @Override
+  public void saveBook(Book request,
+    StreamObserver<Empty> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -6005,6 +6005,45 @@ public class LibraryClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   Book request = Book.newBuilder().build();
+   *   libraryClient.saveBook(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void saveBook(Book request) {
+    saveBookCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   Book request = Book.newBuilder().build();
+   *   ApiFuture&lt;Void&gt; future = libraryClient.saveBookCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<Book, Empty> saveBookCallable() {
+    return stub.saveBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
    * This method is not exposed in the GAPIC config. It should be generated.
    *
    * Sample code:
@@ -6847,6 +6886,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
   }
 
   /**
+   * Returns the object with the settings used for calls to saveBook.
+   */
+  public UnaryCallSettings<Book, Empty> saveBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).saveBookSettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -7205,6 +7251,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
      */
     public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
       return getStubSettingsBuilder().streamingArchiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to saveBook.
+     */
+    public UnaryCallSettings.Builder<Book, Empty> saveBookSettings() {
+      return getStubSettingsBuilder().saveBookSettings();
     }
 
     /**
@@ -8347,6 +8400,13 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<Book, Empty> saveBookMethodDescriptor =
+      MethodDescriptor.<Book, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/SaveBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(Book.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<ListShelvesRequest, Book> privateListShelvesMethodDescriptor =
       MethodDescriptor.<ListShelvesRequest, Book>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -8397,6 +8457,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable;
   private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
   private final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable;
+  private final UnaryCallable<Book, Empty> saveBookCallable;
   private final UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable;
 
   private final GrpcStubCallableFactory callableFactory;
@@ -8749,6 +8810,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
         GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
             .setMethodDescriptor(streamingArchiveBooksMethodDescriptor)
             .build();
+    GrpcCallSettings<Book, Empty> saveBookTransportSettings =
+        GrpcCallSettings.<Book, Empty>newBuilder()
+            .setMethodDescriptor(saveBookMethodDescriptor)
+            .build();
     GrpcCallSettings<ListShelvesRequest, Book> privateListShelvesTransportSettings =
         GrpcCallSettings.<ListShelvesRequest, Book>newBuilder()
             .setMethodDescriptor(privateListShelvesMethodDescriptor)
@@ -8794,6 +8859,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.archiveBooksCallable = callableFactory.createUnaryCallable(archiveBooksTransportSettings,settings.archiveBooksSettings(), clientContext);
     this.longRunningArchiveBooksCallable = callableFactory.createUnaryCallable(longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksSettings(), clientContext);
     this.streamingArchiveBooksCallable = callableFactory.createBidiStreamingCallable(streamingArchiveBooksTransportSettings,settings.streamingArchiveBooksSettings(), clientContext);
+    this.saveBookCallable = callableFactory.createUnaryCallable(saveBookTransportSettings,settings.saveBookSettings(), clientContext);
     this.privateListShelvesCallable = callableFactory.createUnaryCallable(privateListShelvesTransportSettings,settings.privateListShelvesSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -8956,6 +9022,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
     return streamingArchiveBooksCallable;
+  }
+
+  public UnaryCallable<Book, Empty> saveBookCallable() {
+    return saveBookCallable;
   }
 
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
@@ -9524,6 +9594,10 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: streamingArchiveBooksCallable()");
   }
 
+  public UnaryCallable<Book, Empty> saveBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: saveBookCallable()");
+  }
+
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
     throw new UnsupportedOperationException("Not implemented: privateListShelvesCallable()");
   }
@@ -9732,6 +9806,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
   private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
   private final StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
+  private final UnaryCallSettings<Book, Empty> saveBookSettings;
   private final UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings;
 
   /**
@@ -9975,6 +10050,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to saveBook.
+   */
+  public UnaryCallSettings<Book, Empty> saveBookSettings() {
+    return saveBookSettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -10101,6 +10183,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     archiveBooksSettings = settingsBuilder.archiveBooksSettings().build();
     longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
     streamingArchiveBooksSettings = settingsBuilder.streamingArchiveBooksSettings().build();
+    saveBookSettings = settingsBuilder.saveBookSettings().build();
     privateListShelvesSettings = settingsBuilder.privateListShelvesSettings().build();
   }
 
@@ -10459,6 +10542,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
     private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
     private final StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
+    private final UnaryCallSettings.Builder<Book, Empty> saveBookSettings;
     private final UnaryCallSettings.Builder<ListShelvesRequest, Book> privateListShelvesSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
@@ -10575,6 +10659,8 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       streamingArchiveBooksSettings = StreamingCallSettings.newBuilder();
 
+      saveBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       privateListShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -10604,6 +10690,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
+          saveBookSettings,
           privateListShelvesSettings
       );
 
@@ -10753,6 +10840,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.saveBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       builder.privateListShelvesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
@@ -10837,6 +10928,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       archiveBooksSettings = settings.archiveBooksSettings.toBuilder();
       longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
       streamingArchiveBooksSettings = settings.streamingArchiveBooksSettings.toBuilder();
+      saveBookSettings = settings.saveBookSettings.toBuilder();
       privateListShelvesSettings = settings.privateListShelvesSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -10866,6 +10958,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
+          saveBookSettings,
           privateListShelvesSettings
       );
     }
@@ -11123,6 +11216,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
       return streamingArchiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to saveBook.
+     */
+    public UnaryCallSettings.Builder<Book, Empty> saveBookSettings() {
+      return saveBookSettings;
     }
 
     /**
@@ -13570,6 +13670,42 @@ public class LibraryClientTest {
 
   @Test
   @SuppressWarnings("all")
+  public void saveBookTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    Book request = Book.newBuilder().build();
+
+    client.saveBook(request);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    Book actualRequest = (Book)actualRequests.get(0);
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void saveBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      Book request = Book.newBuilder().build();
+
+      client.saveBook(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
   public void privateListShelvesTest() {
     BookName name = ShelfBookName.of("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
@@ -14450,6 +14586,21 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
       }
     };
     return requestObserver;
+  }
+
+  @Override
+  public void saveBook(Book request,
+    StreamObserver<Empty> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -5264,6 +5264,7 @@ class LibraryServiceClient {
       'archiveBooks',
       'longRunningArchiveBooks',
       'streamingArchiveBooks',
+      'saveBook',
       'privateListShelves',
     ];
     for (const methodName of libraryServiceStubMethods) {
@@ -7862,6 +7863,112 @@ class LibraryServiceClient {
   }
 
   /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.name]
+   *   The resource name of the book.
+   *   Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+   *   Message field comment may include special characters: <>&"`'@.
+   * @param {string} [request.author]
+   *   The name of the book author.
+   * @param {string} [request.title]
+   *   The title of the book.
+   * @param {boolean} [request.read]
+   *   Value indicating whether the book has been read.
+   * @param {number} [request.rating]
+   *   For testing enums.
+   *
+   *   The number should be among the values of [Rating]{@link google.example.library.v1.Rating}
+   * @param {Object} [request.anyValue]
+   *   For testing all well-known types.
+   *
+   *   This object should have the same structure as [Any]{@link google.protobuf.Any}
+   * @param {Object} [request.structValue]
+   *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
+   * @param {Object} [request.valueValue]
+   *   This object should have the same structure as [Value]{@link google.protobuf.Value}
+   * @param {Object} [request.listValueValue]
+   *   This object should have the same structure as [ListValue]{@link google.protobuf.ListValue}
+   * @param {Object.<string, Object>} [request.mapListValueValue]
+   * @param {Object} [request.timeValue]
+   *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
+   * @param {Object} [request.durationValue]
+   *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+   * @param {Object} [request.fieldMaskValue]
+   *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+   * @param {Object} [request.int32Value]
+   *   This object should have the same structure as [Int32Value]{@link google.protobuf.Int32Value}
+   * @param {Object} [request.uint32Value]
+   *   This object should have the same structure as [UInt32Value]{@link google.protobuf.UInt32Value}
+   * @param {Object} [request.int64Value]
+   *   This object should have the same structure as [Int64Value]{@link google.protobuf.Int64Value}
+   * @param {Object} [request.uint64Value]
+   *   This object should have the same structure as [UInt64Value]{@link google.protobuf.UInt64Value}
+   * @param {Object} [request.floatValue]
+   *   This object should have the same structure as [FloatValue]{@link google.protobuf.FloatValue}
+   * @param {Object} [request.doubleValue]
+   *   This object should have the same structure as [DoubleValue]{@link google.protobuf.DoubleValue}
+   * @param {Object} [request.stringValue]
+   *   This object should have the same structure as [StringValue]{@link google.protobuf.StringValue}
+   * @param {Object} [request.boolValue]
+   *   This object should have the same structure as [BoolValue]{@link google.protobuf.BoolValue}
+   * @param {Object} [request.bytesValue]
+   *   This object should have the same structure as [BytesValue]{@link google.protobuf.BytesValue}
+   * @param {Object.<number, string>} [request.mapStringValue]
+   *   Test doc generation of lists:
+   *
+   *   +   Here is a sentence about the first element of the list that continues
+   *       into a second line.
+   *   +   The second element of the list.
+   *   +   Another element of the list where the indentation isn't consistent
+   *   after a blank space.
+   *
+   *       The second paragraph of the list
+   *   that doesn't have a hanging indent.
+   * @param {Object.<string, Object>} [request.mapMessageValue]
+   * @param {Object} [request.resource]
+   *   Tests Python doc generation: should generate a dummy file for shared_type
+   *   resource, but *not* its import, other_shared_type
+   *
+   *   This object should have the same structure as [Used]{@link google.test.shared.data.Used}
+   * @param {Object.<boolean, string>} [request.mapBoolKey]
+   *   For testing accessing map fields in samplegen
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error)} [callback]
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.saveBook({}).catch(err => {
+   *   console.error(err);
+   * });
+   */
+  saveBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+
+    return this._innerApiCalls.saveBook(request, options, callback);
+  }
+
+  /**
    * This method is not exposed in the GAPIC config. It should be generated.
    *
    * @param {Object} request
@@ -8345,6 +8452,11 @@ module.exports = LibraryServiceClient;
           "retry_params_name": "default"
         },
         "StreamingArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "SaveBook": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -10938,6 +11050,49 @@ describe('LibraryServiceClient', () => {
       });
 
       stream.write(request);
+    });
+  });
+
+  describe('saveBook', () => {
+    it('invokes saveBook without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.saveBook = mockSimpleGrpcMethod(request);
+
+      client.saveBook(request, err => {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('invokes saveBook with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.saveBook = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.saveBook(request, err => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        done();
+      });
     });
   });
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
@@ -4501,6 +4501,7 @@ class LibraryServiceClient {
       'archiveBooks',
       'longRunningArchiveBooks',
       'streamingArchiveBooks',
+      'saveBook',
       'privateListShelves',
     ];
     for (const methodName of libraryServiceStubMethods) {
@@ -7026,6 +7027,112 @@ class LibraryServiceClient {
   }
 
   /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.name]
+   *   The resource name of the book.
+   *   Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+   *   Message field comment may include special characters: <>&"`'@.
+   * @param {string} [request.author]
+   *   The name of the book author.
+   * @param {string} [request.title]
+   *   The title of the book.
+   * @param {boolean} [request.read]
+   *   Value indicating whether the book has been read.
+   * @param {number} [request.rating]
+   *   For testing enums.
+   *
+   *   The number should be among the values of [Rating]{@link google.example.library.v1.Rating}
+   * @param {Object} [request.anyValue]
+   *   For testing all well-known types.
+   *
+   *   This object should have the same structure as [Any]{@link google.protobuf.Any}
+   * @param {Object} [request.structValue]
+   *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
+   * @param {Object} [request.valueValue]
+   *   This object should have the same structure as [Value]{@link google.protobuf.Value}
+   * @param {Object} [request.listValueValue]
+   *   This object should have the same structure as [ListValue]{@link google.protobuf.ListValue}
+   * @param {Object.<string, Object>} [request.mapListValueValue]
+   * @param {Object} [request.timeValue]
+   *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
+   * @param {Object} [request.durationValue]
+   *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+   * @param {Object} [request.fieldMaskValue]
+   *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+   * @param {Object} [request.int32Value]
+   *   This object should have the same structure as [Int32Value]{@link google.protobuf.Int32Value}
+   * @param {Object} [request.uint32Value]
+   *   This object should have the same structure as [UInt32Value]{@link google.protobuf.UInt32Value}
+   * @param {Object} [request.int64Value]
+   *   This object should have the same structure as [Int64Value]{@link google.protobuf.Int64Value}
+   * @param {Object} [request.uint64Value]
+   *   This object should have the same structure as [UInt64Value]{@link google.protobuf.UInt64Value}
+   * @param {Object} [request.floatValue]
+   *   This object should have the same structure as [FloatValue]{@link google.protobuf.FloatValue}
+   * @param {Object} [request.doubleValue]
+   *   This object should have the same structure as [DoubleValue]{@link google.protobuf.DoubleValue}
+   * @param {Object} [request.stringValue]
+   *   This object should have the same structure as [StringValue]{@link google.protobuf.StringValue}
+   * @param {Object} [request.boolValue]
+   *   This object should have the same structure as [BoolValue]{@link google.protobuf.BoolValue}
+   * @param {Object} [request.bytesValue]
+   *   This object should have the same structure as [BytesValue]{@link google.protobuf.BytesValue}
+   * @param {Object.<number, string>} [request.mapStringValue]
+   *   Test doc generation of lists:
+   *
+   *   +   Here is a sentence about the first element of the list that continues
+   *       into a second line.
+   *   +   The second element of the list.
+   *   +   Another element of the list where the indentation isn't consistent
+   *   after a blank space.
+   *
+   *       The second paragraph of the list
+   *   that doesn't have a hanging indent.
+   * @param {Object.<string, Object>} [request.mapMessageValue]
+   * @param {Object} [request.resource]
+   *   Tests Python doc generation: should generate a dummy file for shared_type
+   *   resource, but *not* its import, other_shared_type
+   *
+   *   This object should have the same structure as [Used]{@link google.test.shared.data.Used}
+   * @param {Object.<boolean, string>} [request.mapBoolKey]
+   *   For testing accessing map fields in samplegen
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error)} [callback]
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.saveBook({}).catch(err => {
+   *   console.error(err);
+   * });
+   */
+  saveBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+
+    return this._innerApiCalls.saveBook(request, options, callback);
+  }
+
+  /**
    * This method is not exposed in the GAPIC config. It should be generated.
    *
    * @param {Object} request
@@ -7404,6 +7511,11 @@ module.exports = LibraryServiceClient;
           "retry_params_name": "default"
         },
         "StreamingArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "SaveBook": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -9857,6 +9969,49 @@ describe('LibraryServiceClient', () => {
       });
 
       stream.write(request);
+    });
+  });
+
+  describe('saveBook', () => {
+    it('invokes saveBook without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.saveBook = mockSimpleGrpcMethod(request);
+
+      client.saveBook(request, err => {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('invokes saveBook with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const request = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.saveBook = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.saveBook(request, err => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        done();
+      });
     });
   });
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -2294,6 +2294,11 @@ use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
+use Google\Example\Library\V1\Book\MapBoolKeyEntry;
+use Google\Example\Library\V1\Book\MapListValueValueEntry;
+use Google\Example\Library\V1\Book\MapMessageValueEntry;
+use Google\Example\Library\V1\Book\MapStringValueEntry;
+use Google\Example\Library\V1\Book\Rating;
 use Google\Example\Library\V1\Comment;
 use Google\Example\Library\V1\CreateBookRequest;
 use Google\Example\Library\V1\CreateShelfRequest;
@@ -2358,6 +2363,7 @@ use Google\Protobuf\Value;
 use Google\Tagger\CustomNamespace\V1\AddLabelRequest;
 use Google\Tagger\CustomNamespace\V1\AddLabelResponse;
 use Google\Tagger\CustomNamespace\V1\LabelerGrpcClient;
+use Google\Test\Shared\Data\Used;
 
 /**
  * Service Description: This API represents a simple digital library.  It lets you manage Shelf
@@ -5070,6 +5076,170 @@ class LibraryServiceGapicClient
     }
 
     /**
+     * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+     * New APIs should always create a separate message for a request.
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $libraryServiceClient->saveBook();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $name
+     *          The resource name of the book.
+     *          Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+     *          Message field comment may include special characters: <>&"`'&#64;.
+     *     @type string $author
+     *          The name of the book author.
+     *     @type string $title
+     *          The title of the book.
+     *     @type bool $read
+     *          Value indicating whether the book has been read.
+     *     @type int $rating
+     *          For testing enums.
+     *          For allowed values, use constants defined on {@see \Google\Example\Library\V1\Book\Rating}
+     *     @type Any $anyValue
+     *          For testing all well-known types.
+     *     @type Struct $structValue
+     *     @type Value $valueValue
+     *     @type ListValue $listValueValue
+     *     @type array $mapListValueValue
+     *     @type Timestamp $timeValue
+     *     @type Duration $durationValue
+     *     @type FieldMask $fieldMaskValue
+     *     @type Int32Value $int32Value
+     *     @type UInt32Value $uint32Value
+     *     @type Int64Value $int64Value
+     *     @type UInt64Value $uint64Value
+     *     @type FloatValue $floatValue
+     *     @type DoubleValue $doubleValue
+     *     @type StringValue $stringValue
+     *     @type BoolValue $boolValue
+     *     @type BytesValue $bytesValue
+     *     @type array $mapStringValue
+     *          Test doc generation of lists:
+     *
+     *          +   Here is a sentence about the first element of the list that continues
+     *              into a second line.
+     *          +   The second element of the list.
+     *          +   Another element of the list where the indentation isn't consistent
+     *          after a blank space.
+     *
+     *              The second paragraph of the list
+     *          that doesn't have a hanging indent.
+     *     @type array $mapMessageValue
+     *     @type Used $resource
+     *          Tests Python doc generation: should generate a dummy file for shared_type
+     *          resource, but *not* its import, other_shared_type
+     *     @type array $mapBoolKey
+     *          For testing accessing map fields in samplegen
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function saveBook(array $optionalArgs = [])
+    {
+        $request = new Book();
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+        if (isset($optionalArgs['author'])) {
+            $request->setAuthor($optionalArgs['author']);
+        }
+        if (isset($optionalArgs['title'])) {
+            $request->setTitle($optionalArgs['title']);
+        }
+        if (isset($optionalArgs['read'])) {
+            $request->setRead($optionalArgs['read']);
+        }
+        if (isset($optionalArgs['rating'])) {
+            $request->setRating($optionalArgs['rating']);
+        }
+        if (isset($optionalArgs['anyValue'])) {
+            $request->setAnyValue($optionalArgs['anyValue']);
+        }
+        if (isset($optionalArgs['structValue'])) {
+            $request->setStructValue($optionalArgs['structValue']);
+        }
+        if (isset($optionalArgs['valueValue'])) {
+            $request->setValueValue($optionalArgs['valueValue']);
+        }
+        if (isset($optionalArgs['listValueValue'])) {
+            $request->setListValueValue($optionalArgs['listValueValue']);
+        }
+        if (isset($optionalArgs['mapListValueValue'])) {
+            $request->setMapListValueValue($optionalArgs['mapListValueValue']);
+        }
+        if (isset($optionalArgs['timeValue'])) {
+            $request->setTimeValue($optionalArgs['timeValue']);
+        }
+        if (isset($optionalArgs['durationValue'])) {
+            $request->setDurationValue($optionalArgs['durationValue']);
+        }
+        if (isset($optionalArgs['fieldMaskValue'])) {
+            $request->setFieldMaskValue($optionalArgs['fieldMaskValue']);
+        }
+        if (isset($optionalArgs['int32Value'])) {
+            $request->setInt32Value($optionalArgs['int32Value']);
+        }
+        if (isset($optionalArgs['uint32Value'])) {
+            $request->setUint32Value($optionalArgs['uint32Value']);
+        }
+        if (isset($optionalArgs['int64Value'])) {
+            $request->setInt64Value($optionalArgs['int64Value']);
+        }
+        if (isset($optionalArgs['uint64Value'])) {
+            $request->setUint64Value($optionalArgs['uint64Value']);
+        }
+        if (isset($optionalArgs['floatValue'])) {
+            $request->setFloatValue($optionalArgs['floatValue']);
+        }
+        if (isset($optionalArgs['doubleValue'])) {
+            $request->setDoubleValue($optionalArgs['doubleValue']);
+        }
+        if (isset($optionalArgs['stringValue'])) {
+            $request->setStringValue($optionalArgs['stringValue']);
+        }
+        if (isset($optionalArgs['boolValue'])) {
+            $request->setBoolValue($optionalArgs['boolValue']);
+        }
+        if (isset($optionalArgs['bytesValue'])) {
+            $request->setBytesValue($optionalArgs['bytesValue']);
+        }
+        if (isset($optionalArgs['mapStringValue'])) {
+            $request->setMapStringValue($optionalArgs['mapStringValue']);
+        }
+        if (isset($optionalArgs['mapMessageValue'])) {
+            $request->setMapMessageValue($optionalArgs['mapMessageValue']);
+        }
+        if (isset($optionalArgs['resource'])) {
+            $request->setResource($optionalArgs['resource']);
+        }
+        if (isset($optionalArgs['mapBoolKey'])) {
+            $request->setMapBoolKey($optionalArgs['mapBoolKey']);
+        }
+
+        return $this->startCall(
+            'SaveBook',
+            GPBEmpty::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
      * This method is not exposed in the GAPIC config. It should be generated.
      *
      * Sample code:
@@ -5683,6 +5853,11 @@ class MyProtoClient extends MyProtoGapicClient
         "StreamingArchiveBooks": {
           "timeout_millis": 60000
         },
+        "SaveBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "PrivateListShelves": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -6075,6 +6250,11 @@ return [
                         ],
                     ],
                 ]
+            ],
+            'SaveBook' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1:saveBook',
+                'body' => '*',
             ],
             'PrivateListShelves' => [
                 'method' => 'get',
@@ -9245,6 +9425,67 @@ class LibraryServiceClientTest extends GeneratedTest
             // If the close stream method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         }  catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function saveBookTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $expectedResponse = new GPBEmpty();
+        $transport->addResponse($expectedResponse);
+
+        $client->saveBook();
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/SaveBook', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function saveBookExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->saveBook();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_samplegen_config_migration_library.baseline
@@ -1712,6 +1712,11 @@ use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
+use Google\Example\Library\V1\Book\MapBoolKeyEntry;
+use Google\Example\Library\V1\Book\MapListValueValueEntry;
+use Google\Example\Library\V1\Book\MapMessageValueEntry;
+use Google\Example\Library\V1\Book\MapStringValueEntry;
+use Google\Example\Library\V1\Book\Rating;
 use Google\Example\Library\V1\Comment;
 use Google\Example\Library\V1\CreateBookRequest;
 use Google\Example\Library\V1\CreateShelfRequest;
@@ -1776,6 +1781,7 @@ use Google\Protobuf\Value;
 use Google\Tagger\CustomNamespace\V1\AddLabelRequest;
 use Google\Tagger\CustomNamespace\V1\AddLabelResponse;
 use Google\Tagger\CustomNamespace\V1\LabelerGrpcClient;
+use Google\Test\Shared\Data\Used;
 
 /**
  * Service Description: This API represents a simple digital library.  It lets you manage Shelf
@@ -4438,6 +4444,170 @@ class LibraryServiceGapicClient
     }
 
     /**
+     * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+     * New APIs should always create a separate message for a request.
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $libraryServiceClient->saveBook();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $name
+     *          The resource name of the book.
+     *          Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+     *          Message field comment may include special characters: <>&"`'&#64;.
+     *     @type string $author
+     *          The name of the book author.
+     *     @type string $title
+     *          The title of the book.
+     *     @type bool $read
+     *          Value indicating whether the book has been read.
+     *     @type int $rating
+     *          For testing enums.
+     *          For allowed values, use constants defined on {@see \Google\Example\Library\V1\Book\Rating}
+     *     @type Any $anyValue
+     *          For testing all well-known types.
+     *     @type Struct $structValue
+     *     @type Value $valueValue
+     *     @type ListValue $listValueValue
+     *     @type array $mapListValueValue
+     *     @type Timestamp $timeValue
+     *     @type Duration $durationValue
+     *     @type FieldMask $fieldMaskValue
+     *     @type Int32Value $int32Value
+     *     @type UInt32Value $uint32Value
+     *     @type Int64Value $int64Value
+     *     @type UInt64Value $uint64Value
+     *     @type FloatValue $floatValue
+     *     @type DoubleValue $doubleValue
+     *     @type StringValue $stringValue
+     *     @type BoolValue $boolValue
+     *     @type BytesValue $bytesValue
+     *     @type array $mapStringValue
+     *          Test doc generation of lists:
+     *
+     *          +   Here is a sentence about the first element of the list that continues
+     *              into a second line.
+     *          +   The second element of the list.
+     *          +   Another element of the list where the indentation isn't consistent
+     *          after a blank space.
+     *
+     *              The second paragraph of the list
+     *          that doesn't have a hanging indent.
+     *     @type array $mapMessageValue
+     *     @type Used $resource
+     *          Tests Python doc generation: should generate a dummy file for shared_type
+     *          resource, but *not* its import, other_shared_type
+     *     @type array $mapBoolKey
+     *          For testing accessing map fields in samplegen
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function saveBook(array $optionalArgs = [])
+    {
+        $request = new Book();
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+        if (isset($optionalArgs['author'])) {
+            $request->setAuthor($optionalArgs['author']);
+        }
+        if (isset($optionalArgs['title'])) {
+            $request->setTitle($optionalArgs['title']);
+        }
+        if (isset($optionalArgs['read'])) {
+            $request->setRead($optionalArgs['read']);
+        }
+        if (isset($optionalArgs['rating'])) {
+            $request->setRating($optionalArgs['rating']);
+        }
+        if (isset($optionalArgs['anyValue'])) {
+            $request->setAnyValue($optionalArgs['anyValue']);
+        }
+        if (isset($optionalArgs['structValue'])) {
+            $request->setStructValue($optionalArgs['structValue']);
+        }
+        if (isset($optionalArgs['valueValue'])) {
+            $request->setValueValue($optionalArgs['valueValue']);
+        }
+        if (isset($optionalArgs['listValueValue'])) {
+            $request->setListValueValue($optionalArgs['listValueValue']);
+        }
+        if (isset($optionalArgs['mapListValueValue'])) {
+            $request->setMapListValueValue($optionalArgs['mapListValueValue']);
+        }
+        if (isset($optionalArgs['timeValue'])) {
+            $request->setTimeValue($optionalArgs['timeValue']);
+        }
+        if (isset($optionalArgs['durationValue'])) {
+            $request->setDurationValue($optionalArgs['durationValue']);
+        }
+        if (isset($optionalArgs['fieldMaskValue'])) {
+            $request->setFieldMaskValue($optionalArgs['fieldMaskValue']);
+        }
+        if (isset($optionalArgs['int32Value'])) {
+            $request->setInt32Value($optionalArgs['int32Value']);
+        }
+        if (isset($optionalArgs['uint32Value'])) {
+            $request->setUint32Value($optionalArgs['uint32Value']);
+        }
+        if (isset($optionalArgs['int64Value'])) {
+            $request->setInt64Value($optionalArgs['int64Value']);
+        }
+        if (isset($optionalArgs['uint64Value'])) {
+            $request->setUint64Value($optionalArgs['uint64Value']);
+        }
+        if (isset($optionalArgs['floatValue'])) {
+            $request->setFloatValue($optionalArgs['floatValue']);
+        }
+        if (isset($optionalArgs['doubleValue'])) {
+            $request->setDoubleValue($optionalArgs['doubleValue']);
+        }
+        if (isset($optionalArgs['stringValue'])) {
+            $request->setStringValue($optionalArgs['stringValue']);
+        }
+        if (isset($optionalArgs['boolValue'])) {
+            $request->setBoolValue($optionalArgs['boolValue']);
+        }
+        if (isset($optionalArgs['bytesValue'])) {
+            $request->setBytesValue($optionalArgs['bytesValue']);
+        }
+        if (isset($optionalArgs['mapStringValue'])) {
+            $request->setMapStringValue($optionalArgs['mapStringValue']);
+        }
+        if (isset($optionalArgs['mapMessageValue'])) {
+            $request->setMapMessageValue($optionalArgs['mapMessageValue']);
+        }
+        if (isset($optionalArgs['resource'])) {
+            $request->setResource($optionalArgs['resource']);
+        }
+        if (isset($optionalArgs['mapBoolKey'])) {
+            $request->setMapBoolKey($optionalArgs['mapBoolKey']);
+        }
+
+        return $this->startCall(
+            'SaveBook',
+            GPBEmpty::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
      * This method is not exposed in the GAPIC config. It should be generated.
      *
      * Sample code:
@@ -5051,6 +5221,11 @@ class MyProtoClient extends MyProtoGapicClient
         "StreamingArchiveBooks": {
           "timeout_millis": 60000
         },
+        "SaveBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "PrivateListShelves": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -5443,6 +5618,11 @@ return [
                         ],
                     ],
                 ]
+            ],
+            'SaveBook' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1:saveBook',
+                'body' => '*',
             ],
             'PrivateListShelves' => [
                 'method' => 'get',
@@ -8423,6 +8603,67 @@ class LibraryServiceClientTest extends GeneratedTest
             // If the close stream method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         }  catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function saveBookTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $expectedResponse = new GPBEmpty();
+        $transport->addResponse($expectedResponse);
+
+        $client->saveBook();
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/SaveBook', $actualFuncCall);
+
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function saveBookExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        try {
+            $client->saveBook();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -1089,6 +1089,7 @@ from google.cloud.example.library_v1.proto import book_from_anywhere_pb2
 from google.cloud.example.library_v1.proto import field_mask_pb2 as proto_field_mask_pb2
 from google.cloud.example.library_v1.proto import library_pb2
 from google.cloud.example.library_v1.proto import library_pb2_grpc
+from google.cloud.example.library_v1.proto import shared_type_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2_grpc
 from google.longrunning import operations_pb2
@@ -4215,6 +4216,182 @@ class LibraryServiceClient(object):
 
         return self._inner_api_calls['streaming_archive_books'](requests, retry=retry, timeout=timeout, metadata=metadata)
 
+    def save_book(
+            self,
+            name=None,
+            author=None,
+            title=None,
+            read=None,
+            rating=None,
+            any_value=None,
+            struct_value=None,
+            value_value=None,
+            list_value_value=None,
+            map_list_value_value=None,
+            time_value=None,
+            duration_value=None,
+            field_mask_value=None,
+            int32_value=None,
+            uint32_value=None,
+            int64_value=None,
+            uint64_value=None,
+            float_value=None,
+            double_value=None,
+            string_value=None,
+            bool_value=None,
+            bytes_value=None,
+            map_string_value=None,
+            map_message_value=None,
+            resource=None,
+            map_bool_key=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+        Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        New APIs should always create a separate message for a request.
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> client.save_book()
+
+        Args:
+            name (str): The resource name of the book.
+                Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+                Message field comment may include special characters: <>&"`'@.
+            author (str): The name of the book author.
+            title (str): The title of the book.
+            read (bool): Value indicating whether the book has been read.
+            rating (~google.cloud.example.library_v1.types.Rating): For testing enums.
+            any_value (Union[dict, ~google.cloud.example.library_v1.types.Any]): For testing all well-known types.
+
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Any`
+            struct_value (Union[dict, ~google.cloud.example.library_v1.types.Struct]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Struct`
+            value_value (Union[dict, ~google.cloud.example.library_v1.types.Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Value`
+            list_value_value (Union[dict, ~google.cloud.example.library_v1.types.ListValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.ListValue`
+            map_list_value_value (dict[str -> Union[dict, ~google.cloud.example.library_v1.types.ListValue]]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.ListValue`
+            time_value (Union[dict, ~google.cloud.example.library_v1.types.Timestamp]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Timestamp`
+            duration_value (Union[dict, ~google.cloud.example.library_v1.types.Duration]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Duration`
+            field_mask_value (Union[dict, ~google.cloud.example.library_v1.types.FieldMask]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.FieldMask`
+            int32_value (Union[dict, ~google.cloud.example.library_v1.types.Int32Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Int32Value`
+            uint32_value (Union[dict, ~google.cloud.example.library_v1.types.UInt32Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.UInt32Value`
+            int64_value (Union[dict, ~google.cloud.example.library_v1.types.Int64Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Int64Value`
+            uint64_value (Union[dict, ~google.cloud.example.library_v1.types.UInt64Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.UInt64Value`
+            float_value (Union[dict, ~google.cloud.example.library_v1.types.FloatValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.FloatValue`
+            double_value (Union[dict, ~google.cloud.example.library_v1.types.DoubleValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.DoubleValue`
+            string_value (Union[dict, ~google.cloud.example.library_v1.types.StringValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.StringValue`
+            bool_value (Union[dict, ~google.cloud.example.library_v1.types.BoolValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.BoolValue`
+            bytes_value (Union[dict, ~google.cloud.example.library_v1.types.BytesValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.BytesValue`
+            map_string_value (dict[int -> str]): Test doc generation of lists:
+
+                +   Here is a sentence about the first element of the list that continues
+                    into a second line.
+                +   The second element of the list.
+                +   Another element of the list where the indentation isn't consistent
+                after a blank space.
+
+                    The second paragraph of the list
+                that doesn't have a hanging indent.
+            map_message_value (dict[str -> Union[dict, ~google.cloud.example.library_v1.types.SomeMessage]]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SomeMessage`
+            resource (Union[dict, ~google.cloud.example.library_v1.types.Used]): Tests Python doc generation: should generate a dummy file for shared_type
+                resource, but *not* its import, other_shared_type
+
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Used`
+            map_bool_key (dict[bool -> str]): For testing accessing map fields in samplegen
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'save_book' not in self._inner_api_calls:
+            self._inner_api_calls['save_book'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.save_book,
+                default_retry=self._method_configs['SaveBook'].retry,
+                default_timeout=self._method_configs['SaveBook'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.Book(
+            name=name,
+            author=author,
+            title=title,
+            read=read,
+            rating=rating,
+            any_value=any_value,
+            struct_value=struct_value,
+            value_value=value_value,
+            list_value_value=list_value_value,
+            map_list_value_value=map_list_value_value,
+            time_value=time_value,
+            duration_value=duration_value,
+            field_mask_value=field_mask_value,
+            int32_value=int32_value,
+            uint32_value=uint32_value,
+            int64_value=int64_value,
+            uint64_value=uint64_value,
+            float_value=float_value,
+            double_value=double_value,
+            string_value=string_value,
+            bool_value=bool_value,
+            bytes_value=bytes_value,
+            map_string_value=map_string_value,
+            map_message_value=map_message_value,
+            resource=resource,
+            map_bool_key=map_bool_key,
+        )
+        self._inner_api_calls['save_book'](request, retry=retry, timeout=timeout, metadata=metadata)
+
     def private_list_shelves(
             self,
             page_token=None,
@@ -4464,6 +4641,11 @@ config = {
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "SaveBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "PrivateListShelves": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -4514,6 +4696,7 @@ from google.cloud.example.library_v1.proto import book_from_anywhere_pb2
 from google.cloud.example.library_v1.proto import field_mask_pb2 as proto_field_mask_pb2
 from google.cloud.example.library_v1.proto import library_pb2
 from google.cloud.example.library_v1.proto import library_pb2_grpc
+from google.cloud.example.library_v1.proto import shared_type_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2_grpc
 from google.longrunning import operations_pb2
@@ -5312,6 +5495,20 @@ class LibraryServiceGrpcTransport(object):
                 deserialized response object.
         """
         return self._stubs['library_service_stub'].StreamingArchiveBooks
+
+    @property
+    def save_book(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.save_book`.
+
+        Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        New APIs should always create a separate message for a request.
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].SaveBook
 
     @property
     def private_list_shelves(self):
@@ -8707,6 +8904,31 @@ class TestLibraryServiceClient(object):
 
         with pytest.raises(CustomException):
             client.streaming_archive_books(requests)
+
+    def test_save_book(self):
+        channel = ChannelStub()
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        client.save_book()
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.Book()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_save_book_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        with pytest.raises(CustomException):
+            client.save_book()
 
     def test_private_list_shelves(self):
         # Setup Expected Response

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
@@ -1089,6 +1089,7 @@ from google.cloud.example.library_v1.proto import book_from_anywhere_pb2
 from google.cloud.example.library_v1.proto import field_mask_pb2 as proto_field_mask_pb2
 from google.cloud.example.library_v1.proto import library_pb2
 from google.cloud.example.library_v1.proto import library_pb2_grpc
+from google.cloud.example.library_v1.proto import shared_type_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2_grpc
 from google.longrunning import operations_pb2
@@ -4090,6 +4091,182 @@ class LibraryServiceClient(object):
 
         return self._inner_api_calls['streaming_archive_books'](requests, retry=retry, timeout=timeout, metadata=metadata)
 
+    def save_book(
+            self,
+            name=None,
+            author=None,
+            title=None,
+            read=None,
+            rating=None,
+            any_value=None,
+            struct_value=None,
+            value_value=None,
+            list_value_value=None,
+            map_list_value_value=None,
+            time_value=None,
+            duration_value=None,
+            field_mask_value=None,
+            int32_value=None,
+            uint32_value=None,
+            int64_value=None,
+            uint64_value=None,
+            float_value=None,
+            double_value=None,
+            string_value=None,
+            bool_value=None,
+            bytes_value=None,
+            map_string_value=None,
+            map_message_value=None,
+            resource=None,
+            map_bool_key=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+        Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        New APIs should always create a separate message for a request.
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> client.save_book()
+
+        Args:
+            name (str): The resource name of the book.
+                Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+                Message field comment may include special characters: <>&"`'@.
+            author (str): The name of the book author.
+            title (str): The title of the book.
+            read (bool): Value indicating whether the book has been read.
+            rating (~google.cloud.example.library_v1.types.Rating): For testing enums.
+            any_value (Union[dict, ~google.cloud.example.library_v1.types.Any]): For testing all well-known types.
+
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Any`
+            struct_value (Union[dict, ~google.cloud.example.library_v1.types.Struct]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Struct`
+            value_value (Union[dict, ~google.cloud.example.library_v1.types.Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Value`
+            list_value_value (Union[dict, ~google.cloud.example.library_v1.types.ListValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.ListValue`
+            map_list_value_value (dict[str -> Union[dict, ~google.cloud.example.library_v1.types.ListValue]]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.ListValue`
+            time_value (Union[dict, ~google.cloud.example.library_v1.types.Timestamp]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Timestamp`
+            duration_value (Union[dict, ~google.cloud.example.library_v1.types.Duration]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Duration`
+            field_mask_value (Union[dict, ~google.cloud.example.library_v1.types.FieldMask]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.FieldMask`
+            int32_value (Union[dict, ~google.cloud.example.library_v1.types.Int32Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Int32Value`
+            uint32_value (Union[dict, ~google.cloud.example.library_v1.types.UInt32Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.UInt32Value`
+            int64_value (Union[dict, ~google.cloud.example.library_v1.types.Int64Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Int64Value`
+            uint64_value (Union[dict, ~google.cloud.example.library_v1.types.UInt64Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.UInt64Value`
+            float_value (Union[dict, ~google.cloud.example.library_v1.types.FloatValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.FloatValue`
+            double_value (Union[dict, ~google.cloud.example.library_v1.types.DoubleValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.DoubleValue`
+            string_value (Union[dict, ~google.cloud.example.library_v1.types.StringValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.StringValue`
+            bool_value (Union[dict, ~google.cloud.example.library_v1.types.BoolValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.BoolValue`
+            bytes_value (Union[dict, ~google.cloud.example.library_v1.types.BytesValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.BytesValue`
+            map_string_value (dict[int -> str]): Test doc generation of lists:
+
+                +   Here is a sentence about the first element of the list that continues
+                    into a second line.
+                +   The second element of the list.
+                +   Another element of the list where the indentation isn't consistent
+                after a blank space.
+
+                    The second paragraph of the list
+                that doesn't have a hanging indent.
+            map_message_value (dict[str -> Union[dict, ~google.cloud.example.library_v1.types.SomeMessage]]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SomeMessage`
+            resource (Union[dict, ~google.cloud.example.library_v1.types.Used]): Tests Python doc generation: should generate a dummy file for shared_type
+                resource, but *not* its import, other_shared_type
+
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Used`
+            map_bool_key (dict[bool -> str]): For testing accessing map fields in samplegen
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'save_book' not in self._inner_api_calls:
+            self._inner_api_calls['save_book'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.save_book,
+                default_retry=self._method_configs['SaveBook'].retry,
+                default_timeout=self._method_configs['SaveBook'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.Book(
+            name=name,
+            author=author,
+            title=title,
+            read=read,
+            rating=rating,
+            any_value=any_value,
+            struct_value=struct_value,
+            value_value=value_value,
+            list_value_value=list_value_value,
+            map_list_value_value=map_list_value_value,
+            time_value=time_value,
+            duration_value=duration_value,
+            field_mask_value=field_mask_value,
+            int32_value=int32_value,
+            uint32_value=uint32_value,
+            int64_value=int64_value,
+            uint64_value=uint64_value,
+            float_value=float_value,
+            double_value=double_value,
+            string_value=string_value,
+            bool_value=bool_value,
+            bytes_value=bytes_value,
+            map_string_value=map_string_value,
+            map_message_value=map_message_value,
+            resource=resource,
+            map_bool_key=map_bool_key,
+        )
+        self._inner_api_calls['save_book'](request, retry=retry, timeout=timeout, metadata=metadata)
+
     def private_list_shelves(
             self,
             page_token=None,
@@ -4339,6 +4516,11 @@ config = {
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "SaveBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "PrivateListShelves": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -4389,6 +4571,7 @@ from google.cloud.example.library_v1.proto import book_from_anywhere_pb2
 from google.cloud.example.library_v1.proto import field_mask_pb2 as proto_field_mask_pb2
 from google.cloud.example.library_v1.proto import library_pb2
 from google.cloud.example.library_v1.proto import library_pb2_grpc
+from google.cloud.example.library_v1.proto import shared_type_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2_grpc
 from google.longrunning import operations_pb2
@@ -5187,6 +5370,20 @@ class LibraryServiceGrpcTransport(object):
                 deserialized response object.
         """
         return self._stubs['library_service_stub'].StreamingArchiveBooks
+
+    @property
+    def save_book(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.save_book`.
+
+        Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        New APIs should always create a separate message for a request.
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].SaveBook
 
     @property
     def private_list_shelves(self):
@@ -8358,6 +8555,31 @@ class TestLibraryServiceClient(object):
 
         with pytest.raises(CustomException):
             client.streaming_archive_books(requests)
+
+    def test_save_book(self):
+        channel = ChannelStub()
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        client.save_book()
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.Book()
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_save_book_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        with pytest.raises(CustomException):
+            client.save_book()
 
     def test_private_list_shelves(self):
         # Setup Expected Response

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -3478,6 +3478,11 @@ module Library
           defaults["streaming_archive_books"],
           exception_transformer: exception_transformer
         )
+        @save_book = Google::Gax.create_api_call(
+          @library_service_stub.method(:save_book),
+          defaults["save_book"],
+          exception_transformer: exception_transformer
+        )
         @private_list_shelves = Google::Gax.create_api_call(
           @library_service_stub.method(:private_list_shelves),
           defaults["private_list_shelves"],
@@ -5444,6 +5449,169 @@ module Library
         @streaming_archive_books.call(request_protos, options)
       end
 
+      # Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+      # New APIs should always create a separate message for a request.
+      #
+      # @param name [String]
+      #   The resource name of the book.
+      #   Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+      #   Message field comment may include special characters: <>&"`'@.
+      # @param author [String]
+      #   The name of the book author.
+      # @param title [String]
+      #   The title of the book.
+      # @param read [true, false]
+      #   Value indicating whether the book has been read.
+      # @param rating [Google::Example::Library::V1::Book::Rating]
+      #   For testing enums.
+      # @param any_value [Google::Protobuf::Any | Hash]
+      #   For testing all well-known types.
+      #   A hash of the same form as `Google::Protobuf::Any`
+      #   can also be provided.
+      # @param struct_value [Google::Protobuf::Struct | Hash]
+      #   A hash of the same form as `Google::Protobuf::Struct`
+      #   can also be provided.
+      # @param value_value [Google::Protobuf::Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Value`
+      #   can also be provided.
+      # @param list_value_value [Google::Protobuf::ListValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::ListValue`
+      #   can also be provided.
+      # @param map_list_value_value [Hash{String => Google::Protobuf::ListValue | Hash}]
+      #   A hash of the same form as `Google::Protobuf::ListValue`
+      #   can also be provided.
+      # @param time_value [Google::Protobuf::Timestamp | Hash]
+      #   A hash of the same form as `Google::Protobuf::Timestamp`
+      #   can also be provided.
+      # @param duration_value [Google::Protobuf::Duration | Hash]
+      #   A hash of the same form as `Google::Protobuf::Duration`
+      #   can also be provided.
+      # @param field_mask_value [Google::Protobuf::FieldMask | Hash]
+      #   A hash of the same form as `Google::Protobuf::FieldMask`
+      #   can also be provided.
+      # @param int32_value [Google::Protobuf::Int32Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Int32Value`
+      #   can also be provided.
+      # @param uint32_value [Google::Protobuf::UInt32Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::UInt32Value`
+      #   can also be provided.
+      # @param int64_value [Google::Protobuf::Int64Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Int64Value`
+      #   can also be provided.
+      # @param uint64_value [Google::Protobuf::UInt64Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::UInt64Value`
+      #   can also be provided.
+      # @param float_value [Google::Protobuf::FloatValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::FloatValue`
+      #   can also be provided.
+      # @param double_value [Google::Protobuf::DoubleValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::DoubleValue`
+      #   can also be provided.
+      # @param string_value [Google::Protobuf::StringValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::StringValue`
+      #   can also be provided.
+      # @param bool_value [Google::Protobuf::BoolValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::BoolValue`
+      #   can also be provided.
+      # @param bytes_value [Google::Protobuf::BytesValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::BytesValue`
+      #   can also be provided.
+      # @param map_string_value [Hash{Integer => String}]
+      #   Test doc generation of lists:
+      #
+      #   * Here is a sentence about the first element of the list that continues
+      #     into a second line.
+      #   * The second element of the list.
+      #   * Another element of the list where the indentation isn't consistent
+      #     after a blank space.
+      #
+      #     The second paragraph of the list
+      #     that doesn't have a hanging indent.
+      # @param map_message_value [Hash{String => Google::Example::Library::V1::SomeMessage | Hash}]
+      #   A hash of the same form as `Google::Example::Library::V1::SomeMessage`
+      #   can also be provided.
+      # @param resource [Google::Test::Shared::Data::Used | Hash]
+      #   Tests Python doc generation: should generate a dummy file for shared_type
+      #   resource, but *not* its import, other_shared_type
+      #   A hash of the same form as `Google::Test::Shared::Data::Used`
+      #   can also be provided.
+      # @param map_bool_key [Hash{true, false => String}]
+      #   For testing accessing map fields in samplegen
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result []
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   library_client.save_book
+
+      def save_book \
+          name: nil,
+          author: nil,
+          title: nil,
+          read: nil,
+          rating: nil,
+          any_value: nil,
+          struct_value: nil,
+          value_value: nil,
+          list_value_value: nil,
+          map_list_value_value: nil,
+          time_value: nil,
+          duration_value: nil,
+          field_mask_value: nil,
+          int32_value: nil,
+          uint32_value: nil,
+          int64_value: nil,
+          uint64_value: nil,
+          float_value: nil,
+          double_value: nil,
+          string_value: nil,
+          bool_value: nil,
+          bytes_value: nil,
+          map_string_value: nil,
+          map_message_value: nil,
+          resource: nil,
+          map_bool_key: nil,
+          options: nil,
+          &block
+        req = {
+          name: name,
+          author: author,
+          title: title,
+          read: read,
+          rating: rating,
+          any_value: any_value,
+          struct_value: struct_value,
+          value_value: value_value,
+          list_value_value: list_value_value,
+          map_list_value_value: map_list_value_value,
+          time_value: time_value,
+          duration_value: duration_value,
+          field_mask_value: field_mask_value,
+          int32_value: int32_value,
+          uint32_value: uint32_value,
+          int64_value: int64_value,
+          uint64_value: uint64_value,
+          float_value: float_value,
+          double_value: double_value,
+          string_value: string_value,
+          bool_value: bool_value,
+          bytes_value: bytes_value,
+          map_string_value: map_string_value,
+          map_message_value: map_message_value,
+          resource: resource,
+          map_bool_key: map_bool_key
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::Book)
+        @save_book.call(req, options, &block)
+        nil
+      end
+
       # This method is not exposed in the GAPIC config. It should be generated.
       #
       # @param page_token [String]
@@ -5670,6 +5838,11 @@ end
           "retry_params_name": "default"
         },
         "StreamingArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "SaveBook": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -10610,6 +10783,66 @@ describe Library::V1::LibraryServiceClient do
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.streaming_archive_books([request])
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'save_book' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#save_book."
+
+    it 'invokes save_book without error' do
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: nil)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:save_book, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("save_book")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.save_book
+
+          # Verify the response
+          assert_nil(response)
+
+          # Call method with block
+          client.save_book do |response, operation|
+            # Verify the response
+            assert_nil(response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes save_book with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:save_book, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("save_book")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.save_book
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_samplegen_config_migration_library.baseline
@@ -3429,6 +3429,11 @@ module Library
           defaults["streaming_archive_books"],
           exception_transformer: exception_transformer
         )
+        @save_book = Google::Gax.create_api_call(
+          @library_service_stub.method(:save_book),
+          defaults["save_book"],
+          exception_transformer: exception_transformer
+        )
         @private_list_shelves = Google::Gax.create_api_call(
           @library_service_stub.method(:private_list_shelves),
           defaults["private_list_shelves"],
@@ -5296,6 +5301,169 @@ module Library
         @streaming_archive_books.call(request_protos, options)
       end
 
+      # Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+      # New APIs should always create a separate message for a request.
+      #
+      # @param name [String]
+      #   The resource name of the book.
+      #   Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+      #   Message field comment may include special characters: <>&"`'@.
+      # @param author [String]
+      #   The name of the book author.
+      # @param title [String]
+      #   The title of the book.
+      # @param read [true, false]
+      #   Value indicating whether the book has been read.
+      # @param rating [Google::Example::Library::V1::Book::Rating]
+      #   For testing enums.
+      # @param any_value [Google::Protobuf::Any | Hash]
+      #   For testing all well-known types.
+      #   A hash of the same form as `Google::Protobuf::Any`
+      #   can also be provided.
+      # @param struct_value [Google::Protobuf::Struct | Hash]
+      #   A hash of the same form as `Google::Protobuf::Struct`
+      #   can also be provided.
+      # @param value_value [Google::Protobuf::Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Value`
+      #   can also be provided.
+      # @param list_value_value [Google::Protobuf::ListValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::ListValue`
+      #   can also be provided.
+      # @param map_list_value_value [Hash{String => Google::Protobuf::ListValue | Hash}]
+      #   A hash of the same form as `Google::Protobuf::ListValue`
+      #   can also be provided.
+      # @param time_value [Google::Protobuf::Timestamp | Hash]
+      #   A hash of the same form as `Google::Protobuf::Timestamp`
+      #   can also be provided.
+      # @param duration_value [Google::Protobuf::Duration | Hash]
+      #   A hash of the same form as `Google::Protobuf::Duration`
+      #   can also be provided.
+      # @param field_mask_value [Google::Protobuf::FieldMask | Hash]
+      #   A hash of the same form as `Google::Protobuf::FieldMask`
+      #   can also be provided.
+      # @param int32_value [Google::Protobuf::Int32Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Int32Value`
+      #   can also be provided.
+      # @param uint32_value [Google::Protobuf::UInt32Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::UInt32Value`
+      #   can also be provided.
+      # @param int64_value [Google::Protobuf::Int64Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Int64Value`
+      #   can also be provided.
+      # @param uint64_value [Google::Protobuf::UInt64Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::UInt64Value`
+      #   can also be provided.
+      # @param float_value [Google::Protobuf::FloatValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::FloatValue`
+      #   can also be provided.
+      # @param double_value [Google::Protobuf::DoubleValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::DoubleValue`
+      #   can also be provided.
+      # @param string_value [Google::Protobuf::StringValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::StringValue`
+      #   can also be provided.
+      # @param bool_value [Google::Protobuf::BoolValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::BoolValue`
+      #   can also be provided.
+      # @param bytes_value [Google::Protobuf::BytesValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::BytesValue`
+      #   can also be provided.
+      # @param map_string_value [Hash{Integer => String}]
+      #   Test doc generation of lists:
+      #
+      #   * Here is a sentence about the first element of the list that continues
+      #     into a second line.
+      #   * The second element of the list.
+      #   * Another element of the list where the indentation isn't consistent
+      #     after a blank space.
+      #
+      #     The second paragraph of the list
+      #     that doesn't have a hanging indent.
+      # @param map_message_value [Hash{String => Google::Example::Library::V1::SomeMessage | Hash}]
+      #   A hash of the same form as `Google::Example::Library::V1::SomeMessage`
+      #   can also be provided.
+      # @param resource [Google::Test::Shared::Data::Used | Hash]
+      #   Tests Python doc generation: should generate a dummy file for shared_type
+      #   resource, but *not* its import, other_shared_type
+      #   A hash of the same form as `Google::Test::Shared::Data::Used`
+      #   can also be provided.
+      # @param map_bool_key [Hash{true, false => String}]
+      #   For testing accessing map fields in samplegen
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result []
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   library_client.save_book
+
+      def save_book \
+          name: nil,
+          author: nil,
+          title: nil,
+          read: nil,
+          rating: nil,
+          any_value: nil,
+          struct_value: nil,
+          value_value: nil,
+          list_value_value: nil,
+          map_list_value_value: nil,
+          time_value: nil,
+          duration_value: nil,
+          field_mask_value: nil,
+          int32_value: nil,
+          uint32_value: nil,
+          int64_value: nil,
+          uint64_value: nil,
+          float_value: nil,
+          double_value: nil,
+          string_value: nil,
+          bool_value: nil,
+          bytes_value: nil,
+          map_string_value: nil,
+          map_message_value: nil,
+          resource: nil,
+          map_bool_key: nil,
+          options: nil,
+          &block
+        req = {
+          name: name,
+          author: author,
+          title: title,
+          read: read,
+          rating: rating,
+          any_value: any_value,
+          struct_value: struct_value,
+          value_value: value_value,
+          list_value_value: list_value_value,
+          map_list_value_value: map_list_value_value,
+          time_value: time_value,
+          duration_value: duration_value,
+          field_mask_value: field_mask_value,
+          int32_value: int32_value,
+          uint32_value: uint32_value,
+          int64_value: int64_value,
+          uint64_value: uint64_value,
+          float_value: float_value,
+          double_value: double_value,
+          string_value: string_value,
+          bool_value: bool_value,
+          bytes_value: bytes_value,
+          map_string_value: map_string_value,
+          map_message_value: map_message_value,
+          resource: resource,
+          map_bool_key: map_bool_key
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::Book)
+        @save_book.call(req, options, &block)
+        nil
+      end
+
       # This method is not exposed in the GAPIC config. It should be generated.
       #
       # @param page_token [String]
@@ -5522,6 +5690,11 @@ end
           "retry_params_name": "default"
         },
         "StreamingArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "SaveBook": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -9955,6 +10128,66 @@ describe Library::V1::LibraryServiceClient do
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.streaming_archive_books([request])
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'save_book' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#save_book."
+
+    it 'invokes save_book without error' do
+
+      # Mock Grpc layer
+      mock_method = proc do
+        OpenStruct.new(execute: nil)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:save_book, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("save_book")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.save_book
+
+          # Verify the response
+          assert_nil(response)
+
+          # Call method with block
+          client.save_book do |response, operation|
+            # Verify the response
+            assert_nil(response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes save_book with error' do
+      # Mock Grpc layer
+      mock_method = proc do
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:save_book, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("save_book")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.save_book
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -7944,6 +7944,72 @@ namespace Google.Example.Library.V1.Snippets
             // End snippet
         }
 
+        /// <summary>Snippet for SaveBookAsync</summary>
+        public async Task SaveBookAsync()
+        {
+            // Snippet: SaveBookAsync(BookNameOneof,string,string,Book.Types.Rating?,CallSettings)
+            // Additional: SaveBookAsync(BookNameOneof,string,string,Book.Types.Rating?,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            string author = "";
+            string title = "";
+            Book.Types.Rating rating = Book.Types.Rating.Good;
+            // Make the request
+            await libraryServiceClient.SaveBookAsync(name, author, title, rating);
+            // End snippet
+        }
+
+        /// <summary>Snippet for SaveBook</summary>
+        public void SaveBook()
+        {
+            // Snippet: SaveBook(BookNameOneof,string,string,Book.Types.Rating?,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            string author = "";
+            string title = "";
+            Book.Types.Rating rating = Book.Types.Rating.Good;
+            // Make the request
+            libraryServiceClient.SaveBook(name, author, title, rating);
+            // End snippet
+        }
+
+        /// <summary>Snippet for SaveBookAsync</summary>
+        public async Task SaveBookAsync_RequestObject()
+        {
+            // Snippet: SaveBookAsync(Book,CallSettings)
+            // Additional: SaveBookAsync(Book,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            Book request = new Book
+            {
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+            };
+            // Make the request
+            await libraryServiceClient.SaveBookAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for SaveBook</summary>
+        public void SaveBook_RequestObject()
+        {
+            // Snippet: SaveBook(Book,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            Book request = new Book
+            {
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+            };
+            // Make the request
+            libraryServiceClient.SaveBook(request);
+            // End snippet
+        }
+
         /// <summary>Snippet for PrivateListShelvesAsync</summary>
         public async Task PrivateListShelvesAsync()
         {
@@ -10942,6 +11008,100 @@ namespace Google.Example.Library.V1.Tests
         }
 
         [Fact]
+        public void SaveBook()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            Book expectedRequest = new Book
+            {
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                Author = "author-1406328437",
+                Title = "title110371416",
+                Rating = Book.Types.Rating.Good,
+            };
+            Empty expectedResponse = new Empty();
+            mockGrpcClient.Setup(x => x.SaveBook(expectedRequest, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            string author = "author-1406328437";
+            string title = "title110371416";
+            Book.Types.Rating rating = Book.Types.Rating.Good;
+            client.SaveBook(name, author, title, rating);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task SaveBookAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            Book expectedRequest = new Book
+            {
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                Author = "author-1406328437",
+                Title = "title110371416",
+                Rating = Book.Types.Rating.Good,
+            };
+            Empty expectedResponse = new Empty();
+            mockGrpcClient.Setup(x => x.SaveBookAsync(expectedRequest, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            BookNameOneof name = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]"));
+            string author = "author-1406328437";
+            string title = "title110371416";
+            Book.Types.Rating rating = Book.Types.Rating.Good;
+            await client.SaveBookAsync(name, author, title, rating);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void SaveBook2()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            Book request = new Book
+            {
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+            };
+            Empty expectedResponse = new Empty();
+            mockGrpcClient.Setup(x => x.SaveBook(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            client.SaveBook(request);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task SaveBookAsync2()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            Book request = new Book
+            {
+                BookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+            };
+            Empty expectedResponse = new Empty();
+            mockGrpcClient.Setup(x => x.SaveBookAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<Empty>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            await client.SaveBookAsync(request);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
         public void PrivateListShelves()
         {
             Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
@@ -11256,6 +11416,7 @@ namespace Google.Example.Library.V1
             LongRunningArchiveBooksOperationsSettings = existing.LongRunningArchiveBooksOperationsSettings?.Clone();
             StreamingArchiveBooksSettings = existing.StreamingArchiveBooksSettings;
             StreamingArchiveBooksStreamingSettings = existing.StreamingArchiveBooksStreamingSettings;
+            SaveBookSettings = existing.SaveBookSettings;
             PrivateListShelvesSettings = existing.PrivateListShelvesSettings;
             OnCopy(existing);
         }
@@ -12211,6 +12372,35 @@ namespace Google.Example.Library.V1
         /// </remarks>
         public gaxgrpc::BidirectionalStreamingSettings StreamingArchiveBooksStreamingSettings { get; set; } =
             new gaxgrpc::BidirectionalStreamingSettings(100);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.SaveBook</c> and <c>LibraryServiceClient.SaveBookAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.SaveBook</c> and
+        /// <c>LibraryServiceClient.SaveBookAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings SaveBookSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -23057,6 +23247,284 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="name">
+        /// The resource name of the book.
+        /// Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+        /// Message field comment may include special characters: &lt;&gt;&amp;"`'@.
+        /// </param>
+        /// <param name="author">
+        /// The name of the book author.
+        /// </param>
+        /// <param name="title">
+        /// The title of the book.
+        /// </param>
+        /// <param name="rating">
+        /// For testing enums.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task SaveBookAsync(
+            BookNameOneof name,
+            string author,
+            string title,
+            Book.Types.Rating? rating,
+            gaxgrpc::CallSettings callSettings = null) => SaveBookAsync(
+                new Book
+                {
+                    BookNameOneof = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    Author = author ?? "", // Optional
+                    Title = title ?? "", // Optional
+                    Rating = rating ?? Book.Types.Rating.Good, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="name">
+        /// The resource name of the book.
+        /// Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+        /// Message field comment may include special characters: &lt;&gt;&amp;"`'@.
+        /// </param>
+        /// <param name="author">
+        /// The name of the book author.
+        /// </param>
+        /// <param name="title">
+        /// The title of the book.
+        /// </param>
+        /// <param name="rating">
+        /// For testing enums.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task SaveBookAsync(
+            BookNameOneof name,
+            string author,
+            string title,
+            Book.Types.Rating? rating,
+            st::CancellationToken cancellationToken) => SaveBookAsync(
+                name,
+                author,
+                title,
+                rating,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="name">
+        /// The resource name of the book.
+        /// Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+        /// Message field comment may include special characters: &lt;&gt;&amp;"`'@.
+        /// </param>
+        /// <param name="author">
+        /// The name of the book author.
+        /// </param>
+        /// <param name="title">
+        /// The title of the book.
+        /// </param>
+        /// <param name="rating">
+        /// For testing enums.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void SaveBook(
+            BookNameOneof name,
+            string author,
+            string title,
+            Book.Types.Rating? rating,
+            gaxgrpc::CallSettings callSettings = null) => SaveBook(
+                new Book
+                {
+                    BookNameOneof = gax::GaxPreconditions.CheckNotNull(name, nameof(name)),
+                    Author = author ?? "", // Optional
+                    Title = title ?? "", // Optional
+                    Rating = rating ?? Book.Types.Rating.Good, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="name">
+        /// The resource name of the book.
+        /// Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+        /// Message field comment may include special characters: &lt;&gt;&amp;"`'@.
+        /// </param>
+        /// <param name="author">
+        /// The name of the book author.
+        /// </param>
+        /// <param name="title">
+        /// The title of the book.
+        /// </param>
+        /// <param name="rating">
+        /// For testing enums.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task SaveBookAsync(
+            string name,
+            string author,
+            string title,
+            Book.Types.Rating? rating,
+            gaxgrpc::CallSettings callSettings = null) => SaveBookAsync(
+                new Book
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Author = author ?? "", // Optional
+                    Title = title ?? "", // Optional
+                    Rating = rating ?? Book.Types.Rating.Good, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="name">
+        /// The resource name of the book.
+        /// Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+        /// Message field comment may include special characters: &lt;&gt;&amp;"`'@.
+        /// </param>
+        /// <param name="author">
+        /// The name of the book author.
+        /// </param>
+        /// <param name="title">
+        /// The title of the book.
+        /// </param>
+        /// <param name="rating">
+        /// For testing enums.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task SaveBookAsync(
+            string name,
+            string author,
+            string title,
+            Book.Types.Rating? rating,
+            st::CancellationToken cancellationToken) => SaveBookAsync(
+                name,
+                author,
+                title,
+                rating,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="name">
+        /// The resource name of the book.
+        /// Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+        /// Message field comment may include special characters: &lt;&gt;&amp;"`'@.
+        /// </param>
+        /// <param name="author">
+        /// The name of the book author.
+        /// </param>
+        /// <param name="title">
+        /// The title of the book.
+        /// </param>
+        /// <param name="rating">
+        /// For testing enums.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void SaveBook(
+            string name,
+            string author,
+            string title,
+            Book.Types.Rating? rating,
+            gaxgrpc::CallSettings callSettings = null) => SaveBook(
+                new Book
+                {
+                    Name = gax::GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name)),
+                    Author = author ?? "", // Optional
+                    Title = title ?? "", // Optional
+                    Rating = rating ?? Book.Types.Rating.Good, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task SaveBookAsync(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public virtual stt::Task SaveBookAsync(
+            Book request,
+            st::CancellationToken cancellationToken) => SaveBookAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public virtual void SaveBook(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
         /// This method is not exposed in the GAPIC config. It should be generated.
         /// </summary>
         /// <param name="callSettings">
@@ -23194,6 +23662,7 @@ namespace Google.Example.Library.V1
         private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> _callArchiveBooks;
         private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> _callLongRunningArchiveBooks;
         private readonly gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> _callStreamingArchiveBooks;
+        private readonly gaxgrpc::ApiCall<Book, pbwkt::Empty> _callSaveBook;
         private readonly gaxgrpc::ApiCall<ListShelvesRequest, Book> _callPrivateListShelves;
 
         /// <summary>
@@ -23295,6 +23764,8 @@ namespace Google.Example.Library.V1
                 .WithGoogleRequestParam("source", request => request.Source);
             _callStreamingArchiveBooks = clientHelper.BuildApiCall<ArchiveBooksRequest, ArchiveBooksResponse>(
                 GrpcClient.StreamingArchiveBooks, effectiveSettings.StreamingArchiveBooksSettings, effectiveSettings.StreamingArchiveBooksStreamingSettings);
+            _callSaveBook = clientHelper.BuildApiCall<Book, pbwkt::Empty>(
+                GrpcClient.SaveBookAsync, GrpcClient.SaveBook, effectiveSettings.SaveBookSettings);
             _callPrivateListShelves = clientHelper.BuildApiCall<ListShelvesRequest, Book>(
                 GrpcClient.PrivateListShelvesAsync, GrpcClient.PrivateListShelves, effectiveSettings.PrivateListShelvesSettings);
             Modify_ApiCall(ref _callCreateShelf);
@@ -23357,6 +23828,8 @@ namespace Google.Example.Library.V1
             Modify_LongRunningArchiveBooksApiCall(ref _callLongRunningArchiveBooks);
             Modify_ApiCall(ref _callStreamingArchiveBooks);
             Modify_StreamingArchiveBooksApiCall(ref _callStreamingArchiveBooks);
+            Modify_ApiCall(ref _callSaveBook);
+            Modify_SaveBookApiCall(ref _callSaveBook);
             Modify_ApiCall(ref _callPrivateListShelves);
             Modify_PrivateListShelvesApiCall(ref _callPrivateListShelves);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);
@@ -23408,6 +23881,7 @@ namespace Google.Example.Library.V1
         partial void Modify_ArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
         partial void Modify_LongRunningArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> call);
         partial void Modify_StreamingArchiveBooksApiCall(ref gaxgrpc::ApiBidirectionalStreamingCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
+        partial void Modify_SaveBookApiCall(ref gaxgrpc::ApiCall<Book, pbwkt::Empty> call);
         partial void Modify_PrivateListShelvesApiCall(ref gaxgrpc::ApiCall<ListShelvesRequest, Book> call);
         partial void OnConstruction(LibraryService.LibraryServiceClient grpcClient, LibraryServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
 
@@ -23446,6 +23920,7 @@ namespace Google.Example.Library.V1
         partial void Modify_TestOptionalRequiredFlatteningParamsRequest(ref TestOptionalRequiredFlatteningParamsRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_MoveBooksRequest(ref MoveBooksRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_ArchiveBooksRequest(ref ArchiveBooksRequest request, ref gaxgrpc::CallSettings settings);
+        partial void Modify_Book(ref Book request, ref gaxgrpc::CallSettings settings);
 
         /// <summary>
         /// Creates a shelf, and returns the new Shelf.
@@ -24752,6 +25227,45 @@ namespace Google.Example.Library.V1
             /// <inheritdoc/>
             public override scg::IAsyncEnumerator<ArchiveBooksResponse> ResponseStream =>
                 GrpcCall.ResponseStream;
+        }
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task that completes when the RPC has completed.
+        /// </returns>
+        public override stt::Task SaveBookAsync(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Book(ref request, ref callSettings);
+            return _callSaveBook.Async(request, callSettings);
+        }
+
+        /// <summary>
+        /// Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        /// New APIs should always create a separate message for a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        public override void SaveBook(
+            Book request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Book(ref request, ref callSettings);
+            _callSaveBook.Sync(request, callSettings);
         }
 
         /// <summary>

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -248,6 +248,7 @@ type CallOptions struct {
     ArchiveBooks []gax.CallOption
     LongRunningArchiveBooks []gax.CallOption
     StreamingArchiveBooks []gax.CallOption
+    SaveBook []gax.CallOption
     PrivateListShelves []gax.CallOption
 }
 
@@ -307,6 +308,7 @@ func defaultCallOptions() *CallOptions {
         ArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
         LongRunningArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
         StreamingArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
+        SaveBook: retry[[2]string{"default", "non_idempotent"}],
         PrivateListShelves: retry[[2]string{"default", "idempotent"}],
     }
 }
@@ -997,6 +999,19 @@ func (c *LibClient) StreamingArchiveBooks(ctx context.Context, opts ...gax.CallO
         return nil, err
     }
     return resp, nil
+}
+
+// SaveBook test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+// New APIs should always create a separate message for a request.
+func (c *LibClient) SaveBook(ctx context.Context, req *librarypb.Book, opts ...gax.CallOption) error {
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
+    opts = append(c.CallOptions.SaveBook[0:len(c.CallOptions.SaveBook):len(c.CallOptions.SaveBook)], opts...)
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        _, err = c.client.SaveBook(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    return err
 }
 
 // PrivateListShelves this method is not exposed in the GAPIC config. It should be generated.
@@ -2008,6 +2023,22 @@ func ExampleClient_StreamingArchiveBooks() {
     }
 }
 
+func ExampleClient_SaveBook() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &librarypb.Book{
+        // TODO: Fill request struct fields.
+    }
+    err = c.SaveBook(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+}
+
 func ExampleClient_PrivateListShelves() {
     ctx := context.Background()
     c, err := library.NewClient(ctx)
@@ -2499,6 +2530,18 @@ func (s *mockLibraryServer) StreamingArchiveBooks(stream librarypb.LibraryServic
         }
     }
     return nil
+}
+
+func (s *mockLibraryServer) SaveBook(ctx context.Context, req *librarypb.Book) (*emptypb.Empty, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*emptypb.Empty), nil
 }
 
 func (s *mockLibraryServer) TestOptionalRequiredFlatteningParams(ctx context.Context, req *librarypb.TestOptionalRequiredFlatteningParamsRequest) (*librarypb.TestOptionalRequiredFlatteningParamsResponse, error) {
@@ -4975,6 +5018,58 @@ func TestLibraryServiceStreamingArchiveBooksError(t *testing.T) {
         t.Errorf("got error code %q, want %q", c, errCode)
     }
     _ = resp
+}
+func TestLibraryServiceSaveBook(t *testing.T) {
+    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
+
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var request = &librarypb.Book{
+        Name: formattedName,
+    }
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    err = c.SaveBook(context.Background(), request)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+}
+
+func TestLibraryServiceSaveBookError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockLibrary.err = gstatus.Error(errCode, "test error")
+
+    var formattedName string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var request = &librarypb.Book{
+        Name: formattedName,
+    }
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    err = c.SaveBook(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
 }
 func TestLibraryServicePrivateListShelves(t *testing.T) {
     var name string = "name3373707"

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -4288,6 +4288,7 @@ import com.google.api.resourcenames.ResourceName;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.stub.LibraryServiceStub;
@@ -9194,6 +9195,121 @@ public class LibraryClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   String author = "";
+   *   String title = "";
+   *   Book.Rating rating = Book.Rating.GOOD;
+   *   libraryClient.saveBook(name, author, title, rating);
+   * }
+   * </code></pre>
+   *
+   * @param name The resource name of the book.
+   * Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+   * Message field comment may include special characters: &lt;&gt;&amp;"`'{@literal @}.
+   * @param author The name of the book author.
+   * @param title The title of the book.
+   * @param rating For testing enums.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void saveBook(BookName name, String author, String title, Book.Rating rating) {
+    Book request =
+        Book.newBuilder()
+            .setName(name == null ? null : name.toString())
+            .setAuthor(author)
+            .setTitle(title)
+            .setRating(rating)
+            .build();
+    saveBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   String author = "";
+   *   String title = "";
+   *   Book.Rating rating = Book.Rating.GOOD;
+   *   libraryClient.saveBook(name.toString(), author, title, rating);
+   * }
+   * </code></pre>
+   *
+   * @param name The resource name of the book.
+   * Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+   * Message field comment may include special characters: &lt;&gt;&amp;"`'{@literal @}.
+   * @param author The name of the book author.
+   * @param title The title of the book.
+   * @param rating For testing enums.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void saveBook(String name, String author, String title, Book.Rating rating) {
+    Book request =
+        Book.newBuilder()
+            .setName(name)
+            .setAuthor(author)
+            .setTitle(title)
+            .setRating(rating)
+            .build();
+    saveBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   Book request = Book.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   libraryClient.saveBook(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void saveBook(Book request) {
+    saveBookCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   Book request = Book.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   ApiFuture&lt;Void&gt; future = libraryClient.saveBookCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<Book, Empty> saveBookCallable() {
+    return stub.saveBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
    * This method is not exposed in the GAPIC config. It should be generated.
    *
    * Sample code:
@@ -10063,6 +10179,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
   }
 
   /**
+   * Returns the object with the settings used for calls to saveBook.
+   */
+  public UnaryCallSettings<Book, Empty> saveBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).saveBookSettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -10429,6 +10552,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
      */
     public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
       return getStubSettingsBuilder().streamingArchiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to saveBook.
+     */
+    public UnaryCallSettings.Builder<Book, Empty> saveBookSettings() {
+      return getStubSettingsBuilder().saveBookSettings();
     }
 
     /**
@@ -11531,6 +11661,13 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<Book, Empty> saveBookMethodDescriptor =
+      MethodDescriptor.<Book, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/SaveBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(Book.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<ListShelvesRequest, Book> privateListShelvesMethodDescriptor =
       MethodDescriptor.<ListShelvesRequest, Book>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -11582,6 +11719,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
   private final OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable;
   private final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable;
+  private final UnaryCallable<Book, Empty> saveBookCallable;
   private final UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable;
 
   private final GrpcStubCallableFactory callableFactory;
@@ -11934,6 +12072,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
         GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
             .setMethodDescriptor(streamingArchiveBooksMethodDescriptor)
             .build();
+    GrpcCallSettings<Book, Empty> saveBookTransportSettings =
+        GrpcCallSettings.<Book, Empty>newBuilder()
+            .setMethodDescriptor(saveBookMethodDescriptor)
+            .build();
     GrpcCallSettings<ListShelvesRequest, Book> privateListShelvesTransportSettings =
         GrpcCallSettings.<ListShelvesRequest, Book>newBuilder()
             .setMethodDescriptor(privateListShelvesMethodDescriptor)
@@ -11981,6 +12123,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.longRunningArchiveBooksOperationCallable = callableFactory.createOperationCallable(
         longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksOperationSettings(), clientContext, this.operationsStub);
     this.streamingArchiveBooksCallable = callableFactory.createBidiStreamingCallable(streamingArchiveBooksTransportSettings,settings.streamingArchiveBooksSettings(), clientContext);
+    this.saveBookCallable = callableFactory.createUnaryCallable(saveBookTransportSettings,settings.saveBookSettings(), clientContext);
     this.privateListShelvesCallable = callableFactory.createUnaryCallable(privateListShelvesTransportSettings,settings.privateListShelvesSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -12148,6 +12291,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
     return streamingArchiveBooksCallable;
+  }
+
+  public UnaryCallable<Book, Empty> saveBookCallable() {
+    return saveBookCallable;
   }
 
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
@@ -12725,6 +12872,10 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: streamingArchiveBooksCallable()");
   }
 
+  public UnaryCallable<Book, Empty> saveBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: saveBookCallable()");
+  }
+
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
     throw new UnsupportedOperationException("Not implemented: privateListShelvesCallable()");
   }
@@ -12935,6 +13086,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
   private final OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
   private final StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
+  private final UnaryCallSettings<Book, Empty> saveBookSettings;
   private final UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings;
 
   /**
@@ -13186,6 +13338,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to saveBook.
+   */
+  public UnaryCallSettings<Book, Empty> saveBookSettings() {
+    return saveBookSettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -13313,6 +13472,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
     longRunningArchiveBooksOperationSettings = settingsBuilder.longRunningArchiveBooksOperationSettings().build();
     streamingArchiveBooksSettings = settingsBuilder.streamingArchiveBooksSettings().build();
+    saveBookSettings = settingsBuilder.saveBookSettings().build();
     privateListShelvesSettings = settingsBuilder.privateListShelvesSettings().build();
   }
 
@@ -13672,6 +13832,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
     private final OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
     private final StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
+    private final UnaryCallSettings.Builder<Book, Empty> saveBookSettings;
     private final UnaryCallSettings.Builder<ListShelvesRequest, Book> privateListShelvesSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
@@ -13790,6 +13951,8 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       streamingArchiveBooksSettings = StreamingCallSettings.newBuilder();
 
+      saveBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       privateListShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -13819,6 +13982,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
+          saveBookSettings,
           privateListShelvesSettings
       );
 
@@ -13968,6 +14132,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.saveBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       builder.privateListShelvesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
@@ -14073,6 +14241,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
       longRunningArchiveBooksOperationSettings = settings.longRunningArchiveBooksOperationSettings.toBuilder();
       streamingArchiveBooksSettings = settings.streamingArchiveBooksSettings.toBuilder();
+      saveBookSettings = settings.saveBookSettings.toBuilder();
       privateListShelvesSettings = settings.privateListShelvesSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -14102,6 +14271,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
+          saveBookSettings,
           privateListShelvesSettings
       );
     }
@@ -14367,6 +14537,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
       return streamingArchiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to saveBook.
+     */
+    public UnaryCallSettings.Builder<Book, Empty> saveBookSettings() {
+      return saveBookSettings;
     }
 
     /**
@@ -14765,6 +14942,7 @@ import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.Lists;
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.Comment;
 import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
@@ -16954,6 +17132,52 @@ public class LibraryClientTest {
 
   @Test
   @SuppressWarnings("all")
+  public void saveBookTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    Book.Rating rating = Book.Rating.GOOD;
+
+    client.saveBook(name, author, title, rating);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    Book actualRequest = (Book)actualRequests.get(0);
+
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
+    Assert.assertEquals(author, actualRequest.getAuthor());
+    Assert.assertEquals(title, actualRequest.getTitle());
+    Assert.assertEquals(rating, actualRequest.getRating());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void saveBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      String author = "author-1406328437";
+      String title = "title110371416";
+      Book.Rating rating = Book.Rating.GOOD;
+
+      client.saveBook(name, author, title, rating);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
   public void privateListShelvesTest() {
     BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
@@ -17830,6 +18054,21 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
       }
     };
     return requestObserver;
+  }
+
+  @Override
+  public void saveBook(Book request,
+    StreamObserver<Empty> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -117,6 +117,7 @@ import com.google.api.resourcenames.ResourceName;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.stub.LibraryServiceStub;
@@ -3562,6 +3563,121 @@ public class LibraryServiceClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   String author = "";
+   *   String title = "";
+   *   Book.Rating rating = Book.Rating.GOOD;
+   *   libraryServiceClient.saveBook(name, author, title, rating);
+   * }
+   * </code></pre>
+   *
+   * @param name The resource name of the book.
+   * Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+   * Message field comment may include special characters: &lt;&gt;&amp;"`'{@literal @}.
+   * @param author The name of the book author.
+   * @param title The title of the book.
+   * @param rating For testing enums.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void saveBook(BookName name, String author, String title, Book.Rating rating) {
+    Book request =
+        Book.newBuilder()
+            .setName(name == null ? null : name.toString())
+            .setAuthor(author)
+            .setTitle(title)
+            .setRating(rating)
+            .build();
+    saveBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   String author = "";
+   *   String title = "";
+   *   Book.Rating rating = Book.Rating.GOOD;
+   *   libraryServiceClient.saveBook(name.toString(), author, title, rating);
+   * }
+   * </code></pre>
+   *
+   * @param name The resource name of the book.
+   * Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+   * Message field comment may include special characters: &lt;&gt;&amp;"`'{@literal @}.
+   * @param author The name of the book author.
+   * @param title The title of the book.
+   * @param rating For testing enums.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void saveBook(String name, String author, String title, Book.Rating rating) {
+    Book request =
+        Book.newBuilder()
+            .setName(name)
+            .setAuthor(author)
+            .setTitle(title)
+            .setRating(rating)
+            .build();
+    saveBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   Book request = Book.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   libraryServiceClient.saveBook(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void saveBook(Book request) {
+    saveBookCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   Book request = Book.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   ApiFuture&lt;Void&gt; future = libraryServiceClient.saveBookCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<Book, Empty> saveBookCallable() {
+    return stub.saveBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
    * Test optional flattening parameters of all types
    *
    * Sample code:
@@ -5398,6 +5514,13 @@ public class LibraryServiceSettings extends ClientSettings<LibraryServiceSetting
   }
 
   /**
+   * Returns the object with the settings used for calls to saveBook.
+   */
+  public UnaryCallSettings<Book, Empty> saveBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).saveBookSettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to testOptionalRequiredFlatteningParams.
    */
   public UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
@@ -5764,6 +5887,13 @@ public class LibraryServiceSettings extends ClientSettings<LibraryServiceSetting
      */
     public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
       return getStubSettingsBuilder().streamingArchiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to saveBook.
+     */
+    public UnaryCallSettings.Builder<Book, Empty> saveBookSettings() {
+      return getStubSettingsBuilder().saveBookSettings();
     }
 
     /**
@@ -6864,6 +6994,13 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<Book, Empty> saveBookMethodDescriptor =
+      MethodDescriptor.<Book, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/SaveBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(Book.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsMethodDescriptor =
       MethodDescriptor.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -6920,6 +7057,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
   private final OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable;
   private final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable;
+  private final UnaryCallable<Book, Empty> saveBookCallable;
   private final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable;
   private final UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable;
 
@@ -7269,6 +7407,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
         GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
             .setMethodDescriptor(streamingArchiveBooksMethodDescriptor)
             .build();
+    GrpcCallSettings<Book, Empty> saveBookTransportSettings =
+        GrpcCallSettings.<Book, Empty>newBuilder()
+            .setMethodDescriptor(saveBookMethodDescriptor)
+            .build();
     GrpcCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsTransportSettings =
         GrpcCallSettings.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
             .setMethodDescriptor(testOptionalRequiredFlatteningParamsMethodDescriptor)
@@ -7318,6 +7460,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.longRunningArchiveBooksOperationCallable = callableFactory.createOperationCallable(
         longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksOperationSettings(), clientContext, this.operationsStub);
     this.streamingArchiveBooksCallable = callableFactory.createBidiStreamingCallable(streamingArchiveBooksTransportSettings,settings.streamingArchiveBooksSettings(), clientContext);
+    this.saveBookCallable = callableFactory.createUnaryCallable(saveBookTransportSettings,settings.saveBookSettings(), clientContext);
     this.testOptionalRequiredFlatteningParamsCallable = callableFactory.createUnaryCallable(testOptionalRequiredFlatteningParamsTransportSettings,settings.testOptionalRequiredFlatteningParamsSettings(), clientContext);
     this.privateListShelvesCallable = callableFactory.createUnaryCallable(privateListShelvesTransportSettings,settings.privateListShelvesSettings(), clientContext);
 
@@ -7477,6 +7620,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
     return streamingArchiveBooksCallable;
+  }
+
+  public UnaryCallable<Book, Empty> saveBookCallable() {
+    return saveBookCallable;
   }
 
   public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
@@ -8048,6 +8195,10 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: streamingArchiveBooksCallable()");
   }
 
+  public UnaryCallable<Book, Empty> saveBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: saveBookCallable()");
+  }
+
   public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     throw new UnsupportedOperationException("Not implemented: testOptionalRequiredFlatteningParamsCallable()");
   }
@@ -8249,6 +8400,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
   private final OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
   private final StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
+  private final UnaryCallSettings<Book, Empty> saveBookSettings;
   private final UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
   private final UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings;
 
@@ -8494,6 +8646,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to saveBook.
+   */
+  public UnaryCallSettings<Book, Empty> saveBookSettings() {
+    return saveBookSettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to testOptionalRequiredFlatteningParams.
    */
   public UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
@@ -8627,6 +8786,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
     longRunningArchiveBooksOperationSettings = settingsBuilder.longRunningArchiveBooksOperationSettings().build();
     streamingArchiveBooksSettings = settingsBuilder.streamingArchiveBooksSettings().build();
+    saveBookSettings = settingsBuilder.saveBookSettings().build();
     testOptionalRequiredFlatteningParamsSettings = settingsBuilder.testOptionalRequiredFlatteningParamsSettings().build();
     privateListShelvesSettings = settingsBuilder.privateListShelvesSettings().build();
   }
@@ -8819,6 +8979,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
     private final OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
     private final StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
+    private final UnaryCallSettings.Builder<Book, Empty> saveBookSettings;
     private final UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
     private final UnaryCallSettings.Builder<ListShelvesRequest, Book> privateListShelvesSettings;
 
@@ -8931,6 +9092,8 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       streamingArchiveBooksSettings = StreamingCallSettings.newBuilder();
 
+      saveBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       testOptionalRequiredFlatteningParamsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       privateListShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
@@ -8961,6 +9124,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
+          saveBookSettings,
           testOptionalRequiredFlatteningParamsSettings,
           privateListShelvesSettings
       );
@@ -9087,6 +9251,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.saveBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       builder.testOptionalRequiredFlatteningParamsSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
@@ -9195,6 +9363,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
       longRunningArchiveBooksOperationSettings = settings.longRunningArchiveBooksOperationSettings.toBuilder();
       streamingArchiveBooksSettings = settings.streamingArchiveBooksSettings.toBuilder();
+      saveBookSettings = settings.saveBookSettings.toBuilder();
       testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
       privateListShelvesSettings = settings.privateListShelvesSettings.toBuilder();
 
@@ -9224,6 +9393,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
+          saveBookSettings,
           testOptionalRequiredFlatteningParamsSettings,
           privateListShelvesSettings
       );
@@ -9483,6 +9653,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
       return streamingArchiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to saveBook.
+     */
+    public UnaryCallSettings.Builder<Book, Empty> saveBookSettings() {
+      return saveBookSettings;
     }
 
     /**
@@ -9889,6 +10066,7 @@ import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.Lists;
+import com.google.example.library.v1.Book;
 import static com.google.example.library.v1.LibraryServiceClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryServiceClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryServiceClient.ListStringsPagedResponse;
@@ -11588,6 +11766,52 @@ public class LibraryServiceClientTest {
 
   @Test
   @SuppressWarnings("all")
+  public void saveBookTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    Book.Rating rating = Book.Rating.GOOD;
+
+    client.saveBook(name, author, title, rating);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    Book actualRequest = (Book)actualRequests.get(0);
+
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
+    Assert.assertEquals(author, actualRequest.getAuthor());
+    Assert.assertEquals(title, actualRequest.getTitle());
+    Assert.assertEquals(rating, actualRequest.getRating());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void saveBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      String author = "author-1406328437";
+      String title = "title110371416";
+      Book.Rating rating = Book.Rating.GOOD;
+
+      client.saveBook(name, author, title, rating);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
   public void testOptionalRequiredFlatteningParamsTest() {
     TestOptionalRequiredFlatteningParamsResponse expectedResponse = TestOptionalRequiredFlatteningParamsResponse.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
@@ -12711,6 +12935,21 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
       }
     };
     return requestObserver;
+  }
+
+  @Override
+  public void saveBook(Book request,
+    StreamObserver<Empty> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -4288,6 +4288,7 @@ import com.google.api.resourcenames.ResourceName;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest;
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage;
 import com.google.example.library.v1.stub.LibraryServiceStub;
@@ -9194,6 +9195,121 @@ public class LibraryClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   String author = "";
+   *   String title = "";
+   *   Book.Rating rating = Book.Rating.GOOD;
+   *   libraryClient.saveBook(name, author, title, rating);
+   * }
+   * </code></pre>
+   *
+   * @param name The resource name of the book.
+   * Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+   * Message field comment may include special characters: &lt;&gt;&amp;"`'{@literal @}.
+   * @param author The name of the book author.
+   * @param title The title of the book.
+   * @param rating For testing enums.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void saveBook(BookName name, String author, String title, Book.Rating rating) {
+    Book request =
+        Book.newBuilder()
+            .setName(name == null ? null : name.toString())
+            .setAuthor(author)
+            .setTitle(title)
+            .setRating(rating)
+            .build();
+    saveBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   String author = "";
+   *   String title = "";
+   *   Book.Rating rating = Book.Rating.GOOD;
+   *   libraryClient.saveBook(name.toString(), author, title, rating);
+   * }
+   * </code></pre>
+   *
+   * @param name The resource name of the book.
+   * Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+   * Message field comment may include special characters: &lt;&gt;&amp;"`'{@literal @}.
+   * @param author The name of the book author.
+   * @param title The title of the book.
+   * @param rating For testing enums.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void saveBook(String name, String author, String title, Book.Rating rating) {
+    Book request =
+        Book.newBuilder()
+            .setName(name)
+            .setAuthor(author)
+            .setTitle(title)
+            .setRating(rating)
+            .build();
+    saveBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   Book request = Book.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   libraryClient.saveBook(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void saveBook(Book request) {
+    saveBookCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   Book request = Book.newBuilder()
+   *     .setName(name.toString())
+   *     .build();
+   *   ApiFuture&lt;Void&gt; future = libraryClient.saveBookCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<Book, Empty> saveBookCallable() {
+    return stub.saveBookCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
    * This method is not exposed in the GAPIC config. It should be generated.
    *
    * Sample code:
@@ -10063,6 +10179,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
   }
 
   /**
+   * Returns the object with the settings used for calls to saveBook.
+   */
+  public UnaryCallSettings<Book, Empty> saveBookSettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).saveBookSettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -10429,6 +10552,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
      */
     public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
       return getStubSettingsBuilder().streamingArchiveBooksSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to saveBook.
+     */
+    public UnaryCallSettings.Builder<Book, Empty> saveBookSettings() {
+      return getStubSettingsBuilder().saveBookSettings();
     }
 
     /**
@@ -11531,6 +11661,13 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(ArchiveBooksRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(ArchiveBooksResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<Book, Empty> saveBookMethodDescriptor =
+      MethodDescriptor.<Book, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/SaveBook")
+          .setRequestMarshaller(ProtoUtils.marshaller(Book.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<ListShelvesRequest, Book> privateListShelvesMethodDescriptor =
       MethodDescriptor.<ListShelvesRequest, Book>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -11582,6 +11719,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
   private final OperationCallable<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationCallable;
   private final BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable;
+  private final UnaryCallable<Book, Empty> saveBookCallable;
   private final UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable;
 
   private final GrpcStubCallableFactory callableFactory;
@@ -11934,6 +12072,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
         GrpcCallSettings.<ArchiveBooksRequest, ArchiveBooksResponse>newBuilder()
             .setMethodDescriptor(streamingArchiveBooksMethodDescriptor)
             .build();
+    GrpcCallSettings<Book, Empty> saveBookTransportSettings =
+        GrpcCallSettings.<Book, Empty>newBuilder()
+            .setMethodDescriptor(saveBookMethodDescriptor)
+            .build();
     GrpcCallSettings<ListShelvesRequest, Book> privateListShelvesTransportSettings =
         GrpcCallSettings.<ListShelvesRequest, Book>newBuilder()
             .setMethodDescriptor(privateListShelvesMethodDescriptor)
@@ -11981,6 +12123,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.longRunningArchiveBooksOperationCallable = callableFactory.createOperationCallable(
         longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksOperationSettings(), clientContext, this.operationsStub);
     this.streamingArchiveBooksCallable = callableFactory.createBidiStreamingCallable(streamingArchiveBooksTransportSettings,settings.streamingArchiveBooksSettings(), clientContext);
+    this.saveBookCallable = callableFactory.createUnaryCallable(saveBookTransportSettings,settings.saveBookSettings(), clientContext);
     this.privateListShelvesCallable = callableFactory.createUnaryCallable(privateListShelvesTransportSettings,settings.privateListShelvesSettings(), clientContext);
 
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -12148,6 +12291,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public BidiStreamingCallable<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksCallable() {
     return streamingArchiveBooksCallable;
+  }
+
+  public UnaryCallable<Book, Empty> saveBookCallable() {
+    return saveBookCallable;
   }
 
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
@@ -12725,6 +12872,10 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: streamingArchiveBooksCallable()");
   }
 
+  public UnaryCallable<Book, Empty> saveBookCallable() {
+    throw new UnsupportedOperationException("Not implemented: saveBookCallable()");
+  }
+
   public UnaryCallable<ListShelvesRequest, Book> privateListShelvesCallable() {
     throw new UnsupportedOperationException("Not implemented: privateListShelvesCallable()");
   }
@@ -12935,6 +13086,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
   private final OperationCallSettings<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
   private final StreamingCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
+  private final UnaryCallSettings<Book, Empty> saveBookSettings;
   private final UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings;
 
   /**
@@ -13186,6 +13338,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to saveBook.
+   */
+  public UnaryCallSettings<Book, Empty> saveBookSettings() {
+    return saveBookSettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to privateListShelves.
    */
   public UnaryCallSettings<ListShelvesRequest, Book> privateListShelvesSettings() {
@@ -13313,6 +13472,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
     longRunningArchiveBooksOperationSettings = settingsBuilder.longRunningArchiveBooksOperationSettings().build();
     streamingArchiveBooksSettings = settingsBuilder.streamingArchiveBooksSettings().build();
+    saveBookSettings = settingsBuilder.saveBookSettings().build();
     privateListShelvesSettings = settingsBuilder.privateListShelvesSettings().build();
   }
 
@@ -13672,6 +13832,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
     private final OperationCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksOperationSettings;
     private final StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings;
+    private final UnaryCallSettings.Builder<Book, Empty> saveBookSettings;
     private final UnaryCallSettings.Builder<ListShelvesRequest, Book> privateListShelvesSettings;
 
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
@@ -13797,6 +13958,8 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       streamingArchiveBooksSettings = StreamingCallSettings.newBuilder();
 
+      saveBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       privateListShelvesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -13826,6 +13989,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
+          saveBookSettings,
           privateListShelvesSettings
       );
 
@@ -13975,6 +14139,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
 
+      builder.saveBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
       builder.privateListShelvesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
@@ -14080,6 +14248,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
       longRunningArchiveBooksOperationSettings = settings.longRunningArchiveBooksOperationSettings.toBuilder();
       streamingArchiveBooksSettings = settings.streamingArchiveBooksSettings.toBuilder();
+      saveBookSettings = settings.saveBookSettings.toBuilder();
       privateListShelvesSettings = settings.privateListShelvesSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -14109,6 +14278,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
+          saveBookSettings,
           privateListShelvesSettings
       );
     }
@@ -14374,6 +14544,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public StreamingCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> streamingArchiveBooksSettings() {
       return streamingArchiveBooksSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to saveBook.
+     */
+    public UnaryCallSettings.Builder<Book, Empty> saveBookSettings() {
+      return saveBookSettings;
     }
 
     /**
@@ -14769,6 +14946,7 @@ import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.Lists;
+import com.google.example.library.v1.Book;
 import com.google.example.library.v1.Comment;
 import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
@@ -16958,6 +17136,52 @@ public class LibraryClientTest {
 
   @Test
   @SuppressWarnings("all")
+  public void saveBookTest() {
+    Empty expectedResponse = Empty.newBuilder().build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    Book.Rating rating = Book.Rating.GOOD;
+
+    client.saveBook(name, author, title, rating);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    Book actualRequest = (Book)actualRequests.get(0);
+
+    Assert.assertEquals(name, BookName.parse(actualRequest.getName()));
+    Assert.assertEquals(author, actualRequest.getAuthor());
+    Assert.assertEquals(title, actualRequest.getTitle());
+    Assert.assertEquals(rating, actualRequest.getRating());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void saveBookExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      String author = "author-1406328437";
+      String title = "title110371416";
+      Book.Rating rating = Book.Rating.GOOD;
+
+      client.saveBook(name, author, title, rating);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
   public void privateListShelvesTest() {
     BookName name = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
     String author = "author-1406328437";
@@ -17834,6 +18058,21 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
       }
     };
     return requestObserver;
+  }
+
+  @Override
+  public void saveBook(Book request,
+    StreamObserver<Empty> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext((Empty) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -5301,6 +5301,7 @@ class LibraryServiceClient {
       'archiveBooks',
       'longRunningArchiveBooks',
       'streamingArchiveBooks',
+      'saveBook',
       'privateListShelves',
     ];
     for (const methodName of libraryServiceStubMethods) {
@@ -7946,6 +7947,112 @@ class LibraryServiceClient {
   }
 
   /**
+   * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+   * New APIs should always create a separate message for a request.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The resource name of the book.
+   *   Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+   *   Message field comment may include special characters: <>&"`'@.
+   * @param {string} [request.author]
+   *   The name of the book author.
+   * @param {string} [request.title]
+   *   The title of the book.
+   * @param {boolean} [request.read]
+   *   Value indicating whether the book has been read.
+   * @param {number} [request.rating]
+   *   For testing enums.
+   *
+   *   The number should be among the values of [Rating]{@link google.example.library.v1.Rating}
+   * @param {Object} [request.anyValue]
+   *   For testing all well-known types.
+   *
+   *   This object should have the same structure as [Any]{@link google.protobuf.Any}
+   * @param {Object} [request.structValue]
+   *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
+   * @param {Object} [request.valueValue]
+   *   This object should have the same structure as [Value]{@link google.protobuf.Value}
+   * @param {Object} [request.listValueValue]
+   *   This object should have the same structure as [ListValue]{@link google.protobuf.ListValue}
+   * @param {Object.<string, Object>} [request.mapListValueValue]
+   * @param {Object} [request.timeValue]
+   *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
+   * @param {Object} [request.durationValue]
+   *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+   * @param {Object} [request.fieldMaskValue]
+   *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+   * @param {Object} [request.int32Value]
+   *   This object should have the same structure as [Int32Value]{@link google.protobuf.Int32Value}
+   * @param {Object} [request.uint32Value]
+   *   This object should have the same structure as [UInt32Value]{@link google.protobuf.UInt32Value}
+   * @param {Object} [request.int64Value]
+   *   This object should have the same structure as [Int64Value]{@link google.protobuf.Int64Value}
+   * @param {Object} [request.uint64Value]
+   *   This object should have the same structure as [UInt64Value]{@link google.protobuf.UInt64Value}
+   * @param {Object} [request.floatValue]
+   *   This object should have the same structure as [FloatValue]{@link google.protobuf.FloatValue}
+   * @param {Object} [request.doubleValue]
+   *   This object should have the same structure as [DoubleValue]{@link google.protobuf.DoubleValue}
+   * @param {Object} [request.stringValue]
+   *   This object should have the same structure as [StringValue]{@link google.protobuf.StringValue}
+   * @param {Object} [request.boolValue]
+   *   This object should have the same structure as [BoolValue]{@link google.protobuf.BoolValue}
+   * @param {Object} [request.bytesValue]
+   *   This object should have the same structure as [BytesValue]{@link google.protobuf.BytesValue}
+   * @param {Object.<number, string>} [request.mapStringValue]
+   *   Test doc generation of lists:
+   *
+   *   +   Here is a sentence about the first element of the list that continues
+   *       into a second line.
+   *   +   The second element of the list.
+   *   +   Another element of the list where the indentation isn't consistent
+   *   after a blank space.
+   *
+   *       The second paragraph of the list
+   *   that doesn't have a hanging indent.
+   * @param {Object.<string, Object>} [request.mapMessageValue]
+   * @param {Object} [request.resource]
+   *   Tests Python doc generation: should generate a dummy file for shared_type
+   *   resource, but *not* its import, other_shared_type
+   *
+   *   This object should have the same structure as [Used]{@link google.test.shared.data.Used}
+   * @param {Object.<boolean, string>} [request.mapBoolKey]
+   *   For testing accessing map fields in samplegen
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error)} [callback]
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+   * client.saveBook({name: formattedName}).catch(err => {
+   *   console.error(err);
+   * });
+   */
+  saveBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+
+    return this._innerApiCalls.saveBook(request, options, callback);
+  }
+
+  /**
    * This method is not exposed in the GAPIC config. It should be generated.
    *
    * @param {Object} request
@@ -8558,6 +8665,11 @@ module.exports = LibraryServiceClient;
           "retry_params_name": "default"
         },
         "StreamingArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "SaveBook": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -11091,6 +11203,55 @@ describe('LibraryServiceClient', () => {
       });
 
       stream.write(request);
+    });
+  });
+
+  describe('saveBook', () => {
+    it('invokes saveBook without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.saveBook = mockSimpleGrpcMethod(request);
+
+      client.saveBook(request, err => {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('invokes saveBook with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.bookPath('[SHELF]', '[BOOK]');
+      const request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.saveBook = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.saveBook(request, err => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        done();
+      });
     });
   });
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -2303,6 +2303,11 @@ use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
+use Google\Example\Library\V1\Book\MapBoolKeyEntry;
+use Google\Example\Library\V1\Book\MapListValueValueEntry;
+use Google\Example\Library\V1\Book\MapMessageValueEntry;
+use Google\Example\Library\V1\Book\MapStringValueEntry;
+use Google\Example\Library\V1\Book\Rating;
 use Google\Example\Library\V1\Comment;
 use Google\Example\Library\V1\CreateBookRequest;
 use Google\Example\Library\V1\CreateShelfRequest;
@@ -2367,6 +2372,7 @@ use Google\Protobuf\Value;
 use Google\Tagger\CustomNamespace\V1\AddLabelRequest;
 use Google\Tagger\CustomNamespace\V1\AddLabelResponse;
 use Google\Tagger\CustomNamespace\V1\LabelerGrpcClient;
+use Google\Test\Shared\Data\Used;
 
 /**
  * Service Description: This API represents a simple digital library.  It lets you manage Shelf
@@ -5199,6 +5205,168 @@ class LibraryServiceGapicClient
     }
 
     /**
+     * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+     * New APIs should always create a separate message for a request.
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $libraryServiceClient->saveBook($formattedName);
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string $name The resource name of the book.
+     * Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+     * Message field comment may include special characters: <>&"`'&#64;.
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $author
+     *          The name of the book author.
+     *     @type string $title
+     *          The title of the book.
+     *     @type bool $read
+     *          Value indicating whether the book has been read.
+     *     @type int $rating
+     *          For testing enums.
+     *          For allowed values, use constants defined on {@see \Google\Example\Library\V1\Book\Rating}
+     *     @type Any $anyValue
+     *          For testing all well-known types.
+     *     @type Struct $structValue
+     *     @type Value $valueValue
+     *     @type ListValue $listValueValue
+     *     @type array $mapListValueValue
+     *     @type Timestamp $timeValue
+     *     @type Duration $durationValue
+     *     @type FieldMask $fieldMaskValue
+     *     @type Int32Value $int32Value
+     *     @type UInt32Value $uint32Value
+     *     @type Int64Value $int64Value
+     *     @type UInt64Value $uint64Value
+     *     @type FloatValue $floatValue
+     *     @type DoubleValue $doubleValue
+     *     @type StringValue $stringValue
+     *     @type BoolValue $boolValue
+     *     @type BytesValue $bytesValue
+     *     @type array $mapStringValue
+     *          Test doc generation of lists:
+     *
+     *          +   Here is a sentence about the first element of the list that continues
+     *              into a second line.
+     *          +   The second element of the list.
+     *          +   Another element of the list where the indentation isn't consistent
+     *          after a blank space.
+     *
+     *              The second paragraph of the list
+     *          that doesn't have a hanging indent.
+     *     @type array $mapMessageValue
+     *     @type Used $resource
+     *          Tests Python doc generation: should generate a dummy file for shared_type
+     *          resource, but *not* its import, other_shared_type
+     *     @type array $mapBoolKey
+     *          For testing accessing map fields in samplegen
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function saveBook($name, array $optionalArgs = [])
+    {
+        $request = new Book();
+        $request->setName($name);
+        if (isset($optionalArgs['author'])) {
+            $request->setAuthor($optionalArgs['author']);
+        }
+        if (isset($optionalArgs['title'])) {
+            $request->setTitle($optionalArgs['title']);
+        }
+        if (isset($optionalArgs['read'])) {
+            $request->setRead($optionalArgs['read']);
+        }
+        if (isset($optionalArgs['rating'])) {
+            $request->setRating($optionalArgs['rating']);
+        }
+        if (isset($optionalArgs['anyValue'])) {
+            $request->setAnyValue($optionalArgs['anyValue']);
+        }
+        if (isset($optionalArgs['structValue'])) {
+            $request->setStructValue($optionalArgs['structValue']);
+        }
+        if (isset($optionalArgs['valueValue'])) {
+            $request->setValueValue($optionalArgs['valueValue']);
+        }
+        if (isset($optionalArgs['listValueValue'])) {
+            $request->setListValueValue($optionalArgs['listValueValue']);
+        }
+        if (isset($optionalArgs['mapListValueValue'])) {
+            $request->setMapListValueValue($optionalArgs['mapListValueValue']);
+        }
+        if (isset($optionalArgs['timeValue'])) {
+            $request->setTimeValue($optionalArgs['timeValue']);
+        }
+        if (isset($optionalArgs['durationValue'])) {
+            $request->setDurationValue($optionalArgs['durationValue']);
+        }
+        if (isset($optionalArgs['fieldMaskValue'])) {
+            $request->setFieldMaskValue($optionalArgs['fieldMaskValue']);
+        }
+        if (isset($optionalArgs['int32Value'])) {
+            $request->setInt32Value($optionalArgs['int32Value']);
+        }
+        if (isset($optionalArgs['uint32Value'])) {
+            $request->setUint32Value($optionalArgs['uint32Value']);
+        }
+        if (isset($optionalArgs['int64Value'])) {
+            $request->setInt64Value($optionalArgs['int64Value']);
+        }
+        if (isset($optionalArgs['uint64Value'])) {
+            $request->setUint64Value($optionalArgs['uint64Value']);
+        }
+        if (isset($optionalArgs['floatValue'])) {
+            $request->setFloatValue($optionalArgs['floatValue']);
+        }
+        if (isset($optionalArgs['doubleValue'])) {
+            $request->setDoubleValue($optionalArgs['doubleValue']);
+        }
+        if (isset($optionalArgs['stringValue'])) {
+            $request->setStringValue($optionalArgs['stringValue']);
+        }
+        if (isset($optionalArgs['boolValue'])) {
+            $request->setBoolValue($optionalArgs['boolValue']);
+        }
+        if (isset($optionalArgs['bytesValue'])) {
+            $request->setBytesValue($optionalArgs['bytesValue']);
+        }
+        if (isset($optionalArgs['mapStringValue'])) {
+            $request->setMapStringValue($optionalArgs['mapStringValue']);
+        }
+        if (isset($optionalArgs['mapMessageValue'])) {
+            $request->setMapMessageValue($optionalArgs['mapMessageValue']);
+        }
+        if (isset($optionalArgs['resource'])) {
+            $request->setResource($optionalArgs['resource']);
+        }
+        if (isset($optionalArgs['mapBoolKey'])) {
+            $request->setMapBoolKey($optionalArgs['mapBoolKey']);
+        }
+
+        return $this->startCall(
+            'SaveBook',
+            GPBEmpty::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
      * This method is not exposed in the GAPIC config. It should be generated.
      *
      * Sample code:
@@ -5732,6 +5900,11 @@ class MyProtoClient extends MyProtoGapicClient
         "StreamingArchiveBooks": {
           "timeout_millis": 60000
         },
+        "SaveBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "PrivateListShelves": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -6134,6 +6307,11 @@ return [
                         ],
                     ],
                 ]
+            ],
+            'SaveBook' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1:saveBook',
+                'body' => '*',
             ],
             'PrivateListShelves' => [
                 'method' => 'get',
@@ -9371,6 +9549,76 @@ class LibraryServiceClientTest extends GeneratedTest
             // If the close stream method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         }  catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function saveBookTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $expectedResponse = new GPBEmpty();
+        $transport->addResponse($expectedResponse);
+
+        // Mock request
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+
+        $client->saveBook($formattedName);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/SaveBook', $actualFuncCall);
+
+        $actualValue = $actualRequestObject->getName();
+
+        $this->assertProtobufEquals($formattedName, $actualValue);
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function saveBookExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        // Mock request
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+
+        try {
+            $client->saveBook($formattedName);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -2303,6 +2303,11 @@ use Google\Example\Library\V1\ArchiveBooksResponse;
 use Google\Example\Library\V1\Book;
 use Google\Example\Library\V1\BookFromAnywhere;
 use Google\Example\Library\V1\BookFromArchive;
+use Google\Example\Library\V1\Book\MapBoolKeyEntry;
+use Google\Example\Library\V1\Book\MapListValueValueEntry;
+use Google\Example\Library\V1\Book\MapMessageValueEntry;
+use Google\Example\Library\V1\Book\MapStringValueEntry;
+use Google\Example\Library\V1\Book\Rating;
 use Google\Example\Library\V1\Comment;
 use Google\Example\Library\V1\CreateBookRequest;
 use Google\Example\Library\V1\CreateShelfRequest;
@@ -2367,6 +2372,7 @@ use Google\Protobuf\Value;
 use Google\Tagger\CustomNamespace\V1\AddLabelRequest;
 use Google\Tagger\CustomNamespace\V1\AddLabelResponse;
 use Google\Tagger\CustomNamespace\V1\LabelerGrpcClient;
+use Google\Test\Shared\Data\Used;
 
 /**
  * Service Description: This API represents a simple digital library.  It lets you manage Shelf
@@ -5199,6 +5205,168 @@ class LibraryServiceGapicClient
     }
 
     /**
+     * Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+     * New APIs should always create a separate message for a request.
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $libraryServiceClient->saveBook($formattedName);
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string $name The resource name of the book.
+     * Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+     * Message field comment may include special characters: <>&"`'&#64;.
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type string $author
+     *          The name of the book author.
+     *     @type string $title
+     *          The title of the book.
+     *     @type bool $read
+     *          Value indicating whether the book has been read.
+     *     @type int $rating
+     *          For testing enums.
+     *          For allowed values, use constants defined on {@see \Google\Example\Library\V1\Book\Rating}
+     *     @type Any $anyValue
+     *          For testing all well-known types.
+     *     @type Struct $structValue
+     *     @type Value $valueValue
+     *     @type ListValue $listValueValue
+     *     @type array $mapListValueValue
+     *     @type Timestamp $timeValue
+     *     @type Duration $durationValue
+     *     @type FieldMask $fieldMaskValue
+     *     @type Int32Value $int32Value
+     *     @type UInt32Value $uint32Value
+     *     @type Int64Value $int64Value
+     *     @type UInt64Value $uint64Value
+     *     @type FloatValue $floatValue
+     *     @type DoubleValue $doubleValue
+     *     @type StringValue $stringValue
+     *     @type BoolValue $boolValue
+     *     @type BytesValue $bytesValue
+     *     @type array $mapStringValue
+     *          Test doc generation of lists:
+     *
+     *          +   Here is a sentence about the first element of the list that continues
+     *              into a second line.
+     *          +   The second element of the list.
+     *          +   Another element of the list where the indentation isn't consistent
+     *          after a blank space.
+     *
+     *              The second paragraph of the list
+     *          that doesn't have a hanging indent.
+     *     @type array $mapMessageValue
+     *     @type Used $resource
+     *          Tests Python doc generation: should generate a dummy file for shared_type
+     *          resource, but *not* its import, other_shared_type
+     *     @type array $mapBoolKey
+     *          For testing accessing map fields in samplegen
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function saveBook($name, array $optionalArgs = [])
+    {
+        $request = new Book();
+        $request->setName($name);
+        if (isset($optionalArgs['author'])) {
+            $request->setAuthor($optionalArgs['author']);
+        }
+        if (isset($optionalArgs['title'])) {
+            $request->setTitle($optionalArgs['title']);
+        }
+        if (isset($optionalArgs['read'])) {
+            $request->setRead($optionalArgs['read']);
+        }
+        if (isset($optionalArgs['rating'])) {
+            $request->setRating($optionalArgs['rating']);
+        }
+        if (isset($optionalArgs['anyValue'])) {
+            $request->setAnyValue($optionalArgs['anyValue']);
+        }
+        if (isset($optionalArgs['structValue'])) {
+            $request->setStructValue($optionalArgs['structValue']);
+        }
+        if (isset($optionalArgs['valueValue'])) {
+            $request->setValueValue($optionalArgs['valueValue']);
+        }
+        if (isset($optionalArgs['listValueValue'])) {
+            $request->setListValueValue($optionalArgs['listValueValue']);
+        }
+        if (isset($optionalArgs['mapListValueValue'])) {
+            $request->setMapListValueValue($optionalArgs['mapListValueValue']);
+        }
+        if (isset($optionalArgs['timeValue'])) {
+            $request->setTimeValue($optionalArgs['timeValue']);
+        }
+        if (isset($optionalArgs['durationValue'])) {
+            $request->setDurationValue($optionalArgs['durationValue']);
+        }
+        if (isset($optionalArgs['fieldMaskValue'])) {
+            $request->setFieldMaskValue($optionalArgs['fieldMaskValue']);
+        }
+        if (isset($optionalArgs['int32Value'])) {
+            $request->setInt32Value($optionalArgs['int32Value']);
+        }
+        if (isset($optionalArgs['uint32Value'])) {
+            $request->setUint32Value($optionalArgs['uint32Value']);
+        }
+        if (isset($optionalArgs['int64Value'])) {
+            $request->setInt64Value($optionalArgs['int64Value']);
+        }
+        if (isset($optionalArgs['uint64Value'])) {
+            $request->setUint64Value($optionalArgs['uint64Value']);
+        }
+        if (isset($optionalArgs['floatValue'])) {
+            $request->setFloatValue($optionalArgs['floatValue']);
+        }
+        if (isset($optionalArgs['doubleValue'])) {
+            $request->setDoubleValue($optionalArgs['doubleValue']);
+        }
+        if (isset($optionalArgs['stringValue'])) {
+            $request->setStringValue($optionalArgs['stringValue']);
+        }
+        if (isset($optionalArgs['boolValue'])) {
+            $request->setBoolValue($optionalArgs['boolValue']);
+        }
+        if (isset($optionalArgs['bytesValue'])) {
+            $request->setBytesValue($optionalArgs['bytesValue']);
+        }
+        if (isset($optionalArgs['mapStringValue'])) {
+            $request->setMapStringValue($optionalArgs['mapStringValue']);
+        }
+        if (isset($optionalArgs['mapMessageValue'])) {
+            $request->setMapMessageValue($optionalArgs['mapMessageValue']);
+        }
+        if (isset($optionalArgs['resource'])) {
+            $request->setResource($optionalArgs['resource']);
+        }
+        if (isset($optionalArgs['mapBoolKey'])) {
+            $request->setMapBoolKey($optionalArgs['mapBoolKey']);
+        }
+
+        return $this->startCall(
+            'SaveBook',
+            GPBEmpty::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
      * This method is not exposed in the GAPIC config. It should be generated.
      *
      * Sample code:
@@ -5751,6 +5919,11 @@ class MyProtoClient extends MyProtoGapicClient
         "StreamingArchiveBooks": {
           "timeout_millis": 60000
         },
+        "SaveBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "retry_policy_1_codes",
+          "retry_params_name": "retry_policy_1_params"
+        },
         "PrivateListShelves": {
           "timeout_millis": 60000,
           "retry_codes_name": "retry_policy_1_codes",
@@ -6153,6 +6326,11 @@ return [
                         ],
                     ],
                 ]
+            ],
+            'SaveBook' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1:saveBook',
+                'body' => '*',
             ],
             'PrivateListShelves' => [
                 'method' => 'get',
@@ -9396,6 +9574,76 @@ class LibraryServiceClientTest extends GeneratedTest
             // If the close stream method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         }  catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function saveBookTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $expectedResponse = new GPBEmpty();
+        $transport->addResponse($expectedResponse);
+
+        // Mock request
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+
+        $client->saveBook($formattedName);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/SaveBook', $actualFuncCall);
+
+        $actualValue = $actualRequestObject->getName();
+
+        $this->assertProtobufEquals($formattedName, $actualValue);
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function saveBookExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        // Mock request
+        $formattedName = $client->bookName('[SHELF]', '[BOOK]');
+
+        try {
+            $client->saveBook($formattedName);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -1089,6 +1089,7 @@ from google.cloud.example.library_v1.proto import book_from_anywhere_pb2
 from google.cloud.example.library_v1.proto import field_mask_pb2 as proto_field_mask_pb2
 from google.cloud.example.library_v1.proto import library_pb2
 from google.cloud.example.library_v1.proto import library_pb2_grpc
+from google.cloud.example.library_v1.proto import shared_type_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2_grpc
 from google.longrunning import operations_pb2
@@ -4260,6 +4261,184 @@ class LibraryServiceClient(object):
 
         return self._inner_api_calls['streaming_archive_books'](requests, retry=retry, timeout=timeout, metadata=metadata)
 
+    def save_book(
+            self,
+            name,
+            author=None,
+            title=None,
+            read=None,
+            rating=None,
+            any_value=None,
+            struct_value=None,
+            value_value=None,
+            list_value_value=None,
+            map_list_value_value=None,
+            time_value=None,
+            duration_value=None,
+            field_mask_value=None,
+            int32_value=None,
+            uint32_value=None,
+            int64_value=None,
+            uint64_value=None,
+            float_value=None,
+            double_value=None,
+            string_value=None,
+            bool_value=None,
+            bytes_value=None,
+            map_string_value=None,
+            map_message_value=None,
+            resource=None,
+            map_bool_key=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+        Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        New APIs should always create a separate message for a request.
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> name = client.book_path('[SHELF]', '[BOOK]')
+            >>>
+            >>> client.save_book(name)
+
+        Args:
+            name (str): The resource name of the book.
+                Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+                Message field comment may include special characters: <>&"`'@.
+            author (str): The name of the book author.
+            title (str): The title of the book.
+            read (bool): Value indicating whether the book has been read.
+            rating (~google.cloud.example.library_v1.types.Rating): For testing enums.
+            any_value (Union[dict, ~google.cloud.example.library_v1.types.Any]): For testing all well-known types.
+
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Any`
+            struct_value (Union[dict, ~google.cloud.example.library_v1.types.Struct]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Struct`
+            value_value (Union[dict, ~google.cloud.example.library_v1.types.Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Value`
+            list_value_value (Union[dict, ~google.cloud.example.library_v1.types.ListValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.ListValue`
+            map_list_value_value (dict[str -> Union[dict, ~google.cloud.example.library_v1.types.ListValue]]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.ListValue`
+            time_value (Union[dict, ~google.cloud.example.library_v1.types.Timestamp]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Timestamp`
+            duration_value (Union[dict, ~google.cloud.example.library_v1.types.Duration]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Duration`
+            field_mask_value (Union[dict, ~google.cloud.example.library_v1.types.FieldMask]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.FieldMask`
+            int32_value (Union[dict, ~google.cloud.example.library_v1.types.Int32Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Int32Value`
+            uint32_value (Union[dict, ~google.cloud.example.library_v1.types.UInt32Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.UInt32Value`
+            int64_value (Union[dict, ~google.cloud.example.library_v1.types.Int64Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Int64Value`
+            uint64_value (Union[dict, ~google.cloud.example.library_v1.types.UInt64Value]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.UInt64Value`
+            float_value (Union[dict, ~google.cloud.example.library_v1.types.FloatValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.FloatValue`
+            double_value (Union[dict, ~google.cloud.example.library_v1.types.DoubleValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.DoubleValue`
+            string_value (Union[dict, ~google.cloud.example.library_v1.types.StringValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.StringValue`
+            bool_value (Union[dict, ~google.cloud.example.library_v1.types.BoolValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.BoolValue`
+            bytes_value (Union[dict, ~google.cloud.example.library_v1.types.BytesValue]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.BytesValue`
+            map_string_value (dict[int -> str]): Test doc generation of lists:
+
+                +   Here is a sentence about the first element of the list that continues
+                    into a second line.
+                +   The second element of the list.
+                +   Another element of the list where the indentation isn't consistent
+                after a blank space.
+
+                    The second paragraph of the list
+                that doesn't have a hanging indent.
+            map_message_value (dict[str -> Union[dict, ~google.cloud.example.library_v1.types.SomeMessage]]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.SomeMessage`
+            resource (Union[dict, ~google.cloud.example.library_v1.types.Used]): Tests Python doc generation: should generate a dummy file for shared_type
+                resource, but *not* its import, other_shared_type
+
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Used`
+            map_bool_key (dict[bool -> str]): For testing accessing map fields in samplegen
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'save_book' not in self._inner_api_calls:
+            self._inner_api_calls['save_book'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.save_book,
+                default_retry=self._method_configs['SaveBook'].retry,
+                default_timeout=self._method_configs['SaveBook'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.Book(
+            name=name,
+            author=author,
+            title=title,
+            read=read,
+            rating=rating,
+            any_value=any_value,
+            struct_value=struct_value,
+            value_value=value_value,
+            list_value_value=list_value_value,
+            map_list_value_value=map_list_value_value,
+            time_value=time_value,
+            duration_value=duration_value,
+            field_mask_value=field_mask_value,
+            int32_value=int32_value,
+            uint32_value=uint32_value,
+            int64_value=int64_value,
+            uint64_value=uint64_value,
+            float_value=float_value,
+            double_value=double_value,
+            string_value=string_value,
+            bool_value=bool_value,
+            bytes_value=bytes_value,
+            map_string_value=map_string_value,
+            map_message_value=map_message_value,
+            resource=resource,
+            map_bool_key=map_bool_key,
+        )
+        self._inner_api_calls['save_book'](request, retry=retry, timeout=timeout, metadata=metadata)
+
     def private_list_shelves(
             self,
             page_token=None,
@@ -4509,6 +4688,11 @@ config = {
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "SaveBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "PrivateListShelves": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -4558,6 +4742,7 @@ from google.cloud.example.library_v1.proto import book_from_anywhere_pb2
 from google.cloud.example.library_v1.proto import field_mask_pb2 as proto_field_mask_pb2
 from google.cloud.example.library_v1.proto import library_pb2
 from google.cloud.example.library_v1.proto import library_pb2_grpc
+from google.cloud.example.library_v1.proto import shared_type_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2
 from google.cloud.example.library_v1.proto import tagger_pb2_grpc
 from google.longrunning import operations_pb2
@@ -5345,6 +5530,20 @@ class LibraryServiceGrpcTransport(object):
                 deserialized response object.
         """
         return self._stubs['library_service_stub'].StreamingArchiveBooks
+
+    @property
+    def save_book(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.save_book`.
+
+        Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+        New APIs should always create a separate message for a request.
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].SaveBook
 
     @property
     def private_list_shelves(self):
@@ -8753,6 +8952,37 @@ class TestLibraryServiceClient(object):
 
         with pytest.raises(CustomException):
             client.streaming_archive_books(requests)
+
+    def test_save_book(self):
+        channel = ChannelStub()
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        # Setup Request
+        name = client.book_path('[SHELF]', '[BOOK]')
+
+        client.save_book(name)
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.Book(name=name)
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_save_book_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        # Setup request
+        name = client.book_path('[SHELF]', '[BOOK]')
+
+        with pytest.raises(CustomException):
+            client.save_book(name)
 
     def test_private_list_shelves(self):
         # Setup Expected Response

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -3539,6 +3539,11 @@ module Library
           defaults["streaming_archive_books"],
           exception_transformer: exception_transformer
         )
+        @save_book = Google::Gax.create_api_call(
+          @library_service_stub.method(:save_book),
+          defaults["save_book"],
+          exception_transformer: exception_transformer
+        )
         @private_list_shelves = Google::Gax.create_api_call(
           @library_service_stub.method(:private_list_shelves),
           defaults["private_list_shelves"],
@@ -5538,6 +5543,170 @@ module Library
         @streaming_archive_books.call(request_protos, options)
       end
 
+      # Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+      # New APIs should always create a separate message for a request.
+      #
+      # @param name [String]
+      #   The resource name of the book.
+      #   Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+      #   Message field comment may include special characters: <>&"`'@.
+      # @param author [String]
+      #   The name of the book author.
+      # @param title [String]
+      #   The title of the book.
+      # @param read [true, false]
+      #   Value indicating whether the book has been read.
+      # @param rating [Google::Example::Library::V1::Book::Rating]
+      #   For testing enums.
+      # @param any_value [Google::Protobuf::Any | Hash]
+      #   For testing all well-known types.
+      #   A hash of the same form as `Google::Protobuf::Any`
+      #   can also be provided.
+      # @param struct_value [Google::Protobuf::Struct | Hash]
+      #   A hash of the same form as `Google::Protobuf::Struct`
+      #   can also be provided.
+      # @param value_value [Google::Protobuf::Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Value`
+      #   can also be provided.
+      # @param list_value_value [Google::Protobuf::ListValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::ListValue`
+      #   can also be provided.
+      # @param map_list_value_value [Hash{String => Google::Protobuf::ListValue | Hash}]
+      #   A hash of the same form as `Google::Protobuf::ListValue`
+      #   can also be provided.
+      # @param time_value [Google::Protobuf::Timestamp | Hash]
+      #   A hash of the same form as `Google::Protobuf::Timestamp`
+      #   can also be provided.
+      # @param duration_value [Google::Protobuf::Duration | Hash]
+      #   A hash of the same form as `Google::Protobuf::Duration`
+      #   can also be provided.
+      # @param field_mask_value [Google::Protobuf::FieldMask | Hash]
+      #   A hash of the same form as `Google::Protobuf::FieldMask`
+      #   can also be provided.
+      # @param int32_value [Google::Protobuf::Int32Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Int32Value`
+      #   can also be provided.
+      # @param uint32_value [Google::Protobuf::UInt32Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::UInt32Value`
+      #   can also be provided.
+      # @param int64_value [Google::Protobuf::Int64Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Int64Value`
+      #   can also be provided.
+      # @param uint64_value [Google::Protobuf::UInt64Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::UInt64Value`
+      #   can also be provided.
+      # @param float_value [Google::Protobuf::FloatValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::FloatValue`
+      #   can also be provided.
+      # @param double_value [Google::Protobuf::DoubleValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::DoubleValue`
+      #   can also be provided.
+      # @param string_value [Google::Protobuf::StringValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::StringValue`
+      #   can also be provided.
+      # @param bool_value [Google::Protobuf::BoolValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::BoolValue`
+      #   can also be provided.
+      # @param bytes_value [Google::Protobuf::BytesValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::BytesValue`
+      #   can also be provided.
+      # @param map_string_value [Hash{Integer => String}]
+      #   Test doc generation of lists:
+      #
+      #   * Here is a sentence about the first element of the list that continues
+      #     into a second line.
+      #   * The second element of the list.
+      #   * Another element of the list where the indentation isn't consistent
+      #     after a blank space.
+      #
+      #     The second paragraph of the list
+      #     that doesn't have a hanging indent.
+      # @param map_message_value [Hash{String => Google::Example::Library::V1::SomeMessage | Hash}]
+      #   A hash of the same form as `Google::Example::Library::V1::SomeMessage`
+      #   can also be provided.
+      # @param resource [Google::Test::Shared::Data::Used | Hash]
+      #   Tests Python doc generation: should generate a dummy file for shared_type
+      #   resource, but *not* its import, other_shared_type
+      #   A hash of the same form as `Google::Test::Shared::Data::Used`
+      #   can also be provided.
+      # @param map_bool_key [Hash{true, false => String}]
+      #   For testing accessing map fields in samplegen
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result []
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      #   library_client.save_book(formatted_name)
+
+      def save_book \
+          name,
+          author: nil,
+          title: nil,
+          read: nil,
+          rating: nil,
+          any_value: nil,
+          struct_value: nil,
+          value_value: nil,
+          list_value_value: nil,
+          map_list_value_value: nil,
+          time_value: nil,
+          duration_value: nil,
+          field_mask_value: nil,
+          int32_value: nil,
+          uint32_value: nil,
+          int64_value: nil,
+          uint64_value: nil,
+          float_value: nil,
+          double_value: nil,
+          string_value: nil,
+          bool_value: nil,
+          bytes_value: nil,
+          map_string_value: nil,
+          map_message_value: nil,
+          resource: nil,
+          map_bool_key: nil,
+          options: nil,
+          &block
+        req = {
+          name: name,
+          author: author,
+          title: title,
+          read: read,
+          rating: rating,
+          any_value: any_value,
+          struct_value: struct_value,
+          value_value: value_value,
+          list_value_value: list_value_value,
+          map_list_value_value: map_list_value_value,
+          time_value: time_value,
+          duration_value: duration_value,
+          field_mask_value: field_mask_value,
+          int32_value: int32_value,
+          uint32_value: uint32_value,
+          int64_value: int64_value,
+          uint64_value: uint64_value,
+          float_value: float_value,
+          double_value: double_value,
+          string_value: string_value,
+          bool_value: bool_value,
+          bytes_value: bytes_value,
+          map_string_value: map_string_value,
+          map_message_value: map_message_value,
+          resource: resource,
+          map_bool_key: map_bool_key
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::Book)
+        @save_book.call(req, options, &block)
+        nil
+      end
+
       # This method is not exposed in the GAPIC config. It should be generated.
       #
       # @param page_token [String]
@@ -5764,6 +5933,11 @@ end
           "retry_params_name": "default"
         },
         "StreamingArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "SaveBook": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -10728,6 +10902,75 @@ describe Library::V1::LibraryServiceClient do
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.streaming_archive_books([request])
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'save_book' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#save_book."
+
+    it 'invokes save_book without error' do
+      # Create request parameters
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::Book, request)
+        assert_equal(formatted_name, request.name)
+        OpenStruct.new(execute: nil)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:save_book, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("save_book")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.save_book(formatted_name)
+
+          # Verify the response
+          assert_nil(response)
+
+          # Call method with block
+          client.save_book(formatted_name) do |response, operation|
+            # Verify the response
+            assert_nil(response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes save_book with error' do
+      # Create request parameters
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::Book, request)
+        assert_equal(formatted_name, request.name)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:save_book, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("save_book")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.save_book(formatted_name)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -3321,6 +3321,11 @@ module Library
           defaults["streaming_archive_books"],
           exception_transformer: exception_transformer
         )
+        @save_book = Google::Gax.create_api_call(
+          @library_service_stub.method(:save_book),
+          defaults["save_book"],
+          exception_transformer: exception_transformer
+        )
         @test_optional_required_flattening_params = Google::Gax.create_api_call(
           @library_service_stub.method(:test_optional_required_flattening_params),
           defaults["test_optional_required_flattening_params"],
@@ -4638,6 +4643,172 @@ module Library
         @streaming_archive_books.call(request_protos, options)
       end
 
+      # Test use resource message as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+      # New APIs should always create a separate message for a request.
+      #
+      # @param name [String]
+      #   The resource name of the book.
+      #   Book names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+      #   Message field comment may include special characters: <>&"`'@.
+      # @param author [String]
+      #   The name of the book author.
+      # @param title [String]
+      #   The title of the book.
+      # @param read [true, false]
+      #   Value indicating whether the book has been read.
+      # @param rating [Google::Example::Library::V1::Book::Rating]
+      #   For testing enums.
+      # @param any_value [Google::Protobuf::Any | Hash]
+      #   For testing all well-known types.
+      #   A hash of the same form as `Google::Protobuf::Any`
+      #   can also be provided.
+      # @param struct_value [Google::Protobuf::Struct | Hash]
+      #   A hash of the same form as `Google::Protobuf::Struct`
+      #   can also be provided.
+      # @param value_value [Google::Protobuf::Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Value`
+      #   can also be provided.
+      # @param list_value_value [Google::Protobuf::ListValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::ListValue`
+      #   can also be provided.
+      # @param map_list_value_value [Hash{String => Google::Protobuf::ListValue | Hash}]
+      #   A hash of the same form as `Google::Protobuf::ListValue`
+      #   can also be provided.
+      # @param time_value [Google::Protobuf::Timestamp | Hash]
+      #   A hash of the same form as `Google::Protobuf::Timestamp`
+      #   can also be provided.
+      # @param duration_value [Google::Protobuf::Duration | Hash]
+      #   A hash of the same form as `Google::Protobuf::Duration`
+      #   can also be provided.
+      # @param field_mask_value [Google::Protobuf::FieldMask | Hash]
+      #   A hash of the same form as `Google::Protobuf::FieldMask`
+      #   can also be provided.
+      # @param int32_value [Google::Protobuf::Int32Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Int32Value`
+      #   can also be provided.
+      # @param uint32_value [Google::Protobuf::UInt32Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::UInt32Value`
+      #   can also be provided.
+      # @param int64_value [Google::Protobuf::Int64Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::Int64Value`
+      #   can also be provided.
+      # @param uint64_value [Google::Protobuf::UInt64Value | Hash]
+      #   A hash of the same form as `Google::Protobuf::UInt64Value`
+      #   can also be provided.
+      # @param float_value [Google::Protobuf::FloatValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::FloatValue`
+      #   can also be provided.
+      # @param double_value [Google::Protobuf::DoubleValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::DoubleValue`
+      #   can also be provided.
+      # @param string_value [Google::Protobuf::StringValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::StringValue`
+      #   can also be provided.
+      # @param bool_value [Google::Protobuf::BoolValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::BoolValue`
+      #   can also be provided.
+      # @param bytes_value [Google::Protobuf::BytesValue | Hash]
+      #   A hash of the same form as `Google::Protobuf::BytesValue`
+      #   can also be provided.
+      # @param map_string_value [Hash{Integer => String}]
+      #   Test doc generation of lists:
+      #
+      #   * Here is a sentence about the first element of the list that continues
+      #     into a second line.
+      #   * The second element of the list.
+      #   * Another element of the list where the indentation isn't consistent
+      #     after a blank space.
+      #
+      #     The second paragraph of the list
+      #     that doesn't have a hanging indent.
+      # @param map_message_value [Hash{String => Google::Example::Library::V1::SomeMessage | Hash}]
+      #   A hash of the same form as `Google::Example::Library::V1::SomeMessage`
+      #   can also be provided.
+      # @param resource [Google::Test::Shared::Data::Used | Hash]
+      #   Tests Python doc generation: should generate a dummy file for shared_type
+      #   resource, but *not* its import, other_shared_type
+      #   A hash of the same form as `Google::Test::Shared::Data::Used`
+      #   can also be provided.
+      # @param map_bool_key [Hash{true, false => String}]
+      #   For testing accessing map fields in samplegen
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result []
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #
+      #   # TODO: Initialize `name`:
+      #   name = ''
+      #   library_client.save_book(name)
+
+      def save_book \
+          name,
+          author: nil,
+          title: nil,
+          read: nil,
+          rating: nil,
+          any_value: nil,
+          struct_value: nil,
+          value_value: nil,
+          list_value_value: nil,
+          map_list_value_value: nil,
+          time_value: nil,
+          duration_value: nil,
+          field_mask_value: nil,
+          int32_value: nil,
+          uint32_value: nil,
+          int64_value: nil,
+          uint64_value: nil,
+          float_value: nil,
+          double_value: nil,
+          string_value: nil,
+          bool_value: nil,
+          bytes_value: nil,
+          map_string_value: nil,
+          map_message_value: nil,
+          resource: nil,
+          map_bool_key: nil,
+          options: nil,
+          &block
+        req = {
+          name: name,
+          author: author,
+          title: title,
+          read: read,
+          rating: rating,
+          any_value: any_value,
+          struct_value: struct_value,
+          value_value: value_value,
+          list_value_value: list_value_value,
+          map_list_value_value: map_list_value_value,
+          time_value: time_value,
+          duration_value: duration_value,
+          field_mask_value: field_mask_value,
+          int32_value: int32_value,
+          uint32_value: uint32_value,
+          int64_value: int64_value,
+          uint64_value: uint64_value,
+          float_value: float_value,
+          double_value: double_value,
+          string_value: string_value,
+          bool_value: bool_value,
+          bytes_value: bytes_value,
+          map_string_value: map_string_value,
+          map_message_value: map_message_value,
+          resource: resource,
+          map_bool_key: map_bool_key
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::Book)
+        @save_book.call(req, options, &block)
+        nil
+      end
+
       # Test optional flattening parameters of all types
       #
       # @param required_singular_int32 [Integer]
@@ -5557,6 +5728,11 @@ end
           "retry_params_name": "default"
         },
         "StreamingArchiveBooks": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "SaveBook": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -8411,6 +8587,75 @@ describe Library::V1::LibraryServiceClient do
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
             client.streaming_archive_books([request])
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'save_book' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#save_book."
+
+    it 'invokes save_book without error' do
+      # Create request parameters
+      name = ''
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::Book, request)
+        assert_equal(name, request.name)
+        OpenStruct.new(execute: nil)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:save_book, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("save_book")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.save_book(name)
+
+          # Verify the response
+          assert_nil(response)
+
+          # Call method with block
+          client.save_book(name) do |response, operation|
+            # Verify the response
+            assert_nil(response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes save_book with error' do
+      # Create request parameters
+      name = ''
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::Book, request)
+        assert_equal(name, request.name)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:save_book, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("save_book")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.save_book(name)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/testsrc/common/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/library.proto
@@ -283,6 +283,13 @@ service LibraryService {
     option (google.api.method_signature) = "source,archive";
   }
 
+  // Test using resource messages as request objects. Only used by PubSub (CreateSubscription) for historical reasons.
+  // New APIs should always create a separate message for a request.
+  rpc SaveBook(Book) returns (google.protobuf.Empty) {
+    option (google.api.http) = { post: "/v1:saveBook" body: "*"};
+    option (google.api.method_signature) = "name,author,title,rating";
+  }
+
   // Test optional flattening parameters of all types
   rpc TestOptionalRequiredFlatteningParams(TestOptionalRequiredFlatteningParamsRequest) returns (TestOptionalRequiredFlatteningParamsResponse) {
     option (google.api.http) = { post: "/v1/testofp" body: "*" };


### PR DESCRIPTION
We generate flattening overload methods where resource name strings are replaced by resource name types. Previously we only check `resource_reference` to see if a field is a resource name, this is not enough as the field `name` in a resource message is also a resource name field, but does not have `resource_reference` annotation.

I found this while generating the method [CreateSubscription](https://github.com/googleapis/googleapis/blob/638253bf86d1ce1c314108a089b7351440c2f0bf/google/pubsub/v1/pubsub.proto#L375) for PubSub. The pattern is strongly discouraged for new APIs; but we can't break PubSub.

