### PR TITLE
fix(python): use '\\' for string escapes

### DIFF
--- a/rules_gapic/python/py_gapic.bzl
+++ b/rules_gapic/python/py_gapic.bzl
@@ -47,7 +47,7 @@ def _py_gapic_postprocessed_srcjar_impl(ctx):
         zip -q -r {output_dir_name}-smoke-test.srcjar empty_file
         zip -d {output_dir_name}-smoke-test.srcjar empty_file
     fi
-    zip -q -r {output_dir_name}.srcjar . -i \*.py
+    zip -q -r {output_dir_name}.srcjar . -i \\*.py
     popd
     mv {output_dir_path}/{output_dir_name}.srcjar {output_main}
     mv {output_dir_path}/{output_dir_name}-test.srcjar {output_test}

--- a/rules_gapic/python/py_gapic_pkg.bzl
+++ b/rules_gapic/python/py_gapic_pkg.bzl
@@ -50,7 +50,7 @@ def _py_gapic_src_pkg_impl(ctx):
     done
 
     # Replace 555 (forced by Bazel) permissions with 644
-    find {package_dir_path} -type f -exec chmod 644 {{}} \;
+    find {package_dir_path} -type f -exec chmod 644 {{}} \\;
 
     for srcjar_src in {srcjar_srcs}; do
         unzip -q -o $srcjar_src -d {package_dir_path}


### PR DESCRIPTION
https://blog.bazel.build/2021/01/19/bazel-4-0.html

> `--incompatible_restrict_string_escapes=true`. Unnecessary backslashes such as `\`. in string literals now result in an error, instead of silently being treated as `\\.`. To fix the error while preserving behavior, manually add another backslash. However, the error often signals the original code needs to be updated.