### PR TITLE
feat: add the last segment when generating names for singleton resource pattern

### DIFF
--- a/src/main/java/com/google/api/codegen/config/ResourceNamePatternConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNamePatternConfig.java
@@ -98,7 +98,7 @@ public class ResourceNamePatternConfig {
     String patternId = getBindingVariables().stream().collect(Collectors.joining("_"));
 
     String[] segments = pattern.split("/");
-    checkState(segments.length > 0, "internal: pattern %s is fixed pattern.", pattern);
+    checkState(segments.length > 1, "internal: pattern %s is fixed pattern.", pattern);
     String lastSegment = segments[segments.length - 1];
 
     // Singleton resource. Append the last segment.

--- a/src/test/java/com/google/api/codegen/config/ResourceNamePatternConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceNamePatternConfigTest.java
@@ -41,4 +41,19 @@ public class ResourceNamePatternConfigTest {
     assertThat(new ResourceNamePatternConfig("states/{state}/cities/{city}").getBindingVariables())
         .containsExactly("state", "city");
   }
+
+  @Test
+  public void testGetPatternId() {
+    ResourceNamePatternConfig pattern;
+    pattern = new ResourceNamePatternConfig("_deleted_topic");
+    assertThat(pattern.getPatternId()).isEqualTo("deleted_topic");
+    pattern = new ResourceNamePatternConfig("states/{state}/cities/{city}");
+    assertThat(pattern.getPatternId()).isEqualTo("state_city");
+    pattern = new ResourceNamePatternConfig("states/{state}/cities/{city}/mayor");
+    assertThat(pattern.getPatternId()).isEqualTo("state_city_mayor");
+    pattern = new ResourceNamePatternConfig("states/{state}/cities/{city}/mascotAnimal");
+    assertThat(pattern.getPatternId()).isEqualTo("state_city_mascot_animal");
+    pattern = new ResourceNamePatternConfig("states/{state}/mascotAnimals/{mascot_animal}");
+    assertThat(pattern.getPatternId()).isEqualTo("state_mascot_animal");
+  }
 }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -2450,6 +2450,7 @@ class LibraryServiceGapicClient
     private static $folderNameTemplate;
     private static $inventoryNameTemplate;
     private static $locationNameTemplate;
+    private static $organizationReaderNameTemplate;
     private static $projectNameTemplate;
     private static $projectBookNameTemplate;
     private static $projectLocationPublisherBookNameTemplate;
@@ -2553,6 +2554,15 @@ class LibraryServiceGapicClient
         return self::$locationNameTemplate;
     }
 
+    private static function getOrganizationReaderNameTemplate()
+    {
+        if (self::$organizationReaderNameTemplate == null) {
+            self::$organizationReaderNameTemplate = new PathTemplate('organization/{organization}/reader');
+        }
+
+        return self::$organizationReaderNameTemplate;
+    }
+
     private static function getProjectNameTemplate()
     {
         if (self::$projectNameTemplate == null) {
@@ -2647,6 +2657,7 @@ class LibraryServiceGapicClient
                 'folder' => self::getFolderNameTemplate(),
                 'inventory' => self::getInventoryNameTemplate(),
                 'location' => self::getLocationNameTemplate(),
+                'organizationReader' => self::getOrganizationReaderNameTemplate(),
                 'project' => self::getProjectNameTemplate(),
                 'projectBook' => self::getProjectBookNameTemplate(),
                 'projectLocationPublisherBook' => self::getProjectLocationPublisherBookNameTemplate(),
@@ -2792,6 +2803,21 @@ class LibraryServiceGapicClient
         return self::getLocationNameTemplate()->render([
             'project' => $project,
             'location' => $location,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent
+     * a organization_reader resource.
+     *
+     * @param string $organization
+     * @return string The formatted organization_reader resource.
+     * @experimental
+     */
+    public static function organizationReaderName($organization)
+    {
+        return self::getOrganizationReaderNameTemplate()->render([
+            'organization' => $organization,
         ]);
     }
 
@@ -2964,6 +2990,7 @@ class LibraryServiceGapicClient
      * - folder: folders/{folder}
      * - inventory: projects/{project}/locations/{location}/publishers/{publisher}/inventory
      * - location: projects/{project}/locations/{location}
+     * - organizationReader: organization/{organization}/reader
      * - project: projects/{project}
      * - projectBook: projects/{project}/books/{book}
      * - projectLocationPublisherBook: projects/{project}/locations/{location}/publishers/{publisher}/inventory/books/{book}

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -2450,6 +2450,7 @@ class LibraryServiceGapicClient
     private static $folderNameTemplate;
     private static $inventoryNameTemplate;
     private static $locationNameTemplate;
+    private static $organizationReaderNameTemplate;
     private static $projectNameTemplate;
     private static $projectBookNameTemplate;
     private static $projectLocationPublisherBookNameTemplate;
@@ -2553,6 +2554,15 @@ class LibraryServiceGapicClient
         return self::$locationNameTemplate;
     }
 
+    private static function getOrganizationReaderNameTemplate()
+    {
+        if (self::$organizationReaderNameTemplate == null) {
+            self::$organizationReaderNameTemplate = new PathTemplate('organization/{organization}/reader');
+        }
+
+        return self::$organizationReaderNameTemplate;
+    }
+
     private static function getProjectNameTemplate()
     {
         if (self::$projectNameTemplate == null) {
@@ -2647,6 +2657,7 @@ class LibraryServiceGapicClient
                 'folder' => self::getFolderNameTemplate(),
                 'inventory' => self::getInventoryNameTemplate(),
                 'location' => self::getLocationNameTemplate(),
+                'organizationReader' => self::getOrganizationReaderNameTemplate(),
                 'project' => self::getProjectNameTemplate(),
                 'projectBook' => self::getProjectBookNameTemplate(),
                 'projectLocationPublisherBook' => self::getProjectLocationPublisherBookNameTemplate(),
@@ -2792,6 +2803,21 @@ class LibraryServiceGapicClient
         return self::getLocationNameTemplate()->render([
             'project' => $project,
             'location' => $location,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent
+     * a organization_reader resource.
+     *
+     * @param string $organization
+     * @return string The formatted organization_reader resource.
+     * @experimental
+     */
+    public static function organizationReaderName($organization)
+    {
+        return self::getOrganizationReaderNameTemplate()->render([
+            'organization' => $organization,
         ]);
     }
 
@@ -2964,6 +2990,7 @@ class LibraryServiceGapicClient
      * - folder: folders/{folder}
      * - inventory: projects/{project}/locations/{location}/publishers/{publisher}/inventory
      * - location: projects/{project}/locations/{location}
+     * - organizationReader: organization/{organization}/reader
      * - project: projects/{project}
      * - projectBook: projects/{project}/books/{book}
      * - projectLocationPublisherBook: projects/{project}/locations/{location}/publishers/{publisher}/inventory/books/{book}

--- a/src/test/java/com/google/api/codegen/testsrc/protoannotations/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/protoannotations/library.proto
@@ -611,7 +611,8 @@ message Reader {
   option (google.api.resource) = {
     type: "library.googleapis.com/Reader",
     pattern: "projects/{project}/readers/{reader}",
-    pattern: "projects/{project}/shelves/{shelf}/readers/{reader}"
+    pattern: "projects/{project}/shelves/{shelf}/readers/{reader}",
+    pattern: "organization/{organization}/reader"
   };
 
   string name = 1 [


### PR DESCRIPTION
This is to support [SecurityCenter](https://github.com/googleapis/googleapis/blob/master/google/cloud/securitycenter/v1/security_marks.proto#L33-L38).

`SecurityMarks` is a multi-pattern singleton resource:

```
option (google.api.resource) = {
    type: "securitycenter.googleapis.com/SecurityMarks"
    pattern: "organizations/{organization}/assets/{asset}/securityMarks"
    pattern: "organizations/{organization}/sources/{source}/findings/{finding}/securityMarks"
};
```

Currently we generate an ID for a pattern by concatenating all binding values. This leads to slightly unclear helper functions in Java and PHP for the `SecurityMarks` resource:

```
// PHP
client.organizationAssetName("my-org", "ast"); // returns organizations/my-org/assets/ast/securityMarks

// Java
SecurityMarksName.ofOrganizationAssetName("org", "ast");
```
This PR adds the last segment to the resource name pattern ID if the last segment is not a binding value. This will lead to more descriptive function names:

```
// PHP
client.organizationAssetSecurityMarksName("my-org", "ast"); // returns organizations/my-org/assets/ast/securityMarks

// Java
SecurityMarksName.ofOrganizationAssetSecurityMarksName("org", "ast");
```

