### PR TITLE
feat: take source protos in all sub-packages

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -181,11 +181,13 @@ public abstract class GapicProductConfig implements ProductConfig {
               + "or switch to bazel.");
     }
 
+    // Consider all proto files in the defaultPackage as well as its sub-packages
+    // as source files.
     List<ProtoFile> sourceProtos =
         model
             .getFiles()
             .stream()
-            .filter(f -> f.getProto().getPackage().equals(defaultPackage))
+            .filter(f -> f.getProto().getPackage().startsWith(defaultPackage))
             .collect(Collectors.toList());
 
     if (protoPackage != null && configProto == null) {


### PR DESCRIPTION
Mainly for ads need but may be useful for all APIs in general. All sub-packages of the `package` flag passed to gapic-generator from either artman or bazel will be considered source protos to generate gapics for. This is needed beause ads groups their messages and services into different sub-directories: https://github.com/googleapis/googleapis/tree/master/google/ads/googleads/v3.

We mainly need to know what messages belong to this GAPIC to know what resources we should generate helpers for and are legal to be referenced for now, but enabling generating gapics from multiple packages is useful in general.

Tested with Ads build locally and both generation and tests pass.