### PR TITLE
feat: support '*' in resource definition

### DIFF
--- a/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
@@ -130,6 +130,12 @@ public abstract class ResourceDescriptorConfig {
 
     // Single-pattern resource.
     if (getPatterns().size() == 1) {
+      String pattern = getPatterns().get(0);
+
+      if ("*".equals(pattern)) {
+        return Collections.singletonMap(getUnqualifiedTypeName(), AnyResourceNameConfig.instance());
+      }
+
       return Collections.singletonMap(
           getUnqualifiedTypeName(),
           SingleResourceNameConfig.createSingleResourceNameWithOverride(

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -174,32 +174,6 @@ public abstract class ResourceNameMessageConfigs {
                 "unknown resource name type: " + resource.getResourceNameType());
         }
       }
-
-      // if (!childType.isEmpty()) {
-      //   List<ResourceDescriptorConfig> parents =
-      //       childParentResourceMap.getOrDefault(childType, Collections.emptyList());
-      //   for (ResourceDescriptorConfig parentResourceDescriptor : parents) {
-      //     String derivedEntityName = parentResourceDescriptor.getDerivedEntityName();
-      //     ResourceNameConfig parentResource = resourceNameConfigs.get(derivedEntityName);
-      //     Preconditions.checkArgument(
-      //         parentResource != null, "Referencing non-existing parent resource: %s", childType);
-      //     fieldEntityMap.put(field.getSimpleName(), parentResource.getEntityId());
-      //   }
-      //   continue;
-      // }
-
-      // String unqualifiedResourceType = ResourceDescriptorConfig.getUnqualifiedTypeName(type);
-      // ResourceNameConfig resourceNameConfig =
-      //     resourceNameConfigs.get(unqualifiedResourceType + "Oneof");
-      // if (resourceNameConfig != null
-      //     && resourceNameConfig.getResourceNameType() == ResourceNameType.ONEOF) {
-      //   fieldEntityMap.put(field.getSimpleName(), unqualifiedResourceType + "Oneof");
-      //   continue;
-      // }
-      // resourceNameConfig = resourceNameConfigs.get(unqualifiedResourceType);
-      // Preconditions.checkArgument(
-      //     resourceNameConfig != null, "Referencing non-existing resource: %s", type);
-      // fieldEntityMap.put(field.getSimpleName(), unqualifiedResourceType);
     }
   }
 

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -72,7 +72,12 @@ public abstract class ResourceNameMessageConfigs {
 
         // Handle resource references.
         loadFieldEntityPairFromResourceReferenceAnnotation(
-            fieldEntityMapBuilder, parser, message, resourceNameConfigs, childParentResourceMap);
+            fieldEntityMapBuilder,
+            parser,
+            message,
+            resourceNameConfigs,
+            descriptorConfigMap,
+            childParentResourceMap);
 
         ImmutableListMultimap<String, String> fieldEntityMap = fieldEntityMapBuilder.build();
         if (fieldEntityMap.size() > 0) {
@@ -116,6 +121,7 @@ public abstract class ResourceNameMessageConfigs {
       ProtoParser parser,
       MessageType message,
       Map<String, ResourceNameConfig> resourceNameConfigs,
+      Map<String, ResourceDescriptorConfig> descriptorConfigMap,
       Map<String, List<ResourceDescriptorConfig>> childParentResourceMap) {
     for (Field field : message.getFields()) {
       ResourceReference reference = parser.getResourceReference(field);
@@ -134,36 +140,66 @@ public abstract class ResourceNameMessageConfigs {
           "Only one of child_type and type should be set: %s",
           field);
 
-      if (!childType.isEmpty()) {
-        List<ResourceDescriptorConfig> parents =
-            childParentResourceMap.getOrDefault(childType, Collections.emptyList());
-        for (ResourceDescriptorConfig parentResourceDescriptor : parents) {
-          String derivedEntityName = parentResourceDescriptor.getDerivedEntityName();
-          ResourceNameConfig parentResource = resourceNameConfigs.get(derivedEntityName);
-          Preconditions.checkArgument(
-              parentResource != null, "Referencing non-existing parent resource: %s", childType);
-          fieldEntityMap.put(field.getSimpleName(), parentResource.getEntityId());
-        }
-        continue;
-      }
-
-      if (type.equals("*")) {
+      if (type.equals("*") || childType.equals("*")) {
         fieldEntityMap.put(field.getSimpleName(), "*");
         continue;
       }
 
-      String unqualifiedResourceType = ResourceDescriptorConfig.getUnqualifiedTypeName(type);
-      ResourceNameConfig resourceNameConfig =
-          resourceNameConfigs.get(unqualifiedResourceType + "Oneof");
-      if (resourceNameConfig != null
-          && resourceNameConfig.getResourceNameType() == ResourceNameType.ONEOF) {
-        fieldEntityMap.put(field.getSimpleName(), unqualifiedResourceType + "Oneof");
-        continue;
+      List<ResourceDescriptorConfig> referencedResources;
+      if (!childType.isEmpty()) {
+        referencedResources = childParentResourceMap.get(childType);
+      } else {
+        referencedResources = Collections.singletonList(descriptorConfigMap.get(type));
       }
-      resourceNameConfig = resourceNameConfigs.get(unqualifiedResourceType);
-      Preconditions.checkArgument(
-          resourceNameConfig != null, "Referencing non-existing resource: %s", type);
-      fieldEntityMap.put(field.getSimpleName(), unqualifiedResourceType);
+
+      for (ResourceDescriptorConfig descriptor : referencedResources) {
+        String unqualifiedName = descriptor.getDerivedEntityName();
+        ResourceNameConfig resource = resourceNameConfigs.get(unqualifiedName);
+
+        switch (resource.getResourceNameType()) {
+          case ANY:
+            fieldEntityMap.put(field.getSimpleName(), "*");
+            break;
+          case SINGLE:
+            fieldEntityMap.put(field.getSimpleName(), unqualifiedName);
+            break;
+          case ONEOF:
+            fieldEntityMap.put(field.getSimpleName(), unqualifiedName);
+            if (((ResourceNameOneofConfig) resource).hasAnyResourceNamePattern()) {
+              fieldEntityMap.put(field.getSimpleName(), "*");
+            }
+            break;
+          default:
+            throw new IllegalArgumentException(
+                "unknown resource name type: " + resource.getResourceNameType());
+        }
+      }
+
+      // if (!childType.isEmpty()) {
+      //   List<ResourceDescriptorConfig> parents =
+      //       childParentResourceMap.getOrDefault(childType, Collections.emptyList());
+      //   for (ResourceDescriptorConfig parentResourceDescriptor : parents) {
+      //     String derivedEntityName = parentResourceDescriptor.getDerivedEntityName();
+      //     ResourceNameConfig parentResource = resourceNameConfigs.get(derivedEntityName);
+      //     Preconditions.checkArgument(
+      //         parentResource != null, "Referencing non-existing parent resource: %s", childType);
+      //     fieldEntityMap.put(field.getSimpleName(), parentResource.getEntityId());
+      //   }
+      //   continue;
+      // }
+
+      // String unqualifiedResourceType = ResourceDescriptorConfig.getUnqualifiedTypeName(type);
+      // ResourceNameConfig resourceNameConfig =
+      //     resourceNameConfigs.get(unqualifiedResourceType + "Oneof");
+      // if (resourceNameConfig != null
+      //     && resourceNameConfig.getResourceNameType() == ResourceNameType.ONEOF) {
+      //   fieldEntityMap.put(field.getSimpleName(), unqualifiedResourceType + "Oneof");
+      //   continue;
+      // }
+      // resourceNameConfig = resourceNameConfigs.get(unqualifiedResourceType);
+      // Preconditions.checkArgument(
+      //     resourceNameConfig != null, "Referencing non-existing resource: %s", type);
+      // fieldEntityMap.put(field.getSimpleName(), unqualifiedResourceType);
     }
   }
 

--- a/src/main/java/com/google/api/codegen/config/ResourceNameOneofConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameOneofConfig.java
@@ -53,6 +53,11 @@ public abstract class ResourceNameOneofConfig implements ResourceNameConfig {
    */
   public abstract List<ResourceNamePatternConfig> getPatterns();
 
+  /** Returns true of any of its patterns is "*". */
+  public boolean hasAnyResourceNamePattern() {
+    return getPatterns().stream().anyMatch(p -> "*".equals(p));
+  }
+
   /**
    * Returns a list of SingleResourceNameConfigs for this oneof config created from either
    * collections field in gapic v1 or deprecated_collections field in gapic v2.

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -174,6 +174,8 @@ public class PathTemplateTransformer {
           resourceNames.add(
               generateResourceNameFixed(context, index, (FixedResourceNameConfig) config));
           break;
+        case ANY:
+          break; // ignore AnyResourceNameConfigs
         default:
           throw new IllegalStateException("Unexpected resource-name type.");
       }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/csharp_library.baseline
@@ -7657,29 +7657,35 @@ namespace Google.Example.Library.V1.Snippets
         /// <summary>Snippet for CreateInventoryAsync</summary>
         public async Task CreateInventoryAsync()
         {
-            // Snippet: CreateInventoryAsync(PublisherName,Inventory,CallSettings)
-            // Additional: CreateInventoryAsync(PublisherName,Inventory,CancellationToken)
+            // Snippet: CreateInventoryAsync(PublisherName,Inventory,IResourceName,IResourceName,IEnumerable<IResourceName>,CallSettings)
+            // Additional: CreateInventoryAsync(PublisherName,Inventory,IResourceName,IResourceName,IEnumerable<IResourceName>,CancellationToken)
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
             PublisherName parent = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
             Inventory inventory = new Inventory();
+            IResourceName asset = new ArchiveName("[ARCHIVE]");
+            IResourceName parentAsset = new ArchiveName("[ARCHIVE]");
+            IEnumerable<IResourceName> assets = new List<IResourceName>();
             // Make the request
-            Inventory response = await libraryServiceClient.CreateInventoryAsync(parent, inventory);
+            Inventory response = await libraryServiceClient.CreateInventoryAsync(parent, inventory, asset, parentAsset, assets);
             // End snippet
         }
 
         /// <summary>Snippet for CreateInventory</summary>
         public void CreateInventory()
         {
-            // Snippet: CreateInventory(PublisherName,Inventory,CallSettings)
+            // Snippet: CreateInventory(PublisherName,Inventory,IResourceName,IResourceName,IEnumerable<IResourceName>,CallSettings)
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
             PublisherName parent = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
             Inventory inventory = new Inventory();
+            IResourceName asset = new ArchiveName("[ARCHIVE]");
+            IResourceName parentAsset = new ArchiveName("[ARCHIVE]");
+            IEnumerable<IResourceName> assets = new List<IResourceName>();
             // Make the request
-            Inventory response = libraryServiceClient.CreateInventory(parent, inventory);
+            Inventory response = libraryServiceClient.CreateInventory(parent, inventory, asset, parentAsset, assets);
             // End snippet
         }
 
@@ -7694,6 +7700,9 @@ namespace Google.Example.Library.V1.Snippets
             CreateInventoryRequest request = new CreateInventoryRequest
             {
                 ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+                AssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                ParentAssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                AssetsAsResourceNames = { },
             };
             // Make the request
             Inventory response = await libraryServiceClient.CreateInventoryAsync(request);
@@ -7710,6 +7719,9 @@ namespace Google.Example.Library.V1.Snippets
             CreateInventoryRequest request = new CreateInventoryRequest
             {
                 ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+                AssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                ParentAssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                AssetsAsResourceNames = { },
             };
             // Make the request
             Inventory response = libraryServiceClient.CreateInventory(request);
@@ -10926,6 +10938,9 @@ namespace Google.Example.Library.V1.Tests
             {
                 ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
                 Inventory = new Inventory(),
+                AssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                ParentAssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                AssetsAsResourceNames = { },
             };
             Inventory expectedResponse = new Inventory
             {
@@ -10936,7 +10951,10 @@ namespace Google.Example.Library.V1.Tests
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
             PublisherName parent = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
             Inventory inventory = new Inventory();
-            Inventory response = client.CreateInventory(parent, inventory);
+            IResourceName asset = new ArchiveName("[ARCHIVE]");
+            IResourceName parentAsset = new ArchiveName("[ARCHIVE]");
+            IEnumerable<IResourceName> assets = new List<IResourceName>();
+            Inventory response = client.CreateInventory(parent, inventory, asset, parentAsset, assets);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
         }
@@ -10953,6 +10971,9 @@ namespace Google.Example.Library.V1.Tests
             {
                 ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
                 Inventory = new Inventory(),
+                AssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                ParentAssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                AssetsAsResourceNames = { },
             };
             Inventory expectedResponse = new Inventory
             {
@@ -10963,7 +10984,10 @@ namespace Google.Example.Library.V1.Tests
             LibraryServiceClient client = new LibraryServiceClientImpl(mockGrpcClient.Object, null);
             PublisherName parent = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
             Inventory inventory = new Inventory();
-            Inventory response = await client.CreateInventoryAsync(parent, inventory);
+            IResourceName asset = new ArchiveName("[ARCHIVE]");
+            IResourceName parentAsset = new ArchiveName("[ARCHIVE]");
+            IEnumerable<IResourceName> assets = new List<IResourceName>();
+            Inventory response = await client.CreateInventoryAsync(parent, inventory, asset, parentAsset, assets);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
         }
@@ -10979,6 +11003,9 @@ namespace Google.Example.Library.V1.Tests
             CreateInventoryRequest request = new CreateInventoryRequest
             {
                 ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+                AssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                ParentAssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                AssetsAsResourceNames = { },
             };
             Inventory expectedResponse = new Inventory
             {
@@ -11003,6 +11030,9 @@ namespace Google.Example.Library.V1.Tests
             CreateInventoryRequest request = new CreateInventoryRequest
             {
                 ParentAsPublisherName = new PublisherName("[PROJECT]", "[LOCATION]", "[PUBLISHER]"),
+                AssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                ParentAssetAsResourceName = new ArchiveName("[ARCHIVE]"),
+                AssetsAsResourceNames = { },
             };
             Inventory expectedResponse = new Inventory
             {
@@ -21628,6 +21658,15 @@ namespace Google.Example.Library.V1
         /// <param name="inventory">
         ///
         /// </param>
+        /// <param name="asset">
+        ///
+        /// </param>
+        /// <param name="parentAsset">
+        ///
+        /// </param>
+        /// <param name="assets">
+        ///
+        /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
@@ -21637,11 +21676,17 @@ namespace Google.Example.Library.V1
         public virtual stt::Task<Inventory> CreateInventoryAsync(
             PublisherName parent,
             Inventory inventory,
+            IResourceName asset,
+            IResourceName parentAsset,
+            scg::IEnumerable<IResourceName> assets,
             gaxgrpc::CallSettings callSettings = null) => CreateInventoryAsync(
                 new CreateInventoryRequest
                 {
                     ParentAsPublisherName = gax::GaxPreconditions.CheckNotNull(parent, nameof(parent)),
                     Inventory = inventory, // Optional
+                    AssetAsResourceName = gax::GaxPreconditions.CheckNotNull(asset, nameof(asset)),
+                    ParentAssetAsResourceName = gax::GaxPreconditions.CheckNotNull(parentAsset, nameof(parentAsset)),
+                    AssetsAsResourceNames = { gax::GaxPreconditions.CheckNotNull(assets, nameof(assets)) },
                 },
                 callSettings);
 
@@ -21652,6 +21697,15 @@ namespace Google.Example.Library.V1
         ///
         /// </param>
         /// <param name="inventory">
+        ///
+        /// </param>
+        /// <param name="asset">
+        ///
+        /// </param>
+        /// <param name="parentAsset">
+        ///
+        /// </param>
+        /// <param name="assets">
         ///
         /// </param>
         /// <param name="cancellationToken">
@@ -21663,9 +21717,15 @@ namespace Google.Example.Library.V1
         public virtual stt::Task<Inventory> CreateInventoryAsync(
             PublisherName parent,
             Inventory inventory,
+            IResourceName asset,
+            IResourceName parentAsset,
+            scg::IEnumerable<IResourceName> assets,
             st::CancellationToken cancellationToken) => CreateInventoryAsync(
                 parent,
                 inventory,
+                asset,
+                parentAsset,
+                assets,
                 gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
@@ -21675,6 +21735,15 @@ namespace Google.Example.Library.V1
         ///
         /// </param>
         /// <param name="inventory">
+        ///
+        /// </param>
+        /// <param name="asset">
+        ///
+        /// </param>
+        /// <param name="parentAsset">
+        ///
+        /// </param>
+        /// <param name="assets">
         ///
         /// </param>
         /// <param name="callSettings">
@@ -21686,11 +21755,17 @@ namespace Google.Example.Library.V1
         public virtual Inventory CreateInventory(
             PublisherName parent,
             Inventory inventory,
+            IResourceName asset,
+            IResourceName parentAsset,
+            scg::IEnumerable<IResourceName> assets,
             gaxgrpc::CallSettings callSettings = null) => CreateInventory(
                 new CreateInventoryRequest
                 {
                     ParentAsPublisherName = gax::GaxPreconditions.CheckNotNull(parent, nameof(parent)),
                     Inventory = inventory, // Optional
+                    AssetAsResourceName = gax::GaxPreconditions.CheckNotNull(asset, nameof(asset)),
+                    ParentAssetAsResourceName = gax::GaxPreconditions.CheckNotNull(parentAsset, nameof(parentAsset)),
+                    AssetsAsResourceNames = { gax::GaxPreconditions.CheckNotNull(assets, nameof(assets)) },
                 },
                 callSettings);
 
@@ -21701,6 +21776,15 @@ namespace Google.Example.Library.V1
         ///
         /// </param>
         /// <param name="inventory">
+        ///
+        /// </param>
+        /// <param name="asset">
+        ///
+        /// </param>
+        /// <param name="parentAsset">
+        ///
+        /// </param>
+        /// <param name="assets">
         ///
         /// </param>
         /// <param name="callSettings">
@@ -21712,11 +21796,17 @@ namespace Google.Example.Library.V1
         public virtual stt::Task<Inventory> CreateInventoryAsync(
             string parent,
             Inventory inventory,
+            string asset,
+            string parentAsset,
+            scg::IEnumerable<string> assets,
             gaxgrpc::CallSettings callSettings = null) => CreateInventoryAsync(
                 new CreateInventoryRequest
                 {
                     Parent = gax::GaxPreconditions.CheckNotNullOrEmpty(parent, nameof(parent)),
                     Inventory = inventory, // Optional
+                    Asset = gax::GaxPreconditions.CheckNotNullOrEmpty(asset, nameof(asset)),
+                    ParentAsset = gax::GaxPreconditions.CheckNotNullOrEmpty(parentAsset, nameof(parentAsset)),
+                    Assets = { gax::GaxPreconditions.CheckNotNull(assets, nameof(assets)) },
                 },
                 callSettings);
 
@@ -21727,6 +21817,15 @@ namespace Google.Example.Library.V1
         ///
         /// </param>
         /// <param name="inventory">
+        ///
+        /// </param>
+        /// <param name="asset">
+        ///
+        /// </param>
+        /// <param name="parentAsset">
+        ///
+        /// </param>
+        /// <param name="assets">
         ///
         /// </param>
         /// <param name="cancellationToken">
@@ -21738,9 +21837,15 @@ namespace Google.Example.Library.V1
         public virtual stt::Task<Inventory> CreateInventoryAsync(
             string parent,
             Inventory inventory,
+            string asset,
+            string parentAsset,
+            scg::IEnumerable<string> assets,
             st::CancellationToken cancellationToken) => CreateInventoryAsync(
                 parent,
                 inventory,
+                asset,
+                parentAsset,
+                assets,
                 gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
@@ -21752,6 +21857,15 @@ namespace Google.Example.Library.V1
         /// <param name="inventory">
         ///
         /// </param>
+        /// <param name="asset">
+        ///
+        /// </param>
+        /// <param name="parentAsset">
+        ///
+        /// </param>
+        /// <param name="assets">
+        ///
+        /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
@@ -21761,11 +21875,17 @@ namespace Google.Example.Library.V1
         public virtual Inventory CreateInventory(
             string parent,
             Inventory inventory,
+            string asset,
+            string parentAsset,
+            scg::IEnumerable<string> assets,
             gaxgrpc::CallSettings callSettings = null) => CreateInventory(
                 new CreateInventoryRequest
                 {
                     Parent = gax::GaxPreconditions.CheckNotNullOrEmpty(parent, nameof(parent)),
                     Inventory = inventory, // Optional
+                    Asset = gax::GaxPreconditions.CheckNotNullOrEmpty(asset, nameof(asset)),
+                    ParentAsset = gax::GaxPreconditions.CheckNotNullOrEmpty(parentAsset, nameof(parentAsset)),
+                    Assets = { gax::GaxPreconditions.CheckNotNull(assets, nameof(assets)) },
                 },
                 callSettings);
 
@@ -29032,6 +29152,31 @@ namespace Google.Example.Library.V1
             get { return string.IsNullOrEmpty(Parent) ? null : Google.Example.Library.V1.PublisherName.Parse(Parent); }
             set { Parent = value != null ? value.ToString() : ""; }
         }
+
+        /// <summary>
+        /// <see cref="gax::IResourceName"/>-typed view over the <see cref="Asset"/> resource name property.
+        /// </summary>
+        public gax::IResourceName AssetAsResourceName
+        {
+            get { return string.IsNullOrEmpty(Asset) ? null : gax::UnknownResourceName.Parse(Asset); }
+            set { Asset = value != null ? value.ToString() : ""; }
+        }
+
+        /// <summary>
+        /// <see cref="gax::IResourceName"/>-typed view over the <see cref="ParentAsset"/> resource name property.
+        /// </summary>
+        public gax::IResourceName ParentAssetAsResourceName
+        {
+            get { return string.IsNullOrEmpty(ParentAsset) ? null : gax::UnknownResourceName.Parse(ParentAsset); }
+            set { ParentAsset = value != null ? value.ToString() : ""; }
+        }
+
+        /// <summary>
+        /// <see cref="gax::ResourceNameList{gax::IResourceName}"/>-typed view over the <see cref="Assets"/> resource name property.
+        /// </summary>
+        public gax::ResourceNameList<gax::IResourceName> AssetsAsResourceNames =>
+            new gax::ResourceNameList<gax::IResourceName>(Assets,
+                str => gax::UnknownResourceName.Parse(str));
 
     }
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -4846,8 +4846,14 @@ func TestLibraryServiceCreateInventory(t *testing.T) {
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
     var formattedParent string = fmt.Sprintf("projects/%s/locations/%s/publishers/%s", "[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+    var asset string = "asset93121264"
+    var parentAsset string = "parentAsset1389473563"
+    var assets []string = nil
     var request = &librarypb.CreateInventoryRequest{
         Parent: formattedParent,
+        Asset: asset,
+        ParentAsset: parentAsset,
+        Assets: assets,
     }
 
     c, err := NewClient(context.Background(), clientOpt)
@@ -4875,8 +4881,14 @@ func TestLibraryServiceCreateInventoryError(t *testing.T) {
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
     var formattedParent string = fmt.Sprintf("projects/%s/locations/%s/publishers/%s", "[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+    var asset string = "asset93121264"
+    var parentAsset string = "parentAsset1389473563"
+    var assets []string = nil
     var request = &librarypb.CreateInventoryRequest{
         Parent: formattedParent,
+        Asset: asset,
+        ParentAsset: parentAsset,
+        Assets: assets,
     }
 
     c, err := NewClient(context.Background(), clientOpt)

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library.baseline
@@ -8605,19 +8605,28 @@ public class LibraryClient implements BackgroundResource {
    * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
    *   Inventory inventory = Inventory.newBuilder().build();
-   *   Inventory response = libraryClient.createInventory(parent, inventory);
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;String&gt; assets = new ArrayList&lt;&gt;();
+   *   Inventory response = libraryClient.createInventory(parent, inventory, asset, parentAsset, assets);
    * }
    * </code></pre>
    *
    * @param parent
    * @param inventory
+   * @param asset
+   * @param parentAsset
+   * @param assets
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  public final Inventory createInventory(PublisherName parent, Inventory inventory) {
+  public final Inventory createInventory(PublisherName parent, Inventory inventory, ResourceName asset, ResourceName parentAsset, List<String> assets) {
     CreateInventoryRequest request =
         CreateInventoryRequest.newBuilder()
             .setParent(parent == null ? null : parent.toString())
             .setInventory(inventory)
+            .setAsset(asset == null ? null : asset.toString())
+            .setParentAsset(parentAsset == null ? null : parentAsset.toString())
+            .addAllAssets(assets)
             .build();
     return createInventory(request);
   }
@@ -8631,19 +8640,28 @@ public class LibraryClient implements BackgroundResource {
    * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
    *   Inventory inventory = Inventory.newBuilder().build();
-   *   Inventory response = libraryClient.createInventory(parent.toString(), inventory);
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;String&gt; assets = new ArrayList&lt;&gt;();
+   *   Inventory response = libraryClient.createInventory(parent.toString(), inventory, asset.toString(), parentAsset.toString(), assets);
    * }
    * </code></pre>
    *
    * @param parent
    * @param inventory
+   * @param asset
+   * @param parentAsset
+   * @param assets
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  public final Inventory createInventory(String parent, Inventory inventory) {
+  public final Inventory createInventory(String parent, Inventory inventory, String asset, String parentAsset, List<String> assets) {
     CreateInventoryRequest request =
         CreateInventoryRequest.newBuilder()
             .setParent(parent)
             .setInventory(inventory)
+            .setAsset(asset)
+            .setParentAsset(parentAsset)
+            .addAllAssets(assets)
             .build();
     return createInventory(request);
   }
@@ -8656,8 +8674,14 @@ public class LibraryClient implements BackgroundResource {
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;ResourceName&gt; assets = new ArrayList&lt;&gt;();
    *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
    *     .setParent(parent.toString())
+   *     .setAsset(asset.toString())
+   *     .setParentAsset(parentAsset.toString())
+   *     .addAllAssets(UntypedResourceName.toStringList(assets))
    *     .build();
    *   Inventory response = libraryClient.createInventory(request);
    * }
@@ -8678,8 +8702,14 @@ public class LibraryClient implements BackgroundResource {
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;ResourceName&gt; assets = new ArrayList&lt;&gt;();
    *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
    *     .setParent(parent.toString())
+   *     .setAsset(asset.toString())
+   *     .setParentAsset(parentAsset.toString())
+   *     .addAllAssets(UntypedResourceName.toStringList(assets))
    *     .build();
    *   ApiFuture&lt;Inventory&gt; future = libraryClient.createInventoryCallable().futureCall(request);
    *   // Do something
@@ -17599,9 +17629,12 @@ public class LibraryClientTest {
 
     PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
     Inventory inventory = Inventory.newBuilder().build();
+    ResourceName asset = ArchiveName.of("[ARCHIVE]");
+    ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+    List<String> assets = new ArrayList<>();
 
     Inventory actualResponse =
-        client.createInventory(parent, inventory);
+        client.createInventory(parent, inventory, asset, parentAsset, assets);
     Assert.assertEquals(expectedResponse, actualResponse);
 
     List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
@@ -17610,6 +17643,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(parent, PublisherName.parse(actualRequest.getParent()));
     Assert.assertEquals(inventory, actualRequest.getInventory());
+    Assert.assertEquals(Objects.toString(asset), Objects.toString(actualRequest.getAsset()));
+    Assert.assertEquals(Objects.toString(parentAsset), Objects.toString(actualRequest.getParentAsset()));
+    Assert.assertEquals(assets, actualRequest.getAssetsList());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -17625,8 +17661,11 @@ public class LibraryClientTest {
     try {
       PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
       Inventory inventory = Inventory.newBuilder().build();
+      ResourceName asset = ArchiveName.of("[ARCHIVE]");
+      ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+      List<String> assets = new ArrayList<>();
 
-      client.createInventory(parent, inventory);
+      client.createInventory(parent, inventory, asset, parentAsset, assets);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config.baseline
@@ -1055,19 +1055,28 @@ public class LibraryServiceClient implements BackgroundResource {
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
    *   Inventory inventory = Inventory.newBuilder().build();
-   *   Inventory response = libraryServiceClient.createInventory(parent, inventory);
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;String&gt; assets = new ArrayList&lt;&gt;();
+   *   Inventory response = libraryServiceClient.createInventory(parent, inventory, asset, parentAsset, assets);
    * }
    * </code></pre>
    *
    * @param parent
    * @param inventory
+   * @param asset
+   * @param parentAsset
+   * @param assets
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  public final Inventory createInventory(PublisherName parent, Inventory inventory) {
+  public final Inventory createInventory(PublisherName parent, Inventory inventory, ResourceName asset, ResourceName parentAsset, List<String> assets) {
     CreateInventoryRequest request =
         CreateInventoryRequest.newBuilder()
             .setParent(parent == null ? null : parent.toString())
             .setInventory(inventory)
+            .setAsset(asset == null ? null : asset.toString())
+            .setParentAsset(parentAsset == null ? null : parentAsset.toString())
+            .addAllAssets(assets)
             .build();
     return createInventory(request);
   }
@@ -1081,19 +1090,28 @@ public class LibraryServiceClient implements BackgroundResource {
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
    *   Inventory inventory = Inventory.newBuilder().build();
-   *   Inventory response = libraryServiceClient.createInventory(parent.toString(), inventory);
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;String&gt; assets = new ArrayList&lt;&gt;();
+   *   Inventory response = libraryServiceClient.createInventory(parent.toString(), inventory, asset.toString(), parentAsset.toString(), assets);
    * }
    * </code></pre>
    *
    * @param parent
    * @param inventory
+   * @param asset
+   * @param parentAsset
+   * @param assets
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  public final Inventory createInventory(String parent, Inventory inventory) {
+  public final Inventory createInventory(String parent, Inventory inventory, String asset, String parentAsset, List<String> assets) {
     CreateInventoryRequest request =
         CreateInventoryRequest.newBuilder()
             .setParent(parent)
             .setInventory(inventory)
+            .setAsset(asset)
+            .setParentAsset(parentAsset)
+            .addAllAssets(assets)
             .build();
     return createInventory(request);
   }
@@ -1106,8 +1124,14 @@ public class LibraryServiceClient implements BackgroundResource {
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;ResourceName&gt; assets = new ArrayList&lt;&gt;();
    *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
    *     .setParent(parent.toString())
+   *     .setAsset(asset.toString())
+   *     .setParentAsset(parentAsset.toString())
+   *     .addAllAssets(UntypedResourceName.toStringList(assets))
    *     .build();
    *   Inventory response = libraryServiceClient.createInventory(request);
    * }
@@ -1128,8 +1152,14 @@ public class LibraryServiceClient implements BackgroundResource {
    * <pre><code>
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;ResourceName&gt; assets = new ArrayList&lt;&gt;();
    *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
    *     .setParent(parent.toString())
+   *     .setAsset(asset.toString())
+   *     .setParentAsset(parentAsset.toString())
+   *     .addAllAssets(UntypedResourceName.toStringList(assets))
    *     .build();
    *   ApiFuture&lt;Inventory&gt; future = libraryServiceClient.createInventoryCallable().futureCall(request);
    *   // Do something
@@ -11137,9 +11167,12 @@ public class LibraryServiceClientTest {
 
     PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
     Inventory inventory = Inventory.newBuilder().build();
+    ResourceName asset = ArchiveName.of("[ARCHIVE]");
+    ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+    List<String> assets = new ArrayList<>();
 
     Inventory actualResponse =
-        client.createInventory(parent, inventory);
+        client.createInventory(parent, inventory, asset, parentAsset, assets);
     Assert.assertEquals(expectedResponse, actualResponse);
 
     List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
@@ -11148,6 +11181,9 @@ public class LibraryServiceClientTest {
 
     Assert.assertEquals(parent, PublisherName.parse(actualRequest.getParent()));
     Assert.assertEquals(inventory, actualRequest.getInventory());
+    Assert.assertEquals(Objects.toString(asset), Objects.toString(actualRequest.getAsset()));
+    Assert.assertEquals(Objects.toString(parentAsset), Objects.toString(actualRequest.getParentAsset()));
+    Assert.assertEquals(assets, actualRequest.getAssetsList());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -11163,8 +11199,11 @@ public class LibraryServiceClientTest {
     try {
       PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
       Inventory inventory = Inventory.newBuilder().build();
+      ResourceName asset = ArchiveName.of("[ARCHIVE]");
+      ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+      List<String> assets = new ArrayList<>();
 
-      client.createInventory(parent, inventory);
+      client.createInventory(parent, inventory, asset, parentAsset, assets);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -8605,19 +8605,28 @@ public class LibraryClient implements BackgroundResource {
    * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
    *   Inventory inventory = Inventory.newBuilder().build();
-   *   Inventory response = libraryClient.createInventory(parent, inventory);
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;String&gt; assets = new ArrayList&lt;&gt;();
+   *   Inventory response = libraryClient.createInventory(parent, inventory, asset, parentAsset, assets);
    * }
    * </code></pre>
    *
    * @param parent
    * @param inventory
+   * @param asset
+   * @param parentAsset
+   * @param assets
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  public final Inventory createInventory(PublisherName parent, Inventory inventory) {
+  public final Inventory createInventory(PublisherName parent, Inventory inventory, ResourceName asset, ResourceName parentAsset, List<String> assets) {
     CreateInventoryRequest request =
         CreateInventoryRequest.newBuilder()
             .setParent(parent == null ? null : parent.toString())
             .setInventory(inventory)
+            .setAsset(asset == null ? null : asset.toString())
+            .setParentAsset(parentAsset == null ? null : parentAsset.toString())
+            .addAllAssets(assets)
             .build();
     return createInventory(request);
   }
@@ -8631,19 +8640,28 @@ public class LibraryClient implements BackgroundResource {
    * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
    *   Inventory inventory = Inventory.newBuilder().build();
-   *   Inventory response = libraryClient.createInventory(parent.toString(), inventory);
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;String&gt; assets = new ArrayList&lt;&gt;();
+   *   Inventory response = libraryClient.createInventory(parent.toString(), inventory, asset.toString(), parentAsset.toString(), assets);
    * }
    * </code></pre>
    *
    * @param parent
    * @param inventory
+   * @param asset
+   * @param parentAsset
+   * @param assets
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  public final Inventory createInventory(String parent, Inventory inventory) {
+  public final Inventory createInventory(String parent, Inventory inventory, String asset, String parentAsset, List<String> assets) {
     CreateInventoryRequest request =
         CreateInventoryRequest.newBuilder()
             .setParent(parent)
             .setInventory(inventory)
+            .setAsset(asset)
+            .setParentAsset(parentAsset)
+            .addAllAssets(assets)
             .build();
     return createInventory(request);
   }
@@ -8656,8 +8674,14 @@ public class LibraryClient implements BackgroundResource {
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;ResourceName&gt; assets = new ArrayList&lt;&gt;();
    *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
    *     .setParent(parent.toString())
+   *     .setAsset(asset.toString())
+   *     .setParentAsset(parentAsset.toString())
+   *     .addAllAssets(UntypedResourceName.toStringList(assets))
    *     .build();
    *   Inventory response = libraryClient.createInventory(request);
    * }
@@ -8678,8 +8702,14 @@ public class LibraryClient implements BackgroundResource {
    * <pre><code>
    * try (LibraryClient libraryClient = LibraryClient.create()) {
    *   PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
+   *   ResourceName asset = ArchiveName.of("[ARCHIVE]");
+   *   ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+   *   List&lt;ResourceName&gt; assets = new ArrayList&lt;&gt;();
    *   CreateInventoryRequest request = CreateInventoryRequest.newBuilder()
    *     .setParent(parent.toString())
+   *     .setAsset(asset.toString())
+   *     .setParentAsset(parentAsset.toString())
+   *     .addAllAssets(UntypedResourceName.toStringList(assets))
    *     .build();
    *   ApiFuture&lt;Inventory&gt; future = libraryClient.createInventoryCallable().futureCall(request);
    *   // Do something
@@ -17603,9 +17633,12 @@ public class LibraryClientTest {
 
     PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
     Inventory inventory = Inventory.newBuilder().build();
+    ResourceName asset = ArchiveName.of("[ARCHIVE]");
+    ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+    List<String> assets = new ArrayList<>();
 
     Inventory actualResponse =
-        client.createInventory(parent, inventory);
+        client.createInventory(parent, inventory, asset, parentAsset, assets);
     Assert.assertEquals(expectedResponse, actualResponse);
 
     List<AbstractMessage> actualRequests = mockLibraryService.getRequests();
@@ -17614,6 +17647,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(parent, PublisherName.parse(actualRequest.getParent()));
     Assert.assertEquals(inventory, actualRequest.getInventory());
+    Assert.assertEquals(Objects.toString(asset), Objects.toString(actualRequest.getAsset()));
+    Assert.assertEquals(Objects.toString(parentAsset), Objects.toString(actualRequest.getParentAsset()));
+    Assert.assertEquals(assets, actualRequest.getAssetsList());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -17629,8 +17665,11 @@ public class LibraryClientTest {
     try {
       PublisherName parent = PublisherName.of("[PROJECT]", "[LOCATION]", "[PUBLISHER]");
       Inventory inventory = Inventory.newBuilder().build();
+      ResourceName asset = ArchiveName.of("[ARCHIVE]");
+      ResourceName parentAsset = ArchiveName.of("[ARCHIVE]");
+      List<String> assets = new ArrayList<>();
 
-      client.createInventory(parent, inventory);
+      client.createInventory(parent, inventory, asset, parentAsset, assets);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -3235,6 +3235,12 @@ const ListStringsResponse = {
  * @property {Object} inventory
  *   This object should have the same structure as [Inventory]{@link google.example.library.v1.Inventory}
  *
+ * @property {string} asset
+ *
+ * @property {string} parentAsset
+ *
+ * @property {string[]} assets
+ *
  * @typedef CreateInventoryRequest
  * @memberof google.example.library.v1
  * @see [google.example.library.v1.CreateInventoryRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
@@ -7769,6 +7775,9 @@ class LibraryServiceClient {
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
+   * @param {string} request.asset
+   * @param {string} request.parentAsset
+   * @param {string[]} request.assets
    * @param {Object} [request.inventory]
    *   This object should have the same structure as [Inventory]{@link google.example.library.v1.Inventory}
    * @param {Object} [options]
@@ -7791,7 +7800,16 @@ class LibraryServiceClient {
    * });
    *
    * const formattedParent = client.publisherPath('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
-   * client.createInventory({parent: formattedParent})
+   * const asset = '';
+   * const parentAsset = '';
+   * const assets = [];
+   * const request = {
+   *   parent: formattedParent,
+   *   asset: asset,
+   *   parentAsset: parentAsset,
+   *   assets: assets,
+   * };
+   * client.createInventory(request)
    *   .then(responses => {
    *     const response = responses[0];
    *     // doThingsWith(response)
@@ -11257,8 +11275,14 @@ describe('LibraryServiceClient', () => {
 
       // Mock request
       const formattedParent = client.publisherPath('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+      const asset = 'asset93121264';
+      const parentAsset = 'parentAsset1389473563';
+      const assets = [];
       const request = {
         parent: formattedParent,
+        asset: asset,
+        parentAsset: parentAsset,
+        assets: assets,
       };
 
       // Mock response
@@ -11288,8 +11312,14 @@ describe('LibraryServiceClient', () => {
 
       // Mock request
       const formattedParent = client.publisherPath('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+      const asset = 'asset93121264';
+      const parentAsset = 'parentAsset1389473563';
+      const assets = [];
       const request = {
         parent: formattedParent,
+        asset: asset,
+        parentAsset: parentAsset,
+        assets: assets,
       };
 
       // Mock Grpc layer

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -5160,13 +5160,19 @@ class LibraryServiceGapicClient
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
      *     $formattedParent = $libraryServiceClient->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
-     *     $response = $libraryServiceClient->createInventory($formattedParent);
+     *     $asset = '';
+     *     $parentAsset = '';
+     *     $assets = [];
+     *     $response = $libraryServiceClient->createInventory($formattedParent, $asset, $parentAsset, $assets);
      * } finally {
      *     $libraryServiceClient->close();
      * }
      * ```
      *
      * @param string $parent
+     * @param string $asset
+     * @param string $parentAsset
+     * @param string[] $assets
      * @param array $optionalArgs {
      *     Optional.
      *     @type Inventory $inventory
@@ -5182,10 +5188,13 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function createInventory($parent, array $optionalArgs = [])
+    public function createInventory($parent, $asset, $parentAsset, $assets, array $optionalArgs = [])
     {
         $request = new CreateInventoryRequest();
         $request->setParent($parent);
+        $request->setAsset($asset);
+        $request->setParentAsset($parentAsset);
+        $request->setAssets($assets);
         if (isset($optionalArgs['inventory'])) {
             $request->setInventory($optionalArgs['inventory']);
         }
@@ -9571,8 +9580,11 @@ class LibraryServiceClientTest extends GeneratedTest
 
         // Mock request
         $formattedParent = $client->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+        $asset = 'asset93121264';
+        $parentAsset = 'parentAsset1389473563';
+        $assets = [];
 
-        $response = $client->createInventory($formattedParent);
+        $response = $client->createInventory($formattedParent, $asset, $parentAsset, $assets);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -9583,6 +9595,15 @@ class LibraryServiceClientTest extends GeneratedTest
         $actualValue = $actualRequestObject->getParent();
 
         $this->assertProtobufEquals($formattedParent, $actualValue);
+        $actualValue = $actualRequestObject->getAsset();
+
+        $this->assertProtobufEquals($asset, $actualValue);
+        $actualValue = $actualRequestObject->getParentAsset();
+
+        $this->assertProtobufEquals($parentAsset, $actualValue);
+        $actualValue = $actualRequestObject->getAssets();
+
+        $this->assertProtobufEquals($assets, $actualValue);
 
         $this->assertTrue($transport->isExhausted());
     }
@@ -9611,9 +9632,12 @@ class LibraryServiceClientTest extends GeneratedTest
 
         // Mock request
         $formattedParent = $client->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+        $asset = 'asset93121264';
+        $parentAsset = 'parentAsset1389473563';
+        $assets = [];
 
         try {
-            $client->createInventory($formattedParent);
+            $client->createInventory($formattedParent, $asset, $parentAsset, $assets);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -5160,13 +5160,19 @@ class LibraryServiceGapicClient
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
      *     $formattedParent = $libraryServiceClient->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
-     *     $response = $libraryServiceClient->createInventory($formattedParent);
+     *     $asset = '';
+     *     $parentAsset = '';
+     *     $assets = [];
+     *     $response = $libraryServiceClient->createInventory($formattedParent, $asset, $parentAsset, $assets);
      * } finally {
      *     $libraryServiceClient->close();
      * }
      * ```
      *
      * @param string $parent
+     * @param string $asset
+     * @param string $parentAsset
+     * @param string[] $assets
      * @param array $optionalArgs {
      *     Optional.
      *     @type Inventory $inventory
@@ -5182,10 +5188,13 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function createInventory($parent, array $optionalArgs = [])
+    public function createInventory($parent, $asset, $parentAsset, $assets, array $optionalArgs = [])
     {
         $request = new CreateInventoryRequest();
         $request->setParent($parent);
+        $request->setAsset($asset);
+        $request->setParentAsset($parentAsset);
+        $request->setAssets($assets);
         if (isset($optionalArgs['inventory'])) {
             $request->setInventory($optionalArgs['inventory']);
         }
@@ -9596,8 +9605,11 @@ class LibraryServiceClientTest extends GeneratedTest
 
         // Mock request
         $formattedParent = $client->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+        $asset = 'asset93121264';
+        $parentAsset = 'parentAsset1389473563';
+        $assets = [];
 
-        $response = $client->createInventory($formattedParent);
+        $response = $client->createInventory($formattedParent, $asset, $parentAsset, $assets);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -9608,6 +9620,15 @@ class LibraryServiceClientTest extends GeneratedTest
         $actualValue = $actualRequestObject->getParent();
 
         $this->assertProtobufEquals($formattedParent, $actualValue);
+        $actualValue = $actualRequestObject->getAsset();
+
+        $this->assertProtobufEquals($asset, $actualValue);
+        $actualValue = $actualRequestObject->getParentAsset();
+
+        $this->assertProtobufEquals($parentAsset, $actualValue);
+        $actualValue = $actualRequestObject->getAssets();
+
+        $this->assertProtobufEquals($assets, $actualValue);
 
         $this->assertTrue($transport->isExhausted());
     }
@@ -9636,9 +9657,12 @@ class LibraryServiceClientTest extends GeneratedTest
 
         // Mock request
         $formattedParent = $client->publisherName('[PROJECT]', '[LOCATION]', '[PUBLISHER]');
+        $asset = 'asset93121264';
+        $parentAsset = 'parentAsset1389473563';
+        $assets = [];
 
         try {
-            $client->createInventory($formattedParent);
+            $client->createInventory($formattedParent, $asset, $parentAsset, $assets);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -4017,6 +4017,9 @@ class LibraryServiceClient(object):
     def create_inventory(
             self,
             parent,
+            asset,
+            parent_asset,
+            assets,
             inventory=None,
             retry=google.api_core.gapic_v1.method.DEFAULT,
             timeout=google.api_core.gapic_v1.method.DEFAULT,
@@ -4031,10 +4034,22 @@ class LibraryServiceClient(object):
             >>>
             >>> parent = client.publisher_path('[PROJECT]', '[LOCATION]', '[PUBLISHER]')
             >>>
-            >>> response = client.create_inventory(parent)
+            >>> # TODO: Initialize `asset`:
+            >>> asset = ''
+            >>>
+            >>> # TODO: Initialize `parent_asset`:
+            >>> parent_asset = ''
+            >>>
+            >>> # TODO: Initialize `assets`:
+            >>> assets = []
+            >>>
+            >>> response = client.create_inventory(parent, asset, parent_asset, assets)
 
         Args:
             parent (str)
+            asset (str)
+            parent_asset (str)
+            assets (list[str])
             inventory (Union[dict, ~google.cloud.example.library_v1.types.Inventory]):
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.example.library_v1.types.Inventory`
@@ -4068,6 +4083,9 @@ class LibraryServiceClient(object):
 
         request = library_pb2.CreateInventoryRequest(
             parent=parent,
+            asset=asset,
+            parent_asset=parent_asset,
+            assets=assets,
             inventory=inventory,
         )
         if metadata is None:
@@ -8996,12 +9014,15 @@ class TestLibraryServiceClient(object):
 
         # Setup Request
         parent = client.publisher_path('[PROJECT]', '[LOCATION]', '[PUBLISHER]')
+        asset = 'asset93121264'
+        parent_asset = 'parentAsset1389473563'
+        assets = []
 
-        response = client.create_inventory(parent)
+        response = client.create_inventory(parent, asset, parent_asset, assets)
         assert expected_response == response
 
         assert len(channel.requests) == 1
-        expected_request = library_pb2.CreateInventoryRequest(parent=parent)
+        expected_request = library_pb2.CreateInventoryRequest(parent=parent, asset=asset, parent_asset=parent_asset, assets=assets)
         actual_request = channel.requests[0][1]
         assert expected_request == actual_request
 
@@ -9015,9 +9036,12 @@ class TestLibraryServiceClient(object):
 
         # Setup request
         parent = client.publisher_path('[PROJECT]', '[LOCATION]', '[PUBLISHER]')
+        asset = 'asset93121264'
+        parent_asset = 'parentAsset1389473563'
+        assets = []
 
         with pytest.raises(CustomException):
-            client.create_inventory(parent)
+            client.create_inventory(parent, asset, parent_asset, assets)
 
     def test_move_books(self):
         # Setup Expected Response

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -2459,6 +2459,12 @@ module Google
         #   @return [String]
         # @!attribute [rw] inventory
         #   @return [Google::Example::Library::V1::Inventory]
+        # @!attribute [rw] asset
+        #   @return [String]
+        # @!attribute [rw] parent_asset
+        #   @return [String]
+        # @!attribute [rw] assets
+        #   @return [Array<String>]
         class CreateInventoryRequest; end
 
         # @!attribute [rw] name
@@ -5454,6 +5460,9 @@ module Library
       # Creates an inventory. Tests singleton resources.
       #
       # @param parent [String]
+      # @param asset [String]
+      # @param parent_asset [String]
+      # @param assets [Array<String>]
       # @param inventory [Google::Example::Library::V1::Inventory | Hash]
       #   A hash of the same form as `Google::Example::Library::V1::Inventory`
       #   can also be provided.
@@ -5470,15 +5479,30 @@ module Library
       #
       #   library_client = Library::Library.new(version: :v1)
       #   formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
-      #   response = library_client.create_inventory(formatted_parent)
+      #
+      #   # TODO: Initialize `asset`:
+      #   asset = ''
+      #
+      #   # TODO: Initialize `parent_asset`:
+      #   parent_asset = ''
+      #
+      #   # TODO: Initialize `assets`:
+      #   assets = []
+      #   response = library_client.create_inventory(formatted_parent, asset, parent_asset, assets)
 
       def create_inventory \
           parent,
+          asset,
+          parent_asset,
+          assets,
           inventory: nil,
           options: nil,
           &block
         req = {
           parent: parent,
+          asset: asset,
+          parent_asset: parent_asset,
+          assets: assets,
           inventory: inventory
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateInventoryRequest)
@@ -10796,6 +10820,9 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes create_inventory without error' do
       # Create request parameters
       formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+      asset = ''
+      parent_asset = ''
+      assets = []
 
       # Create expected grpc response
       name = "name3373707"
@@ -10806,6 +10833,9 @@ describe Library::V1::LibraryServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Example::Library::V1::CreateInventoryRequest, request)
         assert_equal(formatted_parent, request.parent)
+        assert_equal(asset, request.asset)
+        assert_equal(parent_asset, request.parent_asset)
+        assert_equal(assets, request.assets)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v1.new(:create_inventory, mock_method)
@@ -10818,13 +10848,23 @@ describe Library::V1::LibraryServiceClient do
           client = Library::Library.new(version: :v1)
 
           # Call method
-          response = client.create_inventory(formatted_parent)
+          response = client.create_inventory(
+            formatted_parent,
+            asset,
+            parent_asset,
+            assets
+          )
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.create_inventory(formatted_parent) do |response, operation|
+          client.create_inventory(
+            formatted_parent,
+            asset,
+            parent_asset,
+            assets
+          ) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -10836,11 +10876,17 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes create_inventory with error' do
       # Create request parameters
       formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+      asset = ''
+      parent_asset = ''
+      assets = []
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Example::Library::V1::CreateInventoryRequest, request)
         assert_equal(formatted_parent, request.parent)
+        assert_equal(asset, request.asset)
+        assert_equal(parent_asset, request.parent_asset)
+        assert_equal(assets, request.assets)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:create_inventory, mock_method)
@@ -10854,7 +10900,12 @@ describe Library::V1::LibraryServiceClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.create_inventory(formatted_parent)
+            client.create_inventory(
+              formatted_parent,
+              asset,
+              parent_asset,
+              assets
+            )
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -2339,6 +2339,12 @@ module Google
         #   @return [String]
         # @!attribute [rw] inventory
         #   @return [Google::Example::Library::V1::Inventory]
+        # @!attribute [rw] asset
+        #   @return [String]
+        # @!attribute [rw] parent_asset
+        #   @return [String]
+        # @!attribute [rw] assets
+        #   @return [Array<String>]
         class CreateInventoryRequest; end
 
         # @!attribute [rw] name
@@ -3709,6 +3715,9 @@ module Library
       # Creates an inventory. Tests singleton resources.
       #
       # @param parent [String]
+      # @param asset [String]
+      # @param parent_asset [String]
+      # @param assets [Array<String>]
       # @param inventory [Google::Example::Library::V1::Inventory | Hash]
       #   A hash of the same form as `Google::Example::Library::V1::Inventory`
       #   can also be provided.
@@ -3725,15 +3734,30 @@ module Library
       #
       #   library_client = Library::Library.new(version: :v1)
       #   formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
-      #   response = library_client.create_inventory(formatted_parent)
+      #
+      #   # TODO: Initialize `asset`:
+      #   asset = ''
+      #
+      #   # TODO: Initialize `parent_asset`:
+      #   parent_asset = ''
+      #
+      #   # TODO: Initialize `assets`:
+      #   assets = []
+      #   response = library_client.create_inventory(formatted_parent, asset, parent_asset, assets)
 
       def create_inventory \
           parent,
+          asset,
+          parent_asset,
+          assets,
           inventory: nil,
           options: nil,
           &block
         req = {
           parent: parent,
+          asset: asset,
+          parent_asset: parent_asset,
+          assets: assets,
           inventory: inventory
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateInventoryRequest)
@@ -6847,6 +6871,9 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes create_inventory without error' do
       # Create request parameters
       formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+      asset = ''
+      parent_asset = ''
+      assets = []
 
       # Create expected grpc response
       name = "name3373707"
@@ -6857,6 +6884,9 @@ describe Library::V1::LibraryServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Example::Library::V1::CreateInventoryRequest, request)
         assert_equal(formatted_parent, request.parent)
+        assert_equal(asset, request.asset)
+        assert_equal(parent_asset, request.parent_asset)
+        assert_equal(assets, request.assets)
         OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub_v1.new(:create_inventory, mock_method)
@@ -6869,13 +6899,23 @@ describe Library::V1::LibraryServiceClient do
           client = Library::Library.new(version: :v1)
 
           # Call method
-          response = client.create_inventory(formatted_parent)
+          response = client.create_inventory(
+            formatted_parent,
+            asset,
+            parent_asset,
+            assets
+          )
 
           # Verify the response
           assert_equal(expected_response, response)
 
           # Call method with block
-          client.create_inventory(formatted_parent) do |response, operation|
+          client.create_inventory(
+            formatted_parent,
+            asset,
+            parent_asset,
+            assets
+          ) do |response, operation|
             # Verify the response
             assert_equal(expected_response, response)
             refute_nil(operation)
@@ -6887,11 +6927,17 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes create_inventory with error' do
       # Create request parameters
       formatted_parent = Library::V1::LibraryServiceClient.publisher_path("[PROJECT]", "[LOCATION]", "[PUBLISHER]")
+      asset = ''
+      parent_asset = ''
+      assets = []
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Example::Library::V1::CreateInventoryRequest, request)
         assert_equal(formatted_parent, request.parent)
+        assert_equal(asset, request.asset)
+        assert_equal(parent_asset, request.parent_asset)
+        assert_equal(assets, request.assets)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub_v1.new(:create_inventory, mock_method)
@@ -6905,7 +6951,12 @@ describe Library::V1::LibraryServiceClient do
 
           # Call method
           err = assert_raises Google::Gax::GaxError, CustomTestError_v1 do
-            client.create_inventory(formatted_parent)
+            client.create_inventory(
+              formatted_parent,
+              asset,
+              parent_asset,
+              assets
+            )
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/src/test/java/com/google/api/codegen/testsrc/protoannotations/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/protoannotations/library.proto
@@ -37,6 +37,11 @@ option (google.api.resource_definition) = {
   pattern: "archives/{archive}"
 };
 
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/Asset",
+  pattern: "*"
+};
+
 // This API represents a simple digital library.  It lets you manage Shelf
 // resources and Book resources in the library. It defines the following
 // resource model:
@@ -122,7 +127,7 @@ service LibraryService {
   // Creates an inventory. Tests singleton resources.
   rpc CreateInventory(CreateInventoryRequest) returns (Inventory) {
     option (google.api.http) = { post: "/v1/{parent=projects/*/locations/*/publishers/*}" body: "inventory" };
-    option (google.api.method_signature) = "parent,inventory";
+    option (google.api.method_signature) = "parent,inventory,asset,parent_asset,assets";
   }
 
   // Gets a book.
@@ -885,6 +890,18 @@ message ListStringsResponse {
     ];
 
     Inventory inventory = 2;
+
+    string asset = 3 [
+      (google.api.resource_reference).type = "library.googleapis.com/Asset",
+      (google.api.field_behavior) = REQUIRED];
+
+    string parent_asset = 4 [
+      (google.api.resource_reference).child_type = "library.googleapis.com/Asset",
+      (google.api.field_behavior) = REQUIRED];
+
+    repeated string assets = 5 [
+      (google.api.resource_reference).type = "library.googleapis.com/Asset",
+      (google.api.field_behavior) = REQUIRED];
  }
 
 message AddCommentsRequest {


### PR DESCRIPTION
This is to support Asset.

If referencing a resource with only one `*` pattern, treats it the same as `resource_reference.type = "*"`. That is, do not generate any resource name class for it, and use `ResourceName` interface on the client surface.