### PR TITLE
fix: de-duplicate deprecated_collections when constructing gapic product config

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -254,6 +254,7 @@ public abstract class GapicProductConfig implements ProductConfig {
               .getInterfacesList()
               .stream()
               .flatMap(i -> i.getDeprecatedCollectionsList().stream())
+              .distinct()
               .collect(
                   ImmutableMap.toImmutableMap(
                       DeprecatedCollectionConfigProto::getNamePattern, c -> c));


### PR DESCRIPTION
Multi-interface APIs may use the same resource pattern in different interfaces. Without the `distinct()` filter, `toImmutableMap` errors when trying to add two identical keys into the map.

Example: Talent API ([CompanyService](https://github.com/googleapis/google-cloud-php/blob/83b70734ae17ca680b5b6e14f881d182da28bd9d/Talent/src/V4beta1/Gapic/CompanyServiceGapicClient.php#L128), [Completion](https://github.com/googleapis/google-cloud-php/blob/83b70734ae17ca680b5b6e14f881d182da28bd9d/Talent/src/V4beta1/Gapic/CompletionGapicClient.php#L124))