### PR TITLE
fix(PYTHON): update nox file and modernize to new interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ anchor_test_python_client: &anchor_test_python_client
     if [ -e ${PYTHON_GEN_DIR}/${TEST_API} ]
     then
       cd ${PYTHON_GEN_DIR}/${TEST_API}
+      ls
       echo "Running test commands: $NOX_COMMANDS"
       eval "$NOX_COMMANDS"
     else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,7 @@ anchor_test_python_client: &anchor_test_python_client
 anchor_verify_and_test_python: &anchor_verify_and_test_python
   working_directory: /tmp/
   docker:
-    # Use Docker image version v0.17.0 because latest v0.18.2 is not compatible with `attach_workspace` step.
-    # https://github.com/googleapis/gapic-generator/issues/2237
-    - image: googleapis/nox:0.17.0
+    - image: l.gcr.io/google/python:latest
     - image: gcr.io/gapic-images/gapic-showcase:0.4.0
   steps:
     - attach_workspace:
@@ -76,6 +74,10 @@ anchor_verify_and_test_python: &anchor_verify_and_test_python
         <<: *anchor_run_decrypt
     - run:
         <<: *anchor_check_generation
+    - run:
+        name: Install nox
+        command: |
+          pip3 install nox
     # Generated Logging client is broken: https://github.com/googleapis/gapic-generator/issues/2209.
     - run:
        name: Run Showcase Generated Unit Tests.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,9 +562,9 @@ jobs:
       <<: *anchor_artman_vars
       PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python
       NOX_COMMANDS: "
-        nox --session \"unit(py='2.7')\";
-        nox --session \"unit(py='3.5')\";
-        nox --session \"unit(py='3.6')\";"
+        nox --noxfile noxfile.py --session \"unit(py='2.7')\";
+        nox --noxfile noxfile.py --session \"unit(py='3.5')\";
+        nox --noxfile noxfile.py --session \"unit(py='3.6')\";"
     <<: *anchor_verify_and_test_python
   python-system-test:
     environment:
@@ -573,9 +573,9 @@ jobs:
       <<: *anchor_artman_vars
       PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python
       NOX_COMMANDS: "
-        nox --session \"unit(py='2.7')\";
-        nox --session \"unit(py='3.5')\";
-        nox --session \"unit(py='3.6')\";"
+        nox --noxfile noxfile.py --session \"unit(py='2.7')\";
+        nox --noxfile noxfile.py --session \"unit(py='3.5')\";
+        nox --noxfile noxfile.py --session \"unit(py='3.6')\";"
     <<: *anchor_verify_and_test_python
   ruby-2.4-test:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,12 +77,11 @@ anchor_verify_and_test_python: &anchor_verify_and_test_python
     - run:
         name: Install nox
         command: |
-          pip3 install nox
+         pip3 install nox-automation==0.17.0  # TODO showcase and generated artman code still use old nox format
     # Generated Logging client is broken: https://github.com/googleapis/gapic-generator/issues/2209.
     - run:
        name: Run Showcase Generated Unit Tests.
        command: |
-         pip3 install nox-automation==0.17.0  # TODO showcase still has old nox format
          nox --session "unit(py='2.7')" \
              --noxfile /tmp/workspace/gapic-generator/showcase/python/nox.py
          nox --session "unit(py='3.6')" \
@@ -91,7 +90,6 @@ anchor_verify_and_test_python: &anchor_verify_and_test_python
     - run:
        name: Run Showcase Integration Tests.
        command: |
-         pip3 install nox-automation==0.17.0  # TODO showcase still has old nox format
          nox --session "showcase(py='2.7')" \
              --noxfile /tmp/workspace/gapic-generator/showcase/python/nox.py
          nox --session "showcase(py='3.6')" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ anchor_verify_and_test_python: &anchor_verify_and_test_python
     - run:
        name: Run Showcase Generated Unit Tests.
        command: |
+         pip3 install nox-automation==0.17.0  # TODO showcase still has old nox format
          nox --session "unit(py='2.7')" \
              --noxfile /tmp/workspace/gapic-generator/showcase/python/nox.py
          nox --session "unit(py='3.6')" \
@@ -89,6 +90,7 @@ anchor_verify_and_test_python: &anchor_verify_and_test_python
     - run:
        name: Run Showcase Integration Tests.
        command: |
+         pip3 install nox-automation==0.17.0  # TODO showcase still has old nox format
          nox --session "showcase(py='2.7')" \
              --noxfile /tmp/workspace/gapic-generator/showcase/python/nox.py
          nox --session "showcase(py='3.6')" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ anchor_check_generation: &anchor_check_generation
       exit 0
     fi
 
-# Test a Ruby client if generation succeeded.
 anchor_test_python_client: &anchor_test_python_client
   command: |
     if [ -z "$NOX_COMMANDS" ]
@@ -562,11 +561,9 @@ jobs:
     environment:
       LANGUAGE: python
       <<: *anchor_artman_vars
-      PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python
-      NOX_COMMANDS: "
-        nox --noxfile noxfile.py --session \"unit(py='2.7')\";
-        nox --noxfile noxfile.py --session \"unit(py='3.5')\";
-        nox --noxfile noxfile.py --session \"unit(py='3.6')\";"
+      PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python      
+      NOX_COMMANDS: |
+        nox --noxfile nox.py;  # TODO update to noxfile.py when artman uses newest version of gapic-generator
     <<: *anchor_verify_and_test_python
   python-system-test:
     environment:
@@ -574,10 +571,8 @@ jobs:
       LANGUAGE: python
       <<: *anchor_artman_vars
       PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python
-      NOX_COMMANDS: "
-        nox --noxfile noxfile.py --session \"unit(py='2.7')\";
-        nox --noxfile noxfile.py --session \"unit(py='3.5')\";
-        nox --noxfile noxfile.py --session \"unit(py='3.6')\";"
+      NOX_COMMANDS: |
+        nox --noxfile nox.py;  # TODO update to noxfile.py when artman uses newest version of gapic-generator
     <<: *anchor_verify_and_test_python
   ruby-2.4-test:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,9 +566,9 @@ jobs:
       <<: *anchor_artman_vars
       PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python
       NOX_COMMANDS: "
-        nox --session \"unit(py='2.7')\";
-        nox --session \"unit(py='3.5')\";
-        nox --session \"unit(py='3.6')\";"
+        nox --noxfile noxfile.py --session \"unit(py='2.7')\";
+        nox --noxfile noxfile.py --session \"unit(py='3.5')\";
+        nox --noxfile noxfile.py --session \"unit(py='3.6')\";"
     <<: *anchor_verify_and_test_python
   python-system-test:
     environment:
@@ -577,9 +577,9 @@ jobs:
       <<: *anchor_artman_vars
       PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python
       NOX_COMMANDS: "
-        nox --session \"unit(py='2.7')\";
-        nox --session \"unit(py='3.5')\";
-        nox --session \"unit(py='3.6')\";"
+        nox --noxfile noxfile.py --session \"unit(py='2.7')\";
+        nox --noxfile noxfile.py --session \"unit(py='3.5')\";
+        nox --noxfile noxfile.py --session \"unit(py='3.6')\";"
     <<: *anchor_verify_and_test_python
   ruby-2.4-test:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -563,9 +563,11 @@ jobs:
     environment:
       LANGUAGE: python
       <<: *anchor_artman_vars
-      PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python      
-      NOX_COMMANDS: |
-        nox --noxfile nox.py;  # TODO update to noxfile.py when artman uses newest version of gapic-generator
+      PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python
+      NOX_COMMANDS: "
+        nox --session \"unit(py='2.7')\";
+        nox --session \"unit(py='3.5')\";
+        nox --session \"unit(py='3.6')\";"
     <<: *anchor_verify_and_test_python
   python-system-test:
     environment:
@@ -573,8 +575,10 @@ jobs:
       LANGUAGE: python
       <<: *anchor_artman_vars
       PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python
-      NOX_COMMANDS: |
-        nox --noxfile nox.py;  # TODO update to noxfile.py when artman uses newest version of gapic-generator
+      NOX_COMMANDS: "
+        nox --session \"unit(py='2.7')\";
+        nox --session \"unit(py='3.5')\";
+        nox --session \"unit(py='3.6')\";"
     <<: *anchor_verify_and_test_python
   ruby-2.4-test:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,6 @@ anchor_test_python_client: &anchor_test_python_client
     if [ -e ${PYTHON_GEN_DIR}/${TEST_API} ]
     then
       cd ${PYTHON_GEN_DIR}/${TEST_API}
-      ls
       echo "Running test commands: $NOX_COMMANDS"
       eval "$NOX_COMMANDS"
     else
@@ -75,9 +74,9 @@ anchor_verify_and_test_python: &anchor_verify_and_test_python
     - run:
         <<: *anchor_check_generation
     - run:
-        name: Install nox
+        name: Install nox==0.17.0
         command: |
-         pip3 install nox-automation==0.17.0  # TODO showcase and generated artman code still use old nox format
+         pip3 install nox-automation==0.17.0  # TODO showcase still has old nox format
     # Generated Logging client is broken: https://github.com/googleapis/gapic-generator/issues/2209.
     - run:
        name: Run Showcase Generated Unit Tests.
@@ -95,6 +94,10 @@ anchor_verify_and_test_python: &anchor_verify_and_test_python
          nox --session "showcase(py='3.6')" \
              --noxfile /tmp/workspace/gapic-generator/showcase/python/nox.py
        when: always
+    - run:
+        name: Install nox latest
+        command: |
+         pip3 install nox
     - run:
         name: Prepare for Pubsub testing.
         command: echo 'export TEST_API="pubsub-v1"' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,10 +566,8 @@ jobs:
       LANGUAGE: python
       <<: *anchor_artman_vars
       PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python
-      NOX_COMMANDS: "
-        nox --noxfile noxfile.py --session \"unit(py='2.7')\";
-        nox --noxfile noxfile.py --session \"unit(py='3.5')\";
-        nox --noxfile noxfile.py --session \"unit(py='3.6')\";"
+      NOX_COMMANDS: |
+        nox --noxfile noxfile.py 
     <<: *anchor_verify_and_test_python
   python-system-test:
     environment:
@@ -577,10 +575,8 @@ jobs:
       LANGUAGE: python
       <<: *anchor_artman_vars
       PYTHON_GEN_DIR: /tmp/workspace/gapic-generator/artman-genfiles/python
-      NOX_COMMANDS: "
-        nox --noxfile noxfile.py --session \"unit(py='2.7')\";
-        nox --noxfile noxfile.py --session \"unit(py='3.5')\";
-        nox --noxfile noxfile.py --session \"unit(py='3.6')\";"
+      NOX_COMMANDS: |
+        nox --noxfile noxfile.py
     <<: *anchor_verify_and_test_python
   ruby-2.4-test:
     environment:

--- a/rules_gapic/python/py_gapic.bzl
+++ b/rules_gapic/python/py_gapic.bzl
@@ -35,8 +35,8 @@ def _py_gapic_postprocessed_srcjar_impl(ctx):
     {formatter} -q {output_dir_path}
 
     pushd {output_dir_path}
-    zip -q -r {output_dir_name}-pkg.srcjar nox.py setup.py setup.cfg docs MANIFEST.in README.rst LICENSE
-    rm -rf nox.py setup.py docs
+    zip -q -r {output_dir_name}-pkg.srcjar noxfile.py setup.py setup.cfg docs MANIFEST.in README.rst LICENSE
+    rm -rf noxfile.py setup.py docs
     zip -q -r {output_dir_name}-test.srcjar tests/unit
     rm -rf tests/unit
     if [ -d "tests/system" ]; then

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
@@ -88,7 +88,7 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer<
   private static final String NAMESPACE_INIT_TEMPLATE_FILE = "py/namespace__init__.py.snip";
   private static final String API_DOC_TEMPLATE_FILE = "py/docs/api.rst.snip";
   private static final String TYPES_DOC_TEMPLATE_FILE = "py/docs/types.rst.snip";
-  private static final String NOX_TEMPLATE_FILE = "py/nox.py.snip";
+  private static final String NOX_TEMPLATE_FILE = "py/noxfile.py.snip";
 
   private static final Set<String> GOOGLE_CLOUD_NAMESPACE_PACKAGES =
       ImmutableSet.of("google", "google.cloud");
@@ -159,7 +159,7 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer<
   private ViewModel generateNoxFile(ApiModel model, GapicProductConfig productConfig) {
     PackageMetadataNamer namer = new PackageMetadataNamer();
     SurfaceNamer surfaceNamer = new PythonSurfaceNamer(productConfig.getPackageName());
-    String outputPath = "nox.py";
+    String outputPath = "noxfile.py";
     return generateMetadataView(
             model, productConfig, NOX_TEMPLATE_FILE, namer, surfaceNamer, outputPath)
         .fileHeader(

--- a/src/main/resources/com/google/api/codegen/py/noxfile.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/noxfile.py.snip
@@ -30,8 +30,7 @@
         return unit(session, 'default')
 
 
-    @@nox.session
-    @@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
+    @@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
     def unit(session, py):
         """Run the unit test suite."""
 
@@ -51,8 +50,7 @@
 @end
 
 @private system_tests()
-    @@nox.session
-    @@nox.parametrize('py', ['2.7', '3.7'])
+    @@nox.session(python=['2.7', '3.7'])
     def system(session, py):
         """Run the system test suite."""
 

--- a/src/main/resources/com/google/api/codegen/py/noxfile.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/noxfile.py.snip
@@ -31,15 +31,8 @@
 
 
     @@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
-    def unit(session, py):
+    def unit(session):
         """Run the unit test suite."""
-
-        @# Run unit tests against all supported versions of Python.
-        if py != 'default':
-            session.interpreter = 'python{}'.format(py)
-
-        @# Set the virtualenv directory name.
-        session.virtualenv_dirname = 'unit-' + py
 
         @# Install all test dependencies, then install this package in-place.
         session.install('pytest', 'mock')
@@ -51,18 +44,12 @@
 
 @private system_tests()
     @@nox.session(python=['2.7', '3.7'])
-    def system(session, py):
+    def system(session):
         """Run the system test suite."""
 
         @# Sanity check: Only run system tests if the environment variable is set.
         if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
             session.skip('Credentials must be set via environment variable.')
-
-        @# Run unit tests against all supported versions of Python.
-        session.interpreter = 'python{}'.format(py)
-
-        @# Set the virtualenv dirname.
-        session.virtualenv_dirname = 'sys-' + py
 
         @# Install all test dependencies, then install this package in-place.
         session.install('pytest')
@@ -81,7 +68,6 @@
     @@nox.session
     def lint_setup_py(session):
         """Verify that setup.py is valid (including RST check)."""
-        session.interpreter = 'python3.6'
         session.install('docutils', 'pygments')
         session.run(
             'python', 'setup.py', 'check', '--restructuredtext', '--strict')

--- a/src/main/resources/com/google/api/codegen/py/noxfile.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/noxfile.py.snip
@@ -27,7 +27,7 @@
 @private unit_tests()
     @@nox.session
     def default(session):
-        return unit(session, 'default')
+        return unit(session)
 
 
     @@nox.session(python=['2.7', '3.5', '3.6', '3.7'])

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -5684,7 +5684,7 @@ for module in _local_modules:
 
 __all__ = tuple(sorted(names))
 
-============== file: nox.py ==============
+============== file: noxfile.py ==============
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 Google LLC
@@ -5713,8 +5713,7 @@ def default(session):
     return unit(session, 'default')
 
 
-@nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
+@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 
@@ -5733,8 +5732,7 @@ def unit(session, py):
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
-@nox.session
-@nox.parametrize('py', ['2.7', '3.7'])
+@nox.session(python=['2.7', '3.7'])
 def system(session, py):
     """Run the system test suite."""
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -5710,7 +5710,7 @@ import nox
 
 @nox.session
 def default(session):
-    return unit(session, 'default')
+    return unit(session)
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7'])

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -5714,15 +5714,8 @@ def default(session):
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7'])
-def unit(session, py):
+def unit(session):
     """Run the unit test suite."""
-
-    # Run unit tests against all supported versions of Python.
-    if py != 'default':
-        session.interpreter = 'python{}'.format(py)
-
-    # Set the virtualenv directory name.
-    session.virtualenv_dirname = 'unit-' + py
 
     # Install all test dependencies, then install this package in-place.
     session.install('pytest', 'mock')
@@ -5733,18 +5726,12 @@ def unit(session, py):
 
 
 @nox.session(python=['2.7', '3.7'])
-def system(session, py):
+def system(session):
     """Run the system test suite."""
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
         session.skip('Credentials must be set via environment variable.')
-
-    # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python{}'.format(py)
-
-    # Set the virtualenv dirname.
-    session.virtualenv_dirname = 'sys-' + py
 
     # Install all test dependencies, then install this package in-place.
     session.install('pytest')
@@ -5762,7 +5749,6 @@ def system(session, py):
 @nox.session
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
-    session.interpreter = 'python3.6'
     session.install('docutils', 'pygments')
     session.run(
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1679,7 +1679,7 @@ for module in _local_modules:
 
 __all__ = tuple(sorted(names))
 
-============== file: nox.py ==============
+============== file: noxfile.py ==============
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 Google LLC
@@ -1708,8 +1708,7 @@ def default(session):
     return unit(session, 'default')
 
 
-@nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
+@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1705,7 +1705,7 @@ import nox
 
 @nox.session
 def default(session):
-    return unit(session, 'default')
+    return unit(session)
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7'])

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1709,15 +1709,8 @@ def default(session):
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7'])
-def unit(session, py):
+def unit(session):
     """Run the unit test suite."""
-
-    # Run unit tests against all supported versions of Python.
-    if py != 'default':
-        session.interpreter = 'python{}'.format(py)
-
-    # Set the virtualenv directory name.
-    session.virtualenv_dirname = 'unit-' + py
 
     # Install all test dependencies, then install this package in-place.
     session.install('pytest', 'mock')
@@ -1727,10 +1720,30 @@ def unit(session, py):
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
+@nox.session(python=['2.7', '3.7'])
+def system(session):
+    """Run the system test suite."""
+
+    # Sanity check: Only run system tests if the environment variable is set.
+    if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
+        session.skip('Credentials must be set via environment variable.')
+
+    # Install all test dependencies, then install this package in-place.
+    session.install('pytest')
+    session.install('-e', '.')
+
+    # Run py.test against the unit tests.
+    session.run(
+        'py.test',
+        '--quiet',
+        os.path.join('tests', 'system'),
+        *session.posargs
+    )
+
+
 @nox.session
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
-    session.interpreter = 'python3.6'
     session.install('docutils', 'pygments')
     session.run(
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1720,27 +1720,6 @@ def unit(session):
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
-@nox.session(python=['2.7', '3.7'])
-def system(session):
-    """Run the system test suite."""
-
-    # Sanity check: Only run system tests if the environment variable is set.
-    if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        session.skip('Credentials must be set via environment variable.')
-
-    # Install all test dependencies, then install this package in-place.
-    session.install('pytest')
-    session.install('-e', '.')
-
-    # Run py.test against the unit tests.
-    session.run(
-        'py.test',
-        '--quiet',
-        os.path.join('tests', 'system'),
-        *session.posargs
-    )
-
-
 @nox.session
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1273,7 +1273,7 @@ import nox
 
 @nox.session
 def default(session):
-    return unit(session, 'default')
+    return unit(session)
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7'])

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1247,7 +1247,7 @@ for module in _local_modules:
 
 __all__ = tuple(sorted(names))
 
-============== file: nox.py ==============
+============== file: noxfile.py ==============
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 Google LLC
@@ -1276,8 +1276,7 @@ def default(session):
     return unit(session, 'default')
 
 
-@nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
+@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1288,27 +1288,6 @@ def unit(session):
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
-@nox.session(python=['2.7', '3.7'])
-def system(session):
-    """Run the system test suite."""
-
-    # Sanity check: Only run system tests if the environment variable is set.
-    if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        session.skip('Credentials must be set via environment variable.')
-
-    # Install all test dependencies, then install this package in-place.
-    session.install('pytest')
-    session.install('-e', '.')
-
-    # Run py.test against the unit tests.
-    session.run(
-        'py.test',
-        '--quiet',
-        os.path.join('tests', 'system'),
-        *session.posargs
-    )
-
-
 @nox.session
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1277,15 +1277,8 @@ def default(session):
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7'])
-def unit(session, py):
+def unit(session):
     """Run the unit test suite."""
-
-    # Run unit tests against all supported versions of Python.
-    if py != 'default':
-        session.interpreter = 'python{}'.format(py)
-
-    # Set the virtualenv directory name.
-    session.virtualenv_dirname = 'unit-' + py
 
     # Install all test dependencies, then install this package in-place.
     session.install('pytest', 'mock')
@@ -1295,10 +1288,30 @@ def unit(session, py):
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
+@nox.session(python=['2.7', '3.7'])
+def system(session):
+    """Run the system test suite."""
+
+    # Sanity check: Only run system tests if the environment variable is set.
+    if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
+        session.skip('Credentials must be set via environment variable.')
+
+    # Install all test dependencies, then install this package in-place.
+    session.install('pytest')
+    session.install('-e', '.')
+
+    # Run py.test against the unit tests.
+    session.run(
+        'py.test',
+        '--quiet',
+        os.path.join('tests', 'system'),
+        *session.posargs
+    )
+
+
 @nox.session
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
-    session.interpreter = 'python3.6'
     session.install('docutils', 'pygments')
     session.run(
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -5984,15 +5984,8 @@ def default(session):
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7'])
-def unit(session, py):
+def unit(session):
     """Run the unit test suite."""
-
-    # Run unit tests against all supported versions of Python.
-    if py != 'default':
-        session.interpreter = 'python{}'.format(py)
-
-    # Set the virtualenv directory name.
-    session.virtualenv_dirname = 'unit-' + py
 
     # Install all test dependencies, then install this package in-place.
     session.install('pytest', 'mock')
@@ -6003,18 +5996,12 @@ def unit(session, py):
 
 
 @nox.session(python=['2.7', '3.7'])
-def system(session, py):
+def system(session):
     """Run the system test suite."""
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
         session.skip('Credentials must be set via environment variable.')
-
-    # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python{}'.format(py)
-
-    # Set the virtualenv dirname.
-    session.virtualenv_dirname = 'sys-' + py
 
     # Install all test dependencies, then install this package in-place.
     session.install('pytest')
@@ -6032,7 +6019,6 @@ def system(session, py):
 @nox.session
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
-    session.interpreter = 'python3.6'
     session.install('docutils', 'pygments')
     session.run(
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -5980,7 +5980,7 @@ import nox
 
 @nox.session
 def default(session):
-    return unit(session, 'default')
+    return unit(session)
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7'])

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -5954,7 +5954,7 @@ for module in _local_modules:
 
 __all__ = tuple(sorted(names))
 
-============== file: nox.py ==============
+============== file: noxfile.py ==============
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 Google LLC
@@ -5983,8 +5983,7 @@ def default(session):
     return unit(session, 'default')
 
 
-@nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
+@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 
@@ -6003,8 +6002,7 @@ def unit(session, py):
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
-@nox.session
-@nox.parametrize('py', ['2.7', '3.7'])
+@nox.session(python=['2.7', '3.7'])
 def system(session, py):
     """Run the system test suite."""
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
@@ -4809,15 +4809,8 @@ def default(session):
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7'])
-def unit(session, py):
+def unit(session):
     """Run the unit test suite."""
-
-    # Run unit tests against all supported versions of Python.
-    if py != 'default':
-        session.interpreter = 'python{}'.format(py)
-
-    # Set the virtualenv directory name.
-    session.virtualenv_dirname = 'unit-' + py
 
     # Install all test dependencies, then install this package in-place.
     session.install('pytest', 'mock')
@@ -4827,10 +4820,30 @@ def unit(session, py):
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
+@nox.session(python=['2.7', '3.7'])
+def system(session):
+    """Run the system test suite."""
+
+    # Sanity check: Only run system tests if the environment variable is set.
+    if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
+        session.skip('Credentials must be set via environment variable.')
+
+    # Install all test dependencies, then install this package in-place.
+    session.install('pytest')
+    session.install('-e', '.')
+
+    # Run py.test against the unit tests.
+    session.run(
+        'py.test',
+        '--quiet',
+        os.path.join('tests', 'system'),
+        *session.posargs
+    )
+
+
 @nox.session
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
-    session.interpreter = 'python3.6'
     session.install('docutils', 'pygments')
     session.run(
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
@@ -4805,7 +4805,7 @@ import nox
 
 @nox.session
 def default(session):
-    return unit(session, 'default')
+    return unit(session)
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7'])

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
@@ -4779,7 +4779,7 @@ Api Reference
 
     gapic/v1/api
     gapic/v1/types
-============== file: nox.py ==============
+============== file: noxfile.py ==============
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 Google LLC
@@ -4808,8 +4808,7 @@ def default(session):
     return unit(session, 'default')
 
 
-@nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
+@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
@@ -4820,27 +4820,6 @@ def unit(session):
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
-@nox.session(python=['2.7', '3.7'])
-def system(session):
-    """Run the system test suite."""
-
-    # Sanity check: Only run system tests if the environment variable is set.
-    if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        session.skip('Credentials must be set via environment variable.')
-
-    # Install all test dependencies, then install this package in-place.
-    session.install('pytest')
-    session.install('-e', '.')
-
-    # Run py.test against the unit tests.
-    session.run(
-        'py.test',
-        '--quiet',
-        os.path.join('tests', 'system'),
-        *session.posargs
-    )
-
-
 @nox.session
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""


### PR DESCRIPTION
closes #2208, #3157 

This updates to use a recent version of nox. The previous version was nox==0.17.0 from quite some time ago... not even on the changelog https://nox.thea.codes/en/stable/CHANGELOG.html
