### PR TITLE
feat: generate GAPIC metadata file for Node.js by default

### DIFF
--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -221,7 +221,9 @@ load(
 
 nodejs_gapic_library(
     name = "{{name}}_nodejs_gapic",
+    package_name = "{{name}}",
     src = ":{{name}}_proto_with_info",
+    extra_protoc_parameters = ["metadata"],
     grpc_service_config = {{grpc_service_config}},
     package = "{{package}}",
     service_yaml = "{{service_yaml}}",

--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -221,7 +221,7 @@ load(
 
 nodejs_gapic_library(
     name = "{{name}}_nodejs_gapic",
-    package_name = "{{name}}",
+    package_name = "@google-cloud/{{name}}",
     src = ":{{name}}_proto_with_info",
     extra_protoc_parameters = ["metadata"],
     grpc_service_config = {{grpc_service_config}},

--- a/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -225,7 +225,7 @@ load(
 
 nodejs_gapic_library(
     name = "library_nodejs_gapic",
-    package_name = "library",
+    package_name = "@google-cloud/library",
     src = ":library_proto_with_info",
     extra_protoc_parameters = ["metadata"],
     grpc_service_config = "library_example_grpc_service_config.json",

--- a/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -225,7 +225,9 @@ load(
 
 nodejs_gapic_library(
     name = "library_nodejs_gapic",
+    package_name = "library",
     src = ":library_proto_with_info",
+    extra_protoc_parameters = ["metadata"],
     grpc_service_config = "library_example_grpc_service_config.json",
     package = "google.example.library.v1",
     service_yaml = "//google/example/library:library_example_v1.yaml",


### PR DESCRIPTION
Since we have [enabled](https://github.com/googleapis/googleapis/commit/d189e871205fea665a9648f7c4676f027495ccaf) GAPIC metadata generation for all Node.js builds, let's have this setting enabled by default.

Also setting the default `package_name` since it is always defined for all the libraries (it's normally renamed manually to something like `@google-cloud/library` but having some reasonable default is good).