### PR TITLE
fix: handle wildcard parent patterns

### DIFF
--- a/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -74,6 +75,19 @@ public abstract class ResourceDescriptorConfig {
 
   /** The entity name for the resource config. */
   public abstract String getDerivedEntityName();
+
+  public static ResourceDescriptorConfig getWildcardResource(ProtoFile protoFile) {
+    return new AutoValue_ResourceDescriptorConfig(
+        /* isDefinedAtMessageLevel= */ false,
+        /* unifiedResourceType= */ "",
+        /*patterns=*/ ImmutableList.of("*"),
+        /*nameField=*/ "",
+        /* history= */ ResourceDescriptor.History.HISTORY_UNSPECIFIED,
+        /* requiresOneofConfig= */ false,
+        /* singlePattern= */ "*",
+        protoFile,
+        /* derivedEntityName= */ "");
+  }
 
   public static ResourceDescriptorConfig from(
       ResourceDescriptor descriptor, ProtoFile assignedProtoFile, boolean isDefinedAtMessageLevel) {
@@ -218,7 +232,25 @@ public abstract class ResourceDescriptorConfig {
         ImmutableList.copyOf(descriptorConfigMap.values());
     for (Map.Entry<String, ResourceDescriptorConfig> entry : descriptorConfigMap.entrySet()) {
       ResourceDescriptorConfig childResource = entry.getValue();
+      System.out.println(
+          "DEL: Looking at entry "
+              + entry.getKey()
+              + " : "
+              + entry.getValue()
+              + ", getparent: "
+              + getParentPatternsMap(childResource));
       for (int i = 0; i < allResources.size(); i++) {
+        if (childResource.getPatterns().contains("*")) {
+          System.out.println("DEL: Contains pattern wildcard");
+          System.out.println(
+              "DEL: Will use wildcard pattern "
+                  + getWildcardResource(childResource.getAssignedProtoFile()));
+          builder.put(
+              entry.getKey(),
+              Arrays.asList(getWildcardResource(childResource.getAssignedProtoFile())));
+          break;
+        }
+
         List<ResourceDescriptorConfig> parentResource =
             matchParentResourceDescriptor(
                 getParentPatternsMap(childResource),

--- a/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceDescriptorConfig.java
@@ -80,8 +80,8 @@ public abstract class ResourceDescriptorConfig {
     return new AutoValue_ResourceDescriptorConfig(
         /* isDefinedAtMessageLevel= */ false,
         /* unifiedResourceType= */ "",
-        /*patterns=*/ ImmutableList.of("*"),
-        /*nameField=*/ "",
+        /* patterns= */ ImmutableList.of("*"),
+        /* nameField= */ "",
         /* history= */ ResourceDescriptor.History.HISTORY_UNSPECIFIED,
         /* requiresOneofConfig= */ false,
         /* singlePattern= */ "*",
@@ -232,19 +232,8 @@ public abstract class ResourceDescriptorConfig {
         ImmutableList.copyOf(descriptorConfigMap.values());
     for (Map.Entry<String, ResourceDescriptorConfig> entry : descriptorConfigMap.entrySet()) {
       ResourceDescriptorConfig childResource = entry.getValue();
-      System.out.println(
-          "DEL: Looking at entry "
-              + entry.getKey()
-              + " : "
-              + entry.getValue()
-              + ", getparent: "
-              + getParentPatternsMap(childResource));
       for (int i = 0; i < allResources.size(); i++) {
         if (childResource.getPatterns().contains("*")) {
-          System.out.println("DEL: Contains pattern wildcard");
-          System.out.println(
-              "DEL: Will use wildcard pattern "
-                  + getWildcardResource(childResource.getAssignedProtoFile()));
           builder.put(
               entry.getKey(),
               Arrays.asList(getWildcardResource(childResource.getAssignedProtoFile())));

--- a/src/test/java/com/google/api/codegen/config/ResourceDescriptorConfigTest.java
+++ b/src/test/java/com/google/api/codegen/config/ResourceDescriptorConfigTest.java
@@ -294,6 +294,61 @@ public class ResourceDescriptorConfigTest {
     assertThat(childParentResourceMap.get("food.google.com/Sauce")).containsExactly(veggie, meat);
   }
 
+  @Test
+  public void testGetChildParentResourceMap_MultiParentsMultiPatternsWithWildcard() {
+    ResourceDescriptorConfig sauce =
+        ResourceDescriptorConfig.from(
+            ResourceDescriptor.newBuilder()
+                .setType("food.google.com/Sauce")
+                .addPattern("steaks/{steak}/sauces/{sauce}")
+                .addPattern("barbeques/{barbeque}/sauces/{sauce}")
+                .addPattern("tofus/{tofu}/sauces/{sauce}")
+                .addPattern("salads/{salad}/sauces/{sauce}")
+                .addPattern("*")
+                .build(),
+            protoFile,
+            true);
+
+    ResourceDescriptorConfig meat =
+        ResourceDescriptorConfig.from(
+            ResourceDescriptor.newBuilder()
+                .setType("food.google.com/Meat")
+                .addPattern("steaks/{steak}")
+                .addPattern("barbeques/{barbeque}")
+                .build(),
+            protoFile,
+            true);
+
+    ResourceDescriptorConfig veggie =
+        ResourceDescriptorConfig.from(
+            ResourceDescriptor.newBuilder()
+                .setType("food.google.com/Veggie")
+                .addPattern("tofus/{tofu}")
+                .addPattern("salads/{salad}")
+                .build(),
+            protoFile,
+            true);
+
+    ResourceDescriptorConfig wildcard =
+        ResourceDescriptorConfig.from(
+            ResourceDescriptor.newBuilder().addPattern("*").build(), protoFile, false);
+
+    Map<String, ResourceDescriptorConfig> descriptorConfigMap =
+        getDescriptorConfigMap(sauce, meat, veggie);
+    Map<String, List<ResourceDescriptorConfig>> patternResourceDescriptorMap =
+        ResourceDescriptorConfig.getPatternResourceMap(Arrays.asList(sauce, meat, veggie));
+
+    Map<String, List<ResourceDescriptorConfig>> childParentResourceMap =
+        ResourceDescriptorConfig.getChildParentResourceMap(
+            descriptorConfigMap, patternResourceDescriptorMap);
+    System.out.println(
+        "DEL: MAP: " + childParentResourceMap.get("food.google.com/Sauce").toString());
+    System.out.println("DEL: wildcard: " + wildcard.toString());
+
+    assertThat(childParentResourceMap.size()).isEqualTo(1);
+    assertThat(childParentResourceMap.get("food.google.com/Sauce")).containsExactly(wildcard);
+  }
+
   private static Map<String, ResourceDescriptorConfig> getDescriptorConfigMap(
       ResourceDescriptorConfig... resources) {
     ImmutableMap.Builder<String, ResourceDescriptorConfig> builder = ImmutableMap.builder();


### PR DESCRIPTION
The monolith generator currently NPEs when it encounters `pattern: "*"` in conjunction with actual patterns, such as with [AlertPolicy](https://github.com/googleapis/googleapis/blob/master/google/monitoring/v3/alert.proto#L44).