### PR TITLE
feat: allow static substitution for group name

### DIFF
--- a/rules_gapic/java/resources/gradle/client.gradle.tmpl
+++ b/rules_gapic/java/resources/gradle/client.gradle.tmpl
@@ -7,7 +7,7 @@ buildscript {
 apply plugin: 'java'
 
 description = 'GAPIC library for {{name}}'
-group = 'com.google.cloud'
+group = '{{group}}'
 version = '0.0.0-SNAPSHOT'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7


### PR DESCRIPTION
The build.gradle file `group = 'com.google.cloud'` does not work for other groups without postprocessing. The approach here is to allow the macro to pass the substitutions dict. Alternatively, I could bring the group name up as an argument to the macro.