### PR TITLE
fix: Make java lowerCamel methos naming match protobuf java stubs output methods naming

### DIFF
--- a/src/main/java/com/google/api/codegen/util/Name.java
+++ b/src/main/java/com/google/api/codegen/util/Name.java
@@ -243,7 +243,15 @@ public class Name {
   }
 
   public String toUpperCamelAndDigits() {
-    char[] upper = toUpperCamel().toCharArray();
+    return capitalizeDigitsAfterNumbers(toUpperCamel());
+  }
+
+  public String toLowerCamelAndDigits() {
+    return capitalizeDigitsAfterNumbers(toLowerCamel());
+  }
+
+  private String capitalizeDigitsAfterNumbers(String camelCaseIdentifier) {
+    char[] upper = camelCaseIdentifier.toCharArray();
     boolean digit = false;
     for (int i = 0; i < upper.length; i++) {
       if (Character.isDigit(upper[i])) {

--- a/src/main/java/com/google/api/codegen/util/java/JavaNameFormatter.java
+++ b/src/main/java/com/google/api/codegen/util/java/JavaNameFormatter.java
@@ -66,7 +66,7 @@ public class JavaNameFormatter implements NameFormatter {
 
   @Override
   public String publicMethodName(Name name) {
-    return wrapIfKeywordOrBuiltIn(name.toLowerCamel());
+    return wrapIfKeywordOrBuiltIn(name.toLowerCamelAndDigits());
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/util/NameTest.java
+++ b/src/test/java/com/google/api/codegen/util/NameTest.java
@@ -27,6 +27,7 @@ public class NameTest {
     assertThat(name.toUpperUnderscore()).isEqualTo("");
     assertThat(name.toLowerCamel()).isEqualTo("");
     assertThat(name.toUpperCamel()).isEqualTo("");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("");
   }
 
   @Test
@@ -36,6 +37,7 @@ public class NameTest {
     assertThat(name.toUpperUnderscore()).isEqualTo("DOG");
     assertThat(name.toLowerCamel()).isEqualTo("dog");
     assertThat(name.toUpperCamel()).isEqualTo("Dog");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("dog");
   }
 
   @Test
@@ -45,6 +47,7 @@ public class NameTest {
     assertThat(name.toUpperUnderscore()).isEqualTo("FACTORY_DECORATOR_DELEGATE_IMPL");
     assertThat(name.toLowerCamel()).isEqualTo("factoryDecoratorDelegateImpl");
     assertThat(name.toUpperCamel()).isEqualTo("FactoryDecoratorDelegateImpl");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("factoryDecoratorDelegateImpl");
   }
 
   @Test
@@ -54,6 +57,7 @@ public class NameTest {
     assertThat(name.toUpperUnderscore()).isEqualTo("FACTORY_DECORATOR_DELEGATE_IMPL");
     assertThat(name.toLowerCamel()).isEqualTo("factoryDecoratorDelegateImpl");
     assertThat(name.toUpperCamel()).isEqualTo("FactoryDecoratorDelegateImpl");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("factoryDecoratorDelegateImpl");
   }
 
   @Test
@@ -63,6 +67,7 @@ public class NameTest {
     assertThat(name.toUpperUnderscore()).isEqualTo("FACTORY_DECORATOR_DELEGATE_IMPL");
     assertThat(name.toLowerCamel()).isEqualTo("factoryDecoratorDelegateImpl");
     assertThat(name.toUpperCamel()).isEqualTo("FactoryDecoratorDelegateImpl");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("factoryDecoratorDelegateImpl");
   }
 
   @Test
@@ -72,6 +77,7 @@ public class NameTest {
     assertThat(name.toUpperUnderscore()).isEqualTo("DOG_2");
     assertThat(name.toLowerCamel()).isEqualTo("dog2");
     assertThat(name.toUpperCamel()).isEqualTo("Dog2");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("dog2");
   }
 
   @Test
@@ -84,12 +90,23 @@ public class NameTest {
   }
 
   @Test
+  public void testUpperWordAndNumberWithCharacter() {
+    Name name = Name.upperCamel("Dog", "V2cc");
+    assertThat(name.toLowerUnderscore()).isEqualTo("dog_v2cc");
+    assertThat(name.toUpperUnderscore()).isEqualTo("DOG_V2CC");
+    assertThat(name.toLowerCamel()).isEqualTo("dogV2cc");
+    assertThat(name.toUpperCamel()).isEqualTo("DogV2cc");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("dogV2Cc");
+  }
+
+  @Test
   public void testLowerWordAndNumber() {
     Name name = Name.lowerCamel("dog", "v2");
     assertThat(name.toLowerUnderscore()).isEqualTo("dog_v2");
     assertThat(name.toUpperUnderscore()).isEqualTo("DOG_V2");
     assertThat(name.toLowerCamel()).isEqualTo("dogV2");
     assertThat(name.toUpperCamel()).isEqualTo("DogV2");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("dogV2");
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -119,6 +136,7 @@ public class NameTest {
     assertThat(name.toUpperUnderscore()).isEqualTo("IAM_HTTP_XML_DOG");
     assertThat(name.toLowerCamel()).isEqualTo("iamHttpXmlDog");
     assertThat(name.toUpperCamel()).isEqualTo("IamHttpXmlDog");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("iamHttpXmlDog");
   }
 
   @Test
@@ -128,6 +146,7 @@ public class NameTest {
     assertThat(name.toUpperUnderscore()).isEqualTo("IAM_HTTP_XML");
     assertThat(name.toLowerCamel()).isEqualTo("iamHttpXml");
     assertThat(name.toUpperCamel()).isEqualTo("IamHttpXml");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("iamHttpXml");
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -147,6 +166,7 @@ public class NameTest {
     assertThat(name.toUpperUnderscore()).isEqualTo("IAM_HTTP_XML_DOG");
     assertThat(name.toLowerCamel()).isEqualTo("iamHTTPXMLDog");
     assertThat(name.toUpperCamel()).isEqualTo("IAMHTTPXMLDog");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("iamHTTPXMLDog");
   }
 
   @Test
@@ -156,5 +176,6 @@ public class NameTest {
     assertThat(name.toUpperUnderscore()).isEqualTo("IAM_HTTP_XML");
     assertThat(name.toLowerCamel()).isEqualTo("iamHTTPXML");
     assertThat(name.toUpperCamel()).isEqualTo("IAMHTTPXML");
+    assertThat(name.toLowerCamelAndDigits()).isEqualTo("iamHTTPXML");
   }
 }


### PR DESCRIPTION
Specifically, before this fix, for a field named `one_two3four` protobuf was generating java method named `setOneTwo3Four()`, while gapic generator was assuming it to be `setOneTwo3four()`.

This change is applied in the most limited scope (only for java methods naming, because this logic is applied only for methods  naming in protobuf). This should be a relatively safe change because protobuf in general does not let fields to differ only by the underscore characters `_`. I.e. one message cannot have two fields one named `one_two` and the other one `onetwo` or `oneTwo`. This restriction greatly reduces number of possible `snake_case` `camelCase` conversion combinations. 