### PR TITLE
fix: do not use fixed resource names in samples if possible

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -1008,6 +1008,7 @@ public class InitCodeTransformer {
         oneofConfig
             .getPatterns()
             .stream()
+            .filter(p -> !p.getBindingVariables().isEmpty())
             .filter(p -> p.getBindingVariables().equals(bindingValues))
             .findAny();
     return pattern.isPresent() ? pattern.get() : oneofConfig.getPatterns().get(0);


### PR DESCRIPTION
If a multi-pattern resource includes a fixed pattern, do not use the fixed pattern in samples if there are other resource names, they are usually not the most common ways users use the resource name.

I apologize that It's hard to demonstrate this change in the baseline but see the difference here: [before](https://github.com/hzyi-google/multi-pattern-resource-names/pull/7/commits/2cd18ecb7b684aad9be3bd897649de618d9df796#diff-238d68631bd551c6928226ac576623b9R84) and [after](https://github.com/hzyi-google/multi-pattern-resource-names/pull/7/files#diff-238d68631bd551c6928226ac576623b9R84).