### PR TITLE
fix: don't change PHP functions which are reserved words 

### DIFF
--- a/showcase/php/tests/ShowcaseIntegrationTest.php
+++ b/showcase/php/tests/ShowcaseIntegrationTest.php
@@ -48,7 +48,7 @@ class ShowcaseIntegrationTest extends TestCase
      */
     public function testUnary($client)
     {
-        $response = $client->echo_([
+        $response = $client->echo([
             'content' => '"Wales snail hail fails!" wails Gail'
         ]);
         $this->assertEquals(
@@ -65,7 +65,7 @@ class ShowcaseIntegrationTest extends TestCase
     public function testFailUnary($client)
     {
         try {
-            $client->echo_([
+            $client->echo([
                 'error' => (new Status())
                     ->setCode(Code::INVALID_ARGUMENT)
                     ->setMessage("Unary error message"),

--- a/src/main/java/com/google/api/codegen/util/php/PhpNameFormatter.java
+++ b/src/main/java/com/google/api/codegen/util/php/PhpNameFormatter.java
@@ -31,15 +31,6 @@ public class PhpNameFormatter implements NameFormatter {
     }
   }
 
-  private String wrapIfFunctionKeyword(String name) {
-    // PHP keywords are case-insensitive.
-    if (FUNCTION_KEYWORD_SET.contains(name.toLowerCase())) {
-      return name + "_";
-    } else {
-      return name;
-    }
-  }
-
   @Override
   public String publicClassName(Name name) {
     return wrapIfKeywordOrBuiltIn(name.toUpperCamel());
@@ -72,17 +63,17 @@ public class PhpNameFormatter implements NameFormatter {
 
   @Override
   public String publicMethodName(Name name) {
-    return wrapIfFunctionKeyword(name.toLowerCamel());
+    return name.toLowerCamel();
   }
 
   @Override
   public String privateMethodName(Name name) {
-    return wrapIfFunctionKeyword(name.toLowerCamel());
+    return name.toLowerCamel();
   }
 
   @Override
   public String staticFunctionName(Name name) {
-    return wrapIfFunctionKeyword(name.toLowerCamel());
+    return name.toLowerCamel();
   }
 
   @Override
@@ -191,18 +182,5 @@ public class PhpNameFormatter implements NameFormatter {
               "__METHOD__",
               "__NAMESPACE__",
               "__TRAIT__")
-          .build();
-
-  private static final ImmutableSet<String> FUNCTION_KEYWORD_SET =
-      ImmutableSet.<String>builder()
-          .add(
-              "__halt_compiler",
-              "abstract",
-              "final",
-              "function",
-              "private",
-              "protected",
-              "public",
-              "static")
           .build();
 }

--- a/src/main/java/com/google/api/codegen/util/php/PhpNameFormatter.java
+++ b/src/main/java/com/google/api/codegen/util/php/PhpNameFormatter.java
@@ -31,6 +31,15 @@ public class PhpNameFormatter implements NameFormatter {
     }
   }
 
+  private String wrapIfFunctionKeyword(String name) {
+    // PHP keywords are case-insensitive.
+    if (FUNCTION_KEYWORD_SET.contains(name.toLowerCase())) {
+      return name + "_";
+    } else {
+      return name;
+    }
+  }
+
   @Override
   public String publicClassName(Name name) {
     return wrapIfKeywordOrBuiltIn(name.toUpperCamel());
@@ -63,17 +72,17 @@ public class PhpNameFormatter implements NameFormatter {
 
   @Override
   public String publicMethodName(Name name) {
-    return wrapIfKeywordOrBuiltIn(name.toLowerCamel());
+    return wrapIfFunctionKeyword(name.toLowerCamel());
   }
 
   @Override
   public String privateMethodName(Name name) {
-    return wrapIfKeywordOrBuiltIn(name.toLowerCamel());
+    return wrapIfFunctionKeyword(name.toLowerCamel());
   }
 
   @Override
   public String staticFunctionName(Name name) {
-    return wrapIfKeywordOrBuiltIn(name.toLowerCamel());
+    return wrapIfFunctionKeyword(name.toLowerCamel());
   }
 
   @Override
@@ -182,5 +191,18 @@ public class PhpNameFormatter implements NameFormatter {
               "__METHOD__",
               "__NAMESPACE__",
               "__TRAIT__")
+          .build();
+
+  private static final ImmutableSet<String> FUNCTION_KEYWORD_SET =
+      ImmutableSet.<String>builder()
+          .add(
+              "__halt_compiler",
+              "abstract",
+              "final",
+              "function",
+              "private",
+              "protected",
+              "public",
+              "static")
           .build();
 }


### PR DESCRIPTION
with the exception of `__halt_compiler`, which is so unlikely to be generated as a function name that we don't need to write a case for it, none of the PHP keywords are invalid as class function names. We can safely remove wrapping them.