### PR TITLE
feat: Add support for `optional` field in HttpJson stubs for Java

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -7,7 +7,7 @@
 # Target workspace name: com_google_api_codegen
 
 # Versions only, for dependencies which actual artifacts differ between Bazel and Gradle
-version.com_google_protobuf=3.13.0
+version.com_google_protobuf=3.15.8
 version.google_java_format=1.6
 
 # Maven artifacts.

--- a/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
@@ -300,10 +300,23 @@ public class ApiCallableTransformer {
       HttpMethodSelectorView.Builder methodSelectorView = HttpMethodSelectorView.newBuilder();
       methodSelectorView.fullyQualifiedName(Name.anyLower(fs.toString()).toLowerCamel());
       ImmutableList.Builder<String> gettersChain = ImmutableList.builder();
+      ImmutableList.Builder<String> gettersHasChain = ImmutableList.builder();
+      ProtoField pf = null;
       for (Field f : fs.getFields()) {
-        gettersChain.add(namer.getFieldGetFunctionName(new ProtoField(f)));
+        if (pf != null) {
+          gettersHasChain.add(namer.getFieldGetFunctionName(pf));
+        }
+        pf = new ProtoField(f);
+        gettersChain.add(namer.getFieldGetFunctionName(pf));
       }
       methodSelectorView.gettersChain(gettersChain.build());
+      if (pf != null && pf.getProtoField().getProto().getProto3Optional()) {
+        gettersHasChain.add(namer.getFieldHasFunctionName(pf));
+        methodSelectorView.gettersHasChain(gettersHasChain.build());
+      } else {
+        methodSelectorView.gettersHasChain(ImmutableList.of());
+      }
+
       paramSelectors.add(methodSelectorView.build());
     }
 

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -390,6 +390,21 @@ public class SurfaceNamer extends NameFormatterDelegator {
     }
   }
 
+  public String getFieldHasFunctionName(FieldModel field) {
+    return getFieldHasFunctionName(
+        field.getNameAsParameterName(),
+        MapType.ofMap(field.isMap()),
+        Cardinality.ofRepeated(field.isRepeated()));
+  }
+
+  public String getFieldHasFunctionName(Name identifier, MapType mapType, Cardinality cardinality) {
+    if (mapType == MapType.IS_MAP && cardinality == Cardinality.IS_REPEATED) {
+      throw new IllegalArgumentException("Maps and repeated fields don't have has*() methods");
+    } else {
+      return publicMethodName(Name.from("has").join(identifier));
+    }
+  }
+
   /** The function name to get a field having the given type and name. */
   public String getFieldGetFunctionName(TypeModel type, Name identifier) {
     return getFieldGetFunctionName(

--- a/src/main/java/com/google/api/codegen/viewmodel/HttpMethodSelectorView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/HttpMethodSelectorView.java
@@ -9,6 +9,12 @@ public abstract class HttpMethodSelectorView {
 
   public abstract List<String> gettersChain();
 
+  public abstract List<String> gettersHasChain();
+
+  public boolean isProto3Optional() {
+    return !gettersHasChain().isEmpty();
+  }
+
   public static HttpMethodSelectorView.Builder newBuilder() {
     return new AutoValue_HttpMethodSelectorView.Builder();
   }
@@ -18,6 +24,8 @@ public abstract class HttpMethodSelectorView {
     public abstract Builder fullyQualifiedName(String val);
 
     public abstract Builder gettersChain(List<String> val);
+
+    public abstract Builder gettersHasChain(List<String> val);
 
     public abstract HttpMethodSelectorView build();
   }

--- a/src/main/resources/com/google/api/codegen/java/stub.snip
+++ b/src/main/resources/com/google/api/codegen/java/stub.snip
@@ -116,7 +116,13 @@
 
 @private queryMethodSelectors(methodSelectors)
   @join methodSelector : @methodSelectors
-    serializer.putQueryParam(fields, "{@methodSelector.fullyQualifiedName}", request.{@methodSelectorGetter(methodSelector.gettersChain)});
+    @if methodSelector.isProto3Optional
+      if (request.{@methodSelectorGetter(methodSelector.gettersHasChain)}) {
+        serializer.putQueryParam(fields, "{@methodSelector.fullyQualifiedName}", request.{@methodSelectorGetter(methodSelector.gettersChain)});
+      }
+    @else
+      serializer.putQueryParam(fields, "{@methodSelector.fullyQualifiedName}", request.{@methodSelectorGetter(methodSelector.gettersChain)});
+    @end
   @end
 @end
 

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -213,6 +213,7 @@ import (
     "google.golang.org/grpc"
     "google.golang.org/grpc/codes"
     "google.golang.org/grpc/metadata"
+    emptypbpb "google.golang.org/protobuf/types/known/emptypb"
 )
 
 // CallOptions contains the retry settings for each method of LibClient.
@@ -2004,10 +2005,10 @@ package library
 import (
     pb ""
 
-    emptypb "github.com/golang/protobuf/ptypes/empty"
     librarypb "google.golang.org/genproto/googleapis/example/library/v1"
     longrunningpb "google.golang.org/genproto/googleapis/longrunning"
     taggerpb "google.golang.org/genproto/googleapis/tagger/v1"
+    emptypbpb "google.golang.org/protobuf/types/known/emptypb"
 )
 
 import (
@@ -2086,7 +2087,7 @@ func (s *mockLibraryServer) ListShelves(ctx context.Context, req *librarypb.List
     return s.resps[0].(*librarypb.ListShelvesResponse), nil
 }
 
-func (s *mockLibraryServer) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest) (*emptypb.Empty, error) {
+func (s *mockLibraryServer) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest) (*emptypbpb.Empty, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
         return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
@@ -2095,7 +2096,7 @@ func (s *mockLibraryServer) DeleteShelf(ctx context.Context, req *librarypb.Dele
     if s.err != nil {
         return nil, s.err
     }
-    return s.resps[0].(*emptypb.Empty), nil
+    return s.resps[0].(*emptypbpb.Empty), nil
 }
 
 func (s *mockLibraryServer) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRequest) (*librarypb.Shelf, error) {
@@ -2158,7 +2159,7 @@ func (s *mockLibraryServer) ListBooks(ctx context.Context, req *librarypb.ListBo
     return s.resps[0].(*librarypb.ListBooksResponse), nil
 }
 
-func (s *mockLibraryServer) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest) (*emptypb.Empty, error) {
+func (s *mockLibraryServer) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest) (*emptypbpb.Empty, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
         return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
@@ -2167,7 +2168,7 @@ func (s *mockLibraryServer) DeleteBook(ctx context.Context, req *librarypb.Delet
     if s.err != nil {
         return nil, s.err
     }
-    return s.resps[0].(*emptypb.Empty), nil
+    return s.resps[0].(*emptypbpb.Empty), nil
 }
 
 func (s *mockLibraryServer) UpdateBook(ctx context.Context, req *librarypb.UpdateBookRequest) (*librarypb.Book, error) {
@@ -2206,7 +2207,7 @@ func (s *mockLibraryServer) ListStrings(ctx context.Context, req *librarypb.List
     return s.resps[0].(*librarypb.ListStringsResponse), nil
 }
 
-func (s *mockLibraryServer) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest) (*emptypb.Empty, error) {
+func (s *mockLibraryServer) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest) (*emptypbpb.Empty, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
         return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
@@ -2215,7 +2216,7 @@ func (s *mockLibraryServer) AddComments(ctx context.Context, req *librarypb.AddC
     if s.err != nil {
         return nil, s.err
     }
-    return s.resps[0].(*emptypb.Empty), nil
+    return s.resps[0].(*emptypbpb.Empty), nil
 }
 
 func (s *mockLibraryServer) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBookFromAnywhereRequest) (*librarypb.BookFromAnywhere, error) {
@@ -2242,7 +2243,7 @@ func (s *mockLibraryServer) GetBookFromAbsolutelyAnywhere(ctx context.Context, r
     return s.resps[0].(*librarypb.BookFromAnywhere), nil
 }
 
-func (s *mockLibraryServer) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest) (*emptypb.Empty, error) {
+func (s *mockLibraryServer) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest) (*emptypbpb.Empty, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
         return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
@@ -2251,7 +2252,7 @@ func (s *mockLibraryServer) UpdateBookIndex(ctx context.Context, req *librarypb.
     if s.err != nil {
         return nil, s.err
     }
-    return s.resps[0].(*emptypb.Empty), nil
+    return s.resps[0].(*emptypbpb.Empty), nil
 }
 
 func (s *mockLibraryServer) StreamShelves(req *librarypb.StreamShelvesRequest, stream librarypb.LibraryService_StreamShelvesServer) error {
@@ -2350,7 +2351,7 @@ func (s *mockLibraryServer) BabbleAboutBook(stream librarypb.LibraryService_Babb
     if s.err != nil {
         return s.err
     }
-    return stream.SendAndClose(s.resps[0].(*emptypb.Empty))
+    return stream.SendAndClose(s.resps[0].(*emptypbpb.Empty))
 }
 
 func (s *mockLibraryServer) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelatedBooksRequest) (*librarypb.FindRelatedBooksResponse, error) {
@@ -2450,7 +2451,7 @@ func (s *mockLibraryServer) StreamingArchiveBooks(stream librarypb.LibraryServic
     return nil
 }
 
-func (s *mockLibraryServer) SaveBook(ctx context.Context, req *librarypb.Book) (*emptypb.Empty, error) {
+func (s *mockLibraryServer) SaveBook(ctx context.Context, req *librarypb.Book) (*emptypbpb.Empty, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
         return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
@@ -2459,7 +2460,7 @@ func (s *mockLibraryServer) SaveBook(ctx context.Context, req *librarypb.Book) (
     if s.err != nil {
         return nil, s.err
     }
-    return s.resps[0].(*emptypb.Empty), nil
+    return s.resps[0].(*emptypbpb.Empty), nil
 }
 
 func (s *mockLibraryServer) TestOptionalRequiredFlatteningParams(ctx context.Context, req *librarypb.TestOptionalRequiredFlatteningParamsRequest) (*librarypb.TestOptionalRequiredFlatteningParamsResponse, error) {
@@ -2783,7 +2784,7 @@ func TestLibraryServiceListShelvesError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceDeleteShelf(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -3190,7 +3191,7 @@ func TestLibraryServiceListBooksError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceDeleteBook(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -3446,7 +3447,7 @@ func TestLibraryServiceListStringsError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceAddComments(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -3652,7 +3653,7 @@ func TestLibraryServiceGetBookFromAbsolutelyAnywhereError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceUpdateBookIndex(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -4015,7 +4016,7 @@ func TestLibraryServiceMonologAboutBookError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceBabbleAboutBook(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -4304,7 +4305,7 @@ func TestLibraryServiceGetBigBookError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceGetBigNothing(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -4784,7 +4785,7 @@ func TestLibraryServiceStreamingArchiveBooksError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceSaveBook(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -3177,10 +3177,13 @@ const Operation = {
  *  Example 4: Pack and unpack a message in Go
  *
  *      foo := &pb.Foo{...}
- *      any, err := ptypes.MarshalAny(foo)
+ *      any, err := anypb.New(foo)
+ *      if err != nil {
+ *        ...
+ *      }
  *      ...
  *      foo := &pb.Foo{}
- *      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+ *      if err := any.UnmarshalTo(foo); err != nil {
  *        ...
  *      }
  *
@@ -3803,7 +3806,16 @@ const NullValue = {
  *         .setNanos((int) ((millis % 1000) * 1000000)).build();
  *
  *
- * Example 5: Compute Timestamp from current time in Python.
+ * Example 5: Compute Timestamp from Java `Instant.now()`.
+ *
+ *     Instant now = Instant.now();
+ *
+ *     Timestamp timestamp =
+ *         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+ *             .setNanos(now.getNano()).build();
+ *
+ *
+ * Example 6: Compute Timestamp from current time in Python.
  *
  *     timestamp = Timestamp()
  *     timestamp.GetCurrentTime()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -1272,10 +1272,13 @@ module Google
     #  Example 4: Pack and unpack a message in Go
     #
     #      foo := &pb.Foo{...}
-    #      any, err := ptypes.MarshalAny(foo)
+    #      any, err := anypb.New(foo)
+    #      if err != nil {
+    #        ...
+    #      }
     #      ...
     #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      if err := any.UnmarshalTo(foo); err != nil {
     #        ...
     #      }
     #
@@ -1832,7 +1835,16 @@ module Google
     #         .setNanos((int) ((millis % 1000) * 1000000)).build();
     #
     #
-    # Example 5: Compute Timestamp from current time in Python.
+    # Example 5: Compute Timestamp from Java `Instant.now()`.
+    #
+    #     Instant now = Instant.now();
+    #
+    #     Timestamp timestamp =
+    #         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+    #             .setNanos(now.getNano()).build();
+    #
+    #
+    # Example 6: Compute Timestamp from current time in Python.
     #
     #     timestamp = Timestamp()
     #     timestamp.GetCurrentTime()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_longrunning.baseline
@@ -848,10 +848,13 @@ module Google
     #  Example 4: Pack and unpack a message in Go
     #
     #      foo := &pb.Foo{...}
-    #      any, err := ptypes.MarshalAny(foo)
+    #      any, err := anypb.New(foo)
+    #      if err != nil {
+    #        ...
+    #      }
     #      ...
     #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      if err := any.UnmarshalTo(foo); err != nil {
     #        ...
     #      }
     #

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/go_library.baseline
@@ -213,6 +213,7 @@ import (
     "google.golang.org/grpc"
     "google.golang.org/grpc/codes"
     "google.golang.org/grpc/metadata"
+    emptypbpb "google.golang.org/protobuf/types/known/emptypb"
 )
 
 // CallOptions contains the retry settings for each method of LibClient.
@@ -2153,16 +2154,16 @@ package library
 import (
     pb ""
 
-    anypb "github.com/golang/protobuf/ptypes/any"
-    durationpb "github.com/golang/protobuf/ptypes/duration"
-    emptypb "github.com/golang/protobuf/ptypes/empty"
-    structpbpb "github.com/golang/protobuf/ptypes/struct"
-    timestamppb "github.com/golang/protobuf/ptypes/timestamp"
-    wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
     librarypb "google.golang.org/genproto/googleapis/example/library/v1"
     longrunningpb "google.golang.org/genproto/googleapis/longrunning"
     taggerpb "google.golang.org/genproto/googleapis/tagger/v1"
-    field_maskpb "google.golang.org/genproto/protobuf/field_mask"
+    anypbpb "google.golang.org/protobuf/types/known/anypb"
+    durationpbpb "google.golang.org/protobuf/types/known/durationpb"
+    emptypbpb "google.golang.org/protobuf/types/known/emptypb"
+    fieldmaskpbpb "google.golang.org/protobuf/types/known/fieldmaskpb"
+    structpbpb "google.golang.org/protobuf/types/known/structpb"
+    timestamppbpb "google.golang.org/protobuf/types/known/timestamppb"
+    wrapperspbpb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 import (
@@ -2253,7 +2254,7 @@ func (s *mockLibraryServer) ListAggregatedShelves(ctx context.Context, req *libr
     return s.resps[0].(*librarypb.ListAggregatedShelvesResponse), nil
 }
 
-func (s *mockLibraryServer) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest) (*emptypb.Empty, error) {
+func (s *mockLibraryServer) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest) (*emptypbpb.Empty, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
         return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
@@ -2262,7 +2263,7 @@ func (s *mockLibraryServer) DeleteShelf(ctx context.Context, req *librarypb.Dele
     if s.err != nil {
         return nil, s.err
     }
-    return s.resps[0].(*emptypb.Empty), nil
+    return s.resps[0].(*emptypbpb.Empty), nil
 }
 
 func (s *mockLibraryServer) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRequest) (*librarypb.Shelf, error) {
@@ -2337,7 +2338,7 @@ func (s *mockLibraryServer) ListBooks(ctx context.Context, req *librarypb.ListBo
     return s.resps[0].(*librarypb.ListBooksResponse), nil
 }
 
-func (s *mockLibraryServer) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest) (*emptypb.Empty, error) {
+func (s *mockLibraryServer) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest) (*emptypbpb.Empty, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
         return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
@@ -2346,7 +2347,7 @@ func (s *mockLibraryServer) DeleteBook(ctx context.Context, req *librarypb.Delet
     if s.err != nil {
         return nil, s.err
     }
-    return s.resps[0].(*emptypb.Empty), nil
+    return s.resps[0].(*emptypbpb.Empty), nil
 }
 
 func (s *mockLibraryServer) UpdateBook(ctx context.Context, req *librarypb.UpdateBookRequest) (*librarypb.Book, error) {
@@ -2385,7 +2386,7 @@ func (s *mockLibraryServer) ListStrings(ctx context.Context, req *librarypb.List
     return s.resps[0].(*librarypb.ListStringsResponse), nil
 }
 
-func (s *mockLibraryServer) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest) (*emptypb.Empty, error) {
+func (s *mockLibraryServer) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest) (*emptypbpb.Empty, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
         return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
@@ -2394,7 +2395,7 @@ func (s *mockLibraryServer) AddComments(ctx context.Context, req *librarypb.AddC
     if s.err != nil {
         return nil, s.err
     }
-    return s.resps[0].(*emptypb.Empty), nil
+    return s.resps[0].(*emptypbpb.Empty), nil
 }
 
 func (s *mockLibraryServer) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBookFromAnywhereRequest) (*librarypb.BookFromAnywhere, error) {
@@ -2421,7 +2422,7 @@ func (s *mockLibraryServer) GetBookFromAbsolutelyAnywhere(ctx context.Context, r
     return s.resps[0].(*librarypb.BookFromAnywhere), nil
 }
 
-func (s *mockLibraryServer) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest) (*emptypb.Empty, error) {
+func (s *mockLibraryServer) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest) (*emptypbpb.Empty, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
         return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
@@ -2430,7 +2431,7 @@ func (s *mockLibraryServer) UpdateBookIndex(ctx context.Context, req *librarypb.
     if s.err != nil {
         return nil, s.err
     }
-    return s.resps[0].(*emptypb.Empty), nil
+    return s.resps[0].(*emptypbpb.Empty), nil
 }
 
 func (s *mockLibraryServer) StreamShelves(req *librarypb.StreamShelvesRequest, stream librarypb.LibraryService_StreamShelvesServer) error {
@@ -2529,7 +2530,7 @@ func (s *mockLibraryServer) BabbleAboutBook(stream librarypb.LibraryService_Babb
     if s.err != nil {
         return s.err
     }
-    return stream.SendAndClose(s.resps[0].(*emptypb.Empty))
+    return stream.SendAndClose(s.resps[0].(*emptypbpb.Empty))
 }
 
 func (s *mockLibraryServer) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelatedBooksRequest) (*librarypb.FindRelatedBooksResponse, error) {
@@ -2629,7 +2630,7 @@ func (s *mockLibraryServer) StreamingArchiveBooks(stream librarypb.LibraryServic
     return nil
 }
 
-func (s *mockLibraryServer) SaveBook(ctx context.Context, req *librarypb.Book) (*emptypb.Empty, error) {
+func (s *mockLibraryServer) SaveBook(ctx context.Context, req *librarypb.Book) (*emptypbpb.Empty, error) {
     md, _ := metadata.FromIncomingContext(ctx)
     if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
         return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
@@ -2638,7 +2639,7 @@ func (s *mockLibraryServer) SaveBook(ctx context.Context, req *librarypb.Book) (
     if s.err != nil {
         return nil, s.err
     }
-    return s.resps[0].(*emptypb.Empty), nil
+    return s.resps[0].(*emptypbpb.Empty), nil
 }
 
 func (s *mockLibraryServer) TestOptionalRequiredFlatteningParams(ctx context.Context, req *librarypb.TestOptionalRequiredFlatteningParamsRequest) (*librarypb.TestOptionalRequiredFlatteningParamsResponse, error) {
@@ -2962,7 +2963,7 @@ func TestLibraryServiceListShelvesError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceDeleteShelf(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -3314,7 +3315,9 @@ func TestLibraryServiceListBooks(t *testing.T) {
     var filter string = "book-filter-string"
     var request = &librarypb.ListBooksRequest{
         Name: formattedName,
-        Filter: filter,
+        Filter: &librarypb.ListBooksRequest_Filter{
+            Filter: filter,
+        },
     }
 
     c, err := NewClient(context.Background(), clientOpt)
@@ -3355,7 +3358,9 @@ func TestLibraryServiceListBooksError(t *testing.T) {
     var filter string = "book-filter-string"
     var request = &librarypb.ListBooksRequest{
         Name: formattedName,
-        Filter: filter,
+        Filter: &librarypb.ListBooksRequest_Filter{
+            Filter: filter,
+        },
     }
 
     c, err := NewClient(context.Background(), clientOpt)
@@ -3373,7 +3378,7 @@ func TestLibraryServiceListBooksError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceDeleteBook(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -3633,7 +3638,7 @@ func TestLibraryServiceListStringsError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceAddComments(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -3847,7 +3852,7 @@ func TestLibraryServiceGetBookFromAbsolutelyAnywhereError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceUpdateBookIndex(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -4212,7 +4217,7 @@ func TestLibraryServiceMonologAboutBookError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceBabbleAboutBook(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -4509,7 +4514,7 @@ func TestLibraryServiceGetBigBookError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceGetBigNothing(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil
@@ -4623,38 +4628,38 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParams(t *testing.T) {
     var requiredRepeatedFixed32 []int32 = nil
     var requiredRepeatedFixed64 []int64 = nil
     var requiredMap map[int32]string = nil
-    var requiredAnyValue *anypb.Any = &anypb.Any{}
+    var requiredAnyValue *anypbpb.Any = &anypbpb.Any{}
     var requiredStructValue *structpbpb.Struct = &structpbpb.Struct{}
     var requiredValueValue *structpbpb.Value = &structpbpb.Value{}
     var requiredListValueValue *structpbpb.ListValue = &structpbpb.ListValue{}
-    var requiredTimeValue *timestamppb.Timestamp = &timestamppb.Timestamp{}
-    var requiredDurationValue *durationpb.Duration = &durationpb.Duration{}
-    var requiredFieldMaskValue *field_maskpb.FieldMask = &field_maskpb.FieldMask{}
-    var requiredInt32Value *wrapperspb.Int32Value = &wrapperspb.Int32Value{}
-    var requiredUint32Value *wrapperspb.UInt32Value = &wrapperspb.UInt32Value{}
-    var requiredInt64Value *wrapperspb.Int64Value = &wrapperspb.Int64Value{}
-    var requiredUint64Value *wrapperspb.UInt64Value = &wrapperspb.UInt64Value{}
-    var requiredFloatValue *wrapperspb.FloatValue = &wrapperspb.FloatValue{}
-    var requiredDoubleValue *wrapperspb.DoubleValue = &wrapperspb.DoubleValue{}
-    var requiredStringValue *wrapperspb.StringValue = &wrapperspb.StringValue{}
-    var requiredBoolValue *wrapperspb.BoolValue = &wrapperspb.BoolValue{}
-    var requiredBytesValue *wrapperspb.BytesValue = &wrapperspb.BytesValue{}
-    var requiredRepeatedAnyValue []*anypb.Any = nil
+    var requiredTimeValue *timestamppbpb.Timestamp = &timestamppbpb.Timestamp{}
+    var requiredDurationValue *durationpbpb.Duration = &durationpbpb.Duration{}
+    var requiredFieldMaskValue *fieldmaskpbpb.FieldMask = &fieldmaskpbpb.FieldMask{}
+    var requiredInt32Value *wrapperspbpb.Int32Value = &wrapperspbpb.Int32Value{}
+    var requiredUint32Value *wrapperspbpb.UInt32Value = &wrapperspbpb.UInt32Value{}
+    var requiredInt64Value *wrapperspbpb.Int64Value = &wrapperspbpb.Int64Value{}
+    var requiredUint64Value *wrapperspbpb.UInt64Value = &wrapperspbpb.UInt64Value{}
+    var requiredFloatValue *wrapperspbpb.FloatValue = &wrapperspbpb.FloatValue{}
+    var requiredDoubleValue *wrapperspbpb.DoubleValue = &wrapperspbpb.DoubleValue{}
+    var requiredStringValue *wrapperspbpb.StringValue = &wrapperspbpb.StringValue{}
+    var requiredBoolValue *wrapperspbpb.BoolValue = &wrapperspbpb.BoolValue{}
+    var requiredBytesValue *wrapperspbpb.BytesValue = &wrapperspbpb.BytesValue{}
+    var requiredRepeatedAnyValue []*anypbpb.Any = nil
     var requiredRepeatedStructValue []*structpbpb.Struct = nil
     var requiredRepeatedValueValue []*structpbpb.Value = nil
     var requiredRepeatedListValueValue []*structpbpb.ListValue = nil
-    var requiredRepeatedTimeValue []*timestamppb.Timestamp = nil
-    var requiredRepeatedDurationValue []*durationpb.Duration = nil
-    var requiredRepeatedFieldMaskValue []*field_maskpb.FieldMask = nil
-    var requiredRepeatedInt32Value []*wrapperspb.Int32Value = nil
-    var requiredRepeatedUint32Value []*wrapperspb.UInt32Value = nil
-    var requiredRepeatedInt64Value []*wrapperspb.Int64Value = nil
-    var requiredRepeatedUint64Value []*wrapperspb.UInt64Value = nil
-    var requiredRepeatedFloatValue []*wrapperspb.FloatValue = nil
-    var requiredRepeatedDoubleValue []*wrapperspb.DoubleValue = nil
-    var requiredRepeatedStringValue []*wrapperspb.StringValue = nil
-    var requiredRepeatedBoolValue []*wrapperspb.BoolValue = nil
-    var requiredRepeatedBytesValue []*wrapperspb.BytesValue = nil
+    var requiredRepeatedTimeValue []*timestamppbpb.Timestamp = nil
+    var requiredRepeatedDurationValue []*durationpbpb.Duration = nil
+    var requiredRepeatedFieldMaskValue []*fieldmaskpbpb.FieldMask = nil
+    var requiredRepeatedInt32Value []*wrapperspbpb.Int32Value = nil
+    var requiredRepeatedUint32Value []*wrapperspbpb.UInt32Value = nil
+    var requiredRepeatedInt64Value []*wrapperspbpb.Int64Value = nil
+    var requiredRepeatedUint64Value []*wrapperspbpb.UInt64Value = nil
+    var requiredRepeatedFloatValue []*wrapperspbpb.FloatValue = nil
+    var requiredRepeatedDoubleValue []*wrapperspbpb.DoubleValue = nil
+    var requiredRepeatedStringValue []*wrapperspbpb.StringValue = nil
+    var requiredRepeatedBoolValue []*wrapperspbpb.BoolValue = nil
+    var requiredRepeatedBytesValue []*wrapperspbpb.BytesValue = nil
     var request = &librarypb.TestOptionalRequiredFlatteningParamsRequest{
         RequiredSingularInt32: requiredSingularInt32,
         RequiredSingularInt64: requiredSingularInt64,
@@ -4772,38 +4777,38 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
     var requiredRepeatedFixed32 []int32 = nil
     var requiredRepeatedFixed64 []int64 = nil
     var requiredMap map[int32]string = nil
-    var requiredAnyValue *anypb.Any = &anypb.Any{}
+    var requiredAnyValue *anypbpb.Any = &anypbpb.Any{}
     var requiredStructValue *structpbpb.Struct = &structpbpb.Struct{}
     var requiredValueValue *structpbpb.Value = &structpbpb.Value{}
     var requiredListValueValue *structpbpb.ListValue = &structpbpb.ListValue{}
-    var requiredTimeValue *timestamppb.Timestamp = &timestamppb.Timestamp{}
-    var requiredDurationValue *durationpb.Duration = &durationpb.Duration{}
-    var requiredFieldMaskValue *field_maskpb.FieldMask = &field_maskpb.FieldMask{}
-    var requiredInt32Value *wrapperspb.Int32Value = &wrapperspb.Int32Value{}
-    var requiredUint32Value *wrapperspb.UInt32Value = &wrapperspb.UInt32Value{}
-    var requiredInt64Value *wrapperspb.Int64Value = &wrapperspb.Int64Value{}
-    var requiredUint64Value *wrapperspb.UInt64Value = &wrapperspb.UInt64Value{}
-    var requiredFloatValue *wrapperspb.FloatValue = &wrapperspb.FloatValue{}
-    var requiredDoubleValue *wrapperspb.DoubleValue = &wrapperspb.DoubleValue{}
-    var requiredStringValue *wrapperspb.StringValue = &wrapperspb.StringValue{}
-    var requiredBoolValue *wrapperspb.BoolValue = &wrapperspb.BoolValue{}
-    var requiredBytesValue *wrapperspb.BytesValue = &wrapperspb.BytesValue{}
-    var requiredRepeatedAnyValue []*anypb.Any = nil
+    var requiredTimeValue *timestamppbpb.Timestamp = &timestamppbpb.Timestamp{}
+    var requiredDurationValue *durationpbpb.Duration = &durationpbpb.Duration{}
+    var requiredFieldMaskValue *fieldmaskpbpb.FieldMask = &fieldmaskpbpb.FieldMask{}
+    var requiredInt32Value *wrapperspbpb.Int32Value = &wrapperspbpb.Int32Value{}
+    var requiredUint32Value *wrapperspbpb.UInt32Value = &wrapperspbpb.UInt32Value{}
+    var requiredInt64Value *wrapperspbpb.Int64Value = &wrapperspbpb.Int64Value{}
+    var requiredUint64Value *wrapperspbpb.UInt64Value = &wrapperspbpb.UInt64Value{}
+    var requiredFloatValue *wrapperspbpb.FloatValue = &wrapperspbpb.FloatValue{}
+    var requiredDoubleValue *wrapperspbpb.DoubleValue = &wrapperspbpb.DoubleValue{}
+    var requiredStringValue *wrapperspbpb.StringValue = &wrapperspbpb.StringValue{}
+    var requiredBoolValue *wrapperspbpb.BoolValue = &wrapperspbpb.BoolValue{}
+    var requiredBytesValue *wrapperspbpb.BytesValue = &wrapperspbpb.BytesValue{}
+    var requiredRepeatedAnyValue []*anypbpb.Any = nil
     var requiredRepeatedStructValue []*structpbpb.Struct = nil
     var requiredRepeatedValueValue []*structpbpb.Value = nil
     var requiredRepeatedListValueValue []*structpbpb.ListValue = nil
-    var requiredRepeatedTimeValue []*timestamppb.Timestamp = nil
-    var requiredRepeatedDurationValue []*durationpb.Duration = nil
-    var requiredRepeatedFieldMaskValue []*field_maskpb.FieldMask = nil
-    var requiredRepeatedInt32Value []*wrapperspb.Int32Value = nil
-    var requiredRepeatedUint32Value []*wrapperspb.UInt32Value = nil
-    var requiredRepeatedInt64Value []*wrapperspb.Int64Value = nil
-    var requiredRepeatedUint64Value []*wrapperspb.UInt64Value = nil
-    var requiredRepeatedFloatValue []*wrapperspb.FloatValue = nil
-    var requiredRepeatedDoubleValue []*wrapperspb.DoubleValue = nil
-    var requiredRepeatedStringValue []*wrapperspb.StringValue = nil
-    var requiredRepeatedBoolValue []*wrapperspb.BoolValue = nil
-    var requiredRepeatedBytesValue []*wrapperspb.BytesValue = nil
+    var requiredRepeatedTimeValue []*timestamppbpb.Timestamp = nil
+    var requiredRepeatedDurationValue []*durationpbpb.Duration = nil
+    var requiredRepeatedFieldMaskValue []*fieldmaskpbpb.FieldMask = nil
+    var requiredRepeatedInt32Value []*wrapperspbpb.Int32Value = nil
+    var requiredRepeatedUint32Value []*wrapperspbpb.UInt32Value = nil
+    var requiredRepeatedInt64Value []*wrapperspbpb.Int64Value = nil
+    var requiredRepeatedUint64Value []*wrapperspbpb.UInt64Value = nil
+    var requiredRepeatedFloatValue []*wrapperspbpb.FloatValue = nil
+    var requiredRepeatedDoubleValue []*wrapperspbpb.DoubleValue = nil
+    var requiredRepeatedStringValue []*wrapperspbpb.StringValue = nil
+    var requiredRepeatedBoolValue []*wrapperspbpb.BoolValue = nil
+    var requiredRepeatedBytesValue []*wrapperspbpb.BytesValue = nil
     var request = &librarypb.TestOptionalRequiredFlatteningParamsRequest{
         RequiredSingularInt32: requiredSingularInt32,
         RequiredSingularInt64: requiredSingularInt64,
@@ -5265,7 +5270,7 @@ func TestLibraryServiceStreamingArchiveBooksError(t *testing.T) {
     _ = resp
 }
 func TestLibraryServiceSaveBook(t *testing.T) {
-    var expectedResponse *emptypb.Empty = &emptypb.Empty{}
+    var expectedResponse *emptypbpb.Empty = &emptypbpb.Empty{}
 
     mockLibrary.err = nil
     mockLibrary.reqs = nil

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config_http.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/java_library_no_gapic_config_http.baseline
@@ -7660,7 +7660,9 @@ public class HttpJsonLibraryServiceStub extends LibraryServiceStub {
                               ProtoRestSerializer.create();
                           serializer.putQueryParam(fields, "pageSize", request.getPageSize());
                           serializer.putQueryParam(fields, "pageToken", request.getPageToken());
-                          serializer.putQueryParam(fields, "filter", request.getFilter());
+                          if (request.hasFilter()) {
+                            serializer.putQueryParam(fields, "filter", request.getFilter());
+                          }
                           return fields;
                         }
                       })

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/nodejs_library.baseline
@@ -4015,10 +4015,13 @@ const Operation = {
  *  Example 4: Pack and unpack a message in Go
  *
  *      foo := &pb.Foo{...}
- *      any, err := ptypes.MarshalAny(foo)
+ *      any, err := anypb.New(foo)
+ *      if err != nil {
+ *        ...
+ *      }
  *      ...
  *      foo := &pb.Foo{}
- *      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+ *      if err := any.UnmarshalTo(foo); err != nil {
  *        ...
  *      }
  *
@@ -4641,7 +4644,16 @@ const NullValue = {
  *         .setNanos((int) ((millis % 1000) * 1000000)).build();
  *
  *
- * Example 5: Compute Timestamp from current time in Python.
+ * Example 5: Compute Timestamp from Java `Instant.now()`.
+ *
+ *     Instant now = Instant.now();
+ *
+ *     Timestamp timestamp =
+ *         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+ *             .setNanos(now.getNano()).build();
+ *
+ *
+ * Example 6: Compute Timestamp from current time in Python.
  *
  *     timestamp = Timestamp()
  *     timestamp.GetCurrentTime()

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/python_library.baseline
@@ -2013,6 +2013,12 @@ class LibraryServiceClient(object):
                 client_info=self._client_info,
             )
 
+        # Sanity check: We have some fields which are mutually exclusive;
+        # raise ValueError if more than one is sent.
+        google.api_core.protobuf_helpers.check_oneof(
+            filter_=filter_,
+        )
+
         request = library_pb2.ListBooksRequest(
             name=name,
             page_size=page_size,

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library.baseline
@@ -1272,10 +1272,13 @@ module Google
     #  Example 4: Pack and unpack a message in Go
     #
     #      foo := &pb.Foo{...}
-    #      any, err := ptypes.MarshalAny(foo)
+    #      any, err := anypb.New(foo)
+    #      if err != nil {
+    #        ...
+    #      }
     #      ...
     #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      if err := any.UnmarshalTo(foo); err != nil {
     #        ...
     #      }
     #
@@ -1832,7 +1835,16 @@ module Google
     #         .setNanos((int) ((millis % 1000) * 1000000)).build();
     #
     #
-    # Example 5: Compute Timestamp from current time in Python.
+    # Example 5: Compute Timestamp from Java `Instant.now()`.
+    #
+    #     Instant now = Instant.now();
+    #
+    #     Timestamp timestamp =
+    #         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+    #             .setNanos(now.getNano()).build();
+    #
+    #
+    # Example 6: Compute Timestamp from current time in Python.
     #
     #     timestamp = Timestamp()
     #     timestamp.GetCurrentTime()

--- a/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
+++ b/src/test/java/com/google/api/codegen/protoannotations/testdata/ruby_library_no_gapic_config.baseline
@@ -1152,10 +1152,13 @@ module Google
     #  Example 4: Pack and unpack a message in Go
     #
     #      foo := &pb.Foo{...}
-    #      any, err := ptypes.MarshalAny(foo)
+    #      any, err := anypb.New(foo)
+    #      if err != nil {
+    #        ...
+    #      }
     #      ...
     #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      if err := any.UnmarshalTo(foo); err != nil {
     #        ...
     #      }
     #
@@ -1712,7 +1715,16 @@ module Google
     #         .setNanos((int) ((millis % 1000) * 1000000)).build();
     #
     #
-    # Example 5: Compute Timestamp from current time in Python.
+    # Example 5: Compute Timestamp from Java `Instant.now()`.
+    #
+    #     Instant now = Instant.now();
+    #
+    #     Timestamp timestamp =
+    #         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+    #             .setNanos(now.getNano()).build();
+    #
+    #
+    # Example 6: Compute Timestamp from current time in Python.
     #
     #     timestamp = Timestamp()
     #     timestamp.GetCurrentTime()

--- a/src/test/java/com/google/api/codegen/testsrc/protoannotations/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/protoannotations/library.proto
@@ -829,7 +829,7 @@ message ListBooksRequest {
   string page_token = 3;
 
   // To test python built-in wrapping.
-  string filter = 4;
+  optional string filter = 4;
 }
 
 // Response message for LibraryService.ListBooks.


### PR DESCRIPTION
This PR also updates the dependency to protobuf `3.15.8`, and the chagnes ini baseline files for the othe langauges but Java are caused by the update to the protobuf dependency and are not caused by the chagnes in the generator.