### PR TITLE
buildgen: tighten gopkg version regexp

### DIFF
--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -96,7 +96,7 @@ class BazelBuildFileView {
     String goImport = "";
     if (isCloud) {
       goImport = "cloud.google.com/go/";
-      goPkg = goPkg.replaceFirst("\\/v([a-z1-9]+);", "\\/apiv$1;");
+      goPkg = goPkg.replaceFirst("\\/v([a-z0-9]+);", "\\/apiv$1;");
     } else {
       goImport = "google.golang.org/";
       String pkgName = goPkg.split(";")[1];

--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -96,7 +96,7 @@ class BazelBuildFileView {
     String goImport = "";
     if (isCloud) {
       goImport = "cloud.google.com/go/";
-      goPkg = goPkg.replaceFirst("v(.+);", "apiv$1;");
+      goPkg = goPkg.replaceFirst("\\/v([a-z1-9]+);", "\\/apiv$1;");
     } else {
       goImport = "google.golang.org/";
       String pkgName = goPkg.split(";")[1];


### PR DESCRIPTION
The original regexp was naive and didn't account for the presence of a `v` in earlier in the path than the version. For example `bigquery/reservation/v1;reservation` would become `bigquery/reservapiation/v1;reservation`.

Asserting that the matching group starts with `\\/` and restricting the capture group to `a-z0-9` (rather than anything) fixes this.