### PR TITLE
fix: build_gen use lro gapic as lro dep

### DIFF
--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -233,16 +233,9 @@ class BazelBuildFileView {
       }
 
       if (protoImport.endsWith(":operations_proto")) {
-        // Disable injection of unused longrunning GAPIC target as dependency.
-        //
-        // TODO(ndietz) enable this dependency once issue is closed:
-        // https://github.com/googleapis/gapic-generator-go/issues/387
-        // goImports.add(replaceLabelName(protoImport, ":longrunning_go_gapic"));
+        goImports.add(replaceLabelName(protoImport, ":longrunning_go_gapic"));
         goImports.add(replaceLabelName(protoImport, ":longrunning_go_proto"));
         goImports.add("@com_google_cloud_go//longrunning:go_default_library");
-        // TODO(ndietz) remove this dependency once issue is closed:
-        // https://github.com/googleapis/gapic-generator-go/issues/387
-        goImports.add("@com_google_cloud_go//longrunning/autogen:go_default_library");
         for (String pi : protoImports) {
           if (pi.startsWith("@com_google_protobuf//")) {
             if (pi.endsWith(":struct_proto")) {


### PR DESCRIPTION
Go back to using the local (to googleapis) `//google/longrunning:longrunning_go_gapic` target as the LRO gapic dep for other `go_gapic_library` targets. https://github.com/googleapis/gapic-generator-go/pull/405 fixes the shading issue that required the remote dep `@com_google_cloud_go//longrunning/autogen:go_default_library` be provided.