### PR TITLE
feat: switch PHP GAPICs to using default scopes

### DIFF
--- a/src/main/resources/com/google/api/codegen/php/client_impl.snip
+++ b/src/main/resources/com/google/api/codegen/php/client_impl.snip
@@ -135,7 +135,7 @@
             'gcpApiConfigPath' => __DIR__ . '/../resources/{@xapiClass.clientConfigName}_grpc_config.json',
             'credentialsConfig' => [
                 @if xapiClass.hasDefaultServiceScopes
-                    'scopes' => self::$serviceScopes,
+                    'defaultScopes' => self::$serviceScopes,
                 @end
             ],
             'transportConfig' => [
@@ -168,7 +168,7 @@
         {@""} * @@param string ${@param.name}
     @end
      * @@return string The formatted {@function.entityName} resource.
-    @if function.isResourceNameDeprecated 
+    @if function.isResourceNameDeprecated
      {@""} * @@deprecated Multi-pattern resource names will have unified formatting functions.
      {@""} *             This helper function will be deleted in the next major version.
     @else

--- a/src/main/resources/com/google/api/codegen/php/test.snip
+++ b/src/main/resources/com/google/api/codegen/php/test.snip
@@ -47,12 +47,6 @@
             @if testClass.hasMissingDefaultOptions
                 @if testClass.missingDefaultServiceAddress
                     'serviceAddress' => '',
-
-                @end
-                @if testClass.missingDefaultServiceScopes
-                    'credentialsConfig' => [
-                        'scopes' => [],
-                    ],
                 @end
             @end
         ];

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -1865,7 +1865,7 @@ class LibraryServiceGapicClient
             'descriptorsConfigPath' => __DIR__ . '/../resources/library_service_descriptor_config.php',
             'gcpApiConfigPath' => __DIR__ . '/../resources/library_service_grpc_config.json',
             'credentialsConfig' => [
-                'scopes' => self::$serviceScopes,
+                'defaultScopes' => self::$serviceScopes,
             ],
             'transportConfig' => [
                 'rest' => [
@@ -4763,7 +4763,7 @@ class MyProtoGapicClient
             'descriptorsConfigPath' => __DIR__ . '/../resources/my_proto_descriptor_config.php',
             'gcpApiConfigPath' => __DIR__ . '/../resources/my_proto_grpc_config.json',
             'credentialsConfig' => [
-                'scopes' => self::$serviceScopes,
+                'defaultScopes' => self::$serviceScopes,
             ],
             'transportConfig' => [
                 'rest' => [

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_longrunning.baseline
@@ -768,9 +768,6 @@ class OperationsClientTest extends GeneratedTest
         $options += [
             'credentials' => $this->createCredentials(),
             'serviceAddress' => '',
-            'credentialsConfig' => [
-                'scopes' => [],
-            ],
         ];
         return new OperationsClient($options);
     }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_no_path_templates.baseline
@@ -409,9 +409,6 @@ class NoTemplatesApiServiceClientTest extends GeneratedTest
         $options += [
             'credentials' => $this->createCredentials(),
             'serviceAddress' => '',
-            'credentialsConfig' => [
-                'scopes' => [],
-            ],
         ];
         return new NoTemplatesApiServiceClient($options);
     }

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library.baseline
@@ -2474,7 +2474,7 @@ class LibraryServiceGapicClient
             'descriptorsConfigPath' => __DIR__ . '/../resources/library_service_descriptor_config.php',
             'gcpApiConfigPath' => __DIR__ . '/../resources/library_service_grpc_config.json',
             'credentialsConfig' => [
-                'scopes' => self::$serviceScopes,
+                'defaultScopes' => self::$serviceScopes,
             ],
             'transportConfig' => [
                 'rest' => [
@@ -5878,7 +5878,7 @@ class MyProtoGapicClient
             'descriptorsConfigPath' => __DIR__ . '/../resources/my_proto_descriptor_config.php',
             'gcpApiConfigPath' => __DIR__ . '/../resources/my_proto_grpc_config.json',
             'credentialsConfig' => [
-                'scopes' => self::$serviceScopes,
+                'defaultScopes' => self::$serviceScopes,
             ],
             'transportConfig' => [
                 'rest' => [

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/php_library_with_grpc_service_config.baseline
@@ -2474,7 +2474,7 @@ class LibraryServiceGapicClient
             'descriptorsConfigPath' => __DIR__ . '/../resources/library_service_descriptor_config.php',
             'gcpApiConfigPath' => __DIR__ . '/../resources/library_service_grpc_config.json',
             'credentialsConfig' => [
-                'scopes' => self::$serviceScopes,
+                'defaultScopes' => self::$serviceScopes,
             ],
             'transportConfig' => [
                 'rest' => [
@@ -5878,7 +5878,7 @@ class MyProtoGapicClient
             'descriptorsConfigPath' => __DIR__ . '/../resources/my_proto_descriptor_config.php',
             'gcpApiConfigPath' => __DIR__ . '/../resources/my_proto_grpc_config.json',
             'credentialsConfig' => [
-                'scopes' => self::$serviceScopes,
+                'defaultScopes' => self::$serviceScopes,
             ],
             'transportConfig' => [
                 'rest' => [


### PR DESCRIPTION
- This PR will activate Self-Signed JWTs for all GAPIC PHP Libraries.

- NodeJS has moved to using Self-Signed JWTs for all of their GAPICs without any issues. We feel we can release this for all our GAPIC clients.

- PHP Self-Signed JWTs have been tested using the integration tests in [php-docs-samples](https://github.com/GoogleCloudPlatform/php-docs-samples) for the following GAPIC clients:

   - [x] Asset
   - [x] BigQueryDataTransfer
   - [x] BigTable
   - [x] Datastore
   - [x] Dialogflow
   - [x] DLP
   - [x] ErrorReporting
   - [x] Firestore
   - [x] Logging
   - [x] IOT
   - [x] KMS
   - [x] Language
   - [x] Monitoring
   - [x] Pub/Sub
   - [x] Spanner
   - [x] SecretsManager
   - [x] SecurityCenter
   - [x] ServiceDirectory
   - [x] Speech
   - [x] Tasks
   - [x] TextToSpeech
   - [x] Translate
   - [x] Trace
   - [x] Vision
   - [x] Video
