### PR TITLE
fix: support reroute_to_grpc_interface with grpc_service_config

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -153,7 +153,8 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
               retryCodesConfig,
               retrySettingsDefinition.keySet(),
               protoParser,
-              grpcGapicRetryMapping);
+              grpcGapicRetryMapping,
+              interfaceInput.getInterfaceConfigProto().getName());
       if (methodConfigsMap == null) {
         diagCollector.addDiag(
             Diag.error(SimpleLocation.TOPLEVEL, "Error constructing methodConfigMap"));
@@ -245,7 +246,8 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
       RetryCodesConfig retryCodesConfig,
       ImmutableSet<String> retryParamsConfigNames,
       ProtoParser protoParser,
-      GrpcGapicRetryMapping retryMapping) {
+      GrpcGapicRetryMapping retryMapping,
+      String gapicInterfaceName) {
     Map<String, GapicMethodConfig> methodConfigMapBuilder = new LinkedHashMap<>();
 
     for (Entry<Method, MethodConfigProto> methodEntry : methodsToGenerate.entrySet()) {
@@ -265,7 +267,8 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
                 retryCodesConfig,
                 retryParamsConfigNames,
                 protoParser,
-                retryMapping);
+                retryMapping,
+                gapicInterfaceName);
       } else {
         methodConfig =
             GapicMethodConfig.createGapicMethodConfigFromGapicYaml(

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_with_grpc_service_config.baseline
@@ -14761,8 +14761,8 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
 
       builder.addLabelSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
-          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"));
 
       builder.getBigBookSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -6244,8 +6244,8 @@ class MyProtoClient extends MyProtoGapicClient
         },
         "AddLabel": {
           "timeout_millis": 60000,
-          "retry_codes_name": "no_retry_codes",
-          "retry_params_name": "no_retry_params"
+          "retry_codes_name": "no_retry_1_codes",
+          "retry_params_name": "no_retry_1_params"
         },
         "GetBigBook": {
           "timeout_millis": 60000,

--- a/src/test/java/com/google/api/codegen/testsrc/protoannotations/library_grpc_service_config.json
+++ b/src/test/java/com/google/api/codegen/testsrc/protoannotations/library_grpc_service_config.json
@@ -32,7 +32,8 @@
       { "service": "google.example.library.v1.LibraryService", "method": "GetBigBook" },
       { "service": "google.example.library.v1.LibraryService", "method": "GetBigNothing" },
       { "service": "google.example.library.v1.LibraryService", "method": "TestOptionalRequiredFlatteningParams" },
-      { "service": "google.example.library.v1.LibraryService", "method": "BabbleAboutBook" }
+      { "service": "google.example.library.v1.LibraryService", "method": "BabbleAboutBook" },
+      { "service": "google.example.library.v1.LibraryService", "method": "AddLabel" }
     ],
 
     "waitForReady": true,


### PR DESCRIPTION
This fixes a bug when supplying a `grpc_service_config` for retry settings and also using the `reroute_to_grpc_interface` GAPIC config option. Only two APIs are known to be using this option and this change was tested against them. 

The approach is slightly hacky, passing the GAPIC interface name through that declares the method being rerouted, and overriding the rerouted service name with the GAPIC interface name when looking up the retry_params assignment. The retry configs name these rerouted RPCs using the same name as the GAPIC interface name.