### PR TITLE
bazel: go build gen check for cloud in pkg name

### DIFF
--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -94,7 +94,7 @@ class BazelBuildFileView {
     goPkg = goPkg.replaceFirst("cloud\\/", "");
 
     String goImport = "";
-    if (isCloud) {
+    if (isCloud || protoPkg.contains("cloud")) {
       goImport = "cloud.google.com/go/";
       goPkg = goPkg.replaceFirst("v(.+);", "apiv$1;");
     } else {

--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -80,9 +80,9 @@ class BazelBuildFileView {
         "java_gapic_test_deps", joinSetWithIndentationNl(mapJavaGapicTestDeps(actualImports)));
 
     // Construct GAPIC import path & package name based on go_package proto option
+    boolean isCloud = bp.getCloudScope() || protoPkg.contains("cloud");
     String goImport =
-        assembleGoImportPath(
-            bp.getCloudScope(), bp.getProtoPackage(), bp.getLangProtoPackages().get("go"));
+        assembleGoImportPath(isCloud, bp.getProtoPackage(), bp.getLangProtoPackages().get("go"));
 
     tokens.put("go_gapic_importpath", goImport);
     tokens.put("go_gapic_test_importpath", goImport.split(";")[0]);
@@ -94,7 +94,7 @@ class BazelBuildFileView {
     goPkg = goPkg.replaceFirst("cloud\\/", "");
 
     String goImport = "";
-    if (isCloud || protoPkg.contains("cloud")) {
+    if (isCloud) {
       goImport = "cloud.google.com/go/";
       goPkg = goPkg.replaceFirst("v(.+);", "apiv$1;");
     } else {

--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -80,9 +80,9 @@ class BazelBuildFileView {
         "java_gapic_test_deps", joinSetWithIndentationNl(mapJavaGapicTestDeps(actualImports)));
 
     // Construct GAPIC import path & package name based on go_package proto option
+    String protoPkg = bp.getProtoPackage();
     boolean isCloud = bp.getCloudScope() || protoPkg.contains("cloud");
-    String goImport =
-        assembleGoImportPath(isCloud, bp.getProtoPackage(), bp.getLangProtoPackages().get("go"));
+    String goImport = assembleGoImportPath(isCloud, protoPkg, bp.getLangProtoPackages().get("go"));
 
     tokens.put("go_gapic_importpath", goImport);
     tokens.put("go_gapic_test_importpath", goImport.split(";")[0]);


### PR DESCRIPTION
The assumption that Cloud APIs will have the Cloud-specific auth scope was not entirely true. I'm not sure if the API I encountered was incorrect or what, but we can also check for `cloud` in the proto package name. This should give us coverage of APIs that either have the Cloud-specific auth scope or are actually placed in the Cloud uber-package.