### PR TITLE
[gapic-generator] chore: remove 2.7 from python showcase tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,16 +81,12 @@ anchor_verify_and_test_python: &anchor_verify_and_test_python
     - run:
        name: Run Showcase Generated Unit Tests.
        command: |
-         nox --session "unit(py='2.7')" \
-             --noxfile /tmp/workspace/gapic-generator/showcase/python/nox.py
          nox --session "unit(py='3.6')" \
              --noxfile /tmp/workspace/gapic-generator/showcase/python/nox.py
        when: always
     - run:
        name: Run Showcase Integration Tests.
        command: |
-         nox --session "showcase(py='2.7')" \
-             --noxfile /tmp/workspace/gapic-generator/showcase/python/nox.py
          nox --session "showcase(py='3.6')" \
              --noxfile /tmp/workspace/gapic-generator/showcase/python/nox.py
        when: always

--- a/showcase/python/nox.py
+++ b/showcase/python/nox.py
@@ -24,7 +24,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
+@nox.parametrize('py', ['3.5', '3.6', '3.7'])
 def showcase(session, py):
     """Run the showcase integration test suite."""
 
@@ -48,7 +48,7 @@ def showcase(session, py):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
+@nox.parametrize('py', ['3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 


### PR DESCRIPTION
It sounds like 2.7 is no longer supported, and it's currently breaking [tests](https://app.circleci.com/pipelines/github/googleapis/gapic-generator/255/workflows/b2063a3b-2ad2-4641-8952-0bc16673a242/jobs/47732/steps) for [this unrelated PR](https://github.com/googleapis/gapic-generator/pull/3190).