### PR TITLE
fix: Support field names like `I_p_address` as valid.

### DIFF
--- a/src/main/java/com/google/api/codegen/util/Name.java
+++ b/src/main/java/com/google/api/codegen/util/Name.java
@@ -179,8 +179,14 @@ public class Name {
 
   private static boolean isLowerUnderscore(String identifier) {
     Character underscore = Character.valueOf('_');
-    for (Character ch : identifier.toCharArray()) {
-      if (!Character.isLowerCase(ch) && !ch.equals(underscore) && !Character.isDigit(ch)) {
+    char[] chars = identifier.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      Character ch = chars[i];
+      if (!Character.isLowerCase(ch)
+          && !ch.equals(underscore)
+          && !Character.isDigit(ch)
+          && !(i == 0 && Character.isUpperCase(ch))
+          && !(i == 1 && Character.isUpperCase(ch) && underscore.equals(chars[0]))) {
         return false;
       }
     }


### PR DESCRIPTION
Specifically support snake_case naming when the first letter is upper case. This is needed to support obscure cases like `Compute.ForwardingRule` API, when some of the fields are names `IPAddress` instead of `ipAddress`.