### PR TITLE
chore: update showcase version for sequence tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,7 +424,7 @@ jobs:
                --languages=nodejs \
                --root-dir=/tmp/workspace/showcase-protos
            mv /tmp/workspace/showcase-protos/google/showcase/v1beta1/sequence.proto /tmp/workspace/
-           sed -i .bak 's/^- name: google\.showcase\.v1beta1\.SequenceService//' /tmp/workspace/showcase-protos/google/showcase/showcase.yaml
+           sed -i 's/^- name: google\.showcase\.v1beta1\.SequenceService//' /tmp/workspace/showcase-protos/google/showcase/showcase.yaml
            python3 generate_clients.py \
                google/showcase/artman_showcase.yaml \
                --user-config=.circleci/artman_config.yaml \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,7 +417,11 @@ jobs:
                google/showcase/artman_showcase.yaml \
                --user-config=.circleci/artman_config.yaml \
                --log-dir=${ARTMAN_REPORTS_DIR} \
-               --languages=java,python,go,php,nodejs \
+               --languages=java \
+               --languages=go \
+               --languages=php \
+               --languages=python \
+               --languages=nodejs \
                --root-dir=/tmp/workspace/showcase-protos
            mv /tmp/workspace/showcase-protos/google/showcase/v1beta1/sequence.proto /tmp/workspace/
            python3 generate_clients.py \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,11 +417,7 @@ jobs:
                google/showcase/artman_showcase.yaml \
                --user-config=.circleci/artman_config.yaml \
                --log-dir=${ARTMAN_REPORTS_DIR} \
-               --languages=java \
-               --languages=go \
-               --languages=php \
-               --languages=python \
-               --languages=nodejs \
+               --languages=java go python php nodejs \
                --root-dir=/tmp/workspace/showcase-protos
            mv /tmp/workspace/showcase-protos/google/showcase/v1beta1/sequence.proto /tmp/workspace/
            sed -i 's/^- name: google\.showcase\.v1beta1\.SequenceService//' /tmp/workspace/showcase-protos/google/showcase/showcase.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,6 +417,14 @@ jobs:
                google/showcase/artman_showcase.yaml \
                --user-config=.circleci/artman_config.yaml \
                --log-dir=${ARTMAN_REPORTS_DIR} \
+               --languages=java,python,go,php,nodejs \
+               --root-dir=/tmp/workspace/showcase-protos
+           mv /tmp/workspace/showcase-protos/google/showcase/v1beta1/sequence.proto /tmp/workspace/
+           python3 generate_clients.py \
+               google/showcase/artman_showcase.yaml \
+               --user-config=.circleci/artman_config.yaml \
+               --log-dir=${ARTMAN_REPORTS_DIR} \
+               --languages=ruby \
                --root-dir=/tmp/workspace/showcase-protos
          when: always
       # This step is also required so long as Java's clients rely on a different

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,6 +424,7 @@ jobs:
                --languages=nodejs \
                --root-dir=/tmp/workspace/showcase-protos
            mv /tmp/workspace/showcase-protos/google/showcase/v1beta1/sequence.proto /tmp/workspace/
+           sed -i .bak 's/^- name: google\.showcase\.v1beta1\.SequenceService//' /tmp/workspace/showcase-protos/google/showcase/showcase.yaml
            python3 generate_clients.py \
                google/showcase/artman_showcase.yaml \
                --user-config=.circleci/artman_config.yaml \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ jobs:
       - image: circleci/openjdk:8-jdk
     working_directory: /tmp/workspace
     environment:
-      SHOWCASE_VERSION: 0.10.1
+      SHOWCASE_VERSION: 0.12.0
     steps:
       - checkout:
           path: gapic-generator
@@ -484,7 +484,7 @@ jobs:
       <<: *anchor_artman_vars
     docker:
       - image: circleci/openjdk:8-jdk
-      - image: gcr.io/gapic-images/gapic-showcase:0.10.1
+      - image: gcr.io/gapic-images/gapic-showcase:0.12.0
     steps:
       - attach_workspace:
           at: workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,7 +417,7 @@ jobs:
                google/showcase/artman_showcase.yaml \
                --user-config=.circleci/artman_config.yaml \
                --log-dir=${ARTMAN_REPORTS_DIR} \
-               --languages=java go python php nodejs \
+               --languages java go python php nodejs \
                --root-dir=/tmp/workspace/showcase-protos
            mv /tmp/workspace/showcase-protos/google/showcase/v1beta1/sequence.proto /tmp/workspace/
            sed -i 's/^- name: google\.showcase\.v1beta1\.SequenceService//' /tmp/workspace/showcase-protos/google/showcase/showcase.yaml

--- a/showcase/java/src/test/java/com/google/api/showcase/ShowcaseTest.java
+++ b/showcase/java/src/test/java/com/google/api/showcase/ShowcaseTest.java
@@ -279,30 +279,6 @@ public class ShowcaseTest {
   }
 
   @Test
-  public void attemptSequence() {
-    Sequence toCreate =
-        Sequence.newBuilder()
-            .addResponses(
-                Sequence.Response.newBuilder()
-                    .setStatus(Status.newBuilder().setCode(Code.UNAVAILABLE_VALUE)))
-            .addResponses(
-                Sequence.Response.newBuilder()
-                    .setStatus(Status.newBuilder().setCode(Code.UNAVAILABLE_VALUE)))
-            .addResponses(
-                Sequence.Response.newBuilder()
-                    .setStatus(Status.newBuilder().setCode(Code.OK_VALUE)))
-            .build();
-    Sequence sequence = seqClient.createSequence(toCreate);
-    assertThat(sequence.getName()).isNotNull();
-
-    seqClient.attemptSequence(sequence.getName());
-
-    SequenceReport report = seqClient.getSequenceReport(sequence.getName() + "/sequenceReport");
-    assertThat(report.getAttemptsList()).isNotNull();
-    assertThat(report.getAttemptsList().size()).isEqualTo(3);
-  }
-
-  @Test
   public void attemptSequenceTimeoutBackoff() {
     Sequence toCreate =
         Sequence.newBuilder()
@@ -327,11 +303,7 @@ public class ShowcaseTest {
     SequenceReport report = seqClient.getSequenceReport(sequence.getName() + "/sequenceReport");
     assertThat(report.getAttemptsList()).isNotNull();
     assertThat(report.getAttemptsList().size()).isEqualTo(3);
-    for (int i = 0; i < report.getAttemptsList().size(); i++) {
-      if (i == 0) {
-        continue;
-      }
-
+    for (int i = 1; i < report.getAttemptsList().size(); i++) {
       SequenceReport.Attempt cur = report.getAttempts(i);
       SequenceReport.Attempt prev = report.getAttempts(i - 1);
       long secondsDiff =

--- a/src/test/java/com/google/api/codegen/testsrc/showcase/showcase.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/showcase/showcase.yaml
@@ -10,6 +10,7 @@ documentation:
 
 apis:
 - name: google.showcase.v1beta1.Echo
+- name: google.showcase.v1beta1.SequenceService
 
 authentication:
   rules:


### PR DESCRIPTION
This updates the version of Showcase used for generation in CI to v0.12.0 and adds a test for the new SequenceService to assert the basic retry attempt logic and timeout-backoff behavior works as implemented.