### PR TITLE
 build(python): default to microgenerator rules

### DIFF
--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -147,44 +147,14 @@ go_gapic_assembly_pkg(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "moved_proto_library",
-    "py_gapic_assembly_pkg",
-    "py_gapic_library",
-    "py_grpc_library",
-    "py_proto_library",
-)
-
-moved_proto_library(
-    name = "{{name}}_moved_proto",
-    srcs = [":{{name}}_proto"],
-    deps = [
-        {{proto_deps}}
-    ],
-)
-
-py_proto_library(
-    name = "{{name}}_py_proto",
-    plugin = "@protoc_docs_plugin//:docs_plugin",
-    deps = [":{{name}}_moved_proto"],
-)
-
-py_grpc_library(
-    name = "{{name}}_py_grpc",
-    srcs = [":{{name}}_moved_proto"],
-    deps = [":{{name}}_py_proto"],
+     py_gapic_assembly_pkg = "py_gapic_assembly_pkg2",
+     py_gapic_library = "py_gapic_library2",
 )
 
 py_gapic_library(
     name = "{{name}}_py_gapic",
-    src = ":{{name}}_proto_with_info",
-    gapic_yaml = "{{gapic_yaml}}",
+    srcs = [":{{name}}_proto_"],
     grpc_service_config = {{grpc_service_config}},
-    package = "{{package}}",
-    service_yaml = "{{service_yaml}}",
-    deps = [
-        ":{{name}}_py_grpc",
-        ":{{name}}_py_proto",
-    ],
 )
 
 # Open Source Packages
@@ -192,8 +162,6 @@ py_gapic_assembly_pkg(
     name = "{{assembly_name}}-{{version}}-py",
     deps = [
         ":{{name}}_py_gapic",
-        ":{{name}}_py_grpc",
-        ":{{name}}_py_proto",
     ],
 )
 

--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -153,7 +153,7 @@ load(
 
 py_gapic_library(
     name = "{{name}}_py_gapic",
-    srcs = [":{{name}}_proto_"],
+    srcs = [":{{name}}_proto"],
     grpc_service_config = {{grpc_service_config}},
 )
 

--- a/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -151,48 +151,14 @@ go_gapic_assembly_pkg(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "moved_proto_library",
-    "py_gapic_assembly_pkg",
-    "py_gapic_library",
-    "py_grpc_library",
-    "py_proto_library",
-)
-
-moved_proto_library(
-    name = "library_moved_proto",
-    srcs = [":library_proto"],
-    deps = [
-        "//google/api:annotations_proto",
-        "//google/api:client_proto",
-        "//google/api:field_behavior_proto",
-        "//google/api:resource_proto",
-        "@com_google_protobuf//:empty_proto",
-    ],
-)
-
-py_proto_library(
-    name = "library_py_proto",
-    plugin = "@protoc_docs_plugin//:docs_plugin",
-    deps = [":library_moved_proto"],
-)
-
-py_grpc_library(
-    name = "library_py_grpc",
-    srcs = [":library_moved_proto"],
-    deps = [":library_py_proto"],
+     py_gapic_assembly_pkg = "py_gapic_assembly_pkg2",
+     py_gapic_library = "py_gapic_library2",
 )
 
 py_gapic_library(
     name = "library_py_gapic",
-    src = ":library_proto_with_info",
-    gapic_yaml = "library_example_gapic.yaml",
+    srcs = [":library_proto"],
     grpc_service_config = "library_example_grpc_service_config.json",
-    package = "google.example.library.v1",
-    service_yaml = "//google/example/library:library_example_v1.yaml",
-    deps = [
-        ":library_py_grpc",
-        ":library_py_proto",
-    ],
 )
 
 # Open Source Packages
@@ -200,8 +166,6 @@ py_gapic_assembly_pkg(
     name = "example-library-v1-py",
     deps = [
         ":library_py_gapic",
-        ":library_py_grpc",
-        ":library_py_proto",
     ],
 )
 


### PR DESCRIPTION
Keep `py_gapic_library2` alias for now. This will be switched to `py_gapic_library` once `repository_rules.bzl` in googleapis is cleaned up. There are still a handful (<5) libraries using the monolith in Python but any new libraries should use the microgenerator.