### PR TITLE
Revert "fix: don't change PHP functions which are reserved words "

### DIFF
--- a/showcase/php/tests/ShowcaseIntegrationTest.php
+++ b/showcase/php/tests/ShowcaseIntegrationTest.php
@@ -48,7 +48,7 @@ class ShowcaseIntegrationTest extends TestCase
      */
     public function testUnary($client)
     {
-        $response = $client->echo([
+        $response = $client->echo_([
             'content' => '"Wales snail hail fails!" wails Gail'
         ]);
         $this->assertEquals(
@@ -65,7 +65,7 @@ class ShowcaseIntegrationTest extends TestCase
     public function testFailUnary($client)
     {
         try {
-            $client->echo([
+            $client->echo_([
                 'error' => (new Status())
                     ->setCode(Code::INVALID_ARGUMENT)
                     ->setMessage("Unary error message"),

--- a/src/main/java/com/google/api/codegen/util/php/PhpNameFormatter.java
+++ b/src/main/java/com/google/api/codegen/util/php/PhpNameFormatter.java
@@ -63,17 +63,17 @@ public class PhpNameFormatter implements NameFormatter {
 
   @Override
   public String publicMethodName(Name name) {
-    return name.toLowerCamel();
+    return wrapIfKeywordOrBuiltIn(name.toLowerCamel());
   }
 
   @Override
   public String privateMethodName(Name name) {
-    return name.toLowerCamel();
+    return wrapIfKeywordOrBuiltIn(name.toLowerCamel());
   }
 
   @Override
   public String staticFunctionName(Name name) {
-    return name.toLowerCamel();
+    return wrapIfKeywordOrBuiltIn(name.toLowerCamel());
   }
 
   @Override


### PR DESCRIPTION
Reverts googleapis/gapic-generator#3317

This PR requires a minimum version of PHP 7.0 in `google/cloud-compute`. We will require this for the `beta`, but for the `alpha` we can use the function names `list_()`.