### PR TITLE
test: do not run Go tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,46 +644,6 @@ jobs:
       - run:
           name: Verify all Golang generation succeeded
           <<: *anchor_check_generation
-      - run:
-          name: Set up golang dev env.
-          command: |
-            mkdir -p $GOPATH/src
-            mkdir -p $GOPATH/bin
-            mkdir -p $GOPATH/pkg
-            export PATH="$PATH:$GOPATH/bin"
-            echo 'export PATH="$PATH:$GOPATH/bin"' >> $BASH_ENV
-            go get -u github.com/golang/protobuf/protoc-gen-go
-            go get -d cloud.google.com/go/...
-      - run:
-          name: Delete exisiting clients for APIs that we generated
-          command: |
-            cd $GOPATH/src/cloud.google.com/go
-            rm -rf logging/apiv2
-            rm -rf pubsub/apiv1
-            cd $GOPATH/src/google.golang.org/genproto/googleapis
-            rm -rf logging/v2
-            rm -rf pubsub
-      - run:
-          name: Copy over generated clients
-          command: cp -r /tmp/workspace/gapic-generator/artman-genfiles/gapi-cloud-*/* $GOPATH/src
-      - run:
-          name: Test Pubsub.
-          command: go test cloud.google.com/go/pubsub/apiv1
-          when: always
-      - run:
-          name: Test Logging
-          command: go test cloud.google.com/go/logging/apiv2
-          when: always
-      - run:
-          name: Test Showcase
-          command: go test cloud.google.com/go/showcase/apiv1beta1
-          when: always
-      - run:
-          name: Run Showcase Integration Tests
-          command: |
-            cd /tmp/workspace/gapic-generator/showcase/go
-            go test .
-  # TODO: test other language clients.
 
   artman_smoke_tests:
     working_directory: /tmp/


### PR DESCRIPTION
Go is migrated to the [micro-generator](https://github.com/googleapis/gapic-generator-go) long time ago and it does not make sense to keep the CI running.  Other migrated languages might also be removed whenever the CI starts failing.