### PR TITLE
chore: remove python speech & pubsub tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,18 +94,6 @@ anchor_verify_and_test_python: &anchor_verify_and_test_python
         name: Install nox latest
         command: |
          pip3 install nox
-    - run:
-        name: Prepare for Pubsub testing.
-        command: echo 'export TEST_API="pubsub-v1"' >> $BASH_ENV
-    - run:
-        name: Test Pubsub.
-        <<: *anchor_test_python_client
-    - run:
-        name: Prepare for Speech testing.
-        command: echo 'export TEST_API="speech-v1"' >> $BASH_ENV
-    - run:
-        name: Test Speech.
-        <<: *anchor_test_python_client
 
 # Test a Ruby client if generation succeeded.
 anchor_test_ruby_client: &anchor_test_ruby_client


### PR DESCRIPTION
The integration tests for python [fail](https://app.circleci.com/pipelines/github/googleapis/gapic-generator/267/workflows/53b0e357-595d-4036-a3e3-4c6c31285af2/jobs/47898/steps) when run against python 2.7. This version is no longer supported
and googleapis generation is moving towards gapic-generator-python anyways.