### PR TITLE
fix: PackagingConfig "org" and "name" calculation

### DIFF
--- a/src/main/java/com/google/api/codegen/config/PackagingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackagingConfig.java
@@ -42,7 +42,7 @@ public abstract class PackagingConfig {
       Pattern.compile(
           "(?i)(?<org>(\\w+\\.)(cloud\\.)*)(?<name>\\w+(\\.\\w+)*)\\.(?<ver>\\w*\\d+[\\w\\d]*)(\\.|$)");
   private static final Pattern NAME_ONLY_PATTERN =
-      Pattern.compile("(?i)(^|\\.)(?<name>[a-zA-Z]+)(\\.\\w*)$");
+      Pattern.compile("(?i)(google\\.|^)(?<name>[a-zA-Z]+)(\\.\\w*)+$");
 
   /** A single-word short name of the API. E.g., "logging". */
   public abstract String apiName();

--- a/src/main/java/com/google/api/codegen/config/PackagingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackagingConfig.java
@@ -39,7 +39,7 @@ import org.yaml.snakeyaml.Yaml;
 @AutoValue
 public abstract class PackagingConfig {
   private static final Pattern COMMON_PKG_PATTERN =
-      Pattern.compile("(?i)(?<org>(\\w+\\.){0,2})(?<name>\\w+)\\.(?<ver>\\w*\\d+[\\w\\d]*)(\\.|$)");
+      Pattern.compile("(?i)(?<org>(\\w+\\.){0,3})(?<name>\\w+)\\.(?<ver>\\w*\\d+[\\w\\d]*)(\\.|$)");
   private static final Pattern NAME_ONLY_PATTERN =
       Pattern.compile("(?i)(^|\\.)(?<name>[a-zA-Z]+)(\\.\\w*)$");
 

--- a/src/main/java/com/google/api/codegen/config/PackagingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackagingConfig.java
@@ -40,7 +40,7 @@ import org.yaml.snakeyaml.Yaml;
 public abstract class PackagingConfig {
   private static final Pattern COMMON_PKG_PATTERN =
       Pattern.compile(
-          "(?i)(?<org>(\\w+\\.){0,2})(?<name>\\w+(\\.\\w+)*)\\.(?<ver>\\w*\\d+[\\w\\d]*)(\\.|$)");
+          "(?i)(?<org>(\\w+\\.)(cloud\\.)*)(?<name>\\w+(\\.\\w+)*)\\.(?<ver>\\w*\\d+[\\w\\d]*)(\\.|$)");
   private static final Pattern NAME_ONLY_PATTERN =
       Pattern.compile("(?i)(^|\\.)(?<name>[a-zA-Z]+)(\\.\\w*)$");
 

--- a/src/main/java/com/google/api/codegen/config/PackagingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackagingConfig.java
@@ -40,7 +40,7 @@ import org.yaml.snakeyaml.Yaml;
 public abstract class PackagingConfig {
   private static final Pattern COMMON_PKG_PATTERN =
       Pattern.compile(
-          "(?i)(?<org>(\\w+\\.)(cloud\\.)*)(?<name>\\w+(\\.\\w+)*)\\.(?<ver>\\w*\\d+[\\w\\d]*)(\\.|$)");
+          "(?i)(?<org>(\\w+\\.)(cloud\\.)*)(?<name>\\w+(\\.\\w+)*)\\.(?<ver>(v|beta|alpha)\\w*\\d+[\\w\\d]*)(\\.|$)");
   private static final Pattern NAME_ONLY_PATTERN =
       Pattern.compile("(?i)(google\\.|^)(?<name>[a-zA-Z]+)(\\.\\w*)+$");
 

--- a/src/main/java/com/google/api/codegen/config/PackagingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackagingConfig.java
@@ -39,7 +39,7 @@ import org.yaml.snakeyaml.Yaml;
 @AutoValue
 public abstract class PackagingConfig {
   private static final Pattern COMMON_PKG_PATTERN =
-      Pattern.compile("(?i)(?<org>(\\w+\\.){0,3})(?<name>\\w+)\\.(?<ver>\\w*\\d+[\\w\\d]*)(\\.|$)");
+      Pattern.compile("(?i)(?<org>(\\w+\\.){0,2})(?<name>\\w+(\\.\\w+)*)\\.(?<ver>\\w*\\d+[\\w\\d]*)(\\.|$)");
   private static final Pattern NAME_ONLY_PATTERN =
       Pattern.compile("(?i)(^|\\.)(?<name>[a-zA-Z]+)(\\.\\w*)$");
 
@@ -196,7 +196,7 @@ public abstract class PackagingConfig {
           m = NAME_ONLY_PATTERN.matcher(interfaceName);
           name = !m.find() ? interfaceName : m.group("name");
         } else {
-          name = m.group("name");
+          name = m.group("name").replace('.', '-');
           org = m.group("org");
           ver = m.group("ver");
         }

--- a/src/main/java/com/google/api/codegen/config/PackagingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackagingConfig.java
@@ -39,7 +39,8 @@ import org.yaml.snakeyaml.Yaml;
 @AutoValue
 public abstract class PackagingConfig {
   private static final Pattern COMMON_PKG_PATTERN =
-      Pattern.compile("(?i)(?<org>(\\w+\\.){0,2})(?<name>\\w+(\\.\\w+)*)\\.(?<ver>\\w*\\d+[\\w\\d]*)(\\.|$)");
+      Pattern.compile(
+          "(?i)(?<org>(\\w+\\.){0,2})(?<name>\\w+(\\.\\w+)*)\\.(?<ver>\\w*\\d+[\\w\\d]*)(\\.|$)");
   private static final Pattern NAME_ONLY_PATTERN =
       Pattern.compile("(?i)(^|\\.)(?<name>[a-zA-Z]+)(\\.\\w*)$");
 

--- a/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
@@ -206,6 +206,12 @@ public class PackagingConfigTest {
             ReleaseLevel.UNSET_RELEASE_LEVEL);
     params.add(param("google.bigtable.admin.v2.BigtableTableAdmin", false, expected));
 
+    // 13
+    expected =
+        config(
+            "grafeas", "v1", "google-cloud", "grafeas/v1", false, ReleaseLevel.UNSET_RELEASE_LEVEL);
+    params.add(param("grafeas.v1.Grafeas", false, expected));
+
     return params.build();
   }
 

--- a/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
@@ -184,7 +184,7 @@ public class PackagingConfigTest {
             ReleaseLevel.UNSET_RELEASE_LEVEL);
     params.add(param("<wrong_input>", false, expected));
 
-    //11
+    // 11
     expected =
         config(
             "bigquery-datatransfer",

--- a/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
@@ -184,6 +184,17 @@ public class PackagingConfigTest {
             ReleaseLevel.UNSET_RELEASE_LEVEL);
     params.add(param("<wrong_input>", false, expected));
 
+    //11
+    expected =
+        config(
+            "datatransfer",
+            "v1",
+            "google-cloud-bigquery",
+            "google/cloud/bigquery/datatransfer/v1",
+            false,
+            ReleaseLevel.UNSET_RELEASE_LEVEL);
+    params.add(param("google.cloud.bigquery.datatransfer.v1.DataTransferService", false, expected));
+
     return params.build();
   }
 

--- a/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
@@ -212,6 +212,17 @@ public class PackagingConfigTest {
             "grafeas", "v1", "google-cloud", "grafeas/v1", false, ReleaseLevel.UNSET_RELEASE_LEVEL);
     params.add(param("grafeas.v1.Grafeas", false, expected));
 
+    // 14
+    expected =
+        config(
+            "logging",
+            "v2",
+            "google-cloud",
+            "google/logging/v2",
+            false,
+            ReleaseLevel.UNSET_RELEASE_LEVEL);
+    params.add(param("google.logging.v2.ConfigServiceV2", false, expected));
+
     return params.build();
   }
 

--- a/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
@@ -131,9 +131,9 @@ public class PackagingConfigTest {
     // 6
     expected =
         config(
-            "graph",
+            "home-graph",
             "v1",
-            "google-home",
+            "google-cloud",
             "google/home/graph/v1",
             false,
             ReleaseLevel.UNSET_RELEASE_LEVEL);
@@ -142,9 +142,9 @@ public class PackagingConfigTest {
     // 7
     expected =
         config(
-            "publish",
+            "streetview-publish",
             "v1",
-            "google-streetview",
+            "google-cloud",
             "google/streetview/publish/v1",
             false,
             ReleaseLevel.UNSET_RELEASE_LEVEL);
@@ -165,9 +165,9 @@ public class PackagingConfigTest {
     // 9
     expected =
         config(
-            "admin",
+            "iam-admin",
             "v1",
-            "google-iam",
+            "google-cloud",
             "google/iam/admin/v1",
             false,
             ReleaseLevel.UNSET_RELEASE_LEVEL);
@@ -194,6 +194,17 @@ public class PackagingConfigTest {
             false,
             ReleaseLevel.UNSET_RELEASE_LEVEL);
     params.add(param("google.cloud.bigquery.datatransfer.v1.DataTransferService", false, expected));
+
+    // 12
+    expected =
+        config(
+            "bigtable-admin",
+            "v2",
+            "google-cloud",
+            "google/bigtable/admin/v2",
+            false,
+            ReleaseLevel.UNSET_RELEASE_LEVEL);
+    params.add(param("google.bigtable.admin.v2.BigtableTableAdmin", false, expected));
 
     return params.build();
   }

--- a/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/PackagingConfigTest.java
@@ -187,9 +187,9 @@ public class PackagingConfigTest {
     //11
     expected =
         config(
-            "datatransfer",
+            "bigquery-datatransfer",
             "v1",
-            "google-cloud-bigquery",
+            "google-cloud",
             "google/cloud/bigquery/datatransfer/v1",
             false,
             ReleaseLevel.UNSET_RELEASE_LEVEL);


### PR DESCRIPTION
This became apparent during python clients migration to bazel.

It fixes the "subclient" cases (like `bigquery` as a "primary" and `bigquery/storage` as a "subclient"), which were not taken into account in the initial implementation.

There are also changes in the expected output for the test cases, because those were guesses initially (turned out to be wrong). 

The CI failure is the same as in the last submitted PR in gapic-generator (https://github.com/googleapis/gapic-generator/pull/3162), must be not related to this change.