### PR TITLE
fix(build_gen): include httpbody import for java/go

### DIFF
--- a/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -176,7 +176,8 @@ class BazelBuildFileView {
     for (String protoImport : protoImports) {
       if (protoImport.endsWith(":iam_policy_proto") || protoImport.endsWith(":policy_proto")) {
         javaImports.add(replaceLabelName(protoImport, ":iam_java_proto"));
-      } else if (protoImport.endsWith(":service_proto")) {
+      } else if (protoImport.endsWith(":service_proto")
+          || protoImport.endsWith(":httpbody_proto")) {
         javaImports.add(replaceLabelName(protoImport, ":api_java_proto"));
       }
     }
@@ -257,6 +258,8 @@ class BazelBuildFileView {
         goImports.add(replaceLabelName(protoImport, ":iam_go_proto"));
       } else if (protoImport.endsWith(":service_proto")) {
         goImports.add(replaceLabelName(protoImport, ":serviceconfig_go_proto"));
+      } else if (protoImport.endsWith(":httpbody_proto")) {
+        goImports.add(replaceLabelName(protoImport, ":httpbody_go_proto"));
       }
     }
     return goImports;

--- a/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -27,6 +27,7 @@ proto_library(
         "//google/api:annotations_proto",
         "//google/api:client_proto",
         "//google/api:field_behavior_proto",
+        "//google/api:httpbody_proto",
         "//google/api:resource_proto",
         "@com_google_protobuf//:empty_proto",
     ],
@@ -73,6 +74,7 @@ java_gapic_library(
     ],
     deps = [
         ":library_java_proto",
+        "//google/api:api_java_proto",
     ],
 )
 
@@ -113,6 +115,7 @@ go_proto_library(
     protos = [":library_proto"],
     deps = [
         "//google/api:annotations_go_proto",
+        "//google/api:httpbody_go_proto",
     ],
 )
 
@@ -124,6 +127,7 @@ go_gapic_library(
     service_yaml = "//google/example/library:library_example_v1.yaml",
     deps = [
         ":library_go_proto",
+        "//google/api:httpbody_go_proto",
     ],
 )
 

--- a/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/library.proto
+++ b/rules_gapic/bazel/src/test/data/googleapis/google/example/library/v1/library.proto
@@ -21,6 +21,7 @@ import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "google/api/httpbody.proto";
 import "google/protobuf/empty.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/example/library/v1;library";


### PR DESCRIPTION
When an API uses `google.api.HttpBody` in the proto, the Java and Go GAPIC targets fail to build for similar reasons. Java complains about having an implicit dependency, while Go complains about not having the dependency at all. So build_gen should inject the target as a direct dependency to the gapic_library targets.