### PR TITLE
Assign the proto file where the interface is defined when generating samples and tests for arbitrary resource names

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -18,9 +18,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.api.codegen.config.FieldConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodContext;
-import com.google.api.codegen.config.MethodModel;
-import com.google.api.codegen.config.ProtoMethodModel;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.config.ProtoTypeRef;
 import com.google.api.codegen.config.ResourceNameConfig;
 import com.google.api.codegen.config.ResourceNameOneofConfig;
@@ -781,9 +781,9 @@ public class InitCodeTransformer {
       case ANY:
         singleResourceNameConfig =
             Iterables.get(context.getProductConfig().getSingleResourceNameConfigs(), 0);
-        MethodModel methodModel = context.getMethodModel();
-        if (methodModel instanceof ProtoMethodModel) {
-          ProtoFile protoFile = ((ProtoMethodModel) methodModel).getProtoMethod().getFile();
+        InterfaceModel interfaceModel = context.getInterfaceModel();
+        if (interfaceModel instanceof ProtoInterfaceModel) {
+          ProtoFile protoFile = ((ProtoInterfaceModel) interfaceModel).getInterface().getFile();
           singleResourceNameConfig =
               singleResourceNameConfig.toBuilder().setAssignedProtoFile(protoFile).build();
         }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -16556,7 +16556,6 @@ namespace Google.Example.Library.V1
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource which the label is being added to.
-        /// In the form "shelves/{shelf_id}/books/{book_id}".
         /// </param>
         /// <param name="label">
         /// REQUIRED: The label to add.
@@ -16583,7 +16582,6 @@ namespace Google.Example.Library.V1
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource which the label is being added to.
-        /// In the form "shelves/{shelf_id}/books/{book_id}".
         /// </param>
         /// <param name="label">
         /// REQUIRED: The label to add.
@@ -16607,7 +16605,6 @@ namespace Google.Example.Library.V1
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource which the label is being added to.
-        /// In the form "shelves/{shelf_id}/books/{book_id}".
         /// </param>
         /// <param name="label">
         /// REQUIRED: The label to add.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_samplegen_config_migration_library.baseline
@@ -12953,7 +12953,6 @@ namespace Google.Example.Library.V1
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource which the label is being added to.
-        /// In the form "shelves/{shelf_id}/books/{book_id}".
         /// </param>
         /// <param name="label">
         /// REQUIRED: The label to add.
@@ -12980,7 +12979,6 @@ namespace Google.Example.Library.V1
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource which the label is being added to.
-        /// In the form "shelves/{shelf_id}/books/{book_id}".
         /// </param>
         /// <param name="label">
         /// REQUIRED: The label to add.
@@ -13004,7 +13002,6 @@ namespace Google.Example.Library.V1
         /// </summary>
         /// <param name="resource">
         /// REQUIRED: The resource which the label is being added to.
-        /// In the form "shelves/{shelf_id}/books/{book_id}".
         /// </param>
         /// <param name="label">
         /// REQUIRED: The label to add.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -7008,7 +7008,6 @@ public class LibraryClient implements BackgroundResource {
    * </code></pre>
    *
    * @param resource REQUIRED: The resource which the label is being added to.
-   * In the form "shelves/{shelf_id}/books/{book_id}".
    * @param label REQUIRED: The label to add.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_samplegen_config_migration_library.baseline
@@ -4825,7 +4825,6 @@ public class LibraryClient implements BackgroundResource {
    * </code></pre>
    *
    * @param resource REQUIRED: The resource which the label is being added to.
-   * In the form "shelves/{shelf_id}/books/{book_id}".
    * @param label REQUIRED: The label to add.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -7080,7 +7080,6 @@ class LibraryServiceClient {
    *   The request object that will be sent.
    * @param {string} request.resource
    *   REQUIRED: The resource which the label is being added to.
-   *   In the form "shelves/{shelf_id}/books/{book_id}".
    * @param {string} request.label
    *   REQUIRED: The label to add.
    * @param {Object} [options]

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_samplegen_config_migration_library.baseline
@@ -6308,7 +6308,6 @@ class LibraryServiceClient {
    *   The request object that will be sent.
    * @param {string} request.resource
    *   REQUIRED: The resource which the label is being added to.
-   *   In the form "shelves/{shelf_id}/books/{book_id}".
    * @param {string} request.label
    *   REQUIRED: The label to add.
    * @param {Object} [options]

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -4182,7 +4182,6 @@ class LibraryServiceGapicClient
      * ```
      *
      * @param string $resource REQUIRED: The resource which the label is being added to.
-     * In the form "shelves/{shelf_id}/books/{book_id}".
      * @param string $label REQUIRED: The label to add.
      * @param array $optionalArgs {
      *     Optional.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_samplegen_config_migration_library.baseline
@@ -3518,7 +3518,6 @@ class LibraryServiceGapicClient
      * ```
      *
      * @param string $resource REQUIRED: The resource which the label is being added to.
-     * In the form "shelves/{shelf_id}/books/{book_id}".
      * @param string $label REQUIRED: The label to add.
      * @param array $optionalArgs {
      *     Optional.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -3032,7 +3032,6 @@ class LibraryServiceClient(object):
 
         Args:
             resource (str): REQUIRED: The resource which the label is being added to.
-                In the form "shelves/{shelf_id}/books/{book_id}".
             label (str): REQUIRED: The label to add.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_samplegen_config_migration_library.baseline
@@ -3003,7 +3003,6 @@ class LibraryServiceClient(object):
 
         Args:
             resource (str): REQUIRED: The resource which the label is being added to.
-                In the form "shelves/{shelf_id}/books/{book_id}".
             label (str): REQUIRED: The label to add.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -4474,7 +4474,6 @@ module Library
       #
       # @param resource [String]
       #   REQUIRED: The resource which the label is being added to.
-      #   In the form "shelves/{shelf_id}/books/{book_id}".
       # @param label [String]
       #   REQUIRED: The label to add.
       # @param options [Google::Gax::CallOptions]

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_samplegen_config_migration_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_samplegen_config_migration_library.baseline
@@ -4422,7 +4422,6 @@ module Library
       #
       # @param resource [String]
       #   REQUIRED: The resource which the label is being added to.
-      #   In the form "shelves/{shelf_id}/books/{book_id}".
       # @param label [String]
       #   REQUIRED: The label to add.
       # @param options [Google::Gax::CallOptions]

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -6922,7 +6922,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                ResourceAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                ResourceAsResourceName = new ArchiveName("[ARCHIVE]"),
                 Label = "",
             };
             // Make the request
@@ -6939,7 +6939,7 @@ namespace Google.Example.Library.V1.Snippets
             // Initialize request argument(s)
             AddLabelRequest request = new AddLabelRequest
             {
-                ResourceAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF]", "[BOOK]")),
+                ResourceAsResourceName = new ArchiveName("[ARCHIVE]"),
                 Label = "",
             };
             // Make the request

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -4256,10 +4256,10 @@ func TestLabelerAddLabel(t *testing.T) {
 
     mockLabeler.resps = append(mockLabeler.resps[:0], expectedResponse)
 
-    var formattedResource string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var resource string = "resource-341064690"
     var label string = "label102727412"
     var request = &taggerpb.AddLabelRequest{
-        Resource: formattedResource,
+        Resource: resource,
         Label: label,
     }
 
@@ -4287,10 +4287,10 @@ func TestLabelerAddLabelError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLabeler.err = gstatus.Error(errCode, "test error")
 
-    var formattedResource string = fmt.Sprintf("shelves/%s/books/%s", "[SHELF]", "[BOOK]")
+    var resource string = "resource-341064690"
     var label string = "label102727412"
     var request = &taggerpb.AddLabelRequest{
-        Resource: formattedResource,
+        Resource: resource,
         Label: label,
     }
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -7164,7 +7164,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   ResourceName resource = ArchiveName.of("[ARCHIVE]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7189,7 +7189,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   ResourceName resource = ArchiveName.of("[ARCHIVE]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -16448,7 +16448,7 @@ public class LibraryClientTest {
     AddLabelResponse expectedResponse = AddLabelResponse.newBuilder().build();
     mockLabeler.addResponse(expectedResponse);
 
-    BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    ResourceName resource = ArchiveName.of("[ARCHIVE]");
     String label = "label102727412";
     AddLabelRequest request = AddLabelRequest.newBuilder()
       .setResource(resource.toString())
@@ -16463,7 +16463,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     AddLabelRequest actualRequest = (AddLabelRequest)actualRequests.get(0);
 
-    Assert.assertEquals(resource, BookName.parse(actualRequest.getResource()));
+    Assert.assertEquals(Objects.toString(resource), Objects.toString(actualRequest.getResource()));
     Assert.assertEquals(label, actualRequest.getLabel());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -16478,7 +16478,7 @@ public class LibraryClientTest {
     mockLabeler.addException(exception);
 
     try {
-      BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      ResourceName resource = ArchiveName.of("[ARCHIVE]");
       String label = "label102727412";
       AddLabelRequest request = AddLabelRequest.newBuilder()
         .setResource(resource.toString())

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -7164,7 +7164,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   ResourceName resource = ArchiveName.of("[ARCHIVE]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -7189,7 +7189,7 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
-   *   BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+   *   ResourceName resource = ArchiveName.of("[ARCHIVE]");
    *   String label = "";
    *   AddLabelRequest request = AddLabelRequest.newBuilder()
    *     .setResource(resource.toString())
@@ -16452,7 +16452,7 @@ public class LibraryClientTest {
     AddLabelResponse expectedResponse = AddLabelResponse.newBuilder().build();
     mockLabeler.addResponse(expectedResponse);
 
-    BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+    ResourceName resource = ArchiveName.of("[ARCHIVE]");
     String label = "label102727412";
     AddLabelRequest request = AddLabelRequest.newBuilder()
       .setResource(resource.toString())
@@ -16467,7 +16467,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     AddLabelRequest actualRequest = (AddLabelRequest)actualRequests.get(0);
 
-    Assert.assertEquals(resource, BookName.parse(actualRequest.getResource()));
+    Assert.assertEquals(Objects.toString(resource), Objects.toString(actualRequest.getResource()));
     Assert.assertEquals(label, actualRequest.getLabel());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -16482,7 +16482,7 @@ public class LibraryClientTest {
     mockLabeler.addException(exception);
 
     try {
-      BookName resource = BookName.ofShelfBookName("[SHELF]", "[BOOK]");
+      ResourceName resource = ArchiveName.of("[ARCHIVE]");
       String label = "label102727412";
       AddLabelRequest request = AddLabelRequest.newBuilder()
         .setResource(resource.toString())

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -7120,7 +7120,6 @@ class LibraryServiceClient {
    *   The request object that will be sent.
    * @param {string} request.resource
    *   REQUIRED: The resource which the label is being added to.
-   *   In the form "shelves/{shelf_id}/books/{book_id}".
    * @param {string} request.label
    *   REQUIRED: The label to add.
    * @param {Object} [options]
@@ -7142,10 +7141,10 @@ class LibraryServiceClient {
    *   // optional auth parameters.
    * });
    *
-   * const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
+   * const resource = '';
    * const label = '';
    * const request = {
-   *   resource: formattedResource,
+   *   resource: resource,
    *   label: label,
    * };
    * client.addLabel(request)
@@ -10558,10 +10557,10 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
+      const resource = 'resource-341064690';
       const label = 'label102727412';
       const request = {
-        resource: formattedResource,
+        resource: resource,
         label: label,
       };
 
@@ -10588,10 +10587,10 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      const formattedResource = client.bookPath('[SHELF]', '[BOOK]');
+      const resource = 'resource-341064690';
       const label = 'label102727412';
       const request = {
-        resource: formattedResource,
+        resource: resource,
         label: label,
       };
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -4274,16 +4274,15 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedResource = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $resource = '';
      *     $label = '';
-     *     $response = $libraryServiceClient->addLabel($formattedResource, $label);
+     *     $response = $libraryServiceClient->addLabel($resource, $label);
      * } finally {
      *     $libraryServiceClient->close();
      * }
      * ```
      *
      * @param string $resource REQUIRED: The resource which the label is being added to.
-     * In the form "shelves/{shelf_id}/books/{book_id}".
      * @param string $label REQUIRED: The label to add.
      * @param array $optionalArgs {
      *     Optional.
@@ -8531,10 +8530,10 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
+        $resource = 'resource-341064690';
         $label = 'label102727412';
 
-        $response = $client->addLabel($formattedResource, $label);
+        $response = $client->addLabel($resource, $label);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -8544,7 +8543,7 @@ class LibraryServiceClientTest extends GeneratedTest
 
         $actualValue = $actualRequestObject->getResource();
 
-        $this->assertProtobufEquals($formattedResource, $actualValue);
+        $this->assertProtobufEquals($resource, $actualValue);
         $actualValue = $actualRequestObject->getLabel();
 
         $this->assertProtobufEquals($label, $actualValue);
@@ -8575,11 +8574,11 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
+        $resource = 'resource-341064690';
         $label = 'label102727412';
 
         try {
-            $client->addLabel($formattedResource, $label);
+            $client->addLabel($resource, $label);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -4274,16 +4274,15 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $formattedResource = $libraryServiceClient->bookName('[SHELF]', '[BOOK]');
+     *     $resource = '';
      *     $label = '';
-     *     $response = $libraryServiceClient->addLabel($formattedResource, $label);
+     *     $response = $libraryServiceClient->addLabel($resource, $label);
      * } finally {
      *     $libraryServiceClient->close();
      * }
      * ```
      *
      * @param string $resource REQUIRED: The resource which the label is being added to.
-     * In the form "shelves/{shelf_id}/books/{book_id}".
      * @param string $label REQUIRED: The label to add.
      * @param array $optionalArgs {
      *     Optional.
@@ -8556,10 +8555,10 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
 
         // Mock request
-        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
+        $resource = 'resource-341064690';
         $label = 'label102727412';
 
-        $response = $client->addLabel($formattedResource, $label);
+        $response = $client->addLabel($resource, $label);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -8569,7 +8568,7 @@ class LibraryServiceClientTest extends GeneratedTest
 
         $actualValue = $actualRequestObject->getResource();
 
-        $this->assertProtobufEquals($formattedResource, $actualValue);
+        $this->assertProtobufEquals($resource, $actualValue);
         $actualValue = $actualRequestObject->getLabel();
 
         $this->assertProtobufEquals($label, $actualValue);
@@ -8600,11 +8599,11 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
 
         // Mock request
-        $formattedResource = $client->bookName('[SHELF]', '[BOOK]');
+        $resource = 'resource-341064690';
         $label = 'label102727412';
 
         try {
-            $client->addLabel($formattedResource, $label);
+            $client->addLabel($resource, $label);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -3051,7 +3051,8 @@ class LibraryServiceClient(object):
             >>>
             >>> client = library_v1.LibraryServiceClient()
             >>>
-            >>> resource = client.book_path('[SHELF]', '[BOOK]')
+            >>> # TODO: Initialize `resource`:
+            >>> resource = ''
             >>>
             >>> # TODO: Initialize `label`:
             >>> label = ''
@@ -3060,7 +3061,6 @@ class LibraryServiceClient(object):
 
         Args:
             resource (str): REQUIRED: The resource which the label is being added to.
-                In the form "shelves/{shelf_id}/books/{book_id}".
             label (str): REQUIRED: The label to add.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will
@@ -8601,7 +8601,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup Request
-        resource = client.book_path('[SHELF]', '[BOOK]')
+        resource = 'resource-341064690'
         label = 'label102727412'
 
         response = client.add_label(resource, label)
@@ -8621,7 +8621,7 @@ class TestLibraryServiceClient(object):
             client = library_v1.LibraryServiceClient()
 
         # Setup request
-        resource = client.book_path('[SHELF]', '[BOOK]')
+        resource = 'resource-341064690'
         label = 'label102727412'
 
         with pytest.raises(CustomException):

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -4536,7 +4536,6 @@ module Library
       #
       # @param resource [String]
       #   REQUIRED: The resource which the label is being added to.
-      #   In the form "shelves/{shelf_id}/books/{book_id}".
       # @param label [String]
       #   REQUIRED: The label to add.
       # @param options [Google::Gax::CallOptions]
@@ -4551,11 +4550,13 @@ module Library
       #   require "library"
       #
       #   library_client = Library::Library.new(version: :v1)
-      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      #
+      #   # TODO: Initialize `resource`:
+      #   resource = ''
       #
       #   # TODO: Initialize `label`:
       #   label = ''
-      #   response = library_client.add_label(formatted_resource, label)
+      #   response = library_client.add_label(resource, label)
 
       def add_label \
           resource,
@@ -9775,7 +9776,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label without error' do
       # Create request parameters
-      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      resource = ''
       label = ''
 
       # Create expected grpc response
@@ -9785,7 +9786,7 @@ describe Library::V1::LibraryServiceClient do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Tagger::V1::AddLabelRequest, request)
-        assert_equal(formatted_resource, request.resource)
+        assert_equal(resource, request.resource)
         assert_equal(label, request.label)
         OpenStruct.new(execute: expected_response)
       end
@@ -9799,13 +9800,13 @@ describe Library::V1::LibraryServiceClient do
           client = Library::Library.new(version: :v1)
 
           # Call method
-          response = client.add_label(formatted_resource, label)
+          response = client.add_label(resource, label)
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.add_label(formatted_resource, label) do |response, operation|
+          client.add_label(resource, label) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -9816,13 +9817,13 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label with error' do
       # Create request parameters
-      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF]", "[BOOK]")
+      resource = ''
       label = ''
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Tagger::V1::AddLabelRequest, request)
-        assert_equal(formatted_resource, request.resource)
+        assert_equal(resource, request.resource)
         assert_equal(label, request.label)
         raise custom_error
       end
@@ -9837,7 +9838,7 @@ describe Library::V1::LibraryServiceClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.add_label(formatted_resource, label)
+            client.add_label(resource, label)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/testsrc/common/tagger.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/common/tagger.proto
@@ -46,10 +46,9 @@ message AddTagRequest {
 
 message AddLabelRequest {
   // REQUIRED: The resource which the label is being added to.
-  // In the form "shelves/{shelf_id}/books/{book_id}".
   string resource = 1  [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "library.googleapis.com/Book"
+    (google.api.resource_reference).type = "*"
   ];
 
   // REQUIRED: The label to add.


### PR DESCRIPTION
Follow-up of #3027

When picking a `SingleResourceNameConfig` to use to generate samples for `AnyResourceNameConfig`, we need to assign the correct proto file to the `SingleResourceNameConfig` so that we know the correct full classpath of the generated resource name class.

#3027 uses the package where the method is defined, which fixed a common case of IAM methods where request objects are imported from the IAM package.

That did not cover the case for PubSub where the IAM methods are added by `reroute_to_grpc_interface` in gapic config. In this case the method is also defined in IAM package.

This PR change the behavior to assigning the proto file where the interface we are generating is defined, which should cover both cases.

Caught this when trying to generate PubSub from gapic v2. Had the following error:

```
ERROR: /tmpfs/src/piper/google3/third_party/googleapis/google/pubsub/v1/BUILD.bazel:69:1: Building google/pubsub/v1/libpubsub_java_gapic_test.jar (1 source jar) failed (Exit 1)
/com/google/cloud/pubsub/v1/TopicAdminClientTest.java:438: error: cannot find symbol
    ResourceName resource = com.google.iam.v1.ProjectName.of("[PROJECT]");
                                             ^
  symbol:   class ProjectName
  location: package com.google.iam.v1
```