### PR TITLE
feat: build_gen all langs use grpc_service_config

### DIFF
--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -54,6 +54,7 @@ java_gapic_library(
     name = "{{name}}_java_gapic",
     src = ":{{name}}_proto_with_info",
     gapic_yaml = "{{gapic_yaml}}",
+    grpc_service_config = {{grpc_service_config}},
     package = "{{package}}",
     service_yaml = "{{service_yaml}}",
     test_deps = [
@@ -168,6 +169,7 @@ py_gapic_library(
     name = "{{name}}_py_gapic",
     src = ":{{name}}_proto_with_info",
     gapic_yaml = "{{gapic_yaml}}",
+    grpc_service_config = {{grpc_service_config}},
     package = "{{package}}",
     service_yaml = "{{service_yaml}}",
     deps = [
@@ -212,6 +214,7 @@ php_gapic_library(
     name = "{{name}}_php_gapic",
     src = ":{{name}}_proto_with_info",
     gapic_yaml = "{{gapic_yaml}}",
+    grpc_service_config = {{grpc_service_config}},
     package = "{{package}}",
     service_yaml = "{{service_yaml}}",
     deps = [
@@ -282,6 +285,7 @@ ruby_gapic_library(
     name = "{{name}}_ruby_gapic",
     src = ":{{name}}_proto_with_info",
     gapic_yaml = "{{gapic_yaml}}",
+    grpc_service_config = {{grpc_service_config}},
     package = "{{package}}",
     service_yaml = "{{service_yaml}}",
     deps = [
@@ -326,6 +330,7 @@ csharp_gapic_library(
     name = "{{name}}_csharp_gapic",
     src = ":{{name}}_proto_with_info",
     gapic_yaml = "{{gapic_yaml}}",
+    grpc_service_config = {{grpc_service_config}},
     package = "{{package}}",
     service_yaml = "{{service_yaml}}",
     deps = [

--- a/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -58,6 +58,7 @@ java_gapic_library(
     name = "library_java_gapic",
     src = ":library_proto_with_info",
     gapic_yaml = "library_example_gapic.yaml",
+    grpc_service_config = "library_example_grpc_service_config.json",
     package = "google.example.library.v1",
     service_yaml = "//google/example/library:library_example_v1.yaml",
     test_deps = [
@@ -176,6 +177,7 @@ py_gapic_library(
     name = "library_py_gapic",
     src = ":library_proto_with_info",
     gapic_yaml = "library_example_gapic.yaml",
+    grpc_service_config = "library_example_grpc_service_config.json",
     package = "google.example.library.v1",
     service_yaml = "//google/example/library:library_example_v1.yaml",
     deps = [
@@ -220,6 +222,7 @@ php_gapic_library(
     name = "library_php_gapic",
     src = ":library_proto_with_info",
     gapic_yaml = "library_example_gapic.yaml",
+    grpc_service_config = "library_example_grpc_service_config.json",
     package = "google.example.library.v1",
     service_yaml = "//google/example/library:library_example_v1.yaml",
     deps = [
@@ -290,6 +293,7 @@ ruby_gapic_library(
     name = "library_ruby_gapic",
     src = ":library_proto_with_info",
     gapic_yaml = "library_example_gapic.yaml",
+    grpc_service_config = "library_example_grpc_service_config.json",
     package = "google.example.library.v1",
     service_yaml = "//google/example/library:library_example_v1.yaml",
     deps = [
@@ -334,6 +338,7 @@ csharp_gapic_library(
     name = "library_csharp_gapic",
     src = ":library_proto_with_info",
     gapic_yaml = "library_example_gapic.yaml",
+    grpc_service_config = "library_example_grpc_service_config.json",
     package = "google.example.library.v1",
     service_yaml = "//google/example/library:library_example_v1.yaml",
     deps = [


### PR DESCRIPTION
As the migration to grpc_service_config has begun, we need to make sure that subsequent runs of `build_gen` doesn't overwrite the changes made in migration.