### PR TITLE
feat: remove python 2.7 from nox files

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/noxfile.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/noxfile.py.snip
@@ -30,7 +30,7 @@
         return unit(session)
 
 
-    @@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
+    @@nox.session(python=['3.5', '3.6', '3.7'])
     def unit(session):
         """Run the unit test suite."""
 
@@ -43,7 +43,7 @@
 @end
 
 @private system_tests()
-    @@nox.session(python=['2.7', '3.7'])
+    @@nox.session(python=['3.7'])
     def system(session):
         """Run the system test suite."""
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -5713,7 +5713,7 @@ def default(session):
     return unit(session)
 
 
-@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
+@nox.session(python=['3.5', '3.6', '3.7'])
 def unit(session):
     """Run the unit test suite."""
 
@@ -5725,7 +5725,7 @@ def unit(session):
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
-@nox.session(python=['2.7', '3.7'])
+@nox.session(python=['3.7'])
 def system(session):
     """Run the system test suite."""
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_multiple_services.baseline
@@ -1708,7 +1708,7 @@ def default(session):
     return unit(session)
 
 
-@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
+@nox.session(python=['3.5', '3.6', '3.7'])
 def unit(session):
     """Run the unit test suite."""
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_no_path_templates.baseline
@@ -1276,7 +1276,7 @@ def default(session):
     return unit(session)
 
 
-@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
+@nox.session(python=['3.5', '3.6', '3.7'])
 def unit(session):
     """Run the unit test suite."""
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -6002,7 +6002,7 @@ def default(session):
     return unit(session)
 
 
-@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
+@nox.session(python=['3.5', '3.6', '3.7'])
 def unit(session):
     """Run the unit test suite."""
 
@@ -6014,7 +6014,7 @@ def unit(session):
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
-@nox.session(python=['2.7', '3.7'])
+@nox.session(python=['3.7'])
 def system(session):
     """Run the system test suite."""
 

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library_no_gapic_config.baseline
@@ -4808,7 +4808,7 @@ def default(session):
     return unit(session)
 
 
-@nox.session(python=['2.7', '3.5', '3.6', '3.7'])
+@nox.session(python=['3.5', '3.6', '3.7'])
 def unit(session):
     """Run the unit test suite."""
 


### PR DESCRIPTION
Removes python version 2.7 from the generated nox files.

The gaipc-generator integration tests for Speech & PubSub are failing on just the python 2.7 runs of the generated tests.