### PR TITLE
feat(JAVA): read version from gradle.properties if specified

### DIFF
--- a/.circleci/discogapic_compute_build.gradle
+++ b/.circleci/discogapic_compute_build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'java'
 
 description = 'GAPIC library for Discovery API'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/rules_gapic/java/resources/gradle/client.gradle.tmpl
+++ b/rules_gapic/java/resources/gradle/client.gradle.tmpl
@@ -8,7 +8,7 @@ apply plugin: 'java'
 
 description = 'GAPIC library for {{name}}'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/rules_gapic/java/resources/gradle/client_disco.gradle.tmpl
+++ b/rules_gapic/java/resources/gradle/client_disco.gradle.tmpl
@@ -8,7 +8,7 @@ apply plugin: 'java'
 
 description = 'GAPIC library for {{name}}'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/rules_gapic/java/resources/gradle/grpc.gradle.tmpl
+++ b/rules_gapic/java/resources/gradle/grpc.gradle.tmpl
@@ -8,7 +8,7 @@ apply plugin: 'java'
 
 description = 'GRPC library for {{name}}'
 group = 'com.google.api.grpc'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/rules_gapic/java/resources/gradle/proto.gradle.tmpl
+++ b/rules_gapic/java/resources/gradle/proto.gradle.tmpl
@@ -8,7 +8,7 @@ apply plugin: 'java'
 
 description = 'PROTO library for {{name}}'
 group = 'com.google.api.grpc'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
@@ -9,7 +9,7 @@
 
   description = 'GAPIC library for {@metadata.identifier}'
   group = 'com.google.cloud'
-  version = '0.0.0-SNAPSHOT'
+  version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
   sourceCompatibility = 1.7
   targetCompatibility = 1.7
 

--- a/src/main/resources/com/google/api/codegen/java/build_gapic_samples.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/java/build_gapic_samples.gradle.snip
@@ -10,7 +10,7 @@
 
   description = 'GAPIC samples for {@metadata.identifier}'
   group = 'com.google.cloud'
-  version = '0.0.0-SNAPSHOT'
+  version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
   sourceCompatibility = 1.7
   targetCompatibility = 1.7
 

--- a/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build_base.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build_base.gradle.snip
@@ -9,7 +9,7 @@
 
   description = {@description(metadata)}
   group = 'com.google.api.grpc'
-  version = '0.0.0-SNAPSHOT'
+  version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
   sourceCompatibility = 1.7
   targetCompatibility = 1.7
 

--- a/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/discogapic/testdata/java/java_simplecompute.v1.json.baseline
@@ -11403,7 +11403,7 @@ apply plugin: 'java'
 
 description = 'GAPIC library for google-cloud-simplecompute-v1'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -21,7 +21,7 @@ apply plugin: 'java'
 
 description = 'GAPIC library for google-cloud-library-v1'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
@@ -88,7 +88,7 @@ apply plugin: 'application'
 
 description = 'GAPIC samples for google-cloud-library-v1'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_multiple_services.baseline
@@ -21,7 +21,7 @@ apply plugin: 'java'
 
 description = 'GAPIC library for google-cloud-multiple_services-v1'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_my_streaming_proto.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_my_streaming_proto.baseline
@@ -21,7 +21,7 @@ apply plugin: 'java'
 
 description = 'GAPIC library for google-cloud-my_streaming_service-v1'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_no_path_templates.baseline
@@ -21,7 +21,7 @@ apply plugin: 'java'
 
 description = 'GAPIC library for google-cloud-library-v1'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/test/java/com/google/api/codegen/packagegen/testdata/java_common_protos.baseline
+++ b/src/test/java/com/google/api/codegen/packagegen/testdata/java_common_protos.baseline
@@ -212,7 +212,7 @@ apply plugin: 'java'
 
 description = 'PROTO library for proto-google-common-protos'
 group = 'com.google.api.grpc'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/test/java/com/google/api/codegen/packagegen/testdata/java_grpc_stubs.baseline
+++ b/src/test/java/com/google/api/codegen/packagegen/testdata/java_grpc_stubs.baseline
@@ -212,7 +212,7 @@ apply plugin: 'java'
 
 description = 'GRPC library for grpc-google-cloud-library-v1'
 group = 'com.google.api.grpc'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/test/java/com/google/api/codegen/packagegen/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/packagegen/testdata/java_library.baseline
@@ -212,7 +212,7 @@ apply plugin: 'java'
 
 description = 'PROTO library for proto-google-cloud-library-v1'
 group = 'com.google.api.grpc'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -21,7 +21,7 @@ apply plugin: 'java'
 
 description = 'GAPIC library for google-cloud-library-v1'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
@@ -88,7 +88,7 @@ apply plugin: 'application'
 
 description = 'GAPIC samples for google-cloud-library-v1'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -21,7 +21,7 @@ apply plugin: 'java'
 
 description = 'GAPIC library for google-cloud-library-v1'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -21,7 +21,7 @@ apply plugin: 'java'
 
 description = 'GAPIC library for google-cloud-library-v1'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
@@ -88,7 +88,7 @@ apply plugin: 'application'
 
 description = 'GAPIC samples for google-cloud-library-v1'
 group = 'com.google.cloud'
-version = '0.0.0-SNAPSHOT'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 


### PR DESCRIPTION
Having a hardcoded value here makes it difficult to continually pull in changes from regeneration. This allows me to not have a diff in the `build.gradle` and manage my `gradle.properties` in my repo separately from generation.