### PR TITLE
feat: trace up only one level when calculating parent types with singleton resource names 

### DIFF
--- a/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
@@ -271,15 +271,16 @@ public abstract class ResourceDescriptorConfig {
   @VisibleForTesting
   static String getParentPattern(String pattern) {
     List<String> segments = getSegments(pattern);
-    int index = segments.size() - 2;
-    while (index >= 0 && !isVariableBinding(segments.get(index))) {
+    int index = segments.size() - 1;
+    if (isVariableBinding(segments.get(index))) {
+      index -= 2;
+    } else {
       index--;
     }
-    index++;
-    if (index <= 0) {
+    if (index < 0) {
       return "";
     }
-    return String.join("/", segments.subList(0, index));
+    return String.join("/", segments.subList(0, index + 1));
   }
 
   private static Map<String, Boolean> getParentPatternsMap(ResourceDescriptorConfig resource) {

--- a/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
@@ -270,16 +270,19 @@ public abstract class ResourceDescriptorConfig {
 
   @VisibleForTesting
   static String getParentPattern(String pattern) {
+    Preconditions.checkArgument(!pattern.equals(""), "resource pattern can't be an empty string.");
+    if (pattern.equals("*")) {
+      return "*";
+    }
+
     List<String> segments = getSegments(pattern);
     int index = segments.size() - 1;
-    if (index < 0) {
-      return "";
-    }
     if (isVariableBinding(segments.get(index))) {
       index -= 2;
     } else {
       index--;
     }
+
     Preconditions.checkArgument(
         index >= -1, "malformatted pattern, can't calculate parent: %s", pattern);
     return String.join("/", segments.subList(0, index + 1));

--- a/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
@@ -272,14 +272,16 @@ public abstract class ResourceDescriptorConfig {
   static String getParentPattern(String pattern) {
     List<String> segments = getSegments(pattern);
     int index = segments.size() - 1;
+    if (index < 0) {
+      return "";
+    }
     if (isVariableBinding(segments.get(index))) {
       index -= 2;
     } else {
       index--;
     }
-    if (index < 0) {
-      return "";
-    }
+    Preconditions.checkArgument(
+        index >= -1, "malformatted pattern, can't calculate parent: %s", pattern);
     return String.join("/", segments.subList(0, index + 1));
   }
 

--- a/src/test/java/com/google/api/codegen/config/ResourceDescriptorConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceDescriptorConfigTest.java
@@ -100,6 +100,7 @@ public class ResourceDescriptorConfigTest {
     assertThat(ResourceDescriptorConfig.getParentPattern("foos/{foo}/bars/{bar}/bang"))
         .isEqualTo("foos/{foo}/bars/{bar}");
     assertThat(ResourceDescriptorConfig.getParentPattern("foos/{foo}")).isEqualTo("");
+    assertThat(ResourceDescriptorConfig.getParentPattern("*")).isEqualTo("*");
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/config/ResourceDescriptorConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceDescriptorConfigTest.java
@@ -96,7 +96,7 @@ public class ResourceDescriptorConfigTest {
     assertThat(ResourceDescriptorConfig.getParentPattern("foos/{foo}/bars/{bar}"))
         .isEqualTo("foos/{foo}");
     assertThat(ResourceDescriptorConfig.getParentPattern("foos/{foo}/busy/bars/{bar}"))
-        .isEqualTo("foos/{foo}");
+        .isEqualTo("foos/{foo}/busy");
     assertThat(ResourceDescriptorConfig.getParentPattern("foos/{foo}/bars/{bar}/bang"))
         .isEqualTo("foos/{foo}/bars/{bar}");
     assertThat(ResourceDescriptorConfig.getParentPattern("foos/{foo}")).isEqualTo("");

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -7654,6 +7654,68 @@ namespace Google.Example.Library.V1.Snippets
             // End snippet
         }
 
+        /// <summary>Snippet for CreateInventoryAsync</summary>
+        public async Task CreateInventoryAsync()
+        {
+            // Snippet: CreateInventoryAsync(PublisherName,Inventory,CallSettings)
+            // Additional: CreateInventoryAsync(PublisherName,Inventory,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            PublisherName parent = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+            Inventory inventory = new Inventory();
+            // Make the request
+            Inventory response = await libraryServiceClient.CreateInventoryAsync(parent, inventory);
+            // End snippet
+        }
+
+        /// <summary>Snippet for CreateInventory</summary>
+        public void CreateInventory()
+        {
+            // Snippet: CreateInventory(PublisherName,Inventory,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            PublisherName parent = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+            Inventory inventory = new Inventory();
+            // Make the request
+            Inventory response = libraryServiceClient.CreateInventory(parent, inventory);
+            // End snippet
+        }
+
+        /// <summary>Snippet for CreateInventoryAsync</summary>
+        public async Task CreateInventoryAsync_RequestObject()
+        {
+            // Snippet: CreateInventoryAsync(CreateInventoryRequest,CallSettings)
+            // Additional: CreateInventoryAsync(CreateInventoryRequest,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            CreateInventoryRequest request = new CreateInventoryRequest
+            {
+                ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+            };
+            // Make the request
+            Inventory response = await libraryServiceClient.CreateInventoryAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for CreateInventory</summary>
+        public void CreateInventory_RequestObject()
+        {
+            // Snippet: CreateInventory(CreateInventoryRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            CreateInventoryRequest request = new CreateInventoryRequest
+            {
+                ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+            };
+            // Make the request
+            Inventory response = libraryServiceClient.CreateInventory(request);
+            // End snippet
+        }
+
         /// <summary>Snippet for MoveBooksAsync</summary>
         public async Task MoveBooksAsync()
         {
@@ -10835,6 +10897,108 @@ namespace Google.Example.Library.V1.Tests
         }
 
         [Fact]
+        public void CreateInventory()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            CreateInventoryRequest expectedRequest = new CreateInventoryRequest
+            {
+                ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+                Inventory = new Inventory(),
+            };
+            Inventory expectedResponse = new Inventory
+            {
+                InventoryName = new InventoryName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+            };
+            mockGrpcClient.Setup(x => x.CreateInventory(expectedRequest, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            PublisherName parent = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+            Inventory inventory = new Inventory();
+            Inventory response = client.CreateInventory(parent, inventory);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task CreateInventoryAsync()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            CreateInventoryRequest expectedRequest = new CreateInventoryRequest
+            {
+                ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+                Inventory = new Inventory(),
+            };
+            Inventory expectedResponse = new Inventory
+            {
+                InventoryName = new InventoryName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+            };
+            mockGrpcClient.Setup(x => x.CreateInventoryAsync(expectedRequest, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<Inventory>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            PublisherName parent = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+            Inventory inventory = new Inventory();
+            Inventory response = await client.CreateInventoryAsync(parent, inventory);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public void CreateInventory2()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            CreateInventoryRequest request = new CreateInventoryRequest
+            {
+                ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+            };
+            Inventory expectedResponse = new Inventory
+            {
+                InventoryName = new InventoryName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+            };
+            mockGrpcClient.Setup(x => x.CreateInventory(request, It.IsAny<CallOptions>()))
+                .Returns(expectedResponse);
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            Inventory response = client.CreateInventory(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
+        public async Task CreateInventoryAsync2()
+        {
+            Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLabelerClient())
+                .Returns(new Mock<Labeler.LabelerClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateOperationsClient())
+                .Returns(new Mock<Operations.OperationsClient>().Object);
+            CreateInventoryRequest request = new CreateInventoryRequest
+            {
+                ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+            };
+            Inventory expectedResponse = new Inventory
+            {
+                InventoryName = new InventoryName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+            };
+            mockGrpcClient.Setup(x => x.CreateInventoryAsync(request, It.IsAny<CallOptions>()))
+                .Returns(new Grpc.Core.AsyncUnaryCall<Inventory>(Task.FromResult(expectedResponse), null, null, null, null));
+            LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
+            Inventory response = await client.CreateInventoryAsync(request);
+            Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [Fact]
         public void MoveBooks()
         {
             Mock<LibraryService.LibraryServiceClient> mockGrpcClient = new Mock<LibraryService.LibraryServiceClient>(MockBehavior.Strict);
@@ -11471,6 +11635,7 @@ namespace Google.Example.Library.V1
             GetBigNothingSettings = existing.GetBigNothingSettings;
             GetBigNothingOperationsSettings = existing.GetBigNothingOperationsSettings?.Clone();
             TestOptionalRequiredFlatteningParamsSettings = existing.TestOptionalRequiredFlatteningParamsSettings;
+            CreateInventorySettings = existing.CreateInventorySettings;
             MoveBooksSettings = existing.MoveBooksSettings;
             ArchiveBooksSettings = existing.ArchiveBooksSettings;
             LongRunningArchiveBooksSettings = existing.LongRunningArchiveBooksSettings;
@@ -12300,6 +12465,35 @@ namespace Google.Example.Library.V1
         /// Default RPC expiration is 30000 milliseconds.
         /// </remarks>
         public gaxgrpc::CallSettings TestOptionalRequiredFlatteningParamsSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.CreateInventory</c> and <c>LibraryServiceClient.CreateInventoryAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.CreateInventory</c> and
+        /// <c>LibraryServiceClient.CreateInventoryAsync</c> <see cref="gaxgrpc::RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings CreateInventorySettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
             gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
@@ -21404,6 +21598,212 @@ namespace Google.Example.Library.V1
         }
 
         /// <summary>
+        /// Creates an inventory. Tests singleton resources.
+        /// </summary>
+        /// <param name="parent">
+        ///
+        /// </param>
+        /// <param name="inventory">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Inventory> CreateInventoryAsync(
+            PublisherName parent,
+            Inventory inventory,
+            gaxgrpc::CallSettings callSettings = null) => CreateInventoryAsync(
+                new CreateInventoryRequest
+                {
+                    ParentAsPublisherName = gax::GaxPreconditions.CheckNotNull(parent, nameof(parent)),
+                    Inventory = inventory, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates an inventory. Tests singleton resources.
+        /// </summary>
+        /// <param name="parent">
+        ///
+        /// </param>
+        /// <param name="inventory">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Inventory> CreateInventoryAsync(
+            PublisherName parent,
+            Inventory inventory,
+            st::CancellationToken cancellationToken) => CreateInventoryAsync(
+                parent,
+                inventory,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Creates an inventory. Tests singleton resources.
+        /// </summary>
+        /// <param name="parent">
+        ///
+        /// </param>
+        /// <param name="inventory">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Inventory CreateInventory(
+            PublisherName parent,
+            Inventory inventory,
+            gaxgrpc::CallSettings callSettings = null) => CreateInventory(
+                new CreateInventoryRequest
+                {
+                    ParentAsPublisherName = gax::GaxPreconditions.CheckNotNull(parent, nameof(parent)),
+                    Inventory = inventory, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates an inventory. Tests singleton resources.
+        /// </summary>
+        /// <param name="parent">
+        ///
+        /// </param>
+        /// <param name="inventory">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Inventory> CreateInventoryAsync(
+            string parent,
+            Inventory inventory,
+            gaxgrpc::CallSettings callSettings = null) => CreateInventoryAsync(
+                new CreateInventoryRequest
+                {
+                    Parent = gax::GaxPreconditions.CheckNotNullOrEmpty(parent, nameof(parent)),
+                    Inventory = inventory, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates an inventory. Tests singleton resources.
+        /// </summary>
+        /// <param name="parent">
+        ///
+        /// </param>
+        /// <param name="inventory">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Inventory> CreateInventoryAsync(
+            string parent,
+            Inventory inventory,
+            st::CancellationToken cancellationToken) => CreateInventoryAsync(
+                parent,
+                inventory,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Creates an inventory. Tests singleton resources.
+        /// </summary>
+        /// <param name="parent">
+        ///
+        /// </param>
+        /// <param name="inventory">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Inventory CreateInventory(
+            string parent,
+            Inventory inventory,
+            gaxgrpc::CallSettings callSettings = null) => CreateInventory(
+                new CreateInventoryRequest
+                {
+                    Parent = gax::GaxPreconditions.CheckNotNullOrEmpty(parent, nameof(parent)),
+                    Inventory = inventory, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        /// Creates an inventory. Tests singleton resources.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Inventory> CreateInventoryAsync(
+            CreateInventoryRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates an inventory. Tests singleton resources.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<Inventory> CreateInventoryAsync(
+            CreateInventoryRequest request,
+            st::CancellationToken cancellationToken) => CreateInventoryAsync(
+                request,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Creates an inventory. Tests singleton resources.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Inventory CreateInventory(
+            CreateInventoryRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
         ///
         /// </summary>
         /// <param name="source">
@@ -21503,6 +21903,111 @@ namespace Google.Example.Library.V1
                 {
                     SourceAsArchiveName = source, // Optional
                     DestinationAsArchiveName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            ArchiveName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooksAsync(
+                new MoveBooksRequest
+                {
+                    SourceAsArchiveName = source, // Optional
+                    DestinationAsInventoryName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            ArchiveName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            st::CancellationToken cancellationToken) => MoveBooksAsync(
+                source,
+                destination,
+                publishers,
+                project,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MoveBooksResponse MoveBooks(
+            ArchiveName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooks(
+                new MoveBooksRequest
+                {
+                    SourceAsArchiveName = source, // Optional
+                    DestinationAsInventoryName = destination, // Optional
                     PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
                     ProjectAsProjectName = project, // Optional
                 },
@@ -21740,6 +22245,426 @@ namespace Google.Example.Library.V1
         /// A Task containing the RPC response.
         /// </returns>
         public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            InventoryName source,
+            ArchiveName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooksAsync(
+                new MoveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
+                    DestinationAsArchiveName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            InventoryName source,
+            ArchiveName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            st::CancellationToken cancellationToken) => MoveBooksAsync(
+                source,
+                destination,
+                publishers,
+                project,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MoveBooksResponse MoveBooks(
+            InventoryName source,
+            ArchiveName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooks(
+                new MoveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
+                    DestinationAsArchiveName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            InventoryName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooksAsync(
+                new MoveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
+                    DestinationAsInventoryName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            InventoryName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            st::CancellationToken cancellationToken) => MoveBooksAsync(
+                source,
+                destination,
+                publishers,
+                project,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MoveBooksResponse MoveBooks(
+            InventoryName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooks(
+                new MoveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
+                    DestinationAsInventoryName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            InventoryName source,
+            ShelfName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooksAsync(
+                new MoveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
+                    DestinationAsShelfName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            InventoryName source,
+            ShelfName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            st::CancellationToken cancellationToken) => MoveBooksAsync(
+                source,
+                destination,
+                publishers,
+                project,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MoveBooksResponse MoveBooks(
+            InventoryName source,
+            ShelfName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooks(
+                new MoveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
+                    DestinationAsShelfName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            InventoryName source,
+            ProjectName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooksAsync(
+                new MoveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
+                    DestinationAsProjectName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            InventoryName source,
+            ProjectName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            st::CancellationToken cancellationToken) => MoveBooksAsync(
+                source,
+                destination,
+                publishers,
+                project,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MoveBooksResponse MoveBooks(
+            InventoryName source,
+            ProjectName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooks(
+                new MoveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
+                    DestinationAsProjectName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
             ShelfName source,
             ArchiveName destination,
             scg::IEnumerable<PublisherName> publishers,
@@ -21818,6 +22743,111 @@ namespace Google.Example.Library.V1
                 {
                     SourceAsShelfName = source, // Optional
                     DestinationAsArchiveName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            ShelfName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooksAsync(
+                new MoveBooksRequest
+                {
+                    SourceAsShelfName = source, // Optional
+                    DestinationAsInventoryName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            ShelfName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            st::CancellationToken cancellationToken) => MoveBooksAsync(
+                source,
+                destination,
+                publishers,
+                project,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MoveBooksResponse MoveBooks(
+            ShelfName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooks(
+                new MoveBooksRequest
+                {
+                    SourceAsShelfName = source, // Optional
+                    DestinationAsInventoryName = destination, // Optional
                     PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
                     ProjectAsProjectName = project, // Optional
                 },
@@ -22133,6 +23163,111 @@ namespace Google.Example.Library.V1
                 {
                     SourceAsProjectName = source, // Optional
                     DestinationAsArchiveName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            ProjectName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooksAsync(
+                new MoveBooksRequest
+                {
+                    SourceAsProjectName = source, // Optional
+                    DestinationAsInventoryName = destination, // Optional
+                    PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
+                    ProjectAsProjectName = project, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<MoveBooksResponse> MoveBooksAsync(
+            ProjectName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            st::CancellationToken cancellationToken) => MoveBooksAsync(
+                source,
+                destination,
+                publishers,
+                project,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="destination">
+        ///
+        /// </param>
+        /// <param name="publishers">
+        ///
+        /// </param>
+        /// <param name="project">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual MoveBooksResponse MoveBooks(
+            ProjectName source,
+            InventoryName destination,
+            scg::IEnumerable<PublisherName> publishers,
+            ProjectName project,
+            gaxgrpc::CallSettings callSettings = null) => MoveBooks(
+                new MoveBooksRequest
+                {
+                    SourceAsProjectName = source, // Optional
+                    DestinationAsInventoryName = destination, // Optional
                     PublishersAsPublisherNames = { publishers ?? linq::Enumerable.Empty<PublisherName>() }, // Optional
                     ProjectAsProjectName = project, // Optional
                 },
@@ -22580,6 +23715,81 @@ namespace Google.Example.Library.V1
                 new ArchiveBooksRequest
                 {
                     SourceAsArchiveName = source, // Optional
+                    ArchiveAsArchiveName = archive, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            InventoryName source,
+            ArchiveName archive,
+            gaxgrpc::CallSettings callSettings = null) => ArchiveBooksAsync(
+                new ArchiveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
+                    ArchiveAsArchiveName = archive, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<ArchiveBooksResponse> ArchiveBooksAsync(
+            InventoryName source,
+            ArchiveName archive,
+            st::CancellationToken cancellationToken) => ArchiveBooksAsync(
+                source,
+                archive,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual ArchiveBooksResponse ArchiveBooks(
+            InventoryName source,
+            ArchiveName archive,
+            gaxgrpc::CallSettings callSettings = null) => ArchiveBooks(
+                new ArchiveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
                     ArchiveAsArchiveName = archive, // Optional
                 },
                 callSettings);
@@ -22936,6 +24146,81 @@ namespace Google.Example.Library.V1
                 new ArchiveBooksRequest
                 {
                     SourceAsArchiveName = source, // Optional
+                    ArchiveAsArchiveName = archive, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata>> LongRunningArchiveBooksAsync(
+            InventoryName source,
+            ArchiveName archive,
+            gaxgrpc::CallSettings callSettings = null) => LongRunningArchiveBooksAsync(
+                new ArchiveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
+                    ArchiveAsArchiveName = archive, // Optional
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="st::CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual stt::Task<lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata>> LongRunningArchiveBooksAsync(
+            InventoryName source,
+            ArchiveName archive,
+            st::CancellationToken cancellationToken) => LongRunningArchiveBooksAsync(
+                source,
+                archive,
+                gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="source">
+        ///
+        /// </param>
+        /// <param name="archive">
+        ///
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual lro::Operation<ArchiveBooksResponse, ArchiveBooksMetadata> LongRunningArchiveBooks(
+            InventoryName source,
+            ArchiveName archive,
+            gaxgrpc::CallSettings callSettings = null) => LongRunningArchiveBooks(
+                new ArchiveBooksRequest
+                {
+                    SourceAsInventoryName = source, // Optional
                     ArchiveAsArchiveName = archive, // Optional
                 },
                 callSettings);
@@ -23236,6 +24521,17 @@ namespace Google.Example.Library.V1
                 gax::GaxPreconditions.CheckNotNullOrEmpty(operationName, nameof(operationName)),
                 LongRunningArchiveBooksOperationsClient,
                 callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The client-server stream.
+        /// </returns>
+        *** ERROR: Cannot handle streaming type 'BidiStreaming' ***
 
         /// <summary>
         ///
@@ -23719,6 +25015,7 @@ namespace Google.Example.Library.V1
         private readonly gaxgrpc::ApiCall<GetBookRequest, lro::Operation> _callGetBigBook;
         private readonly gaxgrpc::ApiCall<GetBookRequest, lro::Operation> _callGetBigNothing;
         private readonly gaxgrpc::ApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> _callTestOptionalRequiredFlatteningParams;
+        private readonly gaxgrpc::ApiCall<CreateInventoryRequest, Inventory> _callCreateInventory;
         private readonly gaxgrpc::ApiCall<MoveBooksRequest, MoveBooksResponse> _callMoveBooks;
         private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> _callArchiveBooks;
         private readonly gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> _callLongRunningArchiveBooks;
@@ -23814,6 +25111,9 @@ namespace Google.Example.Library.V1
                 .WithGoogleRequestParam("name", request => request.Name);
             _callTestOptionalRequiredFlatteningParams = clientHelper.BuildApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>(
                 GrpcClient.TestOptionalRequiredFlatteningParamsAsync, GrpcClient.TestOptionalRequiredFlatteningParams, effectiveSettings.TestOptionalRequiredFlatteningParamsSettings);
+            _callCreateInventory = clientHelper.BuildApiCall<CreateInventoryRequest, Inventory>(
+                GrpcClient.CreateInventoryAsync, GrpcClient.CreateInventory, effectiveSettings.CreateInventorySettings)
+                .WithGoogleRequestParam("parent", request => request.Parent);
             _callMoveBooks = clientHelper.BuildApiCall<MoveBooksRequest, MoveBooksResponse>(
                 GrpcClient.MoveBooksAsync, GrpcClient.MoveBooks, effectiveSettings.MoveBooksSettings)
                 .WithGoogleRequestParam("source", request => request.Source);
@@ -23881,6 +25181,8 @@ namespace Google.Example.Library.V1
             Modify_GetBigNothingApiCall(ref _callGetBigNothing);
             Modify_ApiCall(ref _callTestOptionalRequiredFlatteningParams);
             Modify_TestOptionalRequiredFlatteningParamsApiCall(ref _callTestOptionalRequiredFlatteningParams);
+            Modify_ApiCall(ref _callCreateInventory);
+            Modify_CreateInventoryApiCall(ref _callCreateInventory);
             Modify_ApiCall(ref _callMoveBooks);
             Modify_MoveBooksApiCall(ref _callMoveBooks);
             Modify_ApiCall(ref _callArchiveBooks);
@@ -23938,6 +25240,7 @@ namespace Google.Example.Library.V1
         partial void Modify_GetBigBookApiCall(ref gaxgrpc::ApiCall<GetBookRequest, lro::Operation> call);
         partial void Modify_GetBigNothingApiCall(ref gaxgrpc::ApiCall<GetBookRequest, lro::Operation> call);
         partial void Modify_TestOptionalRequiredFlatteningParamsApiCall(ref gaxgrpc::ApiCall<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> call);
+        partial void Modify_CreateInventoryApiCall(ref gaxgrpc::ApiCall<CreateInventoryRequest, Inventory> call);
         partial void Modify_MoveBooksApiCall(ref gaxgrpc::ApiCall<MoveBooksRequest, MoveBooksResponse> call);
         partial void Modify_ArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, ArchiveBooksResponse> call);
         partial void Modify_LongRunningArchiveBooksApiCall(ref gaxgrpc::ApiCall<ArchiveBooksRequest, lro::Operation> call);
@@ -23979,6 +25282,7 @@ namespace Google.Example.Library.V1
         partial void Modify_FindRelatedBooksRequest(ref FindRelatedBooksRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_AddLabelRequest(ref gtv::AddLabelRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_TestOptionalRequiredFlatteningParamsRequest(ref TestOptionalRequiredFlatteningParamsRequest request, ref gaxgrpc::CallSettings settings);
+        partial void Modify_CreateInventoryRequest(ref CreateInventoryRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_MoveBooksRequest(ref MoveBooksRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_ArchiveBooksRequest(ref ArchiveBooksRequest request, ref gaxgrpc::CallSettings settings);
         partial void Modify_Book(ref Book request, ref gaxgrpc::CallSettings settings);
@@ -25074,6 +26378,46 @@ namespace Google.Example.Library.V1
         {
             Modify_TestOptionalRequiredFlatteningParamsRequest(ref request, ref callSettings);
             return _callTestOptionalRequiredFlatteningParams.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// Creates an inventory. Tests singleton resources.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override stt::Task<Inventory> CreateInventoryAsync(
+            CreateInventoryRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_CreateInventoryRequest(ref request, ref callSettings);
+            return _callCreateInventory.Async(request, callSettings);
+        }
+
+        /// <summary>
+        /// Creates an inventory. Tests singleton resources.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override Inventory CreateInventory(
+            CreateInventoryRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_CreateInventoryRequest(ref request, ref callSettings);
+            return _callCreateInventory.Sync(request, callSettings);
         }
 
         /// <summary>
@@ -26826,6 +28170,113 @@ namespace Google.Example.Library.V1
     }
 
     /// <summary>
+    /// Resource name for the 'inventory' resource.
+    /// </summary>
+    public sealed partial class InventoryName : gax::IResourceName, sys::IEquatable<InventoryName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}/publishers/{publisher}/inventory");
+
+        /// <summary>
+        /// Parses the given inventory resource name in string form into a new
+        /// <see cref="InventoryName"/> instance.
+        /// </summary>
+        /// <param name="inventoryName">The inventory resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="InventoryName"/> if successful.</returns>
+        public static InventoryName Parse(string inventoryName)
+        {
+            gax::GaxPreconditions.CheckNotNull(inventoryName, nameof(inventoryName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(inventoryName);
+            return new InventoryName(resourceName[0], resourceName[1], resourceName[2]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given inventory resource name in string form into a new
+        /// <see cref="InventoryName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="inventoryName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="inventoryName">The inventory resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="InventoryName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string inventoryName, out InventoryName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(inventoryName, nameof(inventoryName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(inventoryName, out resourceName))
+            {
+                result = new InventoryName(resourceName[0], resourceName[1], resourceName[2]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>Formats the IDs into the string representation of the <see cref="InventoryName"/>.</summary>
+        /// <param name="projectId">The <c>project</c> ID. Must not be <c>null</c>.</param>
+        /// <param name="locationId">The <c>location</c> ID. Must not be <c>null</c>.</param>
+        /// <param name="publisherId">The <c>publisher</c> ID. Must not be <c>null</c>.</param>
+        /// <returns>The string representation of the <see cref="InventoryName"/>.</returns>
+        public static string Format(string projectId, string locationId, string publisherId) =>
+            s_template.Expand(gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId)), gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId)), gax::GaxPreconditions.CheckNotNull(publisherId, nameof(publisherId)));
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="InventoryName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
+        /// <param name="publisherId">The publisher ID. Must not be <c>null</c>.</param>
+        public InventoryName(string projectId, string locationId, string publisherId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
+            PublisherId = gax::GaxPreconditions.CheckNotNull(publisherId, nameof(publisherId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The location ID. Never <c>null</c>.
+        /// </summary>
+        public string LocationId { get; }
+
+        /// <summary>
+        /// The publisher ID. Never <c>null</c>.
+        /// </summary>
+        public string PublisherId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, LocationId, PublisherId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as InventoryName);
+
+        /// <inheritdoc />
+        public bool Equals(InventoryName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(InventoryName a, InventoryName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(InventoryName a, InventoryName b) => !(a == b);
+    }
+
+    /// <summary>
     /// Resource name for the 'location' resource.
     /// </summary>
     public sealed partial class LocationName : gax::IResourceName, sys::IEquatable<LocationName>
@@ -27400,6 +28851,19 @@ namespace Google.Example.Library.V1
 
     }
 
+    public partial class CreateInventoryRequest
+    {
+        /// <summary>
+        /// <see cref="Google.Example.Library.V1.PublisherName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// </summary>
+        public Google.Example.Library.V1.PublisherName ParentAsPublisherName
+        {
+            get { return string.IsNullOrEmpty(Parent) ? null : Google.Example.Library.V1.PublisherName.Parse(Parent); }
+            set { Parent = value != null ? value.ToString() : ""; }
+        }
+
+    }
+
     public partial class DeleteBookRequest
     {
         /// <summary>
@@ -27564,6 +29028,19 @@ namespace Google.Example.Library.V1
         public Google.Example.Library.V1.ShelfName ShelfName
         {
             get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
+        }
+
+    }
+
+    public partial class Inventory
+    {
+        /// <summary>
+        /// <see cref="Google.Example.Library.V1.InventoryName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// </summary>
+        public Google.Example.Library.V1.InventoryName InventoryName
+        {
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.InventoryName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -244,6 +244,7 @@ type CallOptions struct {
     GetBigBook []gax.CallOption
     GetBigNothing []gax.CallOption
     TestOptionalRequiredFlatteningParams []gax.CallOption
+    CreateInventory []gax.CallOption
     MoveBooks []gax.CallOption
     ArchiveBooks []gax.CallOption
     LongRunningArchiveBooks []gax.CallOption
@@ -304,6 +305,7 @@ func defaultCallOptions() *CallOptions {
         GetBigBook: retry[[2]string{"default", "non_idempotent"}],
         GetBigNothing: retry[[2]string{"default", "non_idempotent"}],
         TestOptionalRequiredFlatteningParams: retry[[2]string{"default", "non_idempotent"}],
+        CreateInventory: retry[[2]string{"default", "non_idempotent"}],
         MoveBooks: retry[[2]string{"default", "non_idempotent"}],
         ArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
         LongRunningArchiveBooks: retry[[2]string{"default", "non_idempotent"}],
@@ -924,6 +926,23 @@ func (c *LibClient) TestOptionalRequiredFlatteningParams(ctx context.Context, re
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.TestOptionalRequiredFlatteningParams(ctx, req, settings.GRPC...)
+        return err
+    }, opts...)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
+}
+
+// CreateInventory creates an inventory. Tests singleton resources.
+func (c *LibClient) CreateInventory(ctx context.Context, req *librarypb.CreateInventoryRequest, opts ...gax.CallOption) (*librarypb.Inventory, error) {
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "parent", url.QueryEscape(req.GetParent())))
+    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
+    opts = append(c.CallOptions.CreateInventory[0:len(c.CallOptions.CreateInventory):len(c.CallOptions.CreateInventory)], opts...)
+    var resp *librarypb.Inventory
+    err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+        var err error
+        resp, err = c.client.CreateInventory(ctx, req, settings.GRPC...)
         return err
     }, opts...)
     if err != nil {
@@ -1930,6 +1949,24 @@ func ExampleClient_TestOptionalRequiredFlatteningParams() {
     _ = resp
 }
 
+func ExampleClient_CreateInventory() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &librarypb.CreateInventoryRequest{
+        // TODO: Fill request struct fields.
+    }
+    resp, err := c.CreateInventory(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+    // TODO: Use resp.
+    _ = resp
+}
+
 func ExampleClient_MoveBooks() {
     ctx := context.Background()
     c, err := library.NewClient(ctx)
@@ -2214,6 +2251,18 @@ func (s *mockLibraryServer) PublishSeries(ctx context.Context, req *librarypb.Pu
         return nil, s.err
     }
     return s.resps[0].(*librarypb.PublishSeriesResponse), nil
+}
+
+func (s *mockLibraryServer) CreateInventory(ctx context.Context, req *librarypb.CreateInventoryRequest) (*librarypb.Inventory, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
+        return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
+    }
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*librarypb.Inventory), nil
 }
 
 func (s *mockLibraryServer) GetBook(ctx context.Context, req *librarypb.GetBookRequest) (*librarypb.Book, error) {
@@ -4765,6 +4814,65 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
     }
 
     resp, err := c.TestOptionalRequiredFlatteningParams(context.Background(), request)
+
+    if st, ok := gstatus.FromError(err); !ok {
+        t.Errorf("got error %v, expected grpc error", err)
+    } else if c := st.Code(); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
+    _ = resp
+}
+func TestLibraryServiceCreateInventory(t *testing.T) {
+    var name string = "name3373707"
+    var expectedResponse = &librarypb.Inventory{
+        Name: name,
+    }
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
+
+    var formattedParent string = fmt.Sprintf("projects/%s/locations/%s/publishers/%s", "[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+    var request = &librarypb.CreateInventoryRequest{
+        Parent: formattedParent,
+    }
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.CreateInventory(context.Background(), request)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+    if want, got := expectedResponse, resp; !proto.Equal(want, got) {
+        t.Errorf("wrong response %q, want %q)", got, want)
+    }
+}
+
+func TestLibraryServiceCreateInventoryError(t *testing.T) {
+    errCode := codes.PermissionDenied
+    mockLibrary.err = gstatus.Error(errCode, "test error")
+
+    var formattedParent string = fmt.Sprintf("projects/%s/locations/%s/publishers/%s", "[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+    var request = &librarypb.CreateInventoryRequest{
+        Parent: formattedParent,
+    }
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    resp, err := c.CreateInventory(context.Background(), request)
 
     if st, ok := gstatus.FromError(err); !ok {
         t.Errorf("got error %v, expected grpc error", err)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -4426,6 +4426,9 @@ public class LibraryClient implements BackgroundResource {
   private static final PathTemplate FOLDER_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("folders/{folder}");
 
+  private static final PathTemplate INVENTORY_PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("projects/{project}/locations/{location}/publishers/{publisher}/inventory");
+
   private static final PathTemplate LOCATION_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("projects/{project}/locations/{location}");
 
@@ -4502,6 +4505,20 @@ public class LibraryClient implements BackgroundResource {
   public static final String formatFolderName(String folder) {
     return FOLDER_PATH_TEMPLATE.instantiate(
         "folder", folder);
+  }
+
+  /**
+   * Formats a string containing the fully-qualified path to represent
+   * a inventory resource.
+   *
+   * @deprecated Use the {@link InventoryName} class instead.
+   */
+  @Deprecated
+  public static final String formatInventoryName(String project, String location, String publisher) {
+    return INVENTORY_PATH_TEMPLATE.instantiate(
+        "project", project,
+        "location", location,
+        "publisher", publisher);
   }
 
   /**
@@ -4654,6 +4671,39 @@ public class LibraryClient implements BackgroundResource {
   @Deprecated
   public static final String parseFolderFromFolderName(String folderName) {
     return FOLDER_PATH_TEMPLATE.parse(folderName).get("folder");
+  }
+
+  /**
+   * Parses the project from the given fully-qualified path which
+   * represents a inventory resource.
+   *
+   * @deprecated Use the {@link InventoryName} class instead.
+   */
+  @Deprecated
+  public static final String parseProjectFromInventoryName(String inventoryName) {
+    return INVENTORY_PATH_TEMPLATE.parse(inventoryName).get("project");
+  }
+
+  /**
+   * Parses the location from the given fully-qualified path which
+   * represents a inventory resource.
+   *
+   * @deprecated Use the {@link InventoryName} class instead.
+   */
+  @Deprecated
+  public static final String parseLocationFromInventoryName(String inventoryName) {
+    return INVENTORY_PATH_TEMPLATE.parse(inventoryName).get("location");
+  }
+
+  /**
+   * Parses the publisher from the given fully-qualified path which
+   * represents a inventory resource.
+   *
+   * @deprecated Use the {@link InventoryName} class instead.
+   */
+  @Deprecated
+  public static final String parsePublisherFromInventoryName(String inventoryName) {
+    return INVENTORY_PATH_TEMPLATE.parse(inventoryName).get("publisher");
   }
 
   /**
@@ -8510,6 +8560,101 @@ public class LibraryClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   Inventory inventory = Inventory.newBuilder().build();
+   *   Inventory response = libraryClient.createInventory(parent, inventory);
+   * }
+   * </code></pre>
+   *
+   * @param parent
+   * @param inventory
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Inventory createInventory(PublisherName parent, Inventory inventory) {
+    CreateInventoryRequest request =
+        CreateInventoryRequest.newBuilder()
+            .setParent(parent == null ? null : parent.toString())
+            .setInventory(inventory)
+            .build();
+    return createInventory(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   Inventory inventory = Inventory.newBuilder().build();
+   *   Inventory response = libraryClient.createInventory(parent.toString(), inventory);
+   * }
+   * </code></pre>
+   *
+   * @param parent
+   * @param inventory
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Inventory createInventory(String parent, Inventory inventory) {
+    CreateInventoryRequest request =
+        CreateInventoryRequest.newBuilder()
+            .setParent(parent)
+            .setInventory(inventory)
+            .build();
+    return createInventory(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
+   *     .setParent(parent.toString())
+   *     .build();
+   *   Inventory response = libraryClient.createInventory(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Inventory createInventory(CreateInventoryRequest request) {
+    return createInventoryCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
+   *     .setParent(parent.toString())
+   *     .build();
+   *   ApiFuture&lt;Inventory&gt; future = libraryClient.createInventoryCallable().futureCall(request);
+   *   // Do something
+   *   Inventory response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable() {
+    return stub.createInventoryCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
    *
    *
    * Sample code:
@@ -8530,6 +8675,38 @@ public class LibraryClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final MoveBooksResponse moveBooks(ArchiveName source, ArchiveName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveName source = ArchiveName.of("[ARCHIVE]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(ArchiveName source, InventoryName destination, List<String> publishers, ProjectName project) {
     MoveBooksRequest request =
         MoveBooksRequest.newBuilder()
             .setSource(source == null ? null : source.toString())
@@ -8611,6 +8788,134 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ArchiveName destination = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, ArchiveName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, InventoryName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ShelfName destination = ShelfName.of("[SHELF]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, ShelfName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ProjectName destination = ProjectName.of("[PROJECT]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, ProjectName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   ShelfName source = ShelfName.of("[SHELF]");
    *   ArchiveName destination = ArchiveName.of("[ARCHIVE]");
    *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
@@ -8626,6 +8931,38 @@ public class LibraryClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final MoveBooksResponse moveBooks(ShelfName source, ArchiveName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName source = ShelfName.of("[SHELF]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(ShelfName source, InventoryName destination, List<String> publishers, ProjectName project) {
     MoveBooksRequest request =
         MoveBooksRequest.newBuilder()
             .setSource(source == null ? null : source.toString())
@@ -8722,6 +9059,38 @@ public class LibraryClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final MoveBooksResponse moveBooks(ProjectName source, ArchiveName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ProjectName source = ProjectName.of("[PROJECT]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(ProjectName source, InventoryName destination, List<String> publishers, ProjectName project) {
     MoveBooksRequest request =
         MoveBooksRequest.newBuilder()
             .setSource(source == null ? null : source.toString())
@@ -8898,6 +9267,32 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ArchiveName archive = ArchiveName.of("[ARCHIVE]");
+   *   ArchiveBooksResponse response = libraryClient.archiveBooks(source, archive);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ArchiveBooksResponse archiveBooks(InventoryName source, ArchiveName archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setArchive(archive == null ? null : archive.toString())
+            .build();
+    return archiveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   ShelfName source = ShelfName.of("[SHELF]");
    *   ArchiveName archive = ArchiveName.of("[ARCHIVE]");
    *   ArchiveBooksResponse response = libraryClient.archiveBooks(source, archive);
@@ -9025,6 +9420,33 @@ public class LibraryClient implements BackgroundResource {
    */
   @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
   public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(ArchiveName source, ArchiveName archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setArchive(archive == null ? null : archive.toString())
+            .build();
+    return longRunningArchiveBooksAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ArchiveName archive = ArchiveName.of("[ARCHIVE]");
+   *   ArchiveBooksResponse response = libraryClient.longRunningArchiveBooksAsync(source, archive).get();
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(InventoryName source, ArchiveName archive) {
     ArchiveBooksRequest request =
         ArchiveBooksRequest.newBuilder()
             .setSource(source == null ? null : source.toString())
@@ -10143,6 +10565,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
   }
 
   /**
+   * Returns the object with the settings used for calls to createInventory.
+   */
+  public UnaryCallSettings<CreateInventoryRequest, Inventory> createInventorySettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).createInventorySettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to moveBooks.
    */
   public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
@@ -10516,6 +10945,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return getStubSettingsBuilder().testOptionalRequiredFlatteningParamsSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to createInventory.
+     */
+    public UnaryCallSettings.Builder<CreateInventoryRequest, Inventory> createInventorySettings() {
+      return getStubSettingsBuilder().createInventorySettings();
     }
 
     /**
@@ -11216,6 +11652,7 @@ import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -11229,6 +11666,8 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
+import com.google.example.library.v1.InventoryName;
 import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
@@ -11404,6 +11843,7 @@ import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -11417,6 +11857,8 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
+import com.google.example.library.v1.InventoryName;
 import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
@@ -11686,6 +12128,13 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<CreateInventoryRequest, Inventory> createInventoryMethodDescriptor =
+      MethodDescriptor.<CreateInventoryRequest, Inventory>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/CreateInventory")
+          .setRequestMarshaller(ProtoUtils.marshaller(CreateInventoryRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Inventory.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<MoveBooksRequest, MoveBooksResponse> moveBooksMethodDescriptor =
       MethodDescriptor.<MoveBooksRequest, MoveBooksResponse>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -11767,6 +12216,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable;
   private final OperationCallable<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationCallable;
   private final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable;
+  private final UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable;
   private final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable;
   private final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable;
   private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
@@ -12082,6 +12532,19 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
         GrpcCallSettings.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
             .setMethodDescriptor(testOptionalRequiredFlatteningParamsMethodDescriptor)
             .build();
+    GrpcCallSettings<CreateInventoryRequest, Inventory> createInventoryTransportSettings =
+        GrpcCallSettings.<CreateInventoryRequest, Inventory>newBuilder()
+            .setMethodDescriptor(createInventoryMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<CreateInventoryRequest>() {
+                  @Override
+                  public Map<String, String> extract(CreateInventoryRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("parent", String.valueOf(request.getParent()));
+                    return params.build();
+                  }
+                })
+            .build();
     GrpcCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksTransportSettings =
         GrpcCallSettings.<MoveBooksRequest, MoveBooksResponse>newBuilder()
             .setMethodDescriptor(moveBooksMethodDescriptor)
@@ -12170,6 +12633,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.getBigNothingOperationCallable = callableFactory.createOperationCallable(
         getBigNothingTransportSettings,settings.getBigNothingOperationSettings(), clientContext, this.operationsStub);
     this.testOptionalRequiredFlatteningParamsCallable = callableFactory.createUnaryCallable(testOptionalRequiredFlatteningParamsTransportSettings,settings.testOptionalRequiredFlatteningParamsSettings(), clientContext);
+    this.createInventoryCallable = callableFactory.createUnaryCallable(createInventoryTransportSettings,settings.createInventorySettings(), clientContext);
     this.moveBooksCallable = callableFactory.createUnaryCallable(moveBooksTransportSettings,settings.moveBooksSettings(), clientContext);
     this.archiveBooksCallable = callableFactory.createUnaryCallable(archiveBooksTransportSettings,settings.archiveBooksSettings(), clientContext);
     this.longRunningArchiveBooksCallable = callableFactory.createUnaryCallable(longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksSettings(), clientContext);
@@ -12323,6 +12787,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     return testOptionalRequiredFlatteningParamsCallable;
+  }
+
+  public UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable() {
+    return createInventoryCallable;
   }
 
   public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
@@ -12699,6 +13167,7 @@ import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -12712,6 +13181,8 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
+import com.google.example.library.v1.InventoryName;
 import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
@@ -12923,6 +13394,10 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: testOptionalRequiredFlatteningParamsCallable()");
   }
 
+  public UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable() {
+    throw new UnsupportedOperationException("Not implemented: createInventoryCallable()");
+  }
+
   public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
     throw new UnsupportedOperationException("Not implemented: moveBooksCallable()");
   }
@@ -13030,6 +13505,7 @@ import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -13042,6 +13518,7 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
 import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
@@ -13153,6 +13630,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<GetBookRequest, Operation> getBigNothingSettings;
   private final OperationCallSettings<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
   private final UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+  private final UnaryCallSettings<CreateInventoryRequest, Inventory> createInventorySettings;
   private final UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
   private final UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
   private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
@@ -13374,6 +13852,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to createInventory.
+   */
+  public UnaryCallSettings<CreateInventoryRequest, Inventory> createInventorySettings() {
+    return createInventorySettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to moveBooks.
    */
   public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
@@ -13539,6 +14024,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     getBigNothingSettings = settingsBuilder.getBigNothingSettings().build();
     getBigNothingOperationSettings = settingsBuilder.getBigNothingOperationSettings().build();
     testOptionalRequiredFlatteningParamsSettings = settingsBuilder.testOptionalRequiredFlatteningParamsSettings().build();
+    createInventorySettings = settingsBuilder.createInventorySettings().build();
     moveBooksSettings = settingsBuilder.moveBooksSettings().build();
     archiveBooksSettings = settingsBuilder.archiveBooksSettings().build();
     longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
@@ -13899,6 +14385,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings;
     private final OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
     private final UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+    private final UnaryCallSettings.Builder<CreateInventoryRequest, Inventory> createInventorySettings;
     private final UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
     private final UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
     private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
@@ -14013,6 +14500,8 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       testOptionalRequiredFlatteningParamsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      createInventorySettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       moveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       archiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
@@ -14051,6 +14540,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          createInventorySettings,
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
@@ -14192,6 +14682,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.createInventorySettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
       builder.moveBooksSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
@@ -14308,6 +14802,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
       getBigNothingOperationSettings = settings.getBigNothingOperationSettings.toBuilder();
       testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
+      createInventorySettings = settings.createInventorySettings.toBuilder();
       moveBooksSettings = settings.moveBooksSettings.toBuilder();
       archiveBooksSettings = settings.archiveBooksSettings.toBuilder();
       longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
@@ -14340,6 +14835,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          createInventorySettings,
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
@@ -14573,6 +15069,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return testOptionalRequiredFlatteningParamsSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to createInventory.
+     */
+    public UnaryCallSettings.Builder<CreateInventoryRequest, Inventory> createInventorySettings() {
+      return createInventorySettings;
     }
 
     /**
@@ -17035,6 +17538,51 @@ public class LibraryClientTest {
 
   @Test
   @SuppressWarnings("all")
+  public void createInventoryTest() {
+    InventoryName name = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+    Inventory expectedResponse = Inventory.newBuilder()
+      .setName(name.toString())
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+    Inventory inventory = Inventory.newBuilder().build();
+
+    Inventory actualResponse =
+        client.createInventory(parent, inventory);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CreateInventoryRequest actualRequest = (CreateInventoryRequest)actualRequests.get(0);
+
+    Assert.assertEquals(parent, PublisherName.parse(actualRequest.getParent()));
+    Assert.assertEquals(inventory, actualRequest.getInventory());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createInventoryExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+      Inventory inventory = Inventory.newBuilder().build();
+
+      client.createInventory(parent, inventory);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
   public void moveBooksTest() {
     boolean success = false;
     MoveBooksResponse expectedResponse = MoveBooksResponse.newBuilder()
@@ -17747,6 +18295,21 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
     if (response instanceof PublishSeriesResponse) {
       requests.add(request);
       responseObserver.onNext((PublishSeriesResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void createInventory(CreateInventoryRequest request,
+    StreamObserver<Inventory> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Inventory) {
+      requests.add(request);
+      responseObserver.onNext((Inventory) response);
       responseObserver.onCompleted();
     } else if (response instanceof Exception) {
       responseObserver.onError((Exception) response);

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -1048,6 +1048,101 @@ public class LibraryServiceClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   Inventory inventory = Inventory.newBuilder().build();
+   *   Inventory response = libraryServiceClient.createInventory(parent, inventory);
+   * }
+   * </code></pre>
+   *
+   * @param parent
+   * @param inventory
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Inventory createInventory(PublisherName parent, Inventory inventory) {
+    CreateInventoryRequest request =
+        CreateInventoryRequest.newBuilder()
+            .setParent(parent == null ? null : parent.toString())
+            .setInventory(inventory)
+            .build();
+    return createInventory(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   Inventory inventory = Inventory.newBuilder().build();
+   *   Inventory response = libraryServiceClient.createInventory(parent.toString(), inventory);
+   * }
+   * </code></pre>
+   *
+   * @param parent
+   * @param inventory
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Inventory createInventory(String parent, Inventory inventory) {
+    CreateInventoryRequest request =
+        CreateInventoryRequest.newBuilder()
+            .setParent(parent)
+            .setInventory(inventory)
+            .build();
+    return createInventory(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
+   *     .setParent(parent.toString())
+   *     .build();
+   *   Inventory response = libraryServiceClient.createInventory(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Inventory createInventory(CreateInventoryRequest request) {
+    return createInventoryCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
+   *     .setParent(parent.toString())
+   *     .build();
+   *   ApiFuture&lt;Inventory&gt; future = libraryServiceClient.createInventoryCallable().futureCall(request);
+   *   // Do something
+   *   Inventory response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable() {
+    return stub.createInventoryCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
    * Gets a book.
    *
    * Sample code:
@@ -2916,6 +3011,38 @@ public class LibraryServiceClient implements BackgroundResource {
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   ArchiveName source = ArchiveName.of("[ARCHIVE]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryServiceClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(ArchiveName source, InventoryName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ArchiveName source = ArchiveName.of("[ARCHIVE]");
    *   ShelfName destination = ShelfName.of("[SHELF]");
    *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
    *   ProjectName project = ProjectName.of("[PROJECT]");
@@ -2979,6 +3106,134 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ArchiveName destination = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryServiceClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, ArchiveName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryServiceClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, InventoryName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ShelfName destination = ShelfName.of("[SHELF]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryServiceClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, ShelfName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ProjectName destination = ProjectName.of("[PROJECT]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryServiceClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, ProjectName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   ShelfName source = ShelfName.of("[SHELF]");
    *   ArchiveName destination = ArchiveName.of("[ARCHIVE]");
    *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
@@ -2994,6 +3249,38 @@ public class LibraryServiceClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final MoveBooksResponse moveBooks(ShelfName source, ArchiveName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ShelfName source = ShelfName.of("[SHELF]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryServiceClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(ShelfName source, InventoryName destination, List<String> publishers, ProjectName project) {
     MoveBooksRequest request =
         MoveBooksRequest.newBuilder()
             .setSource(source == null ? null : source.toString())
@@ -3090,6 +3377,38 @@ public class LibraryServiceClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final MoveBooksResponse moveBooks(ProjectName source, ArchiveName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ProjectName source = ProjectName.of("[PROJECT]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryServiceClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(ProjectName source, InventoryName destination, List<String> publishers, ProjectName project) {
     MoveBooksRequest request =
         MoveBooksRequest.newBuilder()
             .setSource(source == null ? null : source.toString())
@@ -3266,6 +3585,32 @@ public class LibraryServiceClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ArchiveName archive = ArchiveName.of("[ARCHIVE]");
+   *   ArchiveBooksResponse response = libraryServiceClient.archiveBooks(source, archive);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ArchiveBooksResponse archiveBooks(InventoryName source, ArchiveName archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setArchive(archive == null ? null : archive.toString())
+            .build();
+    return archiveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   ShelfName source = ShelfName.of("[SHELF]");
    *   ArchiveName archive = ArchiveName.of("[ARCHIVE]");
    *   ArchiveBooksResponse response = libraryServiceClient.archiveBooks(source, archive);
@@ -3393,6 +3738,33 @@ public class LibraryServiceClient implements BackgroundResource {
    */
   @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
   public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(ArchiveName source, ArchiveName archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setArchive(archive == null ? null : archive.toString())
+            .build();
+    return longRunningArchiveBooksAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ArchiveName archive = ArchiveName.of("[ARCHIVE]");
+   *   ArchiveBooksResponse response = libraryServiceClient.longRunningArchiveBooksAsync(source, archive).get();
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(InventoryName source, ArchiveName archive) {
     ArchiveBooksRequest request =
         ArchiveBooksRequest.newBuilder()
             .setSource(source == null ? null : source.toString())
@@ -5322,6 +5694,13 @@ public class LibraryServiceSettings extends ClientSettings<LibraryServiceSetting
   }
 
   /**
+   * Returns the object with the settings used for calls to createInventory.
+   */
+  public UnaryCallSettings<CreateInventoryRequest, Inventory> createInventorySettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).createInventorySettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to getBook.
    */
   public UnaryCallSettings<GetBookRequest, Book> getBookSettings() {
@@ -5695,6 +6074,13 @@ public class LibraryServiceSettings extends ClientSettings<LibraryServiceSetting
      */
     public UnaryCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
       return getStubSettingsBuilder().publishSeriesSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to createInventory.
+     */
+    public UnaryCallSettings.Builder<CreateInventoryRequest, Inventory> createInventorySettings() {
+      return getStubSettingsBuilder().createInventorySettings();
     }
 
     /**
@@ -6558,6 +6944,7 @@ import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -6571,6 +6958,8 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
+import com.google.example.library.v1.InventoryName;
 import static com.google.example.library.v1.LibraryServiceClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryServiceClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryServiceClient.ListStringsPagedResponse;
@@ -6745,6 +7134,7 @@ import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -6758,6 +7148,8 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
+import com.google.example.library.v1.InventoryName;
 import static com.google.example.library.v1.LibraryServiceClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryServiceClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryServiceClient.ListStringsPagedResponse;
@@ -6878,6 +7270,13 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setFullMethodName("google.example.library.v1.LibraryService/PublishSeries")
           .setRequestMarshaller(ProtoUtils.marshaller(PublishSeriesRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(PublishSeriesResponse.getDefaultInstance()))
+          .build();
+  private static final MethodDescriptor<CreateInventoryRequest, Inventory> createInventoryMethodDescriptor =
+      MethodDescriptor.<CreateInventoryRequest, Inventory>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/CreateInventory")
+          .setRequestMarshaller(ProtoUtils.marshaller(CreateInventoryRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Inventory.getDefaultInstance()))
           .build();
   private static final MethodDescriptor<GetBookRequest, Book> getBookMethodDescriptor =
       MethodDescriptor.<GetBookRequest, Book>newBuilder()
@@ -7080,6 +7479,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<MergeShelvesRequest, Shelf> mergeShelvesCallable;
   private final UnaryCallable<CreateBookRequest, Book> createBookCallable;
   private final UnaryCallable<PublishSeriesRequest, PublishSeriesResponse> publishSeriesCallable;
+  private final UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable;
   private final UnaryCallable<GetBookRequest, Book> getBookCallable;
   private final UnaryCallable<ListBooksRequest, ListBooksResponse> listBooksCallable;
   private final UnaryCallable<ListBooksRequest, ListBooksPagedResponse> listBooksPagedCallable;
@@ -7215,6 +7615,19 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
                   public Map<String, String> extract(PublishSeriesRequest request) {
                     ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                     params.put("shelf.name", String.valueOf(request.getShelf().getName()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<CreateInventoryRequest, Inventory> createInventoryTransportSettings =
+        GrpcCallSettings.<CreateInventoryRequest, Inventory>newBuilder()
+            .setMethodDescriptor(createInventoryMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<CreateInventoryRequest>() {
+                  @Override
+                  public Map<String, String> extract(CreateInventoryRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("parent", String.valueOf(request.getParent()));
                     return params.build();
                   }
                 })
@@ -7480,6 +7893,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.mergeShelvesCallable = callableFactory.createUnaryCallable(mergeShelvesTransportSettings,settings.mergeShelvesSettings(), clientContext);
     this.createBookCallable = callableFactory.createUnaryCallable(createBookTransportSettings,settings.createBookSettings(), clientContext);
     this.publishSeriesCallable = callableFactory.createUnaryCallable(publishSeriesTransportSettings,settings.publishSeriesSettings(), clientContext);
+    this.createInventoryCallable = callableFactory.createUnaryCallable(createInventoryTransportSettings,settings.createInventorySettings(), clientContext);
     this.getBookCallable = callableFactory.createUnaryCallable(getBookTransportSettings,settings.getBookSettings(), clientContext);
     this.listBooksCallable = callableFactory.createUnaryCallable(listBooksTransportSettings,settings.listBooksSettings(), clientContext);
     this.listBooksPagedCallable = callableFactory.createPagedCallable(listBooksTransportSettings,settings.listBooksSettings(), clientContext);
@@ -7550,6 +7964,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public UnaryCallable<PublishSeriesRequest, PublishSeriesResponse> publishSeriesCallable() {
     return publishSeriesCallable;
+  }
+
+  public UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable() {
+    return createInventoryCallable;
   }
 
   public UnaryCallable<GetBookRequest, Book> getBookCallable() {
@@ -8032,6 +8450,7 @@ import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -8045,6 +8464,8 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
+import com.google.example.library.v1.InventoryName;
 import static com.google.example.library.v1.LibraryServiceClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryServiceClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryServiceClient.ListStringsPagedResponse;
@@ -8142,6 +8563,10 @@ public abstract class LibraryServiceStub implements BackgroundResource {
 
   public UnaryCallable<PublishSeriesRequest, PublishSeriesResponse> publishSeriesCallable() {
     throw new UnsupportedOperationException("Not implemented: publishSeriesCallable()");
+  }
+
+  public UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable() {
+    throw new UnsupportedOperationException("Not implemented: createInventoryCallable()");
   }
 
   public UnaryCallable<GetBookRequest, Book> getBookCallable() {
@@ -8348,6 +8773,7 @@ import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -8360,6 +8786,7 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
 import static com.google.example.library.v1.LibraryServiceClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryServiceClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryServiceClient.ListStringsPagedResponse;
@@ -8445,6 +8872,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<MergeShelvesRequest, Shelf> mergeShelvesSettings;
   private final UnaryCallSettings<CreateBookRequest, Book> createBookSettings;
   private final UnaryCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
+  private final UnaryCallSettings<CreateInventoryRequest, Inventory> createInventorySettings;
   private final UnaryCallSettings<GetBookRequest, Book> getBookSettings;
   private final PagedCallSettings<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings;
   private final UnaryCallSettings<DeleteBookRequest, Empty> deleteBookSettings;
@@ -8523,6 +8951,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
    */
   public UnaryCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
     return publishSeriesSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to createInventory.
+   */
+  public UnaryCallSettings<CreateInventoryRequest, Inventory> createInventorySettings() {
+    return createInventorySettings;
   }
 
   /**
@@ -8831,6 +9266,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     mergeShelvesSettings = settingsBuilder.mergeShelvesSettings().build();
     createBookSettings = settingsBuilder.createBookSettings().build();
     publishSeriesSettings = settingsBuilder.publishSeriesSettings().build();
+    createInventorySettings = settingsBuilder.createInventorySettings().build();
     getBookSettings = settingsBuilder.getBookSettings().build();
     listBooksSettings = settingsBuilder.listBooksSettings().build();
     deleteBookSettings = settingsBuilder.deleteBookSettings().build();
@@ -9024,6 +9460,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<MergeShelvesRequest, Shelf> mergeShelvesSettings;
     private final UnaryCallSettings.Builder<CreateBookRequest, Book> createBookSettings;
     private final UnaryCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
+    private final UnaryCallSettings.Builder<CreateInventoryRequest, Inventory> createInventorySettings;
     private final UnaryCallSettings.Builder<GetBookRequest, Book> getBookSettings;
     private final PagedCallSettings.Builder<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings;
     private final UnaryCallSettings.Builder<DeleteBookRequest, Empty> deleteBookSettings;
@@ -9107,6 +9544,8 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       publishSeriesSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      createInventorySettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       getBookSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       listBooksSettings = PagedCallSettings.newBuilder(
@@ -9178,6 +9617,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           mergeShelvesSettings,
           createBookSettings,
           publishSeriesSettings,
+          createInventorySettings,
           getBookSettings,
           listBooksSettings,
           deleteBookSettings,
@@ -9240,6 +9680,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
       builder.publishSeriesSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.createInventorySettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
@@ -9408,6 +9852,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       mergeShelvesSettings = settings.mergeShelvesSettings.toBuilder();
       createBookSettings = settings.createBookSettings.toBuilder();
       publishSeriesSettings = settings.publishSeriesSettings.toBuilder();
+      createInventorySettings = settings.createInventorySettings.toBuilder();
       getBookSettings = settings.getBookSettings.toBuilder();
       listBooksSettings = settings.listBooksSettings.toBuilder();
       deleteBookSettings = settings.deleteBookSettings.toBuilder();
@@ -9447,6 +9892,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           mergeShelvesSettings,
           createBookSettings,
           publishSeriesSettings,
+          createInventorySettings,
           getBookSettings,
           listBooksSettings,
           deleteBookSettings,
@@ -9533,6 +9979,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public UnaryCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
       return publishSeriesSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to createInventory.
+     */
+    public UnaryCallSettings.Builder<CreateInventoryRequest, Inventory> createInventorySettings() {
+      return createInventorySettings;
     }
 
     /**
@@ -10665,6 +11118,51 @@ public class LibraryServiceClientTest {
       PublisherName publisher = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
 
       client.publishSeries(shelf, books, edition, seriesUuid, publisher);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createInventoryTest() {
+    InventoryName name = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+    Inventory expectedResponse = Inventory.newBuilder()
+      .setName(name.toString())
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+    Inventory inventory = Inventory.newBuilder().build();
+
+    Inventory actualResponse =
+        client.createInventory(parent, inventory);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CreateInventoryRequest actualRequest = (CreateInventoryRequest)actualRequests.get(0);
+
+    Assert.assertEquals(parent, PublisherName.parse(actualRequest.getParent()));
+    Assert.assertEquals(inventory, actualRequest.getInventory());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createInventoryExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+      Inventory inventory = Inventory.newBuilder().build();
+
+      client.createInventory(parent, inventory);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception
@@ -12613,6 +13111,21 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
     if (response instanceof PublishSeriesResponse) {
       requests.add(request);
       responseObserver.onNext((PublishSeriesResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void createInventory(CreateInventoryRequest request,
+    StreamObserver<Inventory> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Inventory) {
+      requests.add(request);
+      responseObserver.onNext((Inventory) response);
       responseObserver.onCompleted();
     } else if (response instanceof Exception) {
       responseObserver.onError((Exception) response);

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -4426,6 +4426,9 @@ public class LibraryClient implements BackgroundResource {
   private static final PathTemplate FOLDER_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("folders/{folder}");
 
+  private static final PathTemplate INVENTORY_PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("projects/{project}/locations/{location}/publishers/{publisher}/inventory");
+
   private static final PathTemplate LOCATION_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("projects/{project}/locations/{location}");
 
@@ -4502,6 +4505,20 @@ public class LibraryClient implements BackgroundResource {
   public static final String formatFolderName(String folder) {
     return FOLDER_PATH_TEMPLATE.instantiate(
         "folder", folder);
+  }
+
+  /**
+   * Formats a string containing the fully-qualified path to represent
+   * a inventory resource.
+   *
+   * @deprecated Use the {@link InventoryName} class instead.
+   */
+  @Deprecated
+  public static final String formatInventoryName(String project, String location, String publisher) {
+    return INVENTORY_PATH_TEMPLATE.instantiate(
+        "project", project,
+        "location", location,
+        "publisher", publisher);
   }
 
   /**
@@ -4654,6 +4671,39 @@ public class LibraryClient implements BackgroundResource {
   @Deprecated
   public static final String parseFolderFromFolderName(String folderName) {
     return FOLDER_PATH_TEMPLATE.parse(folderName).get("folder");
+  }
+
+  /**
+   * Parses the project from the given fully-qualified path which
+   * represents a inventory resource.
+   *
+   * @deprecated Use the {@link InventoryName} class instead.
+   */
+  @Deprecated
+  public static final String parseProjectFromInventoryName(String inventoryName) {
+    return INVENTORY_PATH_TEMPLATE.parse(inventoryName).get("project");
+  }
+
+  /**
+   * Parses the location from the given fully-qualified path which
+   * represents a inventory resource.
+   *
+   * @deprecated Use the {@link InventoryName} class instead.
+   */
+  @Deprecated
+  public static final String parseLocationFromInventoryName(String inventoryName) {
+    return INVENTORY_PATH_TEMPLATE.parse(inventoryName).get("location");
+  }
+
+  /**
+   * Parses the publisher from the given fully-qualified path which
+   * represents a inventory resource.
+   *
+   * @deprecated Use the {@link InventoryName} class instead.
+   */
+  @Deprecated
+  public static final String parsePublisherFromInventoryName(String inventoryName) {
+    return INVENTORY_PATH_TEMPLATE.parse(inventoryName).get("publisher");
   }
 
   /**
@@ -8510,6 +8560,101 @@ public class LibraryClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD
   /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   Inventory inventory = Inventory.newBuilder().build();
+   *   Inventory response = libraryClient.createInventory(parent, inventory);
+   * }
+   * </code></pre>
+   *
+   * @param parent
+   * @param inventory
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Inventory createInventory(PublisherName parent, Inventory inventory) {
+    CreateInventoryRequest request =
+        CreateInventoryRequest.newBuilder()
+            .setParent(parent == null ? null : parent.toString())
+            .setInventory(inventory)
+            .build();
+    return createInventory(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   Inventory inventory = Inventory.newBuilder().build();
+   *   Inventory response = libraryClient.createInventory(parent.toString(), inventory);
+   * }
+   * </code></pre>
+   *
+   * @param parent
+   * @param inventory
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Inventory createInventory(String parent, Inventory inventory) {
+    CreateInventoryRequest request =
+        CreateInventoryRequest.newBuilder()
+            .setParent(parent)
+            .setInventory(inventory)
+            .build();
+    return createInventory(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
+   *     .setParent(parent.toString())
+   *     .build();
+   *   Inventory response = libraryClient.createInventory(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Inventory createInventory(CreateInventoryRequest request) {
+    return createInventoryCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
+   *     .setParent(parent.toString())
+   *     .build();
+   *   ApiFuture&lt;Inventory&gt; future = libraryClient.createInventoryCallable().futureCall(request);
+   *   // Do something
+   *   Inventory response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable() {
+    return stub.createInventoryCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
    *
    *
    * Sample code:
@@ -8530,6 +8675,38 @@ public class LibraryClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final MoveBooksResponse moveBooks(ArchiveName source, ArchiveName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ArchiveName source = ArchiveName.of("[ARCHIVE]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(ArchiveName source, InventoryName destination, List<String> publishers, ProjectName project) {
     MoveBooksRequest request =
         MoveBooksRequest.newBuilder()
             .setSource(source == null ? null : source.toString())
@@ -8611,6 +8788,134 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ArchiveName destination = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, ArchiveName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, InventoryName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ShelfName destination = ShelfName.of("[SHELF]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, ShelfName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ProjectName destination = ProjectName.of("[PROJECT]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(InventoryName source, ProjectName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   ShelfName source = ShelfName.of("[SHELF]");
    *   ArchiveName destination = ArchiveName.of("[ARCHIVE]");
    *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
@@ -8626,6 +8931,38 @@ public class LibraryClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final MoveBooksResponse moveBooks(ShelfName source, ArchiveName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ShelfName source = ShelfName.of("[SHELF]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(ShelfName source, InventoryName destination, List<String> publishers, ProjectName project) {
     MoveBooksRequest request =
         MoveBooksRequest.newBuilder()
             .setSource(source == null ? null : source.toString())
@@ -8722,6 +9059,38 @@ public class LibraryClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final MoveBooksResponse moveBooks(ProjectName source, ArchiveName destination, List<String> publishers, ProjectName project) {
+    MoveBooksRequest request =
+        MoveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setDestination(destination == null ? null : destination.toString())
+            .addAllPublishers(publishers)
+            .setProject(project == null ? null : project.toString())
+            .build();
+    return moveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   ProjectName source = ProjectName.of("[PROJECT]");
+   *   InventoryName destination = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   List&lt;String&gt; formattedPublishers = new ArrayList&lt;&gt;();
+   *   ProjectName project = ProjectName.of("[PROJECT]");
+   *   MoveBooksResponse response = libraryClient.moveBooks(source, destination, formattedPublishers, project);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param destination
+   * @param publishers
+   * @param project
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MoveBooksResponse moveBooks(ProjectName source, InventoryName destination, List<String> publishers, ProjectName project) {
     MoveBooksRequest request =
         MoveBooksRequest.newBuilder()
             .setSource(source == null ? null : source.toString())
@@ -8898,6 +9267,32 @@ public class LibraryClient implements BackgroundResource {
    * Sample code:
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ArchiveName archive = ArchiveName.of("[ARCHIVE]");
+   *   ArchiveBooksResponse response = libraryClient.archiveBooks(source, archive);
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ArchiveBooksResponse archiveBooks(InventoryName source, ArchiveName archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setArchive(archive == null ? null : archive.toString())
+            .build();
+    return archiveBooks(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   ShelfName source = ShelfName.of("[SHELF]");
    *   ArchiveName archive = ArchiveName.of("[ARCHIVE]");
    *   ArchiveBooksResponse response = libraryClient.archiveBooks(source, archive);
@@ -9025,6 +9420,33 @@ public class LibraryClient implements BackgroundResource {
    */
   @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
   public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(ArchiveName source, ArchiveName archive) {
+    ArchiveBooksRequest request =
+        ArchiveBooksRequest.newBuilder()
+            .setSource(source == null ? null : source.toString())
+            .setArchive(archive == null ? null : archive.toString())
+            .build();
+    return longRunningArchiveBooksAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryClient libraryClient = LibraryClient.create()) {
+   *   InventoryName source = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ArchiveName archive = ArchiveName.of("[ARCHIVE]");
+   *   ArchiveBooksResponse response = libraryClient.longRunningArchiveBooksAsync(source, archive).get();
+   * }
+   * </code></pre>
+   *
+   * @param source
+   * @param archive
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi("The surface for long-running operations is not stable yet and may change in the future.")
+  public final OperationFuture<ArchiveBooksResponse, ArchiveBooksMetadata> longRunningArchiveBooksAsync(InventoryName source, ArchiveName archive) {
     ArchiveBooksRequest request =
         ArchiveBooksRequest.newBuilder()
             .setSource(source == null ? null : source.toString())
@@ -10143,6 +10565,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
   }
 
   /**
+   * Returns the object with the settings used for calls to createInventory.
+   */
+  public UnaryCallSettings<CreateInventoryRequest, Inventory> createInventorySettings() {
+    return ((LibraryServiceStubSettings) getStubSettings()).createInventorySettings();
+  }
+
+  /**
    * Returns the object with the settings used for calls to moveBooks.
    */
   public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
@@ -10516,6 +10945,13 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return getStubSettingsBuilder().testOptionalRequiredFlatteningParamsSettings();
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to createInventory.
+     */
+    public UnaryCallSettings.Builder<CreateInventoryRequest, Inventory> createInventorySettings() {
+      return getStubSettingsBuilder().createInventorySettings();
     }
 
     /**
@@ -11216,6 +11652,7 @@ import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -11229,6 +11666,8 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
+import com.google.example.library.v1.InventoryName;
 import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
@@ -11404,6 +11843,7 @@ import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -11417,6 +11857,8 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
+import com.google.example.library.v1.InventoryName;
 import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
@@ -11686,6 +12128,13 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(TestOptionalRequiredFlatteningParamsResponse.getDefaultInstance()))
           .build();
+  private static final MethodDescriptor<CreateInventoryRequest, Inventory> createInventoryMethodDescriptor =
+      MethodDescriptor.<CreateInventoryRequest, Inventory>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.example.library.v1.LibraryService/CreateInventory")
+          .setRequestMarshaller(ProtoUtils.marshaller(CreateInventoryRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Inventory.getDefaultInstance()))
+          .build();
   private static final MethodDescriptor<MoveBooksRequest, MoveBooksResponse> moveBooksMethodDescriptor =
       MethodDescriptor.<MoveBooksRequest, MoveBooksResponse>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -11767,6 +12216,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable;
   private final OperationCallable<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationCallable;
   private final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable;
+  private final UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable;
   private final UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable;
   private final UnaryCallable<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksCallable;
   private final UnaryCallable<ArchiveBooksRequest, Operation> longRunningArchiveBooksCallable;
@@ -12082,6 +12532,19 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
         GrpcCallSettings.<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse>newBuilder()
             .setMethodDescriptor(testOptionalRequiredFlatteningParamsMethodDescriptor)
             .build();
+    GrpcCallSettings<CreateInventoryRequest, Inventory> createInventoryTransportSettings =
+        GrpcCallSettings.<CreateInventoryRequest, Inventory>newBuilder()
+            .setMethodDescriptor(createInventoryMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<CreateInventoryRequest>() {
+                  @Override
+                  public Map<String, String> extract(CreateInventoryRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("parent", String.valueOf(request.getParent()));
+                    return params.build();
+                  }
+                })
+            .build();
     GrpcCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksTransportSettings =
         GrpcCallSettings.<MoveBooksRequest, MoveBooksResponse>newBuilder()
             .setMethodDescriptor(moveBooksMethodDescriptor)
@@ -12170,6 +12633,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.getBigNothingOperationCallable = callableFactory.createOperationCallable(
         getBigNothingTransportSettings,settings.getBigNothingOperationSettings(), clientContext, this.operationsStub);
     this.testOptionalRequiredFlatteningParamsCallable = callableFactory.createUnaryCallable(testOptionalRequiredFlatteningParamsTransportSettings,settings.testOptionalRequiredFlatteningParamsSettings(), clientContext);
+    this.createInventoryCallable = callableFactory.createUnaryCallable(createInventoryTransportSettings,settings.createInventorySettings(), clientContext);
     this.moveBooksCallable = callableFactory.createUnaryCallable(moveBooksTransportSettings,settings.moveBooksSettings(), clientContext);
     this.archiveBooksCallable = callableFactory.createUnaryCallable(archiveBooksTransportSettings,settings.archiveBooksSettings(), clientContext);
     this.longRunningArchiveBooksCallable = callableFactory.createUnaryCallable(longRunningArchiveBooksTransportSettings,settings.longRunningArchiveBooksSettings(), clientContext);
@@ -12323,6 +12787,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
 
   public UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     return testOptionalRequiredFlatteningParamsCallable;
+  }
+
+  public UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable() {
+    return createInventoryCallable;
   }
 
   public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
@@ -12699,6 +13167,7 @@ import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.BookName;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -12712,6 +13181,8 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
+import com.google.example.library.v1.InventoryName;
 import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
@@ -12923,6 +13394,10 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: testOptionalRequiredFlatteningParamsCallable()");
   }
 
+  public UnaryCallable<CreateInventoryRequest, Inventory> createInventoryCallable() {
+    throw new UnsupportedOperationException("Not implemented: createInventoryCallable()");
+  }
+
   public UnaryCallable<MoveBooksRequest, MoveBooksResponse> moveBooksCallable() {
     throw new UnsupportedOperationException("Not implemented: moveBooksCallable()");
   }
@@ -13030,6 +13505,7 @@ import com.google.example.library.v1.BookFromAnywhere;
 import com.google.example.library.v1.BookFromArchive;
 import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateInventoryRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
@@ -13042,6 +13518,7 @@ import com.google.example.library.v1.GetBookFromAnywhereRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.Inventory;
 import static com.google.example.library.v1.LibraryClient.FindRelatedBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListBooksPagedResponse;
 import static com.google.example.library.v1.LibraryClient.ListShelvesPagedResponse;
@@ -13153,6 +13630,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   private final UnaryCallSettings<GetBookRequest, Operation> getBigNothingSettings;
   private final OperationCallSettings<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
   private final UnaryCallSettings<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+  private final UnaryCallSettings<CreateInventoryRequest, Inventory> createInventorySettings;
   private final UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
   private final UnaryCallSettings<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
   private final UnaryCallSettings<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
@@ -13374,6 +13852,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
   }
 
   /**
+   * Returns the object with the settings used for calls to createInventory.
+   */
+  public UnaryCallSettings<CreateInventoryRequest, Inventory> createInventorySettings() {
+    return createInventorySettings;
+  }
+
+  /**
    * Returns the object with the settings used for calls to moveBooks.
    */
   public UnaryCallSettings<MoveBooksRequest, MoveBooksResponse> moveBooksSettings() {
@@ -13539,6 +14024,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     getBigNothingSettings = settingsBuilder.getBigNothingSettings().build();
     getBigNothingOperationSettings = settingsBuilder.getBigNothingOperationSettings().build();
     testOptionalRequiredFlatteningParamsSettings = settingsBuilder.testOptionalRequiredFlatteningParamsSettings().build();
+    createInventorySettings = settingsBuilder.createInventorySettings().build();
     moveBooksSettings = settingsBuilder.moveBooksSettings().build();
     archiveBooksSettings = settingsBuilder.archiveBooksSettings().build();
     longRunningArchiveBooksSettings = settingsBuilder.longRunningArchiveBooksSettings().build();
@@ -13899,6 +14385,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
     private final UnaryCallSettings.Builder<GetBookRequest, Operation> getBigNothingSettings;
     private final OperationCallSettings.Builder<GetBookRequest, Empty, GetBigBookMetadata> getBigNothingOperationSettings;
     private final UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings;
+    private final UnaryCallSettings.Builder<CreateInventoryRequest, Inventory> createInventorySettings;
     private final UnaryCallSettings.Builder<MoveBooksRequest, MoveBooksResponse> moveBooksSettings;
     private final UnaryCallSettings.Builder<ArchiveBooksRequest, ArchiveBooksResponse> archiveBooksSettings;
     private final UnaryCallSettings.Builder<ArchiveBooksRequest, Operation> longRunningArchiveBooksSettings;
@@ -14020,6 +14507,8 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
       testOptionalRequiredFlatteningParamsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
+      createInventorySettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
       moveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       archiveBooksSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
@@ -14058,6 +14547,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          createInventorySettings,
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
@@ -14199,6 +14689,10 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"));
 
+      builder.createInventorySettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
       builder.moveBooksSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
@@ -14315,6 +14809,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
       getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
       getBigNothingOperationSettings = settings.getBigNothingOperationSettings.toBuilder();
       testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
+      createInventorySettings = settings.createInventorySettings.toBuilder();
       moveBooksSettings = settings.moveBooksSettings.toBuilder();
       archiveBooksSettings = settings.archiveBooksSettings.toBuilder();
       longRunningArchiveBooksSettings = settings.longRunningArchiveBooksSettings.toBuilder();
@@ -14347,6 +14842,7 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           getBigBookSettings,
           getBigNothingSettings,
           testOptionalRequiredFlatteningParamsSettings,
+          createInventorySettings,
           moveBooksSettings,
           archiveBooksSettings,
           longRunningArchiveBooksSettings,
@@ -14580,6 +15076,13 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
      */
     public UnaryCallSettings.Builder<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsSettings() {
       return testOptionalRequiredFlatteningParamsSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to createInventory.
+     */
+    public UnaryCallSettings.Builder<CreateInventoryRequest, Inventory> createInventorySettings() {
+      return createInventorySettings;
     }
 
     /**
@@ -17039,6 +17542,51 @@ public class LibraryClientTest {
 
   @Test
   @SuppressWarnings("all")
+  public void createInventoryTest() {
+    InventoryName name = InventoryName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+    Inventory expectedResponse = Inventory.newBuilder()
+      .setName(name.toString())
+      .build();
+    mockLibraryService.addResponse(expectedResponse);
+
+    PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+    Inventory inventory = Inventory.newBuilder().build();
+
+    Inventory actualResponse =
+        client.createInventory(parent, inventory);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CreateInventoryRequest actualRequest = (CreateInventoryRequest)actualRequests.get(0);
+
+    Assert.assertEquals(parent, PublisherName.parse(actualRequest.getParent()));
+    Assert.assertEquals(inventory, actualRequest.getInventory());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void createInventoryExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INVALID_ARGUMENT);
+    mockLibraryService.addException(exception);
+
+    try {
+      PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+      Inventory inventory = Inventory.newBuilder().build();
+
+      client.createInventory(parent, inventory);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @SuppressWarnings("all")
   public void moveBooksTest() {
     boolean success = false;
     MoveBooksResponse expectedResponse = MoveBooksResponse.newBuilder()
@@ -17751,6 +18299,21 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
     if (response instanceof PublishSeriesResponse) {
       requests.add(request);
       responseObserver.onNext((PublishSeriesResponse) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
+  @Override
+  public void createInventory(CreateInventoryRequest request,
+    StreamObserver<Inventory> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Inventory) {
+      requests.add(request);
+      responseObserver.onNext((Inventory) response);
       responseObserver.onCompleted();
     } else if (response instanceof Exception) {
       responseObserver.onError((Exception) response);

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -2668,6 +2668,17 @@ const Book = {
 };
 
 /**
+ * @property {string} name
+ *
+ * @typedef Inventory
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.Inventory definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const Inventory = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
  * A single book in the archives.
  *
  * @property {string} name
@@ -3213,6 +3224,20 @@ const ListStringsRequest = {
  * @see [google.example.library.v1.ListStringsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 const ListStringsResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {string} parent
+ *
+ * @property {Object} inventory
+ *   This object should have the same structure as [Inventory]{@link google.example.library.v1.Inventory}
+ *
+ * @typedef CreateInventoryRequest
+ * @memberof google.example.library.v1
+ * @see [google.example.library.v1.CreateInventoryRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+const CreateInventoryRequest = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
@@ -5133,6 +5158,9 @@ class LibraryServiceClient {
       folderPathTemplate: new gaxModule.PathTemplate(
         'folders/{folder}'
       ),
+      inventoryPathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/locations/{location}/publishers/{publisher}/inventory'
+      ),
       locationPathTemplate: new gaxModule.PathTemplate(
         'projects/{project}/locations/{location}'
       ),
@@ -5310,6 +5338,7 @@ class LibraryServiceClient {
       'getBigBook',
       'getBigNothing',
       'testOptionalRequiredFlatteningParams',
+      'createInventory',
       'moveBooks',
       'archiveBooks',
       'longRunningArchiveBooks',
@@ -7730,6 +7759,60 @@ class LibraryServiceClient {
   }
 
   /**
+   * Creates an inventory. Tests singleton resources.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.parent
+   * @param {Object} [request.inventory]
+   *   This object should have the same structure as [Inventory]{@link google.example.library.v1.Inventory}
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Inventory]{@link google.example.library.v1.Inventory}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Inventory]{@link google.example.library.v1.Inventory}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const library = require('@google-cloud/library');
+   *
+   * const client = new library.v1.LibraryServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * const formattedParent = client.publisherPath('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+   * client.createInventory({parent: formattedParent})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  createInventory(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers['x-goog-request-params'] =
+      gax.routingHeader.fromParams({
+        'parent': request.parent
+      });
+
+    return this._innerApiCalls.createInventory(request, options, callback);
+  }
+
+  /**
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} [request.source]
@@ -8187,6 +8270,22 @@ class LibraryServiceClient {
   }
 
   /**
+   * Return a fully-qualified inventory resource name string.
+   *
+   * @param {String} project
+   * @param {String} location
+   * @param {String} publisher
+   * @returns {String}
+   */
+  inventoryPath(project, location, publisher) {
+    return this._pathTemplates.inventoryPathTemplate.render({
+      project: project,
+      location: location,
+      publisher: publisher,
+    });
+  }
+
+  /**
    * Return a fully-qualified location resource name string.
    *
    * @param {String} project
@@ -8361,6 +8460,45 @@ class LibraryServiceClient {
     return this._pathTemplates.folderPathTemplate
       .match(folderName)
       .folder;
+  }
+
+  /**
+   * Parse the inventoryName from a inventory resource.
+   *
+   * @param {String} inventoryName
+   *   A fully-qualified path representing a inventory resources.
+   * @returns {String} - A string representing the project.
+   */
+  matchProjectFromInventoryName(inventoryName) {
+    return this._pathTemplates.inventoryPathTemplate
+      .match(inventoryName)
+      .project;
+  }
+
+  /**
+   * Parse the inventoryName from a inventory resource.
+   *
+   * @param {String} inventoryName
+   *   A fully-qualified path representing a inventory resources.
+   * @returns {String} - A string representing the location.
+   */
+  matchLocationFromInventoryName(inventoryName) {
+    return this._pathTemplates.inventoryPathTemplate
+      .match(inventoryName)
+      .location;
+  }
+
+  /**
+   * Parse the inventoryName from a inventory resource.
+   *
+   * @param {String} inventoryName
+   *   A fully-qualified path representing a inventory resources.
+   * @returns {String} - A string representing the publisher.
+   */
+  matchPublisherFromInventoryName(inventoryName) {
+    return this._pathTemplates.inventoryPathTemplate
+      .match(inventoryName)
+      .publisher;
   }
 
   /**
@@ -8657,6 +8795,11 @@ module.exports = LibraryServiceClient;
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "CreateInventory": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -11042,6 +11185,66 @@ describe('LibraryServiceClient', () => {
       );
 
       client.testOptionalRequiredFlatteningParams(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('createInventory', () => {
+    it('invokes createInventory without error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedParent = client.publisherPath('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+      const request = {
+        parent: formattedParent,
+      };
+
+      // Mock response
+      const name = 'name3373707';
+      const expectedResponse = {
+        name: name,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.createInventory = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.createInventory(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes createInventory with error', done => {
+      const client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedParent = client.publisherPath('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+      const request = {
+        parent: formattedParent,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.createInventory = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.createInventory(request, (err, response) => {
         assert(err instanceof Error);
         assert.strictEqual(err.code, FAKE_STATUS_CODE);
         assert(typeof response === 'undefined');

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -2310,6 +2310,7 @@ use Google\Example\Library\V1\Book\MapStringValueEntry;
 use Google\Example\Library\V1\Book\Rating;
 use Google\Example\Library\V1\Comment;
 use Google\Example\Library\V1\CreateBookRequest;
+use Google\Example\Library\V1\CreateInventoryRequest;
 use Google\Example\Library\V1\CreateShelfRequest;
 use Google\Example\Library\V1\DeleteBookRequest;
 use Google\Example\Library\V1\DeleteShelfRequest;
@@ -2322,6 +2323,7 @@ use Google\Example\Library\V1\GetBookFromAnywhereRequest;
 use Google\Example\Library\V1\GetBookFromArchiveRequest;
 use Google\Example\Library\V1\GetBookRequest;
 use Google\Example\Library\V1\GetShelfRequest;
+use Google\Example\Library\V1\Inventory;
 use Google\Example\Library\V1\LibraryServiceGrpcClient;
 use Google\Example\Library\V1\ListBooksRequest;
 use Google\Example\Library\V1\ListBooksResponse;
@@ -2445,6 +2447,7 @@ class LibraryServiceGapicClient
     private static $bookNameTemplate;
     private static $bookFromArchiveNameTemplate;
     private static $folderNameTemplate;
+    private static $inventoryNameTemplate;
     private static $locationNameTemplate;
     private static $projectNameTemplate;
     private static $projectBookNameTemplate;
@@ -2517,6 +2520,15 @@ class LibraryServiceGapicClient
         return self::$folderNameTemplate;
     }
 
+    private static function getInventoryNameTemplate()
+    {
+        if (self::$inventoryNameTemplate == null) {
+            self::$inventoryNameTemplate = new PathTemplate('projects/{project}/locations/{location}/publishers/{publisher}/inventory');
+        }
+
+        return self::$inventoryNameTemplate;
+    }
+
     private static function getLocationNameTemplate()
     {
         if (self::$locationNameTemplate == null) {
@@ -2572,6 +2584,7 @@ class LibraryServiceGapicClient
                 'book' => self::getBookNameTemplate(),
                 'bookFromArchive' => self::getBookFromArchiveNameTemplate(),
                 'folder' => self::getFolderNameTemplate(),
+                'inventory' => self::getInventoryNameTemplate(),
                 'location' => self::getLocationNameTemplate(),
                 'project' => self::getProjectNameTemplate(),
                 'projectBook' => self::getProjectBookNameTemplate(),
@@ -2661,6 +2674,25 @@ class LibraryServiceGapicClient
     {
         return self::getFolderNameTemplate()->render([
             'folder' => $folder,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent
+     * a inventory resource.
+     *
+     * @param string $project
+     * @param string $location
+     * @param string $publisher
+     * @return string The formatted inventory resource.
+     * @experimental
+     */
+    public static function inventoryName($project, $location, $publisher)
+    {
+        return self::getInventoryNameTemplate()->render([
+            'project' => $project,
+            'location' => $location,
+            'publisher' => $publisher,
         ]);
     }
 
@@ -2757,6 +2789,7 @@ class LibraryServiceGapicClient
      * - book: shelves/{shelf}/books/{book}
      * - bookFromArchive: archives/{archive}/books/{book}
      * - folder: folders/{folder}
+     * - inventory: projects/{project}/locations/{location}/publishers/{publisher}/inventory
      * - location: projects/{project}/locations/{location}
      * - project: projects/{project}
      * - projectBook: projects/{project}/books/{book}
@@ -4942,6 +4975,59 @@ class LibraryServiceGapicClient
     }
 
     /**
+     * Creates an inventory. Tests singleton resources.
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $formattedParent = $libraryServiceClient->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+     *     $response = $libraryServiceClient->createInventory($formattedParent);
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string $parent
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type Inventory $inventory
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\Inventory
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function createInventory($parent, array $optionalArgs = [])
+    {
+        $request = new CreateInventoryRequest();
+        $request->setParent($parent);
+        if (isset($optionalArgs['inventory'])) {
+            $request->setInventory($optionalArgs['inventory']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'parent' => $request->getParent(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'CreateInventory',
+            Inventory::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
      *
      *
      * Sample code:
@@ -5933,6 +6019,11 @@ class MyProtoClient extends MyProtoGapicClient
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "CreateInventory": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "MoveBooks": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
@@ -6323,6 +6414,18 @@ return [
                 'uriTemplate' => '/v1/testofp',
                 'body' => '*',
             ],
+            'CreateInventory' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{parent=projects/*/locations/*/publishers/*}',
+                'body' => 'inventory',
+                'placeholders' => [
+                    'parent' => [
+                        'getters' => [
+                            'getParent',
+                        ],
+                    ],
+                ]
+            ],
             'MoveBooks' => [
                 'method' => 'post',
                 'uriTemplate' => '/v1/{source=**}:move',
@@ -6552,6 +6655,7 @@ use Google\Example\Library\V1\BookFromArchive;
 use Google\Example\Library\V1\Comment;
 use Google\Example\Library\V1\Comment\Stage;
 use Google\Example\Library\V1\CreateBookRequest;
+use Google\Example\Library\V1\CreateInventoryRequest;
 use Google\Example\Library\V1\CreateShelfRequest;
 use Google\Example\Library\V1\DeleteBookRequest;
 use Google\Example\Library\V1\DeleteShelfRequest;
@@ -6563,6 +6667,7 @@ use Google\Example\Library\V1\GetBookFromAnywhereRequest;
 use Google\Example\Library\V1\GetBookFromArchiveRequest;
 use Google\Example\Library\V1\GetBookRequest;
 use Google\Example\Library\V1\GetShelfRequest;
+use Google\Example\Library\V1\Inventory;
 use Google\Example\Library\V1\LibraryServiceGrpcClient;
 use Google\Example\Library\V1\ListBooksRequest;
 use Google\Example\Library\V1\ListBooksResponse;
@@ -9238,6 +9343,79 @@ class LibraryServiceClientTest extends GeneratedTest
 
         try {
             $client->testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $formattedRequiredSingularResourceName, $formattedRequiredSingularResourceNameOneof, $requiredSingularResourceNameCommon, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $formattedRequiredRepeatedResourceName, $formattedRequiredRepeatedResourceNameOneof, $requiredRepeatedResourceNameCommon, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap, $requiredAnyValue, $requiredStructValue, $requiredValueValue, $requiredListValueValue, $requiredTimeValue, $requiredDurationValue, $requiredFieldMaskValue, $requiredInt32Value, $requiredUint32Value, $requiredInt64Value, $requiredUint64Value, $requiredFloatValue, $requiredDoubleValue, $requiredStringValue, $requiredBoolValue, $requiredBytesValue, $requiredRepeatedAnyValue, $requiredRepeatedStructValue, $requiredRepeatedValueValue, $requiredRepeatedListValueValue, $requiredRepeatedTimeValue, $requiredRepeatedDurationValue, $requiredRepeatedFieldMaskValue, $requiredRepeatedInt32Value, $requiredRepeatedUint32Value, $requiredRepeatedInt64Value, $requiredRepeatedUint64Value, $requiredRepeatedFloatValue, $requiredRepeatedDoubleValue, $requiredRepeatedStringValue, $requiredRepeatedBoolValue, $requiredRepeatedBytesValue);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function createInventoryTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $name = 'name3373707';
+        $expectedResponse = new Inventory();
+        $expectedResponse->setName($name);
+        $transport->addResponse($expectedResponse);
+
+        // Mock request
+        $formattedParent = $client->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+
+        $response = $client->createInventory($formattedParent);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/CreateInventory', $actualFuncCall);
+
+        $actualValue = $actualRequestObject->getParent();
+
+        $this->assertProtobufEquals($formattedParent, $actualValue);
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function createInventoryExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        // Mock request
+        $formattedParent = $client->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+
+        try {
+            $client->createInventory($formattedParent);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -2452,6 +2452,7 @@ class LibraryServiceGapicClient
     private static $locationNameTemplate;
     private static $projectNameTemplate;
     private static $projectBookNameTemplate;
+    private static $projectLocationPublisherBookNameTemplate;
     private static $projectReaderNameTemplate;
     private static $projectShelfReaderNameTemplate;
     private static $publisherNameTemplate;
@@ -2570,6 +2571,15 @@ class LibraryServiceGapicClient
         return self::$projectBookNameTemplate;
     }
 
+    private static function getProjectLocationPublisherBookNameTemplate()
+    {
+        if (self::$projectLocationPublisherBookNameTemplate == null) {
+            self::$projectLocationPublisherBookNameTemplate = new PathTemplate('projects/{project}/locations/{location}/publishers/{publisher}/inventory/books/{book}');
+        }
+
+        return self::$projectLocationPublisherBookNameTemplate;
+    }
+
     private static function getProjectReaderNameTemplate()
     {
         if (self::$projectReaderNameTemplate == null) {
@@ -2639,6 +2649,7 @@ class LibraryServiceGapicClient
                 'location' => self::getLocationNameTemplate(),
                 'project' => self::getProjectNameTemplate(),
                 'projectBook' => self::getProjectBookNameTemplate(),
+                'projectLocationPublisherBook' => self::getProjectLocationPublisherBookNameTemplate(),
                 'projectReader' => self::getProjectReaderNameTemplate(),
                 'projectShelfReader' => self::getProjectShelfReaderNameTemplate(),
                 'publisher' => self::getPublisherNameTemplate(),
@@ -2818,6 +2829,27 @@ class LibraryServiceGapicClient
 
     /**
      * Formats a string containing the fully-qualified path to represent
+     * a project_location_publisher_book resource.
+     *
+     * @param string $project
+     * @param string $location
+     * @param string $publisher
+     * @param string $book
+     * @return string The formatted project_location_publisher_book resource.
+     * @experimental
+     */
+    public static function projectLocationPublisherBookName($project, $location, $publisher, $book)
+    {
+        return self::getProjectLocationPublisherBookNameTemplate()->render([
+            'project' => $project,
+            'location' => $location,
+            'publisher' => $publisher,
+            'book' => $book,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent
      * a project_reader resource.
      *
      * @param string $project
@@ -2934,6 +2966,7 @@ class LibraryServiceGapicClient
      * - location: projects/{project}/locations/{location}
      * - project: projects/{project}
      * - projectBook: projects/{project}/books/{book}
+     * - projectLocationPublisherBook: projects/{project}/locations/{location}/publishers/{publisher}/inventory/books/{book}
      * - projectReader: projects/{project}/readers/{reader}
      * - projectShelfReader: projects/{project}/shelves/{shelf}/readers/{reader}
      * - publisher: projects/{project}/locations/{location}/publishers/{publisher}

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -2310,6 +2310,7 @@ use Google\Example\Library\V1\Book\MapStringValueEntry;
 use Google\Example\Library\V1\Book\Rating;
 use Google\Example\Library\V1\Comment;
 use Google\Example\Library\V1\CreateBookRequest;
+use Google\Example\Library\V1\CreateInventoryRequest;
 use Google\Example\Library\V1\CreateShelfRequest;
 use Google\Example\Library\V1\DeleteBookRequest;
 use Google\Example\Library\V1\DeleteShelfRequest;
@@ -2322,6 +2323,7 @@ use Google\Example\Library\V1\GetBookFromAnywhereRequest;
 use Google\Example\Library\V1\GetBookFromArchiveRequest;
 use Google\Example\Library\V1\GetBookRequest;
 use Google\Example\Library\V1\GetShelfRequest;
+use Google\Example\Library\V1\Inventory;
 use Google\Example\Library\V1\LibraryServiceGrpcClient;
 use Google\Example\Library\V1\ListBooksRequest;
 use Google\Example\Library\V1\ListBooksResponse;
@@ -2445,6 +2447,7 @@ class LibraryServiceGapicClient
     private static $bookNameTemplate;
     private static $bookFromArchiveNameTemplate;
     private static $folderNameTemplate;
+    private static $inventoryNameTemplate;
     private static $locationNameTemplate;
     private static $projectNameTemplate;
     private static $projectBookNameTemplate;
@@ -2517,6 +2520,15 @@ class LibraryServiceGapicClient
         return self::$folderNameTemplate;
     }
 
+    private static function getInventoryNameTemplate()
+    {
+        if (self::$inventoryNameTemplate == null) {
+            self::$inventoryNameTemplate = new PathTemplate('projects/{project}/locations/{location}/publishers/{publisher}/inventory');
+        }
+
+        return self::$inventoryNameTemplate;
+    }
+
     private static function getLocationNameTemplate()
     {
         if (self::$locationNameTemplate == null) {
@@ -2572,6 +2584,7 @@ class LibraryServiceGapicClient
                 'book' => self::getBookNameTemplate(),
                 'bookFromArchive' => self::getBookFromArchiveNameTemplate(),
                 'folder' => self::getFolderNameTemplate(),
+                'inventory' => self::getInventoryNameTemplate(),
                 'location' => self::getLocationNameTemplate(),
                 'project' => self::getProjectNameTemplate(),
                 'projectBook' => self::getProjectBookNameTemplate(),
@@ -2661,6 +2674,25 @@ class LibraryServiceGapicClient
     {
         return self::getFolderNameTemplate()->render([
             'folder' => $folder,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent
+     * a inventory resource.
+     *
+     * @param string $project
+     * @param string $location
+     * @param string $publisher
+     * @return string The formatted inventory resource.
+     * @experimental
+     */
+    public static function inventoryName($project, $location, $publisher)
+    {
+        return self::getInventoryNameTemplate()->render([
+            'project' => $project,
+            'location' => $location,
+            'publisher' => $publisher,
         ]);
     }
 
@@ -2757,6 +2789,7 @@ class LibraryServiceGapicClient
      * - book: shelves/{shelf}/books/{book}
      * - bookFromArchive: archives/{archive}/books/{book}
      * - folder: folders/{folder}
+     * - inventory: projects/{project}/locations/{location}/publishers/{publisher}/inventory
      * - location: projects/{project}/locations/{location}
      * - project: projects/{project}
      * - projectBook: projects/{project}/books/{book}
@@ -4942,6 +4975,59 @@ class LibraryServiceGapicClient
     }
 
     /**
+     * Creates an inventory. Tests singleton resources.
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $formattedParent = $libraryServiceClient->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+     *     $response = $libraryServiceClient->createInventory($formattedParent);
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string $parent
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type Inventory $inventory
+     *     @type RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\ApiCore\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Example\Library\V1\Inventory
+     *
+     * @throws ApiException if the remote call fails
+     * @experimental
+     */
+    public function createInventory($parent, array $optionalArgs = [])
+    {
+        $request = new CreateInventoryRequest();
+        $request->setParent($parent);
+        if (isset($optionalArgs['inventory'])) {
+            $request->setInventory($optionalArgs['inventory']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+          'parent' => $request->getParent(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers'])
+            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
+            : $requestParams->getHeader();
+
+        return $this->startCall(
+            'CreateInventory',
+            Inventory::class,
+            $optionalArgs,
+            $request
+        )->wait();
+    }
+
+    /**
      *
      *
      * Sample code:
@@ -5952,6 +6038,11 @@ class MyProtoClient extends MyProtoGapicClient
           "retry_codes_name": "no_retry_1_codes",
           "retry_params_name": "no_retry_1_params"
         },
+        "CreateInventory": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "retry_policy_1_codes",
+          "retry_params_name": "retry_policy_1_params"
+        },
         "MoveBooks": {
           "timeout_millis": 60000,
           "retry_codes_name": "retry_policy_1_codes",
@@ -6342,6 +6433,18 @@ return [
                 'uriTemplate' => '/v1/testofp',
                 'body' => '*',
             ],
+            'CreateInventory' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{parent=projects/*/locations/*/publishers/*}',
+                'body' => 'inventory',
+                'placeholders' => [
+                    'parent' => [
+                        'getters' => [
+                            'getParent',
+                        ],
+                    ],
+                ]
+            ],
             'MoveBooks' => [
                 'method' => 'post',
                 'uriTemplate' => '/v1/{source=**}:move',
@@ -6577,6 +6680,7 @@ use Google\Example\Library\V1\BookFromArchive;
 use Google\Example\Library\V1\Comment;
 use Google\Example\Library\V1\Comment\Stage;
 use Google\Example\Library\V1\CreateBookRequest;
+use Google\Example\Library\V1\CreateInventoryRequest;
 use Google\Example\Library\V1\CreateShelfRequest;
 use Google\Example\Library\V1\DeleteBookRequest;
 use Google\Example\Library\V1\DeleteShelfRequest;
@@ -6588,6 +6692,7 @@ use Google\Example\Library\V1\GetBookFromAnywhereRequest;
 use Google\Example\Library\V1\GetBookFromArchiveRequest;
 use Google\Example\Library\V1\GetBookRequest;
 use Google\Example\Library\V1\GetShelfRequest;
+use Google\Example\Library\V1\Inventory;
 use Google\Example\Library\V1\LibraryServiceGrpcClient;
 use Google\Example\Library\V1\ListBooksRequest;
 use Google\Example\Library\V1\ListBooksResponse;
@@ -9263,6 +9368,79 @@ class LibraryServiceClientTest extends GeneratedTest
 
         try {
             $client->testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $formattedRequiredSingularResourceName, $formattedRequiredSingularResourceNameOneof, $requiredSingularResourceNameCommon, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $formattedRequiredRepeatedResourceName, $formattedRequiredRepeatedResourceNameOneof, $requiredRepeatedResourceNameCommon, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap, $requiredAnyValue, $requiredStructValue, $requiredValueValue, $requiredListValueValue, $requiredTimeValue, $requiredDurationValue, $requiredFieldMaskValue, $requiredInt32Value, $requiredUint32Value, $requiredInt64Value, $requiredUint64Value, $requiredFloatValue, $requiredDoubleValue, $requiredStringValue, $requiredBoolValue, $requiredBytesValue, $requiredRepeatedAnyValue, $requiredRepeatedStructValue, $requiredRepeatedValueValue, $requiredRepeatedListValueValue, $requiredRepeatedTimeValue, $requiredRepeatedDurationValue, $requiredRepeatedFieldMaskValue, $requiredRepeatedInt32Value, $requiredRepeatedUint32Value, $requiredRepeatedInt64Value, $requiredRepeatedUint64Value, $requiredRepeatedFloatValue, $requiredRepeatedDoubleValue, $requiredRepeatedStringValue, $requiredRepeatedBoolValue, $requiredRepeatedBytesValue);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function createInventoryTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        // Mock response
+        $name = 'name3373707';
+        $expectedResponse = new Inventory();
+        $expectedResponse->setName($name);
+        $transport->addResponse($expectedResponse);
+
+        // Mock request
+        $formattedParent = $client->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+
+        $response = $client->createInventory($formattedParent);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/CreateInventory', $actualFuncCall);
+
+        $actualValue = $actualRequestObject->getParent();
+
+        $this->assertProtobufEquals($formattedParent, $actualValue);
+
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function createInventoryExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient(['transport' => $transport]);
+
+        $this->assertTrue($transport->isExhausted());
+
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           'message' => 'internal error',
+           'code' => Code::DATA_LOSS,
+           'status' => 'DATA_LOSS',
+           'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+
+        // Mock request
+        $formattedParent = $client->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+
+        try {
+            $client->createInventory($formattedParent);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -2452,6 +2452,7 @@ class LibraryServiceGapicClient
     private static $locationNameTemplate;
     private static $projectNameTemplate;
     private static $projectBookNameTemplate;
+    private static $projectLocationPublisherBookNameTemplate;
     private static $projectReaderNameTemplate;
     private static $projectShelfReaderNameTemplate;
     private static $publisherNameTemplate;
@@ -2570,6 +2571,15 @@ class LibraryServiceGapicClient
         return self::$projectBookNameTemplate;
     }
 
+    private static function getProjectLocationPublisherBookNameTemplate()
+    {
+        if (self::$projectLocationPublisherBookNameTemplate == null) {
+            self::$projectLocationPublisherBookNameTemplate = new PathTemplate('projects/{project}/locations/{location}/publishers/{publisher}/inventory/books/{book}');
+        }
+
+        return self::$projectLocationPublisherBookNameTemplate;
+    }
+
     private static function getProjectReaderNameTemplate()
     {
         if (self::$projectReaderNameTemplate == null) {
@@ -2639,6 +2649,7 @@ class LibraryServiceGapicClient
                 'location' => self::getLocationNameTemplate(),
                 'project' => self::getProjectNameTemplate(),
                 'projectBook' => self::getProjectBookNameTemplate(),
+                'projectLocationPublisherBook' => self::getProjectLocationPublisherBookNameTemplate(),
                 'projectReader' => self::getProjectReaderNameTemplate(),
                 'projectShelfReader' => self::getProjectShelfReaderNameTemplate(),
                 'publisher' => self::getPublisherNameTemplate(),
@@ -2818,6 +2829,27 @@ class LibraryServiceGapicClient
 
     /**
      * Formats a string containing the fully-qualified path to represent
+     * a project_location_publisher_book resource.
+     *
+     * @param string $project
+     * @param string $location
+     * @param string $publisher
+     * @param string $book
+     * @return string The formatted project_location_publisher_book resource.
+     * @experimental
+     */
+    public static function projectLocationPublisherBookName($project, $location, $publisher, $book)
+    {
+        return self::getProjectLocationPublisherBookNameTemplate()->render([
+            'project' => $project,
+            'location' => $location,
+            'publisher' => $publisher,
+            'book' => $book,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent
      * a project_reader resource.
      *
      * @param string $project
@@ -2934,6 +2966,7 @@ class LibraryServiceGapicClient
      * - location: projects/{project}/locations/{location}
      * - project: projects/{project}
      * - projectBook: projects/{project}/books/{book}
+     * - projectLocationPublisherBook: projects/{project}/locations/{location}/publishers/{publisher}/inventory/books/{book}
      * - projectReader: projects/{project}/readers/{reader}
      * - projectShelfReader: projects/{project}/shelves/{shelf}/readers/{reader}
      * - publisher: projects/{project}/locations/{location}/publishers/{publisher}

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -1200,6 +1200,16 @@ class LibraryServiceClient(object):
         )
 
     @classmethod
+    def inventory_path(cls, project, location, publisher):
+        """Return a fully-qualified inventory string."""
+        return google.api_core.path_template.expand(
+            'projects/{project}/locations/{location}/publishers/{publisher}/inventory',
+            project=project,
+            location=location,
+            publisher=publisher,
+        )
+
+    @classmethod
     def location_path(cls, project, location):
         """Return a fully-qualified location string."""
         return google.api_core.path_template.expand(
@@ -3995,6 +4005,75 @@ class LibraryServiceClient(object):
         )
         return self._inner_api_calls['test_optional_required_flattening_params'](request, retry=retry, timeout=timeout, metadata=metadata)
 
+    def create_inventory(
+            self,
+            parent,
+            inventory=None,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT,
+            metadata=None):
+        """
+        Creates an inventory. Tests singleton resources.
+
+        Example:
+            >>> from google.cloud.example import library_v1
+            >>>
+            >>> client = library_v1.LibraryServiceClient()
+            >>>
+            >>> parent = client.publisher_path('[PROJECT]', '[LOCATION]', '[PUBLISHER]')
+            >>>
+            >>> response = client.create_inventory(parent)
+
+        Args:
+            parent (str)
+            inventory (Union[dict, ~google.cloud.example.library_v1.types.Inventory]):
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.example.library_v1.types.Inventory`
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
+            metadata (Optional[Sequence[Tuple[str, str]]]): Additional metadata
+                that is provided to the method.
+
+        Returns:
+            A :class:`~google.cloud.example.library_v1.types.Inventory` instance.
+
+        Raises:
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                    failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                    to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
+        """
+        # Wrap the transport method to add retry and timeout logic.
+        if 'create_inventory' not in self._inner_api_calls:
+            self._inner_api_calls['create_inventory'] = google.api_core.gapic_v1.method.wrap_method(
+                self.transport.create_inventory,
+                default_retry=self._method_configs['CreateInventory'].retry,
+                default_timeout=self._method_configs['CreateInventory'].timeout,
+                client_info=self._client_info,
+            )
+
+        request = library_pb2.CreateInventoryRequest(
+            parent=parent,
+            inventory=inventory,
+        )
+        if metadata is None:
+            metadata = []
+        metadata = list(metadata)
+        try:
+            routing_header = [('parent', parent)]
+        except AttributeError:
+            pass
+        else:
+            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
+            metadata.append(routing_metadata)
+
+        return self._inner_api_calls['create_inventory'](request, retry=retry, timeout=timeout, metadata=metadata)
+
     def move_books(
             self,
             source=None,
@@ -4664,6 +4743,11 @@ config = {
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "CreateInventory": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -5550,6 +5634,19 @@ class LibraryServiceGrpcTransport(object):
                 deserialized response object.
         """
         return self._stubs['library_service_stub'].TestOptionalRequiredFlatteningParams
+
+    @property
+    def create_inventory(self):
+        """Return the gRPC stub for :meth:`LibraryServiceClient.create_inventory`.
+
+        Creates an inventory. Tests singleton resources.
+
+        Returns:
+            Callable: A callable which accepts the appropriate
+                deserialized request object and returns a
+                deserialized response object.
+        """
+        return self._stubs['library_service_stub'].CreateInventory
 
     @property
     def move_books(self):
@@ -8881,6 +8978,44 @@ class TestLibraryServiceClient(object):
 
         with pytest.raises(CustomException):
             client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map, required_any_value, required_struct_value, required_value_value, required_list_value_value, required_time_value, required_duration_value, required_field_mask_value, required_int32_value, required_uint32_value, required_int64_value, required_uint64_value, required_float_value, required_double_value, required_string_value, required_bool_value, required_bytes_value, required_repeated_any_value, required_repeated_struct_value, required_repeated_value_value, required_repeated_list_value_value, required_repeated_time_value, required_repeated_duration_value, required_repeated_field_mask_value, required_repeated_int32_value, required_repeated_uint32_value, required_repeated_int64_value, required_repeated_uint64_value, required_repeated_float_value, required_repeated_double_value, required_repeated_string_value, required_repeated_bool_value, required_repeated_bytes_value)
+
+    def test_create_inventory(self):
+        # Setup Expected Response
+        name = 'name3373707'
+        expected_response = {'name': name}
+        expected_response = library_pb2.Inventory(**expected_response)
+
+        # Mock the API response
+        channel = ChannelStub(responses = [expected_response])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        # Setup Request
+        parent = client.publisher_path('[PROJECT]', '[LOCATION]', '[PUBLISHER]')
+
+        response = client.create_inventory(parent)
+        assert expected_response == response
+
+        assert len(channel.requests) == 1
+        expected_request = library_pb2.CreateInventoryRequest(parent=parent)
+        actual_request = channel.requests[0][1]
+        assert expected_request == actual_request
+
+    def test_create_inventory_exception(self):
+        # Mock the API response
+        channel = ChannelStub(responses = [CustomException()])
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = library_v1.LibraryServiceClient()
+
+        # Setup request
+        parent = client.publisher_path('[PROJECT]', '[LOCATION]', '[PUBLISHER]')
+
+        with pytest.raises(CustomException):
+            client.create_inventory(parent)
 
     def test_move_books(self):
         # Setup Expected Response

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -2158,6 +2158,10 @@ module Google
           end
         end
 
+        # @!attribute [rw] name
+        #   @return [String]
+        class Inventory; end
+
         # A single book in the archives.
         # @!attribute [rw] name
         #   @return [String]
@@ -2448,6 +2452,12 @@ module Google
         # @!attribute [rw] next_page_token
         #   @return [String]
         class ListStringsResponse; end
+
+        # @!attribute [rw] parent
+        #   @return [String]
+        # @!attribute [rw] inventory
+        #   @return [Google::Example::Library::V1::Inventory]
+        class CreateInventoryRequest; end
 
         # @!attribute [rw] name
         #   @return [String]
@@ -3056,6 +3066,12 @@ module Library
 
       private_constant :FOLDER_PATH_TEMPLATE
 
+      INVENTORY_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+        "projects/{project}/locations/{location}/publishers/{publisher}/inventory"
+      )
+
+      private_constant :INVENTORY_PATH_TEMPLATE
+
       LOCATION_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
         "projects/{project}/locations/{location}"
       )
@@ -3138,6 +3154,19 @@ module Library
       def self.folder_path folder
         FOLDER_PATH_TEMPLATE.render(
           :"folder" => folder
+        )
+      end
+
+      # Returns a fully-qualified inventory resource name string.
+      # @param project [String]
+      # @param location [String]
+      # @param publisher [String]
+      # @return [String]
+      def self.inventory_path project, location, publisher
+        INVENTORY_PATH_TEMPLATE.render(
+          :"project" => project,
+          :"location" => location,
+          :"publisher" => publisher
         )
       end
 
@@ -3517,6 +3546,14 @@ module Library
           @library_service_stub.method(:test_optional_required_flattening_params),
           defaults["test_optional_required_flattening_params"],
           exception_transformer: exception_transformer
+        )
+        @create_inventory = Google::Gax.create_api_call(
+          @library_service_stub.method(:create_inventory),
+          defaults["create_inventory"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'parent' => request.parent}
+          end
         )
         @move_books = Google::Gax.create_api_call(
           @library_service_stub.method(:move_books),
@@ -5397,6 +5434,40 @@ module Library
         @test_optional_required_flattening_params.call(req, options, &block)
       end
 
+      # Creates an inventory. Tests singleton resources.
+      #
+      # @param parent [String]
+      # @param inventory [Google::Example::Library::V1::Inventory | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::Inventory`
+      #   can also be provided.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::Inventory]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::Inventory]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+      #   response = library_client.create_inventory(formatted_parent)
+
+      def create_inventory \
+          parent,
+          inventory: nil,
+          options: nil,
+          &block
+        req = {
+          parent: parent,
+          inventory: inventory
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateInventoryRequest)
+        @create_inventory.call(req, options, &block)
+      end
+
       # @param source [String]
       # @param destination [String]
       # @param publishers [Array<String>]
@@ -5922,6 +5993,11 @@ end
           "retry_params_name": "default"
         },
         "TestOptionalRequiredFlatteningParams": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "CreateInventory": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
@@ -10673,6 +10749,80 @@ describe Library::V1::LibraryServiceClient do
               required_repeated_bool_value,
               required_repeated_bytes_value
             )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'create_inventory' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#create_inventory."
+
+    it 'invokes create_inventory without error' do
+      # Create request parameters
+      formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+
+      # Create expected grpc response
+      name = "name3373707"
+      expected_response = { name: name }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Inventory)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::CreateInventoryRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:create_inventory, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("create_inventory")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.create_inventory(formatted_parent)
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.create_inventory(formatted_parent) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes create_inventory with error' do
+      # Create request parameters
+      formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::CreateInventoryRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:create_inventory, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("create_inventory")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.create_inventory(formatted_parent)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -2038,6 +2038,10 @@ module Google
           end
         end
 
+        # @!attribute [rw] name
+        #   @return [String]
+        class Inventory; end
+
         # A single book in the archives.
         # @!attribute [rw] name
         #   @return [String]
@@ -2328,6 +2332,12 @@ module Google
         # @!attribute [rw] next_page_token
         #   @return [String]
         class ListStringsResponse; end
+
+        # @!attribute [rw] parent
+        #   @return [String]
+        # @!attribute [rw] inventory
+        #   @return [Google::Example::Library::V1::Inventory]
+        class CreateInventoryRequest; end
 
         # @!attribute [rw] name
         #   @return [String]
@@ -2900,6 +2910,12 @@ module Library
 
       private_constant :FOLDER_PATH_TEMPLATE
 
+      INVENTORY_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+        "projects/{project}/locations/{location}/publishers/{publisher}/inventory"
+      )
+
+      private_constant :INVENTORY_PATH_TEMPLATE
+
       LOCATION_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
         "projects/{project}/locations/{location}"
       )
@@ -2950,6 +2966,19 @@ module Library
       def self.folder_path folder
         FOLDER_PATH_TEMPLATE.render(
           :"folder" => folder
+        )
+      end
+
+      # Returns a fully-qualified inventory resource name string.
+      # @param project [String]
+      # @param location [String]
+      # @param publisher [String]
+      # @return [String]
+      def self.inventory_path project, location, publisher
+        INVENTORY_PATH_TEMPLATE.render(
+          :"project" => project,
+          :"location" => location,
+          :"publisher" => publisher
         )
       end
 
@@ -3159,6 +3188,14 @@ module Library
           exception_transformer: exception_transformer,
           params_extractor: proc do |request|
             {'shelf.name' => request.shelf.name}
+          end
+        )
+        @create_inventory = Google::Gax.create_api_call(
+          @library_service_stub.method(:create_inventory),
+          defaults["create_inventory"],
+          exception_transformer: exception_transformer,
+          params_extractor: proc do |request|
+            {'parent' => request.parent}
           end
         )
         @get_book = Google::Gax.create_api_call(
@@ -3631,6 +3668,40 @@ module Library
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::PublishSeriesRequest)
         @publish_series.call(req, options, &block)
+      end
+
+      # Creates an inventory. Tests singleton resources.
+      #
+      # @param parent [String]
+      # @param inventory [Google::Example::Library::V1::Inventory | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::Inventory`
+      #   can also be provided.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @yield [result, operation] Access the result along with the RPC operation
+      # @yieldparam result [Google::Example::Library::V1::Inventory]
+      # @yieldparam operation [GRPC::ActiveCall::Operation]
+      # @return [Google::Example::Library::V1::Inventory]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library"
+      #
+      #   library_client = Library::Library.new(version: :v1)
+      #   formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+      #   response = library_client.create_inventory(formatted_parent)
+
+      def create_inventory \
+          parent,
+          inventory: nil,
+          options: nil,
+          &block
+        req = {
+          parent: parent,
+          inventory: inventory
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateInventoryRequest)
+        @create_inventory.call(req, options, &block)
       end
 
       # Gets a book.
@@ -5620,6 +5691,11 @@ end
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "CreateInventory": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "GetBook": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -6715,6 +6791,80 @@ describe Library::V1::LibraryServiceClient do
               books,
               series_uuid
             )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'create_inventory' do
+    custom_error = CustomTestError_v1.new "Custom test error for Library::V1::LibraryServiceClient#create_inventory."
+
+    it 'invokes create_inventory without error' do
+      # Create request parameters
+      formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+
+      # Create expected grpc response
+      name = "name3373707"
+      expected_response = { name: name }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Inventory)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::CreateInventoryRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:create_inventory, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("create_inventory")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          response = client.create_inventory(formatted_parent)
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.create_inventory(formatted_parent) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes create_inventory with error' do
+      # Create request parameters
+      formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::CreateInventoryRequest, request)
+        assert_equal(formatted_parent, request.parent)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:create_inventory, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockLibraryServiceCredentials_v1.new("create_inventory")
+
+      Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
+        Library::V1::Credentials.stub(:default, mock_credentials) do
+          client = Library::Library.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
+            client.create_inventory(formatted_parent)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/testsrc/protoannotations/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/protoannotations/library.proto
@@ -119,6 +119,12 @@ service LibraryService {
     option (google.api.method_signature) = "shelf,books,edition,series_uuid,publisher";
   }
 
+  // Creates an inventory. Tests singleton resources.
+  rpc CreateInventory(CreateInventoryRequest) returns (Inventory) {
+    option (google.api.http) = { post: "/v1/{parent=projects/*/locations/*/publishers/*}" body: "inventory" };
+    option (google.api.method_signature) = "parent,inventory";
+  }
+
   // Gets a book.
   rpc GetBook(GetBookRequest) returns (Book) {
     option (google.api.http) = { get: "/v1/{name=bookShelves/*/books/*}" };
@@ -434,6 +440,7 @@ message Book {
     pattern: "shelves/{shelf}/books/{book}",
     pattern: "archives/{archive}/books/{book}",
     pattern: "projects/{project}/books/{book}"
+    pattern: "projects/{project}/locations/{location}/publishers/{publisher}/inventory/books/{book}"
     history: ORIGINALLY_SINGLE_PATTERN,
   };
 
@@ -500,6 +507,16 @@ message Book {
 
   // For testing accessing map fields in samplegen
   map<bool, string>  map_bool_key = 30;
+}
+
+message Inventory {
+
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Inventory",
+    pattern: "projects/{project}/locations/{location}/publishers/{publisher}/inventory"
+  };
+
+  string name = 1;
 }
 
 // A single book in the archives.
@@ -842,6 +859,15 @@ message ListStringsResponse {
   ];
   string next_page_token = 2;
 }
+
+ message CreateInventoryRequest {
+    string parent = 1 [
+      (google.api.resource_reference).child_type = "library.googleapis.com/Inventory",
+      (google.api.field_behavior) = REQUIRED
+    ];
+
+    Inventory inventory = 2;
+ }
 
 message AddCommentsRequest {
   string name = 1 [


### PR DESCRIPTION
parent type of `projects/{project}/foo/bar/{bar}` would be `projects/{project}/foo`.
parent type of `projects/{project}/foo` would be `projects/{project}`.

This is to support dialogflow.