### PR TITLE
fix: use remote lro Go gapic instead of local

### DIFF
--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -240,9 +240,9 @@ class BazelBuildFileView {
       }
 
       if (protoImport.endsWith(":operations_proto")) {
-        goImports.add(replaceLabelName(protoImport, ":longrunning_go_gapic"));
         goImports.add(replaceLabelName(protoImport, ":longrunning_go_proto"));
         goImports.add("@com_google_cloud_go//longrunning:go_default_library");
+        goImports.add("@com_google_cloud_go//longrunning/autogen:go_default_library");
         for (String pi : protoImports) {
           if (pi.startsWith("@com_google_protobuf//")) {
             if (pi.endsWith(":struct_proto")) {


### PR DESCRIPTION
Using the `googleapis` local LRO GAPIC target instead of the remote version in `cloud.google.com/go` is causing some Go linker issues. We've found that if we use the remote dep instead of the local target, the Go linker doesn't complain about it. I believe this is because the remote version depends on some of the remote dependencies (in go-genproto), rather than the local `googleapis` versions of them e.g. `@go_googleapis//google/api:annotations_go_proto` (remote) vs. `//google/api:annotations_go_proto` (local).