### PR TITLE
fix(deps): bump protobuf versions for Java artman builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -403,7 +403,7 @@ task createToolPaths {
     DependencyResolver resolver = new DependencyResolver(project)
 
     def protoGenGrpcJavaExe = resolver.resolveExecutable(
-            'io.grpc:protoc-gen-grpc-java:1.10.0')
+            'io.grpc:protoc-gen-grpc-java:1.30.2')
     Symlinks.createSymbolicLink("$buildDir/toolpaths/protoGenGrpcJavaExe", protoGenGrpcJavaExe)
 
     def protobufJavaDir = resolver.extractArchive(

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -7,7 +7,7 @@
 # Target workspace name: com_google_api_codegen
 
 # Versions only, for dependencies which actual artifacts differ between Bazel and Gradle
-version.com_google_protobuf=3.9.1
+version.com_google_protobuf=3.12.0
 version.google_java_format=1.6
 
 # Maven artifacts.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -3298,7 +3298,7 @@ const Any = {
  *     if (duration.seconds < 0 && duration.nanos > 0) {
  *       duration.seconds += 1;
  *       duration.nanos -= 1000000000;
- *     } else if (durations.seconds > 0 && duration.nanos < 0) {
+ *     } else if (duration.seconds > 0 && duration.nanos < 0) {
  *       duration.seconds -= 1;
  *       duration.nanos += 1000000000;
  *     }
@@ -3608,7 +3608,7 @@ const Empty = {
  *
  * The implementation of any API method which has a FieldMask type field in the
  * request should verify the included field paths, and return an
- * `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
+ * `INVALID_ARGUMENT` error if any path is unmappable.
  *
  * @property {string[]} paths
  *   The set of field mask paths.

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -1386,7 +1386,7 @@ module Google
     #     if (duration.seconds < 0 && duration.nanos > 0) {
     #       duration.seconds += 1;
     #       duration.nanos -= 1000000000;
-    #     } else if (durations.seconds > 0 && duration.nanos < 0) {
+    #     } else if (duration.seconds > 0 && duration.nanos < 0) {
     #       duration.seconds -= 1;
     #       duration.nanos += 1000000000;
     #     }
@@ -1683,7 +1683,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -4102,7 +4102,7 @@ const Any = {
  *     if (duration.seconds < 0 && duration.nanos > 0) {
  *       duration.seconds += 1;
  *       duration.nanos -= 1000000000;
- *     } else if (durations.seconds > 0 && duration.nanos < 0) {
+ *     } else if (duration.seconds > 0 && duration.nanos < 0) {
  *       duration.seconds -= 1;
  *       duration.nanos += 1000000000;
  *     }
@@ -4412,7 +4412,7 @@ const Empty = {
  *
  * The implementation of any API method which has a FieldMask type field in the
  * request should verify the included field paths, and return an
- * `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
+ * `INVALID_ARGUMENT` error if any path is unmappable.
  *
  * @property {string[]} paths
  *   The set of field mask paths.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -1386,7 +1386,7 @@ module Google
     #     if (duration.seconds < 0 && duration.nanos > 0) {
     #       duration.seconds += 1;
     #       duration.nanos -= 1000000000;
-    #     } else if (durations.seconds > 0 && duration.nanos < 0) {
+    #     } else if (duration.seconds > 0 && duration.nanos < 0) {
     #       duration.seconds -= 1;
     #       duration.nanos += 1000000000;
     #     }
@@ -1683,7 +1683,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -1266,7 +1266,7 @@ module Google
     #     if (duration.seconds < 0 && duration.nanos > 0) {
     #       duration.seconds += 1;
     #       duration.nanos -= 1000000000;
-    #     } else if (durations.seconds > 0 && duration.nanos < 0) {
+    #     } else if (duration.seconds > 0 && duration.nanos < 0) {
     #       duration.seconds -= 1;
     #       duration.nanos += 1000000000;
     #     }
@@ -1563,7 +1563,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.


### PR DESCRIPTION
Need to have the latest versions to support `optional` in Artman Java builds.

If you ask me why the baseline changed, I have no idea :)