### PR TITLE
bazel: Update `gapic_assembly_pkg` rules surface

### DIFF
--- a/rules_gapic/csharp/csharp_gapic_pkg.bzl
+++ b/rules_gapic/csharp/csharp_gapic_pkg.bzl
@@ -74,11 +74,14 @@ _csharp_gapic_src_pkg = rule(
     implementation = _csharp_gapic_src_pkg_impl,
 )
 
-def csharp_gapic_assembly_pkg(name, deps, **kwargs):
+def csharp_gapic_assembly_pkg(name, deps, assembly_name = None, **kwargs):
+    package_dir = name
+    if assembly_name:
+        package_dir = "google-cloud-%s-%s" % (assembly_name, name)
     _csharp_gapic_src_pkg(
         name = name,
         deps = deps,
-        package_dir = name,
+        package_dir = package_dir,
         **kwargs
     )
 

--- a/rules_gapic/go/go_gapic_pkg.bzl
+++ b/rules_gapic/go/go_gapic_pkg.bzl
@@ -79,9 +79,12 @@ _go_gapic_src_pkg = rule(
     implementation = _go_gapic_src_pkg_impl,
 )
 
-def go_gapic_assembly_pkg(name, deps):
+def go_gapic_assembly_pkg(name, deps, assembly_name = None):
+    package_dir = name
+    if assembly_name:
+        package_dir = "gapi-cloud-%s-%s" % (assembly_name, name)
     _go_gapic_src_pkg(
         name = name,
         deps = deps,
-        package_dir = name,
+        package_dir = package_dir,
     )

--- a/rules_gapic/java/java_gapic_pkg.bzl
+++ b/rules_gapic/java/java_gapic_pkg.bzl
@@ -158,12 +158,16 @@ java_gapic_srcs_pkg = rule(
 def java_gapic_assembly_gradle_pkg(
         name,
         deps,
+        assembly_name = None,
         **kwargs):
-    proto_target = "proto-%s" % name
+    package_dir = name
+    if assembly_name:
+        package_dir = "google-cloud-%s-%s" % (assembly_name, name)
+    proto_target = "proto-%s" % package_dir
     proto_target_dep = []
-    grpc_target = "grpc-%s" % name
+    grpc_target = "grpc-%s" % package_dir
     grpc_target_dep = []
-    client_target = "gapic-%s" % name
+    client_target = "gapic-%s" % package_dir
     client_target_dep = []
 
     client_deps = []
@@ -212,6 +216,7 @@ def java_gapic_assembly_gradle_pkg(
 
     _java_gapic_assembly_gradle_pkg(
         name = name,
+        assembly_name = package_dir,
         deps = proto_target_dep + grpc_target_dep + client_target_dep,
     )
 
@@ -258,8 +263,8 @@ def _java_gapic_gradle_pkg(
         **kwargs
     )
 
-def _java_gapic_assembly_gradle_pkg(name, deps, visibility = None):
-    resource_target_name = "%s-resources" % name
+def _java_gapic_assembly_gradle_pkg(name, assembly_name, deps, visibility = None):
+    resource_target_name = "%s-resources" % assembly_name
     java_gapic_build_configs_pkg(
         name = resource_target_name,
         deps = deps,
@@ -276,7 +281,7 @@ def _java_gapic_assembly_gradle_pkg(name, deps, visibility = None):
             Label("//rules_gapic/java:gradlew"),
             resource_target_name,
         ] + deps,
-        package_dir = name,
+        package_dir = assembly_name,
         visibility = visibility,
     )
 

--- a/rules_gapic/nodejs/nodejs_gapic_pkg.bzl
+++ b/rules_gapic/nodejs/nodejs_gapic_pkg.bzl
@@ -67,9 +67,12 @@ _nodejs_gapic_src_pkg = rule(
     implementation = _nodejs_gapic_src_pkg_impl,
 )
 
-def nodejs_gapic_assembly_pkg(name, deps):
+def nodejs_gapic_assembly_pkg(name, deps, assembly_name = None):
+    package_dir = name
+    if assembly_name:
+        package_dir = "%s-%s" % (assembly_name, name)
     _nodejs_gapic_src_pkg(
         name = name,
         deps = deps,
-        package_dir = name,
+        package_dir = package_dir,
     )

--- a/rules_gapic/php/php_gapic_pkg.bzl
+++ b/rules_gapic/php/php_gapic_pkg.bzl
@@ -65,11 +65,14 @@ _php_gapic_src_pkg = rule(
     implementation = _php_gapic_src_pkg_impl,
 )
 
-def php_gapic_assembly_pkg(name, deps, **kwargs):
+def php_gapic_assembly_pkg(name, deps, assembly_name = None, **kwargs):
+    package_dir = name
+    if assembly_name:
+        package_dir = "google-cloud-%s-%s" % (assembly_name, name)
     _php_gapic_src_pkg(
         name = name,
         deps = deps,
-        package_dir = name,
+        package_dir = package_dir,
         **kwargs
     )
 

--- a/rules_gapic/python/py_gapic_pkg.bzl
+++ b/rules_gapic/python/py_gapic_pkg.bzl
@@ -85,7 +85,7 @@ _py_gapic_src_pkg = rule(
     implementation = _py_gapic_src_pkg_impl,
 )
 
-def py_gapic_assembly_pkg(name, deps, **kwargs):
+def py_gapic_assembly_pkg(name, deps, assembly_name = None, **kwargs):
     actual_deps = []
     processed_deps = {}
     for dep in deps:
@@ -96,10 +96,13 @@ def py_gapic_assembly_pkg(name, deps, **kwargs):
             put_dep_in_a_bucket("%s_srcjar-smoke-test.srcjar" % dep, actual_deps, processed_deps)
             put_dep_in_a_bucket("%s_srcjar-pkg.srcjar" % dep, actual_deps, processed_deps)
 
+    package_dir = name
+    if assembly_name:
+        package_dir = "%s-%s" % (assembly_name, name)
     _py_gapic_src_pkg(
         name = name,
         deps = actual_deps,
-        package_dir = name,
+        package_dir = package_dir,
         **kwargs
     )
 

--- a/rules_gapic/ruby/ruby_gapic_pkg.bzl
+++ b/rules_gapic/ruby/ruby_gapic_pkg.bzl
@@ -68,11 +68,14 @@ _ruby_gapic_src_pkg = rule(
     implementation = _ruby_gapic_src_pkg_impl,
 )
 
-def ruby_gapic_assembly_pkg(name, deps, **kwargs):
+def ruby_gapic_assembly_pkg(name, deps, assembly_name = None, **kwargs):
+    package_dir = name
+    if assembly_name:
+        package_dir = "google-cloud-%s-%s" % (assembly_name, name)
     _ruby_gapic_src_pkg(
         name = name,
         deps = deps,
-        package_dir = name,
+        package_dir = package_dir,
         **kwargs
     )
 


### PR DESCRIPTION
Add `assembly_name` attribute. This allows us to simplify the `name` attribute value and as result simplify and unify command used to generate the final package.

For example
coommand before:
```
bazel build //google/cloud/language/v1:google-cloud-language-v1-csharp
```

command after:
```
bazel build //google/cloud/language/v1:csharp
```
The changes are **backward-compatible**