### PR TITLE
chore: Update `BuildFileGenerator` to match GAPIC generators suface used in gogoleapis

### DIFF
--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -61,11 +61,9 @@ java_grpc_library(
 
 java_gapic_library(
     name = "{{name}}_java_gapic",
-    src = ":{{name}}_proto_with_info",
-    gapic_yaml = "{{gapic_yaml}}",
+    srcs = [":{{name}}_proto_with_info"],
     grpc_service_config = {{grpc_service_config}},
     package = "{{package}}",
-    service_yaml = "{{service_yaml}}",
     test_deps = [
         ":{{name}}_java_grpc",{{java_gapic_test_deps}}
     ],
@@ -147,8 +145,8 @@ go_gapic_assembly_pkg(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-     py_gapic_assembly_pkg = "py_gapic_assembly_pkg2",
-     py_gapic_library = "py_gapic_library2",
+    "py_gapic_assembly_pkg",
+    "py_gapic_library",
 )
 
 py_gapic_library(
@@ -306,8 +304,8 @@ csharp_grpc_library(
 csharp_gapic_library(
     name = "{{name}}_csharp_gapic",
     srcs = [":{{name}}_proto_with_info"],
-    grpc_service_config = {{grpc_service_config}},
     common_resources_config = "@gax_dotnet//:Google.Api.Gax/ResourceNames/CommonResourcesConfig.json",
+    grpc_service_config = {{grpc_service_config}},
     deps = [
         ":{{name}}_csharp_grpc",
         ":{{name}}_csharp_proto",

--- a/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -65,11 +65,9 @@ java_grpc_library(
 
 java_gapic_library(
     name = "library_java_gapic",
-    src = ":library_proto_with_info",
-    gapic_yaml = "library_example_gapic.yaml",
+    srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
     package = "google.example.library.v1",
-    service_yaml = "//google/example/library:library_example_v1.yaml",
     test_deps = [
         ":library_java_grpc",
     ],
@@ -151,8 +149,8 @@ go_gapic_assembly_pkg(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-     py_gapic_assembly_pkg = "py_gapic_assembly_pkg2",
-     py_gapic_library = "py_gapic_library2",
+    "py_gapic_assembly_pkg",
+    "py_gapic_library",
 )
 
 py_gapic_library(
@@ -310,8 +308,8 @@ csharp_grpc_library(
 csharp_gapic_library(
     name = "library_csharp_gapic",
     srcs = [":library_proto_with_info"],
-    grpc_service_config = "library_example_grpc_service_config.json",
     common_resources_config = "@gax_dotnet//:Google.Api.Gax/ResourceNames/CommonResourcesConfig.json",
+    grpc_service_config = "library_example_grpc_service_config.json",
     deps = [
         ":library_csharp_grpc",
         ":library_csharp_proto",


### PR DESCRIPTION
The generated `BUIDL.bazel` files now use java microgenerator rules surface.
Python rules were "rolled back" to use regular names instead of aliases, because googleapis will be using (once the pending CL is merged) python mocrogenerator by default.

Also changed the order of parameters in C# rule to match default buildozer formatting.