### PR TITLE
fix: Fix bazel for discogapic

### DIFF
--- a/rules_gapic/gapic.bzl
+++ b/rules_gapic/gapic.bzl
@@ -36,7 +36,7 @@ def _gapic_srcjar_impl(ctx):
             _set_args(attr.src, "--descriptor_set=", arguments, inputs)
         _set_args(attr.gapic_yaml, "--gapic_yaml=", arguments, inputs)
         _set_args(attr.package, "--package=", arguments)
-        _set_args(attr.language, "--language=", arguments, required = True)
+        _set_args(attr.language, "--language=", arguments)
         _set_args(attr.service_yaml, "--service_yaml=", arguments, inputs)
         _set_args(attr.package_yaml2, "--package_yaml2=", arguments, inputs)
         _set_args(attr.grpc_service_config, "--grpc_service_config=", arguments, inputs)
@@ -322,6 +322,15 @@ def path_ignoring_repository(f):
     if f.owner.workspace_root:
         return f.path[f.path.find(f.owner.workspace_root) + len(f.owner.workspace_root) + 1:]
     return f.short_path
+
+def discogapic_config(name, src, **kwargs):
+    gapic_srcjar(
+        name = name,
+        src = src,
+        artifact_type = "DISCOGAPIC_CONFIG",
+        output_suffix = ".yaml",
+        **kwargs
+    )
 
 #
 # Private helper functions

--- a/rules_gapic/java/java_gapic.bzl
+++ b/rules_gapic/java/java_gapic.bzl
@@ -74,9 +74,9 @@ def java_gapic_srcjar(
         name,
         src,
         gapic_yaml,
-        service_yaml,
         artifact_type,
-        package,
+        package = None,
+        service_yaml = None,
         grpc_service_config = None,
         **kwargs):
     raw_srcjar_name = "%s_raw" % name
@@ -202,7 +202,6 @@ def java_discogapic_library(
         name,
         src,
         gapic_yaml,
-        service_yaml,
         deps = [],
         test_deps = [],
         **kwargs):
@@ -212,8 +211,7 @@ def java_discogapic_library(
         name = srcjar_name,
         src = src,
         gapic_yaml = gapic_yaml,
-        service_yaml = service_yaml,
-        artifact_type = "GAPIC_CODE",
+        artifact_type = "DISCOGAPIC_CODE",
         **kwargs
     )
 
@@ -229,6 +227,7 @@ def java_discogapic_library(
         "@com_google_auth_google_auth_library_credentials//jar",
         "@com_google_auth_google_auth_library_oauth2_http//jar",
         "@com_google_http_client_google_http_client//jar",
+        "@com_google_code_gson_gson//jar",
     ]
 
     native.java_library(
@@ -243,7 +242,6 @@ def java_discogapic_library(
         "@com_google_http_client_google_http_client_jackson2//jar",
         "@com_fasterxml_jackson_core_jackson_core//jar",
         "@com_google_api_gax_java//gax:gax_testlib",
-        "@com_google_code_gson_gson//jar",
         "@junit_junit//jar",
     ]
 

--- a/rules_gapic/java/resources/gradle/client_disco.gradle.tmpl
+++ b/rules_gapic/java/resources/gradle/client_disco.gradle.tmpl
@@ -1,0 +1,60 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+apply plugin: 'java'
+
+description = 'GAPIC library for {{name}}'
+group = 'com.google.cloud'
+version = '0.0.0-SNAPSHOT'
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+repositories {
+  mavenCentral()
+  mavenLocal()
+}
+
+compileJava.options.encoding = 'UTF-8'
+javadoc.options.encoding = 'UTF-8'
+
+dependencies {
+  compile 'com.google.api:gax:{{version.gax}}'
+  testCompile 'com.google.api:gax:{{version.gax}}:testlib'
+  compile 'com.google.api:gax-httpjson:{{version.gax_httpjson}}'
+  testCompile 'com.google.api:gax-httpjson:{{version.gax_httpjson}}:testlib'
+  testCompile '{{maven.junit_junit}}'
+  {{extra_deps}}
+}
+
+task smokeTest(type: Test) {
+  filter {
+    includeTestsMatching "*SmokeTest"
+    setFailOnNoMatchingTests false
+  }
+}
+
+test {
+  exclude "**/*SmokeTest*"
+}
+
+sourceSets {
+  main {
+    java {
+      srcDir 'src/main/java'
+    }
+  }
+}
+
+clean {
+  delete 'all-jars'
+}
+
+task allJars(type: Copy) {
+  dependsOn test, jar
+  into 'all-jars'
+  // Replace with `from configurations.testRuntime, jar` to include test dependencies
+  from configurations.runtime, jar
+}

--- a/src/main/java/com/google/api/codegen/configgen/transformer/MethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/MethodTransformer.java
@@ -44,7 +44,7 @@ public class MethodTransformer {
 
   // Do not apply flattening if the parameter count exceeds the threshold.
   // TODO(shinfan): Investigate a more intelligent way to handle this.
-  private static final int FLATTENING_THRESHOLD = 4;
+  private static final int FLATTENING_THRESHOLD = 5;
 
   public List<MethodView> generateMethods(
       InterfaceModel apiInterface, Map<String, String> collectionNameMap) {


### PR DESCRIPTION
Also increase flattening threashold to 5, because discogapic now has a method with more than 4 parameters. Without flattening for that method being present in the generated gapic yaml the discogapic client generation fails. 

It should be safe because nobody is generating gapic yaml anymore except for the discogapic case (i.e. now proto annotations are used instead of generated gapi yaml).