### PR TITLE
build_gen: include LRO GAPIC in go_gapic_library dep

### DIFF
--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -231,11 +231,13 @@ class BazelBuildFileView {
       if (protoImport.endsWith(":operations_proto")) {
         // Disable injection of unused longrunning GAPIC target as dependency.
         //
-        // TODO(ndietz) enable this dependency once issue is closed: https://github.com/googleapis/gapic-generator-go/issues/387
+        // TODO(ndietz) enable this dependency once issue is closed:
+        // https://github.com/googleapis/gapic-generator-go/issues/387
         // goImports.add(replaceLabelName(protoImport, ":longrunning_go_gapic"));
         goImports.add(replaceLabelName(protoImport, ":longrunning_go_proto"));
         goImports.add("@com_google_cloud_go//longrunning:go_default_library");
-        // TODO(ndietz) remove this dependency once issue is closed: https://github.com/googleapis/gapic-generator-go/issues/387
+        // TODO(ndietz) remove this dependency once issue is closed:
+        // https://github.com/googleapis/gapic-generator-go/issues/387
         goImports.add("@com_google_cloud_go//longrunning/autogen:go_default_library");
         for (String pi : protoImports) {
           if (pi.startsWith("@com_google_protobuf//")) {

--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -232,6 +232,7 @@ class BazelBuildFileView {
         goImports.add(replaceLabelName(protoImport, ":longrunning_go_gapic"));
         goImports.add(replaceLabelName(protoImport, ":longrunning_go_proto"));
         goImports.add("@com_google_cloud_go//longrunning:go_default_library");
+        goImports.add("@com_google_cloud_go//longrunning/autogen:go_default_library");
         for (String pi : protoImports) {
           if (pi.startsWith("@com_google_protobuf//")) {
             if (pi.endsWith(":struct_proto")) {

--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -229,9 +229,13 @@ class BazelBuildFileView {
       }
 
       if (protoImport.endsWith(":operations_proto")) {
-        goImports.add(replaceLabelName(protoImport, ":longrunning_go_gapic"));
+        // Disable injection of unused longrunning GAPIC target as dependency.
+        //
+        // TODO(ndietz) enable this dependency once issue is closed: https://github.com/googleapis/gapic-generator-go/issues/387
+        // goImports.add(replaceLabelName(protoImport, ":longrunning_go_gapic"));
         goImports.add(replaceLabelName(protoImport, ":longrunning_go_proto"));
         goImports.add("@com_google_cloud_go//longrunning:go_default_library");
+        // TODO(ndietz) remove this dependency once issue is closed: https://github.com/googleapis/gapic-generator-go/issues/387
         goImports.add("@com_google_cloud_go//longrunning/autogen:go_default_library");
         for (String pi : protoImports) {
           if (pi.startsWith("@com_google_protobuf//")) {


### PR DESCRIPTION
Go GAPICs directly depend on the manual LRO module (containing a Operation construction helper), the GAPIC (for LRO client creation, this dependency), and the go-genproto (for the protobuf/grpc code). This adds the autogen target to the go_gapic_library.

There is a discrepancy with the previous monolith implementation in how the microgenerator implementation presents a go_library that requires the direct depedency on `com_google_cloud_go//longrunning/autogen` in the go_gapic_library target. This discrepancy makes the existing `longrunning_go_gapic` dependency insufficient resulting in `com_google_cloud_go//longrunning/autogen` needing to be added. 

Ultimately, we need to realign the microgenerator implementation with the previous monolith implementation of go_gapic_library.